### PR TITLE
fix(webui): sync backend port across frontend startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ flocks stop
 ```
 
 The default service URLs are:
-- Backend API: `http://127.0.0.1:8000`
-- WebUI: `http://127.0.0.1:5173`
+- Backend API: `http://127.0.0.1:8000` by default, configurable via `flocks start --server-port`
+- WebUI: `http://127.0.0.1:5173` by default, configurable via `flocks start --webui-port`
 
 Flocks cli useage:  `flocks --help`
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -94,8 +94,8 @@ flocks stop
 ```
 
 默认服务地址：
-- 后端 API：`http://127.0.0.1:8000`
-- WebUI：`http://127.0.0.1:5173`
+- 后端 API：默认 `http://127.0.0.1:8000`，可通过 `flocks start --server-port` 修改
+- WebUI：默认 `http://127.0.0.1:5173`，可通过 `flocks start --webui-port` 修改
 
 更多 CLI 命令使用 `flocks --help`
 
@@ -137,8 +137,8 @@ docker run -d `
 ```
 
 默认服务地址：
-- 后端 API：`http://127.0.0.1:8000`
-- WebUI：`http://127.0.0.1:5173`
+- 后端 API：默认 `http://127.0.0.1:8000`
+- WebUI：默认 `http://127.0.0.1:5173`
 
 ## 常见问题
 

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -442,12 +442,14 @@ def start_frontend(config: ServiceConfig, console) -> None:
         raise ServiceError(f"检测到的 Node.js 版本过低。启动 WebUI 至少需要 Node.js {MIN_NODE_MAJOR}+。")
 
     webui_dir = root / "webui"
+    frontend_env = build_frontend_env(config)
     if not config.skip_frontend_build:
         console.print("[flocks] 构建 WebUI...")
         completed = subprocess.run(
             [npm, "run", "build"],
             cwd=webui_dir,
             check=False,
+            env=frontend_env,
         )
         if completed.returncode != 0:
             raise ServiceError("WebUI 构建失败。")
@@ -468,6 +470,7 @@ def start_frontend(config: ServiceConfig, console) -> None:
         command,
         cwd=webui_dir,
         log_path=paths.frontend_log,
