### PR TITLE
docs(install): update PowerShell install docs and encoding checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ default = true
 
 ### Docker Issues
 
+Docker registry mirror in China
+``` bash
+ghcr.nju.edu.cn/agentflocks/flocks:latest
+```
+
 Permission issues for `/home/flocks/.flocks` after startup:
 
 ``` bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -52,21 +52,21 @@ Flocks 支持两种部署方式：
 
 ```bash
 # 一键安装后端 + WebUI
-curl -fsSL https://gitee.com/flocks/flocks/raw/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.sh | bash
 # 默认会在当前目录下创建 ./flocks
 
 # 可选：同时安装 TUI 依赖
-curl -fsSL https://gitee.com/flocks/flocks/raw/main/install.sh | bash -s -- --with-tui
+curl -fsSL https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.sh | bash -s -- --with-tui
 ```
 
 #### Windows PowerShell (Administrator)
 
 ```powershell
 # 一键安装后端 + WebUI
-powershell -c "irm https://gitee.com/flocks/flocks/raw/main/install.ps1 | iex"
+powershell -c "irm https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.ps1 | iex"
 
 # 可选：同时安装 TUI 依赖
-powershell -c "& ([scriptblock]::Create((irm https://gitee.com/flocks/flocks/raw/main/install.ps1))) -InstallTui"
+powershell -c "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.ps1))) -InstallTui"
 ```
 
 #### github源码安装
@@ -172,6 +172,11 @@ default = true
 ```
 
 ### Docker 问题
+
+Docker 国内镜像地址
+``` bash
+ghcr.nju.edu.cn/agentflocks/flocks:latest
+```
 
 启动后 `/home/flocks/.flocks` 权限问题
 

--- a/tests/scripts/test_powershell_scripts.py
+++ b/tests/scripts/test_powershell_scripts.py
@@ -12,6 +12,11 @@ POWERSHELL_SCRIPTS = (
     SCRIPT_DIR / "install.ps1",
     SCRIPT_DIR / "run.ps1",
 )
+POWERSHELL_SCRIPT_ENCODINGS = (
+    (REPO_ROOT / "install.ps1", False),
+    (SCRIPT_DIR / "install.ps1", True),
+    (SCRIPT_DIR / "run.ps1", True),
+)
 
 
 def _parse_script(script_path: Path) -> subprocess.CompletedProcess[str]:
@@ -41,6 +46,17 @@ def _parse_script(script_path: Path) -> subprocess.CompletedProcess[str]:
 def test_powershell_scripts_parse_without_errors(script_path: Path) -> None:
     result = _parse_script(script_path)
     assert result.returncode == 0, result.stdout or result.stderr
+
+
+@pytest.mark.parametrize(("script_path", "expect_bom"), POWERSHELL_SCRIPT_ENCODINGS)
+def test_powershell_scripts_use_expected_utf8_encoding_and_crlf(
+    script_path: Path, expect_bom: bool
+) -> None:
+    script_bytes = script_path.read_bytes()
+
+    assert script_bytes.startswith(b"\xef\xbb\xbf") is expect_bom
+    assert b"\r\n" in script_bytes
+    assert script_bytes.replace(b"\r\n", b"").count(b"\n") == 0
 
 
 def test_windows_installer_process_match_logic_avoids_matches_auto_variable() -> None:


### PR DESCRIPTION
Align the documented PowerShell bootstrap URLs with GitHub and add tests that enforce the expected UTF-8 BOM and CRLF policy for installer scripts.