### PR TITLE
fix(webui): hide details tab when creating sub-agent

### DIFF
--- a/webui/src/pages/Agent/AgentSheet.tsx
+++ b/webui/src/pages/Agent/AgentSheet.tsx
@@ -240,6 +240,7 @@ export default function AgentSheet({ agent, onClose, onSaved }: AgentSheetProps)
       submitDisabled={submitDisabled}
       submitLoading={loading}
       submitLabel={isEdit ? undefined : t('sheet.done')}
+      hideForm={!isEdit}
       onClose={onClose}
       onSubmit={handleSubmit}
       onExtractFromRex={isEdit ? handleExtractFromRex : undefined}


### PR DESCRIPTION
The details/form tab in the AgentSheet was misleading users into thinking they should fill out a form to create a sub-agent. Hide it in create mode so only the AI-edit (Rex) tab is shown; the details tab is still available when viewing/editing an existing agent.