+        env=frontend_env,
     )
     write_runtime_record(
         paths.frontend_pid,
@@ -788,7 +791,25 @@ def open_default_browser(url: str, console) -> None:
     console.print(f"[flocks] 未检测到可用的浏览器打开命令，请手动访问: {url}")
 
 
-def _spawn_process(command: Sequence[str], *, cwd: Path, log_path: Path) -> subprocess.Popen:
+def build_frontend_env(config: ServiceConfig) -> dict[str, str]:
+    """Build frontend environment variables from backend service settings."""
+    backend_host = _loopback_host(config.backend_host)
+    api_base_url = f"http://{backend_host}:{config.backend_port}"
+    ws_protocol = "wss" if api_base_url.startswith("https://") else "ws"
+
+    env = os.environ.copy()
+    env["VITE_API_BASE_URL"] = api_base_url
+    env["VITE_WS_BASE_URL"] = f"{ws_protocol}://{backend_host}:{config.backend_port}"
+    return env
+
+
+def _spawn_process(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    log_path: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.Popen:
     """Spawn a detached child process and redirect output to a log file."""
     creationflags = 0
     kwargs: dict[str, object] = {}
@@ -812,6 +833,7 @@ def _spawn_process(command: Sequence[str], *, cwd: Path, log_path: Path) -> subp
         return subprocess.Popen(
             list(command),
             cwd=cwd,
+            env=env,
             stdout=handle,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/scripts/dev-webui.ps1
+++ b/scripts/dev-webui.ps1
@@ -20,6 +20,30 @@ function Write-Fail {
     Write-Host $Message -ForegroundColor Red
 }
 
+function Get-EnvOrDefault {
+    param(
+        [string]$Name,
+        [string]$DefaultValue
+    )
+
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $DefaultValue
+    }
+
+    return $value
+}
+
+function Get-AccessHost {
+    param([string]$Host)
+
+    if ($Host -in @("0.0.0.0", "::")) {
+        return "127.0.0.1"
+    }
+
+    return $Host
+}
+
 function Stop-PortProcess {
     param([int]$Port)
 
@@ -43,11 +67,14 @@ function Stop-PortProcess {
 }
 
 function Test-BackendHealth {
-    param([string]$PythonExe)
+    param(
+        [string]$PythonExe,
+        [string]$BackendBaseUrl
+    )
 
     $healthUrls = @(
-        "http://localhost:8000/api/health",
-        "http://localhost:8000/health"
+        "$BackendBaseUrl/api/health",
+        "$BackendBaseUrl/health"
     )
 
     foreach ($url in $healthUrls) {
@@ -77,6 +104,12 @@ $webuiDir = Join-Path $projectRoot "webui"
 $logsDir = Join-Path $projectRoot "logs"
 $backendStdout = Join-Path $logsDir "flocks-backend.out.log"
 $backendStderr = Join-Path $logsDir "flocks-backend.err.log"
+$backendHost = Get-EnvOrDefault -Name "BACKEND_HOST" -DefaultValue "127.0.0.1"
+$backendAccessHost = Get-AccessHost -Host $backendHost
+$backendPort = [int](Get-EnvOrDefault -Name "BACKEND_PORT" -DefaultValue "8000")
+$frontendPort = [int](Get-EnvOrDefault -Name "FRONTEND_PORT" -DefaultValue "5173")
+$backendBaseUrl = "http://{0}:{1}" -f $backendAccessHost, $backendPort
+$backendWsUrl = "ws://{0}:{1}" -f $backendAccessHost, $backendPort
 
 if (-not (Test-Path $pythonExe)) {
     Write-Fail "Python venv not found: $pythonExe"
@@ -92,16 +125,16 @@ if (-not (Test-Path (Join-Path $webuiDir "package.json"))) {
 New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
 
 Write-Info "Cleaning existing processes..."
-Stop-PortProcess -Port 8000
-Stop-PortProcess -Port 5173
+Stop-PortProcess -Port $backendPort
+Stop-PortProcess -Port $frontendPort
 Start-Sleep -Seconds 2
 
-Write-Info "Starting backend service on port 8000..."
+Write-Info ("Starting backend service on port {0}..." -f $backendPort)
 $backendArgs = @(
     "-m", "uvicorn",
     "flocks.server.app:app",
-    "--host", "127.0.0.1",
-    "--port", "8000",
+    "--host", $backendHost,
+    "--port", $backendPort.ToString(),
     "--reload",
     "--reload-dir", "flocks",
     "--timeout-graceful-shutdown", "3"
@@ -123,7 +156,7 @@ Write-Info "Waiting for backend health check..."
 for ($attempt = 1; $attempt -le 30; $attempt++) {
     Start-Sleep -Seconds 2
 
-    if (Test-BackendHealth -PythonExe $pythonExe) {
+    if (Test-BackendHealth -PythonExe $pythonExe -BackendBaseUrl $backendBaseUrl) {
         $backendReady = $true
         break
     }
@@ -141,7 +174,7 @@ if (-not $backendReady) {
         Write-Host "Backend stderr tail:"
         Get-Content -Path $backendStderr -Tail 20
     }
-    Stop-PortProcess -Port 8000
+    Stop-PortProcess -Port $backendPort
     exit 1
 }
 
@@ -149,13 +182,27 @@ Write-Success "Backend started successfully."
 Write-Warn "Backend stdout log: $backendStdout"
 Write-Warn "Backend stderr log: $backendStderr"
 
-Write-Info "Starting WebUI frontend on port 5173..."
+Write-Info ("Starting WebUI frontend on port {0}..." -f $frontendPort)
 
 Push-Location $webuiDir
 try {
-    & npm.cmd run dev
+    $originalApiBaseUrl = $env:VITE_API_BASE_URL
+    $originalWsBaseUrl = $env:VITE_WS_BASE_URL
+    $env:VITE_API_BASE_URL = $backendBaseUrl
+    $env:VITE_WS_BASE_URL = $backendWsUrl
+    & npm.cmd run dev -- --host 127.0.0.1 --port $frontendPort
 } finally {
+    if ($null -eq $originalApiBaseUrl) {
+        Remove-Item Env:VITE_API_BASE_URL -ErrorAction SilentlyContinue
+    } else {
+        $env:VITE_API_BASE_URL = $originalApiBaseUrl
+    }
+    if ($null -eq $originalWsBaseUrl) {
+        Remove-Item Env:VITE_WS_BASE_URL -ErrorAction SilentlyContinue
+    } else {
+        $env:VITE_WS_BASE_URL = $originalWsBaseUrl
+    }
     Pop-Location
     Write-Warn "Stopping backend service..."
-    Stop-PortProcess -Port 8000
+    Stop-PortProcess -Port $backendPort
 }

--- a/scripts/dev-webui.sh
+++ b/scripts/dev-webui.sh
@@ -9,14 +9,23 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
+BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+BACKEND_ACCESS_HOST="${BACKEND_HOST}"
+if [ "${BACKEND_ACCESS_HOST}" = "0.0.0.0" ] || [ "${BACKEND_ACCESS_HOST}" = "::" ]; then
+    BACKEND_ACCESS_HOST="127.0.0.1"
+fi
+BACKEND_BASE_URL="http://${BACKEND_ACCESS_HOST}:${BACKEND_PORT}"
+BACKEND_WS_URL="ws://${BACKEND_ACCESS_HOST}:${BACKEND_PORT}"
 
 echo -e "${BLUE}🚀 启动 Flocks 开发环境...${NC}"
 
 # 清理所有残留的 flocks 后端进程和端口
 echo "🧹 清理现有进程..."
 pkill -9 -f "uvicorn flocks.server.app" 2>/dev/null || true
-lsof -ti:8000 | xargs kill -9 2>/dev/null || true
-lsof -ti:5173 | xargs kill -9 2>/dev/null || true
+lsof -ti:"${BACKEND_PORT}" | xargs kill -9 2>/dev/null || true
+lsof -ti:"${FRONTEND_PORT}" | xargs kill -9 2>/dev/null || true
 sleep 2
 
 # 获取项目根目录
@@ -24,11 +33,11 @@ cd "$(dirname "$0")/.."
 PROJECT_ROOT=$(pwd)
 
 # 启动后端服务（只监控 flocks 源码目录）
-echo -e "${GREEN}🔧 启动后端服务（端口 8000）...${NC}"
+echo -e "${GREEN}🔧 启动后端服务（端口 ${BACKEND_PORT}）...${NC}"
 PYTHON="${PROJECT_ROOT}/.venv/bin/python"
 nohup "${PYTHON}" -m uvicorn flocks.server.app:app \
-    --host 127.0.0.1 \
-    --port 8000 \
+    --host "${BACKEND_HOST}" \
+    --port "${BACKEND_PORT}" \
     --reload \
     --reload-dir flocks \
     --timeout-graceful-shutdown 3 \
@@ -40,7 +49,7 @@ echo -e "${YELLOW}Backend PID: ${BACKEND_PID}${NC}"
 # 等待后端启动（重试最多 30 秒）
 echo "⏳ 等待后端启动..."
 for i in $(seq 1 15); do
-    if curl -s --max-time 2 http://localhost:8000/api/health > /dev/null 2>&1; then
+    if curl -s --max-time 2 "${BACKEND_BASE_URL}/api/health" > /dev/null 2>&1; then
         echo -e "${GREEN}✓ 后端服务启动成功${NC}"
         echo -e "${YELLOW}📋 后端日志: tail -f /tmp/flocks-backend.log${NC}"
         break
@@ -54,9 +63,11 @@ for i in $(seq 1 15); do
 done
 
 # 启动前端服务
-echo -e "${GREEN}🎨 启动 WebUI 前端（端口 5173）...${NC}"
+echo -e "${GREEN}🎨 启动 WebUI 前端（端口 ${FRONTEND_PORT}）...${NC}"
 cd webui
 
 trap "echo '🛑 停止后端服务...'; kill $BACKEND_PID 2>/dev/null" EXIT
 
-npm run dev
+VITE_API_BASE_URL="${BACKEND_BASE_URL}" \
+VITE_WS_BASE_URL="${BACKEND_WS_URL}" \
+npm run dev -- --host 127.0.0.1 --port "${FRONTEND_PORT}"

--- a/scripts/prod-webui.ps1
+++ b/scripts/prod-webui.ps1
@@ -20,6 +20,30 @@ function Write-Fail {
     Write-Host $Message -ForegroundColor Red
 }
 
+function Get-EnvOrDefault {
+    param(
+        [string]$Name,
+        [string]$DefaultValue
+    )
+
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $DefaultValue
+    }
+
+    return $value
+}
+
+function Get-AccessHost {
+    param([string]$Host)
+
+    if ($Host -in @("0.0.0.0", "::")) {
+        return "127.0.0.1"
+    }
+
+    return $Host
+}
+
 function Stop-PortProcess {
     param([int]$Port)
 
@@ -80,6 +104,12 @@ $frontendStdout = Join-Path $logsDir "webui-preview.out.log"
 $frontendStderr = Join-Path $logsDir "webui-preview.err.log"
 $backendPidFile = Join-Path $logsDir "backend.pid"
 $frontendPidFile = Join-Path $logsDir "frontend.pid"
+$backendHost = Get-EnvOrDefault -Name "BACKEND_HOST" -DefaultValue "127.0.0.1"
+$backendAccessHost = Get-AccessHost -Host $backendHost
+$backendPort = [int](Get-EnvOrDefault -Name "BACKEND_PORT" -DefaultValue "8000")
+$frontendPort = [int](Get-EnvOrDefault -Name "FRONTEND_PORT" -DefaultValue "5173")
+$backendBaseUrl = "http://{0}:{1}" -f $backendAccessHost, $backendPort
+$backendWsUrl = "ws://{0}:{1}" -f $backendAccessHost, $backendPort
 
 if (-not (Test-Path $pythonExe)) {
     Write-Fail "Python venv not found: $pythonExe"
@@ -95,18 +125,32 @@ if (-not (Test-Path (Join-Path $webuiDir "package.json"))) {
 New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
 
 Write-Info "Cleaning existing processes..."
-Stop-PortProcess -Port 8000
-Stop-PortProcess -Port 5173
+Stop-PortProcess -Port $backendPort
+Stop-PortProcess -Port $frontendPort
 Start-Sleep -Seconds 1
 
 Write-Info "Building WebUI frontend..."
 Push-Location $webuiDir
 try {
+    $originalApiBaseUrl = $env:VITE_API_BASE_URL
+    $originalWsBaseUrl = $env:VITE_WS_BASE_URL
+    $env:VITE_API_BASE_URL = $backendBaseUrl
+    $env:VITE_WS_BASE_URL = $backendWsUrl
     & npm.cmd run build
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }
 } finally {
+    if ($null -eq $originalApiBaseUrl) {
+        Remove-Item Env:VITE_API_BASE_URL -ErrorAction SilentlyContinue
+    } else {
+        $env:VITE_API_BASE_URL = $originalApiBaseUrl
+    }
+    if ($null -eq $originalWsBaseUrl) {
+        Remove-Item Env:VITE_WS_BASE_URL -ErrorAction SilentlyContinue
+    } else {
+        $env:VITE_WS_BASE_URL = $originalWsBaseUrl
+    }
     Pop-Location
 }
 
@@ -117,12 +161,12 @@ if (-not (Test-Path $distDir)) {
 
 Write-Success "Frontend build completed."
 
-Write-Info "Starting backend service on port 8000..."
+Write-Info ("Starting backend service on port {0}..." -f $backendPort)
 $backendArgs = @(
     "-m", "uvicorn",
     "flocks.server.app:app",
-    "--host", "127.0.0.1",
-    "--port", "8000"
+    "--host", $backendHost,
+    "--port", $backendPort.ToString()
 )
 
 $backendProcess = Start-Process `
@@ -142,7 +186,7 @@ Write-Info "Waiting for backend startup..."
 for ($attempt = 1; $attempt -le 15; $attempt++) {
     Start-Sleep -Seconds 2
 
-    if (Test-HttpHealth -PythonExe $pythonExe -Urls @("http://localhost:8000/api/health", "http://localhost:8000/health")) {
+    if (Test-HttpHealth -PythonExe $pythonExe -Urls @("$backendBaseUrl/api/health", "$backendBaseUrl/health")) {
         $backendReady = $true
         break
     }
@@ -160,7 +204,7 @@ if (-not $backendReady) {
         Write-Host "Backend stderr tail:"
         Get-Content -Path $backendStderr -Tail 20
     }
-    Stop-PortProcess -Port 8000
+    Stop-PortProcess -Port $backendPort
     exit 1
 }
 
@@ -168,15 +212,15 @@ Write-Success "Backend started successfully."
 Write-Warn "Backend stdout log: $backendStdout"
 Write-Warn "Backend stderr log: $backendStderr"
 
-Write-Info "Starting WebUI preview on port 5173..."
+Write-Info ("Starting WebUI preview on port {0}..." -f $frontendPort)
+$previewCommand = ('set "VITE_API_BASE_URL={0}" && set "VITE_WS_BASE_URL={1}" && npm.cmd run preview -- --host 127.0.0.1 --port {2}' -f $backendBaseUrl, $backendWsUrl, $frontendPort)
 $frontendArgs = @(
-    "run", "preview", "--",
-    "--host", "127.0.0.1",
-    "--port", "5173"
+    "/c",
+    $previewCommand
 )
 
 $frontendProcess = Start-Process `
-    -FilePath "npm.cmd" `
+    -FilePath "cmd.exe" `
     -ArgumentList $frontendArgs `
     -WorkingDirectory $webuiDir `
     -WindowStyle Hidden `
@@ -192,7 +236,7 @@ Write-Info "Waiting for frontend startup..."
 for ($attempt = 1; $attempt -le 10; $attempt++) {
     Start-Sleep -Seconds 2
 
-    if (Test-HttpHealth -PythonExe $pythonExe -Urls @("http://localhost:5173/")) {
+    if (Test-HttpHealth -PythonExe $pythonExe -Urls @("http://127.0.0.1:$frontendPort/")) {
         $frontendReady = $true
         break
     }
@@ -210,8 +254,8 @@ if (-not $frontendReady) {
         Write-Host "Frontend stderr tail:"
         Get-Content -Path $frontendStderr -Tail 20
     }
-    Stop-PortProcess -Port 5173
-    Stop-PortProcess -Port 8000
+    Stop-PortProcess -Port $frontendPort
+    Stop-PortProcess -Port $backendPort
     exit 1
 }
 
@@ -220,6 +264,6 @@ Write-Warn "Frontend stdout log: $frontendStdout"
 Write-Warn "Frontend stderr log: $frontendStderr"
 
 Write-Success "Flocks production environment started."
-Write-Warn "Backend URL: http://localhost:8000"
-Write-Warn "Frontend URL: http://localhost:5173"
+Write-Warn ("Backend URL: {0}" -f $backendBaseUrl)
+Write-Warn ("Frontend URL: http://127.0.0.1:{0}" -f $frontendPort)
 Write-Warn ("Stop services: Stop-Process -Id {0},{1} -Force" -f $backendProcess.Id, $frontendProcess.Id)

--- a/scripts/prod-webui.sh
+++ b/scripts/prod-webui.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # 构建前端并以生产模式启动服务（后台守护）
-# 后端: 8000（uvicorn，无热重载）
-# 前端: 5173（vite preview 托管构建产物，代理 /api 到后端）
+# 后端默认: 8000（uvicorn，无热重载，可通过 BACKEND_PORT 覆盖）
+# 前端默认: 5173（vite preview 托管构建产物，代理 /api 到后端）
 
 set -e
 
@@ -10,7 +10,16 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
-BACKEND_HEALTH_URL="${BACKEND_HEALTH_URL:-http://127.0.0.1:8000/api/health}"
+BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+BACKEND_ACCESS_HOST="${BACKEND_HOST}"
+if [ "${BACKEND_ACCESS_HOST}" = "0.0.0.0" ] || [ "${BACKEND_ACCESS_HOST}" = "::" ]; then
+    BACKEND_ACCESS_HOST="127.0.0.1"
+fi
+BACKEND_BASE_URL="http://${BACKEND_ACCESS_HOST}:${BACKEND_PORT}"
+BACKEND_WS_URL="ws://${BACKEND_ACCESS_HOST}:${BACKEND_PORT}"
+BACKEND_HEALTH_URL="${BACKEND_HEALTH_URL:-${BACKEND_BASE_URL}/api/health}"
 BACKEND_STARTUP_TIMEOUT="${BACKEND_STARTUP_TIMEOUT:-90}"
 BACKEND_HEALTH_CHECK_INTERVAL="${BACKEND_HEALTH_CHECK_INTERVAL:-2}"
 
@@ -19,8 +28,8 @@ echo -e "${BLUE}🚀 启动 Flocks 生产环境...${NC}"
 echo "🧹 清理现有进程..."
 pkill -9 -f "uvicorn flocks.server.app" 2>/dev/null || true
 pkill -9 -f "vite preview" 2>/dev/null || true
-lsof -ti:8000 | xargs kill -9 2>/dev/null || true
-lsof -ti:5173 | xargs kill -9 2>/dev/null || true
+lsof -ti:"${BACKEND_PORT}" | xargs kill -9 2>/dev/null || true
+lsof -ti:"${FRONTEND_PORT}" | xargs kill -9 2>/dev/null || true
 sleep 1
 
 cd "$(dirname "$0")/.."
@@ -30,6 +39,8 @@ mkdir -p "$LOGS_DIR"
 
 echo -e "${BLUE}📦 构建 WebUI 前端...${NC}"
 cd webui
+VITE_API_BASE_URL="${BACKEND_BASE_URL}" \
+VITE_WS_BASE_URL="${BACKEND_WS_URL}" \
 npm run build
 cd "$PROJECT_ROOT"
 
@@ -39,11 +50,11 @@ if [ ! -d "webui/dist" ]; then
 fi
 echo -e "${GREEN}✓ 前端构建完成${NC}"
 
-echo -e "${GREEN}🔧 启动后端服务（端口 8000）...${NC}"
+echo -e "${GREEN}🔧 启动后端服务（端口 ${BACKEND_PORT}）...${NC}"
 source "${PROJECT_ROOT}/.venv/bin/activate"
 nohup python -m uvicorn flocks.server.app:app \
-    --host 127.0.0.1 \
-    --port 8000 \
+    --host "${BACKEND_HOST}" \
+    --port "${BACKEND_PORT}" \
     > /tmp/flocks-backend.log 2>&1 &
 
 BACKEND_PID=$!
@@ -72,9 +83,13 @@ for i in $(seq 1 "$BACKEND_CHECK_ATTEMPTS"); do
 done
 
 # 前端也用 nohup 后台启动，终端断开不会收到 SIGHUP
-echo -e "${GREEN}🎨 启动 WebUI 前端（端口 5173）...${NC}"
+echo -e "${GREEN}🎨 启动 WebUI 前端（端口 ${FRONTEND_PORT}）...${NC}"
 cd webui
-nohup npm run preview > "${LOGS_DIR}/webui-preview.log" 2>&1 &
+nohup env \
+    VITE_API_BASE_URL="${BACKEND_BASE_URL}" \
+    VITE_WS_BASE_URL="${BACKEND_WS_URL}" \
+    npm run preview -- --host 127.0.0.1 --port "${FRONTEND_PORT}" \
+    > "${LOGS_DIR}/webui-preview.log" 2>&1 &
 FRONTEND_PID=$!
 
 sleep 2

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -286,6 +286,78 @@ def test_start_backend_writes_runtime_metadata(monkeypatch, tmp_path: Path) -> N
     assert record.command[:3] == (service_manager.sys.executable, "-m", "uvicorn")
 
 
+def test_build_frontend_env_uses_backend_host_and_port() -> None:
+    config = service_manager.ServiceConfig(
+        backend_host="0.0.0.0",
+        backend_port=9000,
+    )
+
+    env = service_manager.build_frontend_env(config)
+
+    assert env["VITE_API_BASE_URL"] == "http://127.0.0.1:9000"
+    assert env["VITE_WS_BASE_URL"] == "ws://127.0.0.1:9000"
+
+
+def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    paths.log_dir.mkdir(parents=True)
+    console = DummyConsole()
+    build_calls: list[dict[str, object]] = []
+    preview_calls: list[dict[str, object]] = []
+
+    def fake_run(command, **kwargs):
+        build_calls.append({"command": command, "kwargs": kwargs})
+        return SimpleNamespace(returncode=0)
+
+    def fake_spawn(command, **kwargs):
+        preview_calls.append({"command": command, "kwargs": kwargs})
+        return SimpleNamespace(pid=2468)
+
+    monkeypatch.setattr(service_manager, "ensure_install_layout", lambda: tmp_path)
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _path: None)
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
+    monkeypatch.setattr(service_manager, "wait_for_http", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(service_manager.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(service_manager, "which", lambda name: "/usr/bin/npm" if name in {"npm", "npm.cmd"} else None)
+    monkeypatch.setattr(service_manager, "node_version_satisfies_requirement", lambda: True)
+    monkeypatch.setattr(service_manager.subprocess, "run", fake_run)
+    monkeypatch.setattr(service_manager, "_spawn_process", fake_spawn)
+
+    config = service_manager.ServiceConfig(
+        backend_host="0.0.0.0",
+        backend_port=9000,
+        frontend_port=5174,
+    )
+    service_manager.start_frontend(config, console)
+
+    assert build_calls[0]["command"] == ["/usr/bin/npm", "run", "build"]
+    assert build_calls[0]["kwargs"]["env"]["VITE_API_BASE_URL"] == "http://127.0.0.1:9000"
+    assert build_calls[0]["kwargs"]["env"]["VITE_WS_BASE_URL"] == "ws://127.0.0.1:9000"
+
+    assert preview_calls[0]["command"] == [
+        "/usr/bin/npm",
+        "run",
+        "preview",
+        "--",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "5174",
+    ]
+    assert preview_calls[0]["kwargs"]["env"]["VITE_API_BASE_URL"] == "http://127.0.0.1:9000"
+    assert preview_calls[0]["kwargs"]["env"]["VITE_WS_BASE_URL"] == "ws://127.0.0.1:9000"
+
+
 def test_start_backend_raises_on_port_record_mismatch(monkeypatch, tmp_path: Path) -> None:
     paths = service_manager.RuntimePaths(
         root=tmp_path,
@@ -366,6 +438,25 @@ def test_spawn_process_uses_new_session_on_non_windows(monkeypatch, tmp_path: Pa
     assert captured["kwargs"]["creationflags"] == 0
     assert captured["kwargs"]["start_new_session"] is True
     assert "startupinfo" not in captured["kwargs"]
+
+
+def test_spawn_process_passes_custom_environment(monkeypatch, tmp_path: Path) -> None:
+    captured = {}
+    log_path = tmp_path / "logs" / "backend.log"
+    env = {"VITE_API_BASE_URL": "http://127.0.0.1:9000"}
+
+    def fake_popen(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(pid=1111)
+
+    monkeypatch.setattr(service_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(service_manager.subprocess, "Popen", fake_popen)
+
+    process = service_manager._spawn_process(["python", "-m", "uvicorn"], cwd=tmp_path, log_path=log_path, env=env)
+
+    assert process.pid == 1111
+    assert captured["kwargs"]["env"] == env
 
 
 def test_stop_one_prefers_process_group_on_unix(monkeypatch, tmp_path: Path) -> None:

--- a/webui/.env.example
+++ b/webui/.env.example
@@ -1,10 +1,10 @@
-# API Base URL（部署时留空，使用相对路径；本地开发可设为 http://localhost:8000）
+# API Base URL（部署时留空，使用相对路径；本地开发按后端实际端口设置，例如 http://127.0.0.1:8000 或 http://127.0.0.1:9000）
 # VITE_API_BASE_URL=
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_BASE_URL=http://127.0.0.1:8000
 
-# WebSocket URL（部署时留空或设为 wss://your-domain；本地开发可设为 ws://localhost:8000）
+# WebSocket URL（部署时留空或设为 wss://your-domain；本地开发按后端实际端口设置，例如 ws://127.0.0.1:8000 或 ws://127.0.0.1:9000）
 # VITE_WS_BASE_URL=
-VITE_WS_BASE_URL=ws://localhost:8000
+VITE_WS_BASE_URL=ws://127.0.0.1:8000
 
 # Environment
 VITE_APP_ENV=development

--- a/webui/README.md
+++ b/webui/README.md
@@ -70,18 +70,25 @@ src/
 
 ## API 代理配置
 
-开发环境下，API 请求会自动代理到 `http://localhost:8000`：
+开发环境下，API 请求默认代理到 `http://127.0.0.1:8000`，也可通过 `VITE_API_BASE_URL` 覆盖：
 
-- `/api/*` -> `http://localhost:8000/api/*`
-- `/event` -> `http://localhost:8000/event`
+- `/api/*` -> `${VITE_API_BASE_URL:-http://127.0.0.1:8000}/api/*`
+- `/event` -> `${VITE_API_BASE_URL:-http://127.0.0.1:8000}/event`
 
 ## 环境变量
 
 复制 `.env.example` 为 `.env` 并配置：
 
 ```bash
-VITE_API_BASE_URL=http://localhost:8000
-VITE_WS_BASE_URL=ws://localhost:8000
+VITE_API_BASE_URL=http://127.0.0.1:8000
+VITE_WS_BASE_URL=ws://127.0.0.1:8000
+```
+
+如果后端改为 `9000`，对应设置为：
+
+```bash
+VITE_API_BASE_URL=http://127.0.0.1:9000
+VITE_WS_BASE_URL=ws://127.0.0.1:9000
 ```
 
 ## License

--- a/webui/src/config/apiProxy.test.ts
+++ b/webui/src/config/apiProxy.test.ts
@@ -1,0 +1,24 @@
+import { createApiProxy, getApiProxyTarget } from './apiProxy';
+
+describe('apiProxy helpers', () => {
+  it('uses the configured VITE_API_BASE_URL when present', () => {
+    expect(getApiProxyTarget({ VITE_API_BASE_URL: 'http://127.0.0.1:9000' })).toBe('http://127.0.0.1:9000');
+  });
+
+  it('falls back to the default local backend target', () => {
+    expect(getApiProxyTarget({})).toBe('http://127.0.0.1:8000');
+  });
+
+  it('creates matching API and event proxy targets', () => {
+    expect(createApiProxy('http://127.0.0.1:9000')).toEqual({
+      '/api': {
+        target: 'http://127.0.0.1:9000',
+        changeOrigin: true,
+      },
+      '/event': {
+        target: 'http://127.0.0.1:9000',
+        changeOrigin: true,
+      },
+    });
+  });
+});

--- a/webui/src/config/apiProxy.ts
+++ b/webui/src/config/apiProxy.ts
@@ -1,0 +1,18 @@
+export type EnvLike = Record<string, string | undefined>;
+
+export function getApiProxyTarget(env: EnvLike): string {
+  return env.VITE_API_BASE_URL || 'http://127.0.0.1:8000';
+}
+
+export function createApiProxy(target: string) {
+  return {
+    '/api': {
+      target,
+      changeOrigin: true,
+    },
+    '/event': {
+      target,
+      changeOrigin: true,
+    },
+  };
+}

--- a/webui/src/locales/en-US/common.json
+++ b/webui/src/locales/en-US/common.json
@@ -46,7 +46,7 @@
   "error": {
     "backendUnavailable": "Cannot connect to backend service",
     "backendError": "Backend service error",
-    "backendErrorHint": "Please ensure the Flocks backend is running (port 8000)",
+    "backendErrorHint": "Please ensure the Flocks backend is running",
     "processingFailed": "Processing failed",
     "deleteFailed": "Delete failed",
     "saveFailed": "Save failed"
@@ -85,7 +85,7 @@
     "error": "Backend error",
     "checking": "Checking...",
     "restarting": "Backend may be restarting, please wait...",
-    "runningHint": "Please ensure backend is running (port 8000)",
+    "runningHint": "Please ensure backend is running",
     "retry": "Retry"
   },
   "chat": {

--- a/webui/src/locales/zh-CN/common.json
+++ b/webui/src/locales/zh-CN/common.json
@@ -46,7 +46,7 @@
   "error": {
     "backendUnavailable": "无法连接到后端服务",
     "backendError": "后端服务异常",
-    "backendErrorHint": "请确保 Flocks 后端服务正在运行（端口 8000）",
+    "backendErrorHint": "请确保 Flocks 后端服务正在运行",
     "processingFailed": "处理失败",
     "deleteFailed": "删除失败",
     "saveFailed": "保存失败"
@@ -85,7 +85,7 @@
     "error": "后端服务异常",
     "checking": "检查中...",
     "restarting": "后端可能正在重启，请稍候...",
-    "runningHint": "请确保后端服务正在运行（端口 8000）",
+    "runningHint": "请确保后端服务正在运行",
     "retry": "重试"
   },
   "chat": {

--- a/webui/src/pages/Home/index.tsx
+++ b/webui/src/pages/Home/index.tsx
@@ -124,7 +124,7 @@ export default function Home() {
               <AlertCircle className="w-5 h-5 text-red-500 shrink-0" />
               <div>
                 <span className="text-sm font-medium text-red-900">{t('stats.abnormal')}</span>
-                <span className="text-sm text-red-600 ml-2">Please ensure the Flocks backend is running (port 8000)</span>
+                <span className="text-sm text-red-600 ml-2">Please ensure the Flocks backend is running</span>
               </div>
             </div>
           )}

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { createApiProxy, getApiProxyTarget } from './src/config/apiProxy'
+
+const apiProxyTarget = getApiProxyTarget(process.env)
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -70,16 +73,7 @@ export default defineConfig({
       'flocks.threatbook-inc.cn',
       'ops-flocks.threatbook-inc.cn'
     ],
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-      '/event': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-    },
+    proxy: createApiProxy(apiProxyTarget),
   },
   preview: {
     port: 5173,
@@ -88,15 +82,6 @@ export default defineConfig({
       'flocks.threatbook-inc.cn',
       'ops-flocks.threatbook-inc.cn'
     ],
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-      '/event': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-    },
+    proxy: createApiProxy(apiProxyTarget),
   },
 })


### PR DESCRIPTION
Pass the configured backend host and port into WebUI build and preview so API and SSE traffic follow --server-port instead of falling back to 8000. Align local scripts, docs, and regression tests with the new dynamic port behavior.