### PR TITLE
fix(cli): use runtime host/port for stop/status and serialize lifecycle

### DIFF
--- a/flocks/cli/main.py
+++ b/flocks/cli/main.py
@@ -224,7 +224,7 @@ def stop():
     Stop backend and WebUI
     """
     try:
-        stop_all(_service_config(), console)
+        stop_all(console)
     except ServiceError as error:
         _handle_service_error(error)
 
@@ -267,7 +267,7 @@ def status():
     Show backend and WebUI status
     """
     try:
-        show_status(_service_config(), console)
+        show_status(console)
     except ServiceError as error:
         _handle_service_error(error)
 

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -4,6 +4,8 @@ Service lifecycle helpers for local Flocks daemon commands.
 
 from __future__ import annotations
 
+import contextlib
+import datetime
 import json
 import os
 import signal
@@ -18,6 +20,11 @@ from shutil import which
 from typing import Iterable, Sequence
 
 import httpx
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - unavailable on Windows
+    fcntl = None
 
 MIN_NODE_MAJOR = 22
 BACKEND_HEALTH_PATHS = ("/api/health", "/health")
@@ -62,6 +69,7 @@ class RuntimePaths:
 class RuntimeRecord:
     pid: int
     pgid: int | None = None
+    host: str | None = None
     port: int | None = None
     command: tuple[str, ...] = ()
     started_at: float | None = None
