### PR TITLE
fix(webui): sanitize raw HTML in chat to prevent CSS/script injection

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -24,6 +24,7 @@
         "recharts": "^2.15.0",
         "rehype-highlight": "^7.0.2",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.2.1",
@@ -4154,6 +4155,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -6603,6 +6619,20 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/webui/package.json
+++ b/webui/package.json
@@ -30,6 +30,7 @@
     "recharts": "^2.15.0",
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.2.1",

--- a/webui/src/components/common/StreamingMarkdown.tsx
+++ b/webui/src/components/common/StreamingMarkdown.tsx
@@ -2,9 +2,15 @@ import { useState, useEffect, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import 'highlight.js/styles/github-dark.css';
+
+const sanitizeSchema = {
+  ...defaultSchema,
+  strip: [...(defaultSchema.strip || []), 'style'],
+};
 
 /**
  * Throttles content updates to at most once per animation frame while streaming.
@@ -72,7 +78,7 @@ export function StreamingMarkdown({ content, isStreaming }: StreamingMarkdownPro
     <div className="prose prose-sm max-w-none">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
-        rehypePlugins={[rehypeRaw, [rehypeHighlight, { detect: false, ignoreMissing: true }]]}
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], [rehypeHighlight, { detect: false, ignoreMissing: true }]]}
         components={{
           code({ className, children, ...props }) {
             // Detect block-level code (fenced code block):


### PR DESCRIPTION
rehype-raw allowed raw HTML (e.g. <style>, <script>) in chat messages to be rendered as actual DOM elements, causing unintended CSS side-effects.

Add rehype-sanitize between rehype-raw and rehype-highlight with GitHub's default schema extended to strip <style> tags entirely, blocking dangerous elements while preserving safe HTML (tables, links, images, etc.) and keeping syntax highlighting unaffected.