### PR TITLE
fix(install): default bootstrap install dir to $PWD/flocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ If automatic `npm` installation fails during setup, please install `npm` manuall
 
 > **Users in mainland China**: If GitHub or `raw.githubusercontent.com` is slow or unreachable, clone from a Gitee mirror and follow the Source install instructions below.
 
-The recommended host installation entrypoint is the GitHub bootstrap installer. It downloads the repository source archive to a temporary directory, copies it into a persistent local install directory, then installs backend and WebUI dependencies and exposes the `flocks` CLI on your PATH.
+The recommended host installation entrypoint is the GitHub bootstrap installer. It downloads the repository source archive to a temporary directory, copies it into a `flocks/` subdirectory under your current working directory by default, then installs backend and WebUI dependencies and exposes the `flocks` CLI on your PATH. You can still override the destination with `FLOCKS_INSTALL_DIR`.
 
 #### macOS / Linux
 
 ```bash
 # One-click install backend + WebUI
 curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh | bash
+# Creates ./flocks under the current directory
 
 # Optional: also install TUI dependencies
 curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh | bash -s -- --with-tui
@@ -65,6 +66,7 @@ curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh 
 ```powershell
 # One-click install backend + WebUI
 iwr -useb https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1 | iex
+# Creates .\flocks under the current directory
 
 # Optional: also install TUI dependencies
 & ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1))) -InstallTui

--- a/README_zh.md
+++ b/README_zh.md
@@ -53,6 +53,7 @@ Flocks 支持两种部署方式：
 ```bash
 # 一键安装后端 + WebUI
 curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh | bash
+# 默认会在当前目录下创建 ./flocks
 
 # 可选：同时安装 TUI 依赖
 curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh | bash -s -- --with-tui
@@ -63,6 +64,7 @@ curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh 
 ```powershell
 # 一键安装后端 + WebUI
 iwr -useb https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1 | iex
+# 默认会在当前目录下创建 .\flocks
 
 # 可选：同时安装 TUI 依赖
 & ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1))) -InstallTui

--- a/install.ps1
+++ b/install.ps1
@@ -8,7 +8,8 @@ $ErrorActionPreference = "Stop"
 
 $RepoSlug = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_REPO_SLUG)) { "AgentFlocks/Flocks" } else { $env:FLOCKS_REPO_SLUG }
 $DefaultBranch = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_DEFAULT_BRANCH)) { "main" } else { $env:FLOCKS_DEFAULT_BRANCH }
-$InstallDir = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_DIR)) { Join-Path $HOME ".flocks\app" } else { $env:FLOCKS_INSTALL_DIR }
+$DefaultInstallDir = Join-Path (Get-Location) "flocks"
+$InstallDir = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_DIR)) { $DefaultInstallDir } else { $env:FLOCKS_INSTALL_DIR }
 
 if ([string]::IsNullOrWhiteSpace($Version)) {
     $Version = $DefaultBranch
@@ -29,8 +30,9 @@ function Show-Usage {
     Write-Host "Usage: install.ps1 [-InstallTui] [-Version <tag-or-branch>] [-Help]"
     Write-Host ""
     Write-Host "Bootstrap installer for Flocks."
-Write-Host "This script downloads the GitHub source archive to a temporary directory,"
-Write-Host "copies it to a stable install location, and delegates to scripts/install.ps1."
+    Write-Host "This script downloads the GitHub source archive to a temporary directory,"
+    Write-Host "copies it to a persistent install location, and delegates to scripts/install.ps1."
+    Write-Host "By default it creates a 'flocks' subdirectory under the current directory."
     Write-Host ""
     Write-Host "Options:"
     Write-Host "  -InstallTui          Also install TUI dependencies."

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,8 @@ DEFAULT_BRANCH="${FLOCKS_DEFAULT_BRANCH:-main}"
 VERSION="${VERSION:-$DEFAULT_BRANCH}"
 INSTALL_TUI=0
 TMP_DIR=""
-INSTALL_DIR="${FLOCKS_INSTALL_DIR:-$HOME/.flocks/app}"
+DEFAULT_INSTALL_DIR="${PWD%/}/flocks"
+INSTALL_DIR="${FLOCKS_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
 
 info() {
   printf '[flocks-bootstrap] %s\n' "$1"
@@ -36,8 +37,9 @@ Usage: install.sh [--with-tui] [--version <tag-or-branch>]
 
 Bootstrap installer for Flocks.
 This script downloads the GitHub source archive, extracts it to a temporary
-directory, copies it to a stable install location, then delegates to
-scripts/install.sh inside the repository.
+directory, copies it to a persistent install location, then delegates to
+scripts/install.sh inside the repository. By default it creates a "flocks"
+subdirectory under the current working directory.
 
 Options:
   --with-tui, -t         Also install TUI dependencies.

--- a/tests/scripts/test_install_script_help.py
+++ b/tests/scripts/test_install_script_help.py
@@ -8,6 +8,37 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / "scripts"
 
 
+def test_bootstrap_bash_install_help_mentions_current_directory_default() -> None:
+    install_cwd = REPO_ROOT.parent
+    result = subprocess.run(
+        ["bash", str(REPO_ROOT / "install.sh"), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=install_cwd,
+    )
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
+    assert str(install_cwd / "flocks") in output
+    assert "current working directory" in output
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh is required to inspect PowerShell help output")
+def test_bootstrap_powershell_install_help_mentions_current_directory_default() -> None:
+    install_cwd = REPO_ROOT.parent
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-File", str(REPO_ROOT / "install.ps1"), "-Help"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=install_cwd,
+    )
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
+    assert str(install_cwd / "flocks") in output
+    assert "current directory" in output
+
+
 def test_bash_install_help_mentions_optional_tui() -> None:
     result = subprocess.run(
         ["bash", str(SCRIPT_DIR / "install.sh"), "--help"],


### PR DESCRIPTION
The one-click curl/iwr installer now places the project source under the current working directory (./flocks) rather than a hidden home directory, making the install location more intuitive and consistent with `git clone` workflows. FLOCKS_INSTALL_DIR still works as an override.