### PR TITLE
fix/agent config cache sync

### DIFF
--- a/flocks/server/routes/agent.py
+++ b/flocks/server/routes/agent.py
@@ -591,7 +591,7 @@ async def update_agent_model(name: str, req: AgentModelUpdateRequest):
             except Storage.NotFoundError:
                 pass
 
-            if agent_data is not None:
+            if agent_data is not None and agent_data.get("name"):
                 agent_data["model"] = req.model.model_dump() if req.model else None
                 await Storage.write(agent_key, agent_data)
 


### PR DESCRIPTION
pdate_agent_model had the same missing guard as update_agent: a YAML
agent with a skills/tools overlay entry (no "name" key) in Storage
would be mistaken for a full custom agent, causing _agent_data_to_info
to crash with KeyError on the missing "name" field.