### PR TITLE
fix(dingtalk): resolve runner.ts crash loop and improve onboarding UX

### DIFF
--- a/.flocks/plugins/channels/dingtalk/runner.ts
+++ b/.flocks/plugins/channels/dingtalk/runner.ts
@@ -344,10 +344,12 @@ const fakeApi: any = {
 };
 
 // ── 启动：先开代理，再注册插件 ───────────────────────────────────────────────
-await startProxy();
+(async () => {
+  await startProxy();
 
-// 更新 runtime 里的端口（startAccount 读 cfg.gateway.port，cfg 在 registerChannel 里构造，已用最新值）
-fakeRuntime.gateway.port = PROXY_PORT;
+  // 更新 runtime 里的端口（startAccount 读 cfg.gateway.port，cfg 在 registerChannel 里构造，已用最新值）
+  fakeRuntime.gateway.port = PROXY_PORT;
 
-console.log(`[runner] 启动 DingTalk connector → flocks :${FLOCKS_PORT}`);
-plugin.register(fakeApi);
+  console.log(`[runner] 启动 DingTalk connector → flocks :${FLOCKS_PORT}`);
+  plugin.register(fakeApi);
+})();

--- a/README.md
+++ b/README.md
@@ -61,17 +61,6 @@ curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh 
 curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh | bash -s -- --with-tui
 ```
 
-#### Windows PowerShell (Administrator)
-
-```powershell
-# One-click install backend + WebUI
-iwr -useb https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1 | iex
-# Creates .\flocks under the current directory
-
-# Optional: also install TUI dependencies
-& ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1))) -InstallTui
-```
-
 #### Install from source code
 
 If you prefer to inspect the repository before installation, clone it locally and run the installer from the workspace:

--- a/README_zh.md
+++ b/README_zh.md
@@ -59,17 +59,6 @@ curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh 
 curl -fsSL https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.sh | bash -s -- --with-tui
 ```
 
-#### Windows PowerShell（管理员）
-
-```powershell
-# 一键安装后端 + WebUI
-iwr -useb https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1 | iex
-# 默认会在当前目录下创建 .\flocks
-
-# 可选：同时安装 TUI 依赖
-& ([scriptblock]::Create((iwr -useb https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1))) -InstallTui
-```
-
 #### github源码安装
 
 克隆到本地后在工作区执行安装脚本：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.3.30"
+version = "v2026.3.31"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/webui/src/components/common/OnboardingModal.tsx
+++ b/webui/src/components/common/OnboardingModal.tsx
@@ -313,9 +313,12 @@ export default function OnboardingModal({ onClose }: OnboardingModalProps) {
       }
       return;
     }
-    const firstModelId = selectedPrimaryProvider.models[0]?.id || '';
-    if (!selectedPrimaryProvider.models.some((model) => model.id === primaryModelId)) {
-      setPrimaryModelId(firstModelId);
+    const hasModels = selectedPrimaryProvider.models.length > 0;
+    if (hasModels) {
+      const firstModelId = selectedPrimaryProvider.models[0]?.id || '';
+      if (!selectedPrimaryProvider.models.some((model) => model.id === primaryModelId)) {
+        setPrimaryModelId(firstModelId);
+      }
     }
     if (primaryProviderIsThreatBook) {
       setPrimaryBaseUrl('');
@@ -829,7 +832,7 @@ export default function OnboardingModal({ onClose }: OnboardingModalProps) {
                   </div>
                 )}
 
-                {!primaryProviderIsThreatBook && (
+                {!primaryProviderIsThreatBook && (selectedPrimaryProvider?.models?.length ? (
                   <select
                     value={primaryModelId}
                     onChange={(e) => {
@@ -838,13 +841,24 @@ export default function OnboardingModal({ onClose }: OnboardingModalProps) {
                     }}
                     className="w-full text-xs px-3 py-2 rounded-lg border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-red-400/50 focus:border-red-400 transition-all"
                   >
-                    {(selectedPrimaryProvider?.models || []).map((model) => (
+                    {selectedPrimaryProvider.models.map((model) => (
                       <option key={model.id} value={model.id}>
                         {model.name}
                       </option>
                     ))}
                   </select>
-                )}
+                ) : (
+                  <input
+                    type="text"
+                    value={primaryModelId}
+                    onChange={(e) => {
+                      setPrimaryModelId(e.target.value);
+                      setPrimaryStatus(null);
+                    }}
+                    placeholder={t('onboarding.bootstrap.thirdPartyModelIdPlaceholder')}
+                    className="w-full text-xs px-3 py-2 rounded-lg border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-red-400/50 focus:border-red-400 transition-all placeholder-gray-300"
+                  />
+                ))}
 
                 {needsPrimaryBaseUrl && (
                   <input
@@ -897,9 +911,9 @@ export default function OnboardingModal({ onClose }: OnboardingModalProps) {
                       ? t('onboarding.bootstrap.primaryThreatBookCnHint')
                       : t('onboarding.bootstrap.primaryThreatBookGlobalHint')}
                   </p>
-                ) : selectedPrimaryModel ? (
+                ) : (selectedPrimaryModel || primaryModelId) ? (
                   <p className="text-[11px] text-gray-500">
-                    {t('onboarding.bootstrap.thirdPartyModelHint', { model: selectedPrimaryModel.name })}
+                    {t('onboarding.bootstrap.thirdPartyModelHint', { model: selectedPrimaryModel?.name || primaryModelId })}
                   </p>
                 ) : null}
 

--- a/webui/src/locales/en-US/common.json
+++ b/webui/src/locales/en-US/common.json
@@ -232,6 +232,7 @@
       "thirdPartySubtitle": "Choose another provider, enter its key, and select the default model.",
       "thirdPartyKeyPlaceholder": "Paste the third-party model API key",
       "thirdPartyBaseUrlPlaceholder": "Enter the model service base URL if needed",
+      "thirdPartyModelIdPlaceholder": "Enter the model ID (e.g. gpt-4o, deepseek-chat)",
       "thirdPartyModelHint": "Will verify and set this as the default model: {{model}}",
       "thirdPartyAdvancedHint": "For advanced custom setups such as OpenAI Compatible, use the Models page instead.",
       "validateAndApply": "Validate & Apply",

--- a/webui/src/locales/zh-CN/common.json
+++ b/webui/src/locales/zh-CN/common.json
@@ -232,6 +232,7 @@
       "thirdPartySubtitle": "选择一个其他模型厂商，填写其 key，并指定默认模型。",
       "thirdPartyKeyPlaceholder": "粘贴第三方模型 API Key",
       "thirdPartyBaseUrlPlaceholder": "填写模型服务 Base URL（如需要）",
+      "thirdPartyModelIdPlaceholder": "输入模型 ID（例如 gpt-4o、deepseek-chat）",
       "thirdPartyModelHint": "保存后会验证并设为默认模型：{{model}}",
       "thirdPartyAdvancedHint": "如需 OpenAI Compatible 等高级自定义接入，请前往 Models 页面配置。",
       "validateAndApply": "验证并应用",


### PR DESCRIPTION
- Wrap top-level await in async IIFE to fix tsx/esbuild "cjs" format incompatibility that caused the dingtalk channel to crash-loop on start
- Allow manual model ID input when provider has no predefined model list in the onboarding modal
- Remove Windows PowerShell install instructions (not yet supported)
- Bump version to v2026.3.31