### PR TITLE
Ignore npm executable under /mnt/ path for WSL to fix the update issue.

### DIFF
--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -997,7 +997,7 @@ def _build_restart_argv() -> list[str]:
 
 def _find_executable(name: str) -> str | None:
     found = shutil.which(name)
-    if found:
+    if found and not found.startswith("/mnt/"):
         return found
     repo_root = _get_repo_root()
     venv_candidates = [


### PR DESCRIPTION
The `_find_executable` in `flocks/updater/updater.py` doesn't work properly in WSL environment, which causes update failure. In WSL environment, this function call will return `/mnt/c/Program Files/nodejs/npm.cmd` instead of `/usr/local/bin/npm` if you have `npm` in Windows as well as in WSL. Thus, it will cause update failure as below:

<img width="1680" height="675" alt="image" src="https://github.com/user-attachments/assets/cef72e23-ddef-4cdb-85fd-925d3d65f293" />

This PR adds extra check to avoid this issue:
```python
def _find_executable(name: str) -> str | None:
    found = shutil.which(name)
    if found and not found.startswith("/mnt/"): # Added /mnt/ filtering
        return found
    repo_root = _get_repo_root()
    venv_candidates = [
        repo_root / ".venv" / "bin" / name,
        repo_root / ".venv" / "Scripts" / name,
    ]
    for candidate in venv_candidates:
        if candidate.exists():
            return str(candidate)
    return None
```