@@ -189,6 +197,7 @@ def _parse_runtime_record(raw: str) -> RuntimeRecord | None:
     return RuntimeRecord(
         pid=pid,
         pgid=_coerce_positive_int(payload.get("pgid")),
+        host=payload.get("host") if isinstance(payload.get("host"), str) and payload.get("host") else None,
         port=_coerce_positive_int(payload.get("port")),
         command=command,
         started_at=started_value,
@@ -208,6 +217,8 @@ def write_runtime_record(pid_file: Path, record: RuntimeRecord) -> None:
     payload: dict[str, object] = {"pid": record.pid}
     if record.pgid is not None:
         payload["pgid"] = record.pgid
+    if record.host is not None:
+        payload["host"] = record.host
     if record.port is not None:
         payload["port"] = record.port
     if record.command:
@@ -217,7 +228,13 @@ def write_runtime_record(pid_file: Path, record: RuntimeRecord) -> None:
     pid_file.write_text(json.dumps(payload, ensure_ascii=True, sort_keys=True), encoding="utf-8")
 
 
-def process_runtime_record(process: subprocess.Popen, *, port: int, command: Sequence[str]) -> RuntimeRecord:
+def process_runtime_record(
+    process: subprocess.Popen,
+    *,
+    host: str,
+    port: int,
+    command: Sequence[str],
+) -> RuntimeRecord:
     """Build runtime metadata for a freshly started service process."""
     pgid = None
     if sys.platform != "win32":
@@ -228,6 +245,7 @@ def process_runtime_record(process: subprocess.Popen, *, port: int, command: Seq
     return RuntimeRecord(
         pid=process.pid,
         pgid=pgid,
+        host=host,
         port=port,
         command=tuple(command),
         started_at=time.time(),
@@ -397,8 +415,14 @@ def start_backend(config: ServiceConfig, console) -> None:
     )
     write_runtime_record(
         paths.backend_pid,
-        process_runtime_record(process, port=config.backend_port, command=command),
+        process_runtime_record(
+            process,
+            host=config.backend_host,
+            port=config.backend_port,
+            command=command,
+        ),
     )
+    _log_startup_config(paths.backend_log, "backend", config.backend_host, config.backend_port, read_runtime_record(paths.backend_pid))
 
     try:
         wait_for_http(config.backend_urls, "后端服务")
@@ -474,8 +498,14 @@ def start_frontend(config: ServiceConfig, console) -> None:
     )
     write_runtime_record(
         paths.frontend_pid,
-        process_runtime_record(process, port=config.frontend_port, command=command),
+        process_runtime_record(
+            process,
+            host=config.frontend_host,
+            port=config.frontend_port,
+            command=command,
+        ),
     )
+    _log_startup_config(paths.frontend_log, "webui", config.frontend_host, config.frontend_port, read_runtime_record(paths.frontend_pid))
 
     try:
         wait_for_http([config.frontend_url], "WebUI")
@@ -564,11 +594,84 @@ def stop_one(port: int, pid_file: Path, name: str, console) -> None:
     raise ServiceError(f"{name} 未在预期时间内退出，请手动检查端口 {port}。")
 
 
-def stop_all(config: ServiceConfig, console) -> None:
-    """Stop frontend then backend."""
+def _recorded_port(pid_file: Path, default: int) -> int:
+    """Return the port from a runtime record, falling back to *default*."""
+    record = read_runtime_record(pid_file)
+    if record is not None and record.port is not None:
+        return record.port
+    return default
+
+
+def _recorded_host(pid_file: Path, default: str) -> str:
+    """Return the host from a runtime record, falling back to *default*."""
+    record = read_runtime_record(pid_file)
+    if record is not None and record.host:
+        return record.host
+    return default
+
+
+@contextlib.contextmanager
+def service_lock(paths: RuntimePaths):
+    """Serialize lifecycle commands with a cross-process lock file."""
+    lock_path = paths.run_dir / "service.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+", encoding="utf-8")
+    unlock_windows = None
+    try:
+        try:
+            if sys.platform == "win32":
+                import msvcrt
+
+                handle.seek(0)
+                handle.write("0")
+                handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                unlock_windows = msvcrt
+            else:
+                if fcntl is None:  # pragma: no cover - defensive
+                    raise OSError("fcntl unavailable")
+                fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as error:
+            raise ServiceError("另一个 flocks 命令正在执行，请稍后重试。") from error
+        yield
+    finally:
+        try:
+            if unlock_windows is not None:
+                handle.seek(0)
+                unlock_windows.locking(handle.fileno(), unlock_windows.LK_UNLCK, 1)
+            elif fcntl is not None and sys.platform != "win32":
+                fcntl.flock(handle, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        handle.close()
+
+
+def _log_startup_config(
+    log_path: Path,
+    name: str,
+    host: str,
+    port: int,
+    record: RuntimeRecord | None,
+) -> None:
+    """Append a startup summary to the service log."""
+    timestamp = datetime.datetime.now().isoformat(timespec="seconds")
+    pid = record.pid if record is not None else "unknown"
+    pgid = record.pgid if record is not None else None
+    pgid_info = f" pgid={pgid}" if pgid is not None else ""
+    line = f"[{timestamp}] {name} starting: host={host} port={port} pid={pid}{pgid_info}\n"
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
+def stop_all(console) -> None:
+    """Stop frontend then backend using ports persisted in runtime records."""
     paths = ensure_runtime_dirs()
-    stop_one(config.frontend_port, paths.frontend_pid, "WebUI", console)
-    stop_one(config.backend_port, paths.backend_pid, "后端", console)
+    with service_lock(paths):
+        fe_port = _recorded_port(paths.frontend_pid, ServiceConfig.frontend_port)
+        be_port = _recorded_port(paths.backend_pid, ServiceConfig.backend_port)
+        stop_one(fe_port, paths.frontend_pid, "WebUI", console)
+        stop_one(be_port, paths.backend_pid, "后端", console)
 
 
 def _start_all_without_stop(config: ServiceConfig, console) -> None:
@@ -583,16 +686,27 @@ def _start_all_without_stop(config: ServiceConfig, console) -> None:
 
 def start_all(config: ServiceConfig, console) -> None:
     """Ensure backend and frontend are restarted with a clean state."""
-    stop_all(config, console)
-    _start_all_without_stop(config, console)
+    paths = ensure_runtime_dirs()
+    with service_lock(paths):
+        fe_port = _recorded_port(paths.frontend_pid, ServiceConfig.frontend_port)
+        be_port = _recorded_port(paths.backend_pid, ServiceConfig.backend_port)
+        stop_one(fe_port, paths.frontend_pid, "WebUI", console)
+        stop_one(be_port, paths.backend_pid, "后端", console)
+        _start_all_without_stop(config, console)
 
 
 def restart_all(config: ServiceConfig, console) -> None:
     """Restart backend and frontend."""
-    start_all(config, console)
+    paths = ensure_runtime_dirs()
+    with service_lock(paths):
+        fe_port = _recorded_port(paths.frontend_pid, ServiceConfig.frontend_port)
+        be_port = _recorded_port(paths.backend_pid, ServiceConfig.backend_port)
+        stop_one(fe_port, paths.frontend_pid, "WebUI", console)
+        stop_one(be_port, paths.backend_pid, "后端", console)
+        _start_all_without_stop(config, console)
 
 
-def build_status_lines(config: ServiceConfig, paths: RuntimePaths | None = None) -> list[str]:
+def build_status_lines(paths: RuntimePaths | None = None) -> list[str]:
     """Return a human-readable status summary."""
     current = paths or runtime_paths()
     cleanup_stale_pid_file(current.backend_pid)
@@ -600,31 +714,35 @@ def build_status_lines(config: ServiceConfig, paths: RuntimePaths | None = None)
 
     backend_record = read_runtime_record(current.backend_pid)
     frontend_record = read_runtime_record(current.frontend_pid)
+    backend_port = _recorded_port(current.backend_pid, ServiceConfig.backend_port)
+    frontend_port = _recorded_port(current.frontend_pid, ServiceConfig.frontend_port)
+    backend_host = _loopback_host(_recorded_host(current.backend_pid, ServiceConfig.backend_host))
+    frontend_host = _loopback_host(_recorded_host(current.frontend_pid, ServiceConfig.frontend_host))
     backend_pid = backend_record.pid if backend_record else None
     frontend_pid = frontend_record.pid if frontend_record else None
-    backend_listeners = port_owner_pids(config.backend_port)
-    frontend_listeners = port_owner_pids(config.frontend_port)
+    backend_listeners = port_owner_pids(backend_port)
+    frontend_listeners = port_owner_pids(frontend_port)
 
     lines: list[str] = []
     if backend_listeners:
         lines.append(
-            f"[flocks] 后端运行中: PID={_join_pids(backend_listeners)} URL=http://{_loopback_host(config.backend_host)}:{config.backend_port}"
+            f"[flocks] 后端运行中: PID={_join_pids(backend_listeners)} URL=http://{backend_host}:{backend_port}"
         )
     elif pid_is_running(backend_pid):
-        lines.append(f"[flocks] 后端主进程仍在运行，但端口 {config.backend_port} 未监听: PID={backend_pid}")
+        lines.append(f"[flocks] 后端主进程仍在运行，但端口 {backend_port} 未监听: PID={backend_pid}")
     elif process_group_is_running(backend_record.pgid if backend_record else None):
-        lines.append(f"[flocks] 后端进程组仍在运行，但端口 {config.backend_port} 未监听: PGID={backend_record.pgid}")
+        lines.append(f"[flocks] 后端进程组仍在运行，但端口 {backend_port} 未监听: PGID={backend_record.pgid}")
     else:
         lines.append("[flocks] 后端未运行")
 
     if frontend_listeners:
         lines.append(
-            f"[flocks] WebUI 运行中: PID={_join_pids(frontend_listeners)} URL=http://{_loopback_host(config.frontend_host)}:{config.frontend_port}"
+            f"[flocks] WebUI 运行中: PID={_join_pids(frontend_listeners)} URL=http://{frontend_host}:{frontend_port}"
         )
     elif pid_is_running(frontend_pid):
-        lines.append(f"[flocks] WebUI 主进程仍在运行，但端口 {config.frontend_port} 未监听: PID={frontend_pid}")
+        lines.append(f"[flocks] WebUI 主进程仍在运行，但端口 {frontend_port} 未监听: PID={frontend_pid}")
     elif process_group_is_running(frontend_record.pgid if frontend_record else None):
-        lines.append(f"[flocks] WebUI 进程组仍在运行，但端口 {config.frontend_port} 未监听: PGID={frontend_record.pgid}")
+        lines.append(f"[flocks] WebUI 进程组仍在运行，但端口 {frontend_port} 未监听: PGID={frontend_record.pgid}")
     else:
         lines.append("[flocks] WebUI 未运行")
 
@@ -633,9 +751,9 @@ def build_status_lines(config: ServiceConfig, paths: RuntimePaths | None = None)
     return lines
 
 
-def show_status(config: ServiceConfig, console) -> None:
+def show_status(console) -> None:
     """Print service status."""
-    for line in build_status_lines(config):
+    for line in build_status_lines():
         console.print(line)
 
 

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import signal
 from pathlib import Path
@@ -59,6 +60,30 @@ def test_runtime_record_round_trip_preserves_metadata(tmp_path: Path) -> None:
 
     assert json.loads(pid_file.read_text(encoding="utf-8")) == {
         "command": ["python", "-m", "uvicorn"],
+        "pgid": 4321,
+        "pid": 4321,
+        "port": 8000,
+        "started_at": 1234.5,
+    }
+    assert service_manager.read_runtime_record(pid_file) == record
+
+
+def test_runtime_record_round_trip_preserves_host(tmp_path: Path) -> None:
+    pid_file = tmp_path / "backend.pid"
+    record = service_manager.RuntimeRecord(
+        pid=4321,
+        pgid=4321,
+        host="0.0.0.0",
+        port=8000,
+        command=("python", "-m", "uvicorn"),
+        started_at=1234.5,
+    )
+
+    service_manager.write_runtime_record(pid_file, record)
+
+    assert json.loads(pid_file.read_text(encoding="utf-8")) == {
+        "command": ["python", "-m", "uvicorn"],
+        "host": "0.0.0.0",
         "pgid": 4321,
         "pid": 4321,
         "port": 8000,
@@ -145,7 +170,7 @@ def test_build_status_lines_reports_running_and_idle_services(monkeypatch, tmp_p
     )
     monkeypatch.setattr(service_manager, "pid_is_running", lambda pid: pid == 222)
 
-    lines = service_manager.build_status_lines(service_manager.ServiceConfig(), paths)
+    lines = service_manager.build_status_lines(paths)
 
     assert "后端运行中" in lines[0]
     assert "WebUI 主进程仍在运行" in lines[1]
@@ -163,6 +188,14 @@ def test_build_status_lines_uses_custom_server_and_webui_ports(monkeypatch, tmp_
     )
     paths.run_dir.mkdir(parents=True)
     paths.log_dir.mkdir(parents=True)
+    service_manager.write_runtime_record(
+        paths.backend_pid,
+        service_manager.RuntimeRecord(pid=111, host="0.0.0.0", port=9000),
+    )
+    service_manager.write_runtime_record(
+        paths.frontend_pid,
+        service_manager.RuntimeRecord(pid=222, host="0.0.0.0", port=5174),
+    )
 
     monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _: None)
     monkeypatch.setattr(
@@ -172,13 +205,7 @@ def test_build_status_lines_uses_custom_server_and_webui_ports(monkeypatch, tmp_
     )
     monkeypatch.setattr(service_manager, "pid_is_running", lambda _pid: False)
 
-    config = service_manager.ServiceConfig(
-        backend_host="0.0.0.0",
-        backend_port=9000,
-        frontend_host="0.0.0.0",
-        frontend_port=5174,
-    )
-    lines = service_manager.build_status_lines(config, paths)
+    lines = service_manager.build_status_lines(paths)
 
     assert "http://127.0.0.1:9000" in lines[0]
     assert "http://127.0.0.1:5174" in lines[1]
@@ -186,58 +213,75 @@ def test_build_status_lines_uses_custom_server_and_webui_ports(monkeypatch, tmp_
 
 def test_start_all_stops_services_before_starting(monkeypatch) -> None:
     call_order: list[str] = []
+    paths = service_manager.RuntimePaths(
+        root=Path("/tmp"),
+        run_dir=Path("/tmp/run"),
+        log_dir=Path("/tmp/logs"),
+        backend_pid=Path("/tmp/run/backend.pid"),
+        frontend_pid=Path("/tmp/run/webui.pid"),
+        backend_log=Path("/tmp/logs/backend.log"),
+        frontend_log=Path("/tmp/logs/webui.log"),
+    )
 
-    monkeypatch.setattr(service_manager, "stop_all", lambda _config, _console: call_order.append("stop_all"))
-    monkeypatch.setattr(
-        service_manager,
-        "ensure_runtime_dirs",
-        lambda: call_order.append("ensure_runtime_dirs"),
-    )
-    monkeypatch.setattr(service_manager, "start_backend", lambda _config, _console: call_order.append("start_backend"))
-    monkeypatch.setattr(service_manager, "start_frontend", lambda _config, _console: call_order.append("start_frontend"))
-    monkeypatch.setattr(
-        service_manager,
-        "show_start_summary",
-        lambda _config, _console: call_order.append("show_start_summary"),
-    )
-    monkeypatch.setattr(
-        service_manager,
-        "open_default_browser",
-        lambda _url, _console: call_order.append("open_default_browser"),
-    )
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: (call_order.append("ensure_runtime_dirs"), paths)[1])
+    monkeypatch.setattr(service_manager, "service_lock", lambda _paths: _record_call(call_order, "service_lock"))
+    monkeypatch.setattr(service_manager, "stop_one", lambda port, _pid_file, _name, _console: call_order.append(f"stop_one:{port}"))
+    monkeypatch.setattr(service_manager, "_start_all_without_stop", lambda _config, _console: call_order.append("_start_all_without_stop"))
 
     service_manager.start_all(service_manager.ServiceConfig(), console=None)
 
     assert call_order == [
-        "stop_all",
         "ensure_runtime_dirs",
-        "start_backend",
-        "start_frontend",
-        "show_start_summary",
-        "open_default_browser",
+        "service_lock",
+        "stop_one:5173",
+        "stop_one:8000",
+        "_start_all_without_stop",
     ]
 
 
-def test_restart_all_reuses_start_all_flow(monkeypatch) -> None:
-    captured = {}
+def test_restart_all_stops_then_starts_under_lock(monkeypatch) -> None:
+    call_order: list[str] = []
+    paths = service_manager.RuntimePaths(
+        root=Path("/tmp"),
+        run_dir=Path("/tmp/run"),
+        log_dir=Path("/tmp/logs"),
+        backend_pid=Path("/tmp/run/backend.pid"),
+        frontend_pid=Path("/tmp/run/webui.pid"),
+        backend_log=Path("/tmp/logs/backend.log"),
+        frontend_log=Path("/tmp/logs/webui.log"),
+    )
 
-    def fake_start_all(config, console) -> None:
-        captured["config"] = config
-        captured["console"] = console
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: (call_order.append("ensure_runtime_dirs"), paths)[1])
+    monkeypatch.setattr(service_manager, "service_lock", lambda _paths: _record_call(call_order, "service_lock"))
+    monkeypatch.setattr(service_manager, "stop_one", lambda port, _pid_file, _name, _console: call_order.append(f"stop_one:{port}"))
+    monkeypatch.setattr(service_manager, "_start_all_without_stop", lambda _config, _console: call_order.append("_start_all_without_stop"))
 
-    monkeypatch.setattr(service_manager, "start_all", fake_start_all)
+    service_manager.restart_all(service_manager.ServiceConfig(), console=None)
 
-    config = service_manager.ServiceConfig(no_browser=True, skip_frontend_build=True)
-    console = object()
-    service_manager.restart_all(config, console)
-
-    assert captured == {"config": config, "console": console}
+    assert call_order == [
+        "ensure_runtime_dirs",
+        "service_lock",
+        "stop_one:5173",
+        "stop_one:8000",
+        "_start_all_without_stop",
+    ]
 
 
 def test_start_all_stops_on_failure_before_restart(monkeypatch) -> None:
+    paths = service_manager.RuntimePaths(
+        root=Path("/tmp"),
+        run_dir=Path("/tmp/run"),
+        log_dir=Path("/tmp/logs"),
+        backend_pid=Path("/tmp/run/backend.pid"),
+        frontend_pid=Path("/tmp/run/webui.pid"),
+        backend_log=Path("/tmp/logs/backend.log"),
+        frontend_log=Path("/tmp/logs/webui.log"),
+    )
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "service_lock", lambda _paths: _record_call([], "service_lock"))
     monkeypatch.setattr(
         service_manager,
-        "stop_all",
+        "stop_one",
         lambda *_args: (_ for _ in ()).throw(service_manager.ServiceError("stop failed")),
     )
     monkeypatch.setattr(
@@ -282,6 +326,7 @@ def test_start_backend_writes_runtime_metadata(monkeypatch, tmp_path: Path) -> N
     assert record is not None
     assert record.pid == 2468
     assert record.pgid == 2468
+    assert record.host == "127.0.0.1"
     assert record.port == 8000
     assert record.command[:3] == (service_manager.sys.executable, "-m", "uvicorn")
 
@@ -370,6 +415,10 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
     ]
     assert preview_calls[0]["kwargs"]["env"]["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
     assert "VITE_API_BASE_URL" not in preview_calls[0]["kwargs"]["env"]
+    record = service_manager.read_runtime_record(paths.frontend_pid)
+    assert record is not None
+    assert record.host == "0.0.0.0"
+    assert record.port == 5174
 
 
 def test_start_backend_raises_on_port_record_mismatch(monkeypatch, tmp_path: Path) -> None:
@@ -561,3 +610,217 @@ def test_stop_one_uses_taskkill_on_windows(monkeypatch, tmp_path: Path) -> None:
         ["taskkill", "/PID", "111", "/T", "/F"],
         ["taskkill", "/PID", "222", "/T", "/F"],
     ]
