### PR TITLE
fix(install): avoid PowerShell matches auto-variable collision

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -44,7 +44,7 @@ Flocks 支持两种部署方式：
 
 如果安装过程中自动安装 `npm` 失败，请手动安装 `npm`，并使用 `22.+` 或更高版本。
 
-### 一条命令安装
+### 快速安装
 
 > **中国大陆用户**：若 GitHub / `raw.githubusercontent.com` 访问不稳定，可从 Gitee 镜像克隆后安装，见下文「源码安装」。
 
@@ -52,21 +52,21 @@ Flocks 支持两种部署方式：
 
 ```bash
 # 一键安装后端 + WebUI
-curl -fsSL https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.sh | bash
+curl -fsSL https://gitee.com/flocks/flocks/raw/main/install.sh | bash
 # 默认会在当前目录下创建 ./flocks
 
 # 可选：同时安装 TUI 依赖
-curl -fsSL https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.sh | bash -s -- --with-tui
+curl -fsSL https://gitee.com/flocks/flocks/raw/main/install.sh | bash -s -- --with-tui
 ```
 
 #### Windows PowerShell (Administrator)
 
 ```powershell
 # 一键安装后端 + WebUI
-powershell -c "irm https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.ps1 | iex"
+powershell -c "irm https://gitee.com/flocks/flocks/raw/main/install.ps1 | iex"
 
 # 可选：同时安装 TUI 依赖
-powershell -c "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.ps1))) -InstallTui"
+powershell -c "& ([scriptblock]::Create((irm https://gitee.com/flocks/flocks/raw/main/install.ps1))) -InstallTui"
 ```
 
 #### github源码安装

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -375,7 +375,7 @@ function Stop-TrackedProcess {
 function Get-FlocksProcessIds {
     param([string]$ProjectRoot)
 
-    $matches = [System.Collections.Generic.List[int]]::new()
+    $processIds = [System.Collections.Generic.List[int]]::new()
     $toolDir = ""
     if (Test-Command "uv") {
         try {
@@ -405,20 +405,20 @@ function Get-FlocksProcessIds {
             continue
         }
 
-        $isMatch = $commandLine -match "flocks\.server\.app"
+        $isMatch = [Regex]::IsMatch($commandLine, "flocks\.server\.app")
         if (-not $isMatch -and $escapedProjectRoot) {
-            $isMatch = $commandLine -match $escapedProjectRoot -and $commandLine -match "(uv tool|uv sync|npm(\.cmd)? run preview|vite preview)"
+            $isMatch = [Regex]::IsMatch($commandLine, $escapedProjectRoot) -and [Regex]::IsMatch($commandLine, "(uv tool|uv sync|npm(\.cmd)? run preview|vite preview)")
         }
         if (-not $isMatch -and $escapedToolDir) {
-            $isMatch = $commandLine -match $escapedToolDir -and $commandLine -match "flocks"
+            $isMatch = [Regex]::IsMatch($commandLine, $escapedToolDir) -and [Regex]::IsMatch($commandLine, "flocks")
         }
 
         if ($isMatch) {
-            $matches.Add([int]$process.ProcessId)
+            $processIds.Add([int]$process.ProcessId)
         }
     }
 
-    return $matches | Select-Object -Unique
+    return $processIds | Select-Object -Unique
 }
 
 function Stop-FlocksProcesses {

--- a/tests/scripts/test_powershell_scripts.py
+++ b/tests/scripts/test_powershell_scripts.py
@@ -1,5 +1,6 @@
 import shutil
 import subprocess
+import re
 from pathlib import Path
 
 import pytest
@@ -40,3 +41,17 @@ def _parse_script(script_path: Path) -> subprocess.CompletedProcess[str]:
 def test_powershell_scripts_parse_without_errors(script_path: Path) -> None:
     result = _parse_script(script_path)
     assert result.returncode == 0, result.stdout or result.stderr
+
+
+def test_windows_installer_process_match_logic_avoids_matches_auto_variable() -> None:
+    script_text = (SCRIPT_DIR / "install.ps1").read_text(encoding="utf-8")
+    function_match = re.search(
+        r"function Get-FlocksProcessIds \{.*?^}\s*$",
+        script_text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+    assert function_match is not None
+    function_text = function_match.group(0)
+    assert "$matches" not in function_text
+    assert "[Regex]::IsMatch" in function_text


### PR DESCRIPTION
## Summary
- fix the Windows installer cleanup flow so process matching no longer collides with PowerShell's automatic `\$Matches` variable
- add a regression test covering the installer process match logic to prevent the crash from returning
- update the Chinese README quick install commands to use the Gitee mirror links

## Test plan
- [x] `uv run pytest tests/scripts/test_powershell_scripts.py`