### PR TITLE
fix(server): support slash-containing model IDs in V2 routes

### DIFF
--- a/flocks/server/routes/custom_provider.py
+++ b/flocks/server/routes/custom_provider.py
@@ -260,7 +260,7 @@ async def create_model(provider_id: str, body: CreateModelReq):
     )
 
 
-@router.delete("/models/{provider_id}/{model_id}", status_code=204)
+@router.delete("/models/{provider_id}/{model_id:path}", status_code=204)
 async def delete_model(provider_id: str, model_id: str):
     """Remove a model from a provider in flocks.json."""
     removed = ConfigWriter.remove_model(provider_id, model_id)

--- a/flocks/server/routes/model.py
+++ b/flocks/server/routes/model.py
@@ -447,7 +447,24 @@ async def list_model_definitions(
 
 
 @router.get(
-    "/v2/definitions/{provider_id}/{model_id}",
+    "/v2/definitions/{provider_id}/{model_id:path}/parameter-rules",
+    summary="Get model parameter rules",
+    description="Get the parameter rules (constraints) for a model",
+)
+async def get_parameter_rules(provider_id: str, model_id: str):
+    """Get parameter rules for a model."""
+    manager = get_model_manager()
+    definition = manager.get_model(provider_id, model_id)
+    if not definition:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model '{model_id}' not found for provider '{provider_id}'",
+        )
+    return {"parameter_rules": definition.parameter_rules}
+
+
+@router.get(
+    "/v2/definitions/{provider_id}/{model_id:path}",
     response_model=ModelDefinition,
     summary="Get model definition (V2)",
     description="Get full model definition with capabilities, limits, pricing, and parameter rules",
@@ -467,24 +484,7 @@ async def get_model_definition(
 
 
 @router.get(
-    "/v2/definitions/{provider_id}/{model_id}/parameter-rules",
-    summary="Get model parameter rules",
-    description="Get the parameter rules (constraints) for a model",
-)
-async def get_parameter_rules(provider_id: str, model_id: str):
-    """Get parameter rules for a model."""
-    manager = get_model_manager()
-    definition = manager.get_model(provider_id, model_id)
-    if not definition:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Model '{model_id}' not found for provider '{provider_id}'",
-        )
-    return {"parameter_rules": definition.parameter_rules}
-
-
-@router.get(
-    "/v2/settings/{provider_id}/{model_id}",
+    "/v2/settings/{provider_id}/{model_id:path}",
     summary="Get model settings",
 )
 async def get_model_settings(provider_id: str, model_id: str):
@@ -498,7 +498,7 @@ async def get_model_settings(provider_id: str, model_id: str):
 
 
 @router.put(
-    "/v2/settings/{provider_id}/{model_id}",
+    "/v2/settings/{provider_id}/{model_id:path}",
     response_model=ModelSetting,
     summary="Update model settings",
     description="Enable/disable a model or set default parameters",
@@ -517,7 +517,7 @@ async def update_model_settings(
     return setting
 
 @router.delete(
-    "/v2/definitions/{provider_id}/{model_id}",
+    "/v2/definitions/{provider_id}/{model_id:path}",
     status_code=204,
     summary="Delete model definition",
     description="Delete a model from a provider (removes from flocks.json and runtime)",


### PR DESCRIPTION
Custom providers (e.g. custom-内部服务) can have model IDs with slashes
like "bailian/DeepSeek-V3". FastAPI's default {model_id} path parameter
only matches a single path segment, causing 404 on GET settings, PUT
(disable), and DELETE (remove) operations.
Change {model_id} to {model_id:path} in all V2 model routes and
custom_provider DELETE route to match multi-segment model IDs. Reorder
the parameter-rules route before the catch-all definition route to
prevent greedy :path from swallowing the suffix.
V1 legacy routes (/{model_id}, /{model_id}/compatible) are intentionally
left unchanged — using :path there would swallow all subsequently
defined GET routes (/providers/summary, /v2/*, etc.).