+
+
+@contextlib.contextmanager
+def _record_call(call_order: list[str], name: str):
+    call_order.append(name)
+    yield
+
+
+def test_stop_all_reads_port_from_runtime_record(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    service_manager.write_runtime_record(paths.backend_pid, service_manager.RuntimeRecord(pid=111, port=9995))
+    service_manager.write_runtime_record(paths.frontend_pid, service_manager.RuntimeRecord(pid=222, port=9996))
+    calls: list[tuple[int, Path, str]] = []
+
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "service_lock", lambda _paths: _record_call([], "service_lock"))
+    monkeypatch.setattr(
+        service_manager,
+        "stop_one",
+        lambda port, pid_file, name, _console: calls.append((port, pid_file, name)),
+    )
+
+    service_manager.stop_all(console=None)
+
+    assert calls == [
+        (9996, paths.frontend_pid, "WebUI"),
+        (9995, paths.backend_pid, "后端"),
+    ]
+
+
+def test_stop_all_falls_back_to_default_port_when_record_missing(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    calls: list[int] = []
+
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "service_lock", lambda _paths: _record_call([], "service_lock"))
+    monkeypatch.setattr(service_manager, "stop_one", lambda port, *_args: calls.append(port))
+
+    service_manager.stop_all(console=None)
+
+    assert calls == [5173, 8000]
+
+
+def test_stop_all_falls_back_to_default_port_when_record_has_no_port(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    paths.backend_pid.write_text("111", encoding="utf-8")
+    paths.frontend_pid.write_text("222", encoding="utf-8")
+    calls: list[int] = []
+
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "service_lock", lambda _paths: _record_call([], "service_lock"))
+    monkeypatch.setattr(service_manager, "stop_one", lambda port, *_args: calls.append(port))
+
+    service_manager.stop_all(console=None)
+
+    assert calls == [5173, 8000]
+
+
+def test_build_status_lines_reads_port_from_runtime_record(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    paths.log_dir.mkdir(parents=True)
+    service_manager.write_runtime_record(paths.backend_pid, service_manager.RuntimeRecord(pid=111, port=9995))
+    service_manager.write_runtime_record(paths.frontend_pid, service_manager.RuntimeRecord(pid=222, port=9996))
+
+    monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _path: None)
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda port: [port] if port in {9995, 9996} else [])
+    monkeypatch.setattr(service_manager, "pid_is_running", lambda _pid: False)
+
+    lines = service_manager.build_status_lines(paths)
+
+    assert "http://127.0.0.1:9995" in lines[0]
+    assert "http://127.0.0.1:9996" in lines[1]
+
+
+def test_build_status_lines_uses_recorded_host(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    paths.log_dir.mkdir(parents=True)
+    service_manager.write_runtime_record(
+        paths.backend_pid,
+        service_manager.RuntimeRecord(pid=111, host="10.0.0.8", port=9000),
+    )
+    service_manager.write_runtime_record(
+        paths.frontend_pid,
+        service_manager.RuntimeRecord(pid=222, host="0.0.0.0", port=5174),
+    )
+
+    monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _path: None)
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda port: [111] if port == 9000 else [222])
+    monkeypatch.setattr(service_manager, "pid_is_running", lambda _pid: False)
+
+    lines = service_manager.build_status_lines(paths)
+
+    assert "http://10.0.0.8:9000" in lines[0]
+    assert "http://127.0.0.1:5174" in lines[1]
+
+
+def test_service_lock_prevents_concurrent_operations(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    state = {"locked": False}
+
+    class FakeFcntl:
+        LOCK_EX = 1
+        LOCK_NB = 2
+        LOCK_UN = 4
+
+        @staticmethod
+        def flock(_handle, operation):
+            if operation == FakeFcntl.LOCK_UN:
+                state["locked"] = False
+                return
+            if state["locked"]:
+                raise OSError("busy")
+            state["locked"] = True
+
+    monkeypatch.setattr(service_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(service_manager, "fcntl", FakeFcntl)
+
+    with service_manager.service_lock(paths):
+        with pytest.raises(service_manager.ServiceError, match="另一个 flocks 命令正在执行"):
+            with service_manager.service_lock(paths):
+                raise AssertionError("should not acquire nested lock")
+
+
+def test_service_lock_releases_on_completion(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    operations: list[int] = []
+
+    class FakeFcntl:
+        LOCK_EX = 1
+        LOCK_NB = 2
+        LOCK_UN = 4
+
+        @staticmethod
+        def flock(_handle, operation):
+            operations.append(operation)
+
+    monkeypatch.setattr(service_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(service_manager, "fcntl", FakeFcntl)
+
+    with service_manager.service_lock(paths):
+        pass
+
+    assert operations == [FakeFcntl.LOCK_EX | FakeFcntl.LOCK_NB, FakeFcntl.LOCK_UN]
+
+
+def test_log_startup_config_appends_to_log_file(tmp_path: Path) -> None:
+    log_path = tmp_path / "backend.log"
+    record = service_manager.RuntimeRecord(pid=2468, pgid=2468, host="0.0.0.0", port=8000)
+
+    service_manager._log_startup_config(log_path, "backend", "0.0.0.0", 8000, record)
+
+    content = log_path.read_text(encoding="utf-8")
+    assert "backend starting: host=0.0.0.0 port=8000 pid=2468 pgid=2468" in content


### PR DESCRIPTION
- Persist host in pid JSON; stop/status fall back to ServiceConfig defaults
- Cross-process service.lock (fcntl / msvcrt) for start/stop/restart
- Append startup summary (host, port, pid, pgid) to backend/webui logs
- CLI stop/status call stop_all/show_status without ServiceConfig