### PR TITLE
fix(updater): harden Windows upgrade recovery

### DIFF
--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -111,7 +111,7 @@ async def _run_async(
         cmd,
         cwd=cwd or _get_repo_root(),
         capture_output=True,
-        text=True,
+        text=False,
         timeout=timeout,
     )
     return (
@@ -126,7 +126,7 @@ def _run(cmd: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
         cmd,
         cwd=cwd or _get_repo_root(),
         capture_output=True,
-        text=True,
+        text=False,
     )
     return (
         result.returncode,
@@ -1179,9 +1179,11 @@ def _safe_remove(target: Path) -> None:
             _safe_rmtree(target)
         else:
             target.unlink()
-    except PermissionError:
+    except OSError:
         if sys.platform != "win32":
             raise
+        if not target.exists():
+            return
         renamed = _renamed_lock_path(target)
         target.rename(renamed)
         log.info("updater.rename_locked", {"from": str(target), "to": str(renamed)})
@@ -1662,6 +1664,28 @@ def _build_restart_argv() -> list[str]:
                 "reload_stripped": len(rest) - len(clean_rest),
             })
             return [sys.executable, "-m", module] + clean_rest
+
+    if sys.platform == "win32":
+        argv0_path = Path(argv0)
+        candidates: list[str] = []
+        if argv0:
+            candidates.append(argv0)
+        if argv0_path.suffix == "":
+            candidates.extend([
+                f"{argv0}.exe",
+                f"{argv0}.cmd",
+                f"{argv0}.bat",
+            ])
+        for candidate in candidates:
+            resolved = shutil.which(candidate) or (candidate if Path(candidate).exists() else None)
+            if not resolved:
+                continue
+            suffix = Path(resolved).suffix.lower()
+            if suffix == ".exe":
+                return [resolved] + clean_rest
+            if suffix in {".cmd", ".bat"}:
+                comspec = os.environ.get("COMSPEC") or "cmd.exe"
+                return [comspec, "/c", resolved] + clean_rest
 
     return [sys.executable, argv0] + clean_rest
 

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -41,6 +41,28 @@ async def test_run_async_handles_none_process_output(
     assert stderr == ""
 
 
+@pytest.mark.asyncio
+async def test_run_async_replaces_invalid_windows_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout=b"ok\x93done",
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(updater.subprocess, "run", fake_run)
+
+    code, stdout, stderr = await updater._run_async(["npm", "run", "build"], cwd=tmp_path)
+
+    assert code == 0
+    assert stdout == "ok�done"
+    assert stderr == ""
+
+
 def test_find_executable_checks_windows_scripts_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -86,6 +108,33 @@ def test_upgrade_page_probe_urls_support_ipv6_loopback_fallback() -> None:
     ]
 
 
+def test_build_restart_argv_uses_windows_executable_shim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setattr(updater.sys, "executable", r"C:\Python312\python.exe")
+    monkeypatch.setattr(
+        updater.sys,
+        "argv",
+        [r"C:\Users\worker\.local\bin\flocks", "start", "--reload", "--port", "8000"],
+    )
+    monkeypatch.setattr(
+        updater.shutil,
+        "which",
+        lambda name: r"C:\Users\worker\.local\bin\flocks.exe" if name in {
+            r"C:\Users\worker\.local\bin\flocks",
+            r"C:\Users\worker\.local\bin\flocks.exe",
+        } else None,
+    )
+
+    assert updater._build_restart_argv() == [
+        r"C:\Users\worker\.local\bin\flocks.exe",
+        "start",
+        "--port",
+        "8000",
+    ]
+
+
 def test_rmtree_onerror_retries_before_logging_skip(monkeypatch: pytest.MonkeyPatch) -> None:
     attempts: list[str] = []
     warnings: list[tuple[str, dict[str, str]]] = []
@@ -124,6 +173,26 @@ def test_safe_remove_renames_locked_file_on_windows(monkeypatch: pytest.MonkeyPa
     leftovers = list(tmp_path.glob("locked.exe.flocks_old_*"))
     assert not target.exists()
     assert len(leftovers) == 1
+
+
+def test_safe_remove_renames_locked_directory_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "webui"
+    target.mkdir()
+    (target / "dist").mkdir()
+    (target / "dist" / "index.html").write_text("old", encoding="utf-8")
+
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setattr(updater, "_safe_rmtree", lambda _target: (_ for _ in ()).throw(PermissionError("locked")))
+
+    updater._safe_remove(target)
+
+    leftovers = list(tmp_path.glob("webui.flocks_old_*"))
+    assert not target.exists()
+    assert len(leftovers) == 1
+    assert (leftovers[0] / "dist" / "index.html").exists()
 
 
 def test_prepare_upgrade_handover_writes_state_and_stops_frontend(


### PR DESCRIPTION
## Summary
- make updater subprocess capture resilient to non-GBK Windows output so upgrade flows do not crash while reading npm or uv logs
- allow locked Windows files or directories such as `webui/node_modules/@esbuild/.../esbuild.exe` to be renamed aside during replacement instead of aborting the upgrade
- resolve Windows launcher shims during restart and add regression coverage for subprocess decoding, locked directory handling, and restart argv rebuilding