### PR TITLE
feat/add qwen models

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -103,6 +103,42 @@
           "output": 18.0,
           "currency": "CNY"
         }
+      },
+      "qwen3.6-plus": {
+        "name": "qwen3.6-plus",
+        "family": "qwen",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 991000,
+          "max_output_tokens": 64000
+        },
+        "pricing": {
+          "input": 2.0,
+          "output": 12.0,
+          "currency": "CNY"
+        }
+      },
+      "qwen3-max": {
+        "name": "qwen3-max",
+        "family": "qwen",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 252000,
+          "max_output_tokens": 64000
+        },
+        "pricing": {
+          "input": 2.5,
+          "output": 10.0,
+          "currency": "CNY"
+        }
       }
     }
   },
@@ -178,6 +214,42 @@
         "pricing": {
           "input": 4.0,
           "output": 18.0,
+          "currency": "CNY"
+        }
+      },
+      "qwen3.6-plus": {
+        "name": "qwen3.6-plus",
+        "family": "qwen",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 991000,
+          "max_output_tokens": 64000
+        },
+        "pricing": {
+          "input": 2.0,
+          "output": 12.0,
+          "currency": "CNY"
+        }
+      },
+      "qwen3-max": {
+        "name": "qwen3-max",
+        "family": "qwen",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 252000,
+          "max_output_tokens": 64000
+        },
+        "pricing": {
+          "input": 2.5,
+          "output": 10.0,
           "currency": "CNY"
         }
       }

--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -88,6 +88,11 @@ def build_provider_options(
     elif provider_id == "groq":
         options["thinkingLevel"] = "high"
 
+    # -- Qwen reasoning (ThreatBook-hosted or Alibaba DashScope) -------------
+    elif provider_id in ("threatbook-cn-llm", "threatbook-io-llm", "alibaba"):
+        if "qwen3-max" in model_lower or "qwen3.6-plus" in model_lower:
+            options["extra_body"] = {"enable_thinking": True}
+
     # -- Amazon Bedrock reasoning -------------------------------------------
     elif provider_id == "amazon-bedrock":
         if "anthropic" in model_lower:

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -375,12 +375,15 @@ class OpenAIBaseProvider(BaseProvider):
             "messages": openai_messages,
         }
 
+        extra_body = dict(kwargs.get("extra_body") or {})
         if thinking:
-            params["extra_body"] = {"thinking": thinking}
+            extra_body["thinking"] = thinking
         else:
             temperature = kwargs.get("temperature")
             if temperature is not None:
                 params["temperature"] = temperature
+        if extra_body:
+            params["extra_body"] = extra_body
 
         if kwargs.get("max_tokens"):
             params["max_tokens"] = kwargs["max_tokens"]
@@ -433,12 +436,15 @@ class OpenAIBaseProvider(BaseProvider):
             "stream": True,
         }
 
+        extra_body = dict(kwargs.get("extra_body") or {})
         if thinking:
-            params["extra_body"] = {"thinking": thinking}
+            extra_body["thinking"] = thinking
         else:
             temperature = kwargs.get("temperature")
             if temperature is not None:
                 params["temperature"] = temperature
+        if extra_body:
+            params["extra_body"] = extra_body
 
         if kwargs.get("max_tokens"):
             params["max_tokens"] = kwargs["max_tokens"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.4.1"
+version = "v2026.4.3"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.4.1"
+version = "2026.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Add two Qwen models to both threatbook-cn-llm and threatbook-io-llm
providers with enable_thinking enabled by default:

- qwen3.6-plus: 991K context, 64K output, ¥2/12 per MTok
- qwen3-max: 252K context, 64K output, ¥2.5/10 per MTok

Both models are marked with supports_reasoning and will automatically
pass `enable_thinking: true` via extra_body for the Qwen thinking API.

Also refactors OpenAIBaseProvider to merge extra_body from kwargs
instead of overwriting, so provider-specific params like
enable_thinking can coexist with the existing thinking mechanism.