### PR TITLE
fix(webui): preserve chat message line breaks

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -24,6 +24,7 @@
         "recharts": "^2.15.0",
         "rehype-highlight": "^7.0.2",
         "rehype-raw": "^7.0.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.2.1",
         "zustand": "^4.5.0"
@@ -5069,6 +5070,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -6591,6 +6606,21 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/webui/package.json
+++ b/webui/package.json
@@ -30,6 +30,7 @@
     "recharts": "^2.15.0",
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.2.1",
     "zustand": "^4.5.0"

--- a/webui/src/components/common/StreamingMarkdown.test.tsx
+++ b/webui/src/components/common/StreamingMarkdown.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, render } from '@testing-library/react';
 
 // Extract the hook for isolated testing by re-implementing it here.
 // This mirrors the approach in useSessions.test.ts: test pure logic directly.
 import { useState, useEffect, useRef } from 'react';
+import { StreamingMarkdown } from './StreamingMarkdown';
 
 function useStreamingContent(content: string, isStreaming: boolean): string {
   const [displayContent, setDisplayContent] = useState(content);
@@ -171,5 +172,18 @@ describe('useStreamingContent', () => {
     // Only one frame scheduled; it should use the latest ref value (v4)
     act(() => { flushRaf(); });
     expect(result.current).toBe('v4');
+  });
+});
+
+describe('StreamingMarkdown', () => {
+  it('preserves single newlines as visible line breaks', () => {
+    const { container } = render(
+      <StreamingMarkdown content={'first line\nsecond line\nthird line'} isStreaming={false} />,
+    );
+
+    const paragraph = container.querySelector('p');
+    expect(paragraph).not.toBeNull();
+    expect(paragraph?.querySelectorAll('br')).toHaveLength(2);
+    expect(paragraph?.textContent).toBe('first line\nsecond line\nthird line');
   });
 });

--- a/webui/src/components/common/StreamingMarkdown.tsx
+++ b/webui/src/components/common/StreamingMarkdown.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeRaw from 'rehype-raw';
+import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import 'highlight.js/styles/github-dark.css';
 
@@ -70,7 +71,7 @@ export function StreamingMarkdown({ content, isStreaming }: StreamingMarkdownPro
   return (
     <div className="prose prose-sm max-w-none">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkBreaks]}
         rehypePlugins={[rehypeRaw, [rehypeHighlight, { detect: false, ignoreMissing: true }]]}
         components={{
           code({ className, children, ...props }) {


### PR DESCRIPTION
Render single newlines in session chat messages so multi-line input displays correctly, and add a regression test for the markdown renderer.

Made-with: Cursor