### PR TITLE
feat(tool): add pdf/word docs parser

### DIFF
--- a/flocks/tool/file/doc_parser.py
+++ b/flocks/tool/file/doc_parser.py
@@ -1,0 +1,462 @@
+"""
+`doc_parser` built-in file tool.
+
+Converts PDF / Word documents into Markdown files.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import importlib
+import re
+import subprocess
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+from typing import Callable
+
+from flocks.tool.registry import (
+    ParameterType,
+    ToolCategory,
+    ToolContext,
+    ToolParameter,
+    ToolRegistry,
+    ToolResult,
+)
+from flocks.workspace.manager import WorkspaceManager
+
+SUPPORTED_SUFFIXES = {".pdf", ".docx", ".doc"}
+WORD_NAMESPACE = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
+
+
+def _normalize_markdown(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " ")
+    fenced_block_pattern = re.compile(r"(^```.*?^```[ \t]*$)", re.MULTILINE | re.DOTALL)
+    parts = fenced_block_pattern.split(text)
+    normalized_parts: list[str] = []
+
+    for part in parts:
+        if not part:
+            continue
+        if fenced_block_pattern.fullmatch(part):
+            normalized_parts.append(_normalize_fenced_block(part))
+        else:
+            normalized_parts.append(_normalize_text_segment(part))
+
+    result = "".join(normalized_parts).strip()
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result
+
+
+def _normalize_text_segment(text: str) -> str:
+    text = re.sub(r"[ \t]+\n", "\n", text)
+
+    paragraphs = re.split(r"\n\s*\n+", text)
+    normalized: list[str] = []
+    for paragraph in paragraphs:
+        raw_lines = [line.rstrip() for line in paragraph.splitlines() if line.strip()]
+        if not raw_lines:
+            continue
+        if any(_looks_like_markdown(line) for line in raw_lines):
+            normalized.append("\n".join(raw_lines))
+        else:
+            normalized.append(" ".join(line.strip() for line in raw_lines))
+
+    if not normalized:
+        return ""
+    return "\n\n".join(normalized) + "\n\n"
+
+
+def _normalize_fenced_block(text: str) -> str:
+    lines = [line.rstrip() for line in text.splitlines()]
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n\n"
+
+
+def _looks_like_markdown(line: str) -> bool:
+    stripped = line.lstrip()
+    markdown_prefixes = ("#", "-", "*", "+", ">", "|", "```")
+    ordered_list = re.match(r"^\d+\.\s", stripped)
+    return stripped.startswith(markdown_prefixes) or ordered_list is not None
+
+
+def _sanitize_stem(path: Path) -> str:
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", path.stem).strip("._")
+    return stem or "document"
+
+
+def _default_output_path(input_file: Path) -> Path:
+    workspace = WorkspaceManager.get_instance()
+    workspace.ensure_dirs()
+    today = dt.date.today().isoformat()
+    output_dir = workspace.get_workspace_dir() / "outputs" / today
+    output_dir.mkdir(parents=True, exist_ok=True)
+    suffix = input_file.suffix.lower().lstrip(".") or "file"
+    return output_dir / f"{_sanitize_stem(input_file)}_{suffix}.md"
+
+
+def _resolve_input_path(input_path: str) -> Path:
+    path = Path(input_path).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    return path
+
+
+def _resolve_output_path(input_file: Path, output_path: str | None) -> Path:
+    if not output_path:
+        return _default_output_path(input_file)
+
+    path = Path(output_path).expanduser()
+    if not path.is_absolute():
+        workspace = WorkspaceManager.get_instance()
+        workspace.ensure_dirs()
+        path = workspace.get_workspace_dir() / output_path
+    if path.suffix.lower() != ".md":
+        path = path.with_suffix(".md")
+    return path.resolve()
+
+
+def _extract_with_markitdown(file_path: Path) -> str:
+    markitdown = importlib.import_module("markitdown")
+    markitdown_cls = getattr(markitdown, "MarkItDown")
+
+    result = markitdown_cls().convert(str(file_path))
+    return _normalize_markdown(result.text_content or "")
+
+
+def _extract_pdf_with_pymupdf(file_path: Path) -> str:
+    fitz = importlib.import_module("fitz")
+
+    document = fitz.open(file_path)
+    try:
+        text_parts = [page.get_text() for page in document]
+    finally:
+        document.close()
+    return _normalize_markdown("\n\n".join(text_parts))
+
+
+def _extract_pdf_with_pypdf(file_path: Path) -> str:
+    from pypdf import PdfReader
+
+    reader = PdfReader(str(file_path))
+    text_parts = [page.extract_text() or "" for page in reader.pages]
+    return _normalize_markdown("\n\n".join(text_parts))
+
+
+def _word_tag(name: str) -> str:
+    return f"{{{WORD_NAMESPACE['w']}}}{name}"
+
+
+def _docx_styles(archive: zipfile.ZipFile) -> dict[str, str]:
+    try:
+        styles_xml = archive.read("word/styles.xml")
+    except KeyError:
+        return {}
+
+    root = ET.fromstring(styles_xml)
+    styles: dict[str, str] = {}
+    for style in root.findall("w:style", WORD_NAMESPACE):
+        style_id = style.get(_word_tag("styleId")) or style.get("styleId")
+        name = style.find("w:name", WORD_NAMESPACE)
+        style_name = ""
+        if name is not None:
+            style_name = name.get(_word_tag("val")) or name.get("val") or ""
+        if style_id:
+            styles[style_id] = style_name
+    return styles
+
+
+def _format_docx_text(text: str, style_name: str) -> str:
+    if not text:
+        return ""
+
+    style_name = style_name.lower()
+    if "heading 1" in style_name or style_name == "title":
+        return f"# {text}"
+    if "heading 2" in style_name:
+        return f"## {text}"
+    if "heading 3" in style_name:
+        return f"### {text}"
+    if "heading 4" in style_name:
+        return f"#### {text}"
+    if "heading 5" in style_name:
+        return f"##### {text}"
+    if "heading 6" in style_name:
+        return f"###### {text}"
+    if "list bullet" in style_name:
+        return f"- {text}"
+    if "list number" in style_name:
+        return f"1. {text}"
+    return text
+
+
+def _run_text(run: ET.Element) -> str:
+    text_parts = [node.text or "" for node in run.findall(".//w:t", WORD_NAMESPACE)]
+    text = "".join(text_parts)
+    if not text:
+        return ""
+
+    properties = run.find("w:rPr", WORD_NAMESPACE)
+    if properties is not None:
+        if properties.find("w:b", WORD_NAMESPACE) is not None:
+            text = f"**{text}**"
+        if properties.find("w:i", WORD_NAMESPACE) is not None:
+            text = f"*{text}*"
+        if properties.find("w:u", WORD_NAMESPACE) is not None:
+            text = f"__{text}__"
+    return text
+
+
+def _paragraph_text(paragraph: ET.Element, styles: dict[str, str]) -> str:
+    style_name = ""
+    style_node = paragraph.find("w:pPr/w:pStyle", WORD_NAMESPACE)
+    if style_node is not None:
+        style_id = style_node.get(_word_tag("val")) or style_node.get("val") or ""
+        style_name = styles.get(style_id, style_id)
+
+    parts: list[str] = []
+    for child in paragraph:
+        if child.tag == _word_tag("r"):
+            parts.append(_run_text(child))
+        elif child.tag == _word_tag("hyperlink"):
+            for run in child.findall("w:r", WORD_NAMESPACE):
+                parts.append(_run_text(run))
+        elif child.tag == _word_tag("br"):
+            parts.append("\n")
+
+    text = "".join(parts).strip()
+    return _format_docx_text(text, style_name)
+
+
+def _table_to_markdown(table: ET.Element, styles: dict[str, str]) -> str:
+    rows: list[str] = []
+    for row_index, row in enumerate(table.findall("w:tr", WORD_NAMESPACE)):
+        cells = []
+        for cell in row.findall("w:tc", WORD_NAMESPACE):
+            cell_parts = []
+            for paragraph in cell.findall("w:p", WORD_NAMESPACE):
+                paragraph_text = _paragraph_text(paragraph, styles)
+                if paragraph_text:
+                    cell_parts.append(paragraph_text)
+            cell_text = " ".join(cell_parts).strip().replace("\n", " ").replace("|", r"\|")
+            cells.append(cell_text)
+        if not cells:
+            continue
+        rows.append("| " + " | ".join(cells) + " |")
+        if row_index == 0:
+            rows.append("| " + " | ".join(["---"] * len(cells)) + " |")
+    return "\n".join(rows)
+
+
+def _extract_docx_with_zipxml(file_path: Path) -> str:
+    with zipfile.ZipFile(file_path) as archive:
+        document_xml = archive.read("word/document.xml")
+        styles = _docx_styles(archive)
+
+    root = ET.fromstring(document_xml)
+    body = root.find("w:body", WORD_NAMESPACE)
+    if body is None:
+        return ""
+
+    blocks: list[str] = []
+    for child in body:
+        if child.tag == _word_tag("p"):
+            formatted = _paragraph_text(child, styles)
+            if formatted:
+                blocks.append(formatted)
+        elif child.tag == _word_tag("tbl"):
+            table_md = _table_to_markdown(child, styles)
+            if table_md:
+                blocks.append(table_md)
+    return _normalize_markdown("\n\n".join(blocks))
+
+
+def _extract_doc_with_olefile(file_path: Path) -> str:
+    olefile = importlib.import_module("olefile")
+
+    if not olefile.isOleFile(str(file_path)):
+        return ""
+
+    with olefile.OleFileIO(str(file_path)) as ole:
+        if not ole.exists("WordDocument"):
+            return ""
+        stream = ole.openstream("WordDocument")
+        data = stream.read()
+
+    for encoding in ("utf-16le", "gbk", "utf-8"):
+        try:
+            text = data.decode(encoding, errors="ignore")
+            break
+        except Exception:
+            continue
+    else:
+        return ""
+
+    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]", "", text)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = text.replace("\x0b", "\n").replace("\x0c", "\n")
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    normalized = _normalize_markdown(text)
+    if not _looks_like_readable_text(normalized):
+        return ""
+    return normalized
+
+
+def _looks_like_readable_text(text: str) -> bool:
+    compact = re.sub(r"\s+", "", text)
+    if len(compact) < 20:
+        return False
+
+    readable_chars = sum(
+        1
+        for char in compact
+        if char.isalnum() or "\u4e00" <= char <= "\u9fff" or char in ".,;:!?()[]{}<>-_/#%&@'\"，。；：？！、（）【】《》"
+    )
+    return readable_chars / len(compact) >= 0.6
+
+
+def _extract_with_pandoc(file_path: Path) -> str:
+    command = ["pandoc", str(file_path), "-t", "markdown", "--wrap=none"]
+    result = subprocess.run(command, capture_output=True, text=True, timeout=60, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "pandoc conversion failed")
+    return _normalize_markdown(result.stdout)
+
+
+def _run_extractors(file_path: Path) -> tuple[str, str, list[str]]:
+    extractors: list[tuple[str, Callable[[Path], str]]]
+    suffix = file_path.suffix.lower()
+    if suffix == ".pdf":
+        extractors = [
+            ("markitdown", _extract_with_markitdown),
+            ("pymupdf", _extract_pdf_with_pymupdf),
+            ("pypdf", _extract_pdf_with_pypdf),
+        ]
+    elif suffix == ".docx":
+        extractors = [
+            ("markitdown", _extract_with_markitdown),
+            ("docx-xml", _extract_docx_with_zipxml),
+            ("pandoc", _extract_with_pandoc),
+        ]
+    else:
+        extractors = [
+            ("markitdown", _extract_with_markitdown),
+            ("pandoc", _extract_with_pandoc),
+            ("olefile", _extract_doc_with_olefile),
+        ]
+
+    errors: list[str] = []
+    for parser_name, extractor in extractors:
+        try:
+            content = extractor(file_path)
+        except ImportError as exc:
+            errors.append(f"{parser_name}: {exc}")
+            continue
+        except FileNotFoundError as exc:
+            errors.append(f"{parser_name}: {exc}")
+            continue
+        except Exception as exc:
+            errors.append(f"{parser_name}: {exc}")
+            continue
+
+        if content and content.strip():
+            return content, parser_name, errors
+        errors.append(f"{parser_name}: extracted empty content")
+
+    return "", "", errors
+
+
+@ToolRegistry.register_function(
+    name="doc_parser",
+    description=(
+        "Parse a PDF, DOCX, or DOC file into Markdown and write the result "
+        "to an .md file. If output_path is omitted, the markdown file is "
+        "written to the Flocks workspace outputs directory for today."
+    ),
+    category=ToolCategory.FILE,
+    parameters=[
+        ToolParameter(
+            name="input_path",
+            type=ParameterType.STRING,
+            description="Absolute or relative path to the source PDF / DOCX / DOC file.",
+            required=True,
+        ),
+        ToolParameter(
+            name="output_path",
+            type=ParameterType.STRING,
+            description=(
+                "Optional output markdown path. Absolute paths are used directly. "
+                "Relative paths are resolved inside the Flocks workspace directory."
+            ),
+            required=False,
+        ),
+        ToolParameter(
+            name="overwrite",
+            type=ParameterType.BOOLEAN,
+            description="Whether to overwrite an existing markdown output file.",
+            required=False,
+            default=True,
+        ),
+    ],
+)
+async def doc_parser(
+    ctx: ToolContext,
+    input_path: str,
+    output_path: str | None = None,
+    overwrite: bool = True,
+) -> ToolResult:
+    input_file = _resolve_input_path(input_path)
+    if not input_file.exists():
+        return ToolResult(success=False, error=f"Input file not found: {input_file}")
+    if input_file.suffix.lower() not in SUPPORTED_SUFFIXES:
+        supported = ", ".join(sorted(SUPPORTED_SUFFIXES))
+        return ToolResult(
+            success=False,
+            error=f"Unsupported file type: {input_file.suffix or '(none)'}. Supported: {supported}",
+        )
+
+    output_file = _resolve_output_path(input_file, output_path)
+    if output_file.exists() and not overwrite:
+        return ToolResult(success=False, error=f"Output file already exists: {output_file}")
+
+    await ctx.ask(
+        permission="read",
+        patterns=[str(input_file)],
+        always=["*"],
+        metadata={"filepath": str(input_file)},
+    )
+
+    markdown, parser_name, errors = await asyncio.to_thread(_run_extractors, input_file)
+    if not markdown:
+        error_lines = "\n".join(errors) if errors else "No parser produced content."
+        return ToolResult(
+            success=False,
+            error=f"Failed to parse document: {input_file.name}\n{error_lines}",
+        )
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    diff = f"Generated markdown for {input_file.name}"
+    await ctx.ask(
+        permission="edit",
+        patterns=[str(output_file)],
+        always=["*"],
+        metadata={"filepath": str(output_file), "diff": diff},
+    )
+
+    output_file.write_text(markdown + "\n", encoding="utf-8")
+    return ToolResult(
+        success=True,
+        output={
+            "input_path": str(input_file),
+            "output_path": str(output_file),
+            "parser": parser_name,
+            "characters": len(markdown),
+        },
+        title=output_file.name,
+    )

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -866,7 +866,7 @@ class ToolRegistry:
 
         _tool_groups = [
             # file/ — filesystem operations
-            ("flocks.tool.file", ["read", "write", "edit", "multiedit", "apply_patch", "glob", "list_tool", "file_search"]),
+            ("flocks.tool.file", ["read", "write", "edit", "multiedit", "apply_patch", "glob", "list_tool", "file_search", "doc_parser"]),
             # code/ — code analysis + terminal
             ("flocks.tool.code", ["bash", "grep", "codesearch", "lsp_tool"]),
             # web/ — internet access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ dependencies = [
     # Feishu / Lark (WebSocket long-connection + Open API)
     "lark-oapi>=1.3.0",
     "pypdf>=6.8.0",
+    "markitdown>=0.1.5",
+    "pymupdf>=1.27.2.2",
+    "olefile>=0.47",
 ]
 
 [dependency-groups]

--- a/tests/tool/test_doc_parser_plugin.py
+++ b/tests/tool/test_doc_parser_plugin.py
@@ -1,0 +1,158 @@
+import datetime as dt
+import textwrap
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from flocks.tool.registry import ToolContext, ToolRegistry
+from flocks.workspace.manager import WorkspaceManager
+
+def _load_module():
+    import flocks.tool.file.doc_parser as module
+
+    return module
+
+
+def _write_minimal_docx(path: Path) -> None:
+    content_types = textwrap.dedent("""\
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+          <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+          <Default Extension="xml" ContentType="application/xml"/>
+          <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+          <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+        </Types>
+    """)
+    rels = textwrap.dedent("""\
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+        </Relationships>
+    """)
+    styles = textwrap.dedent("""\
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:style w:type="paragraph" w:styleId="Heading1">
+            <w:name w:val="heading 1"/>
+          </w:style>
+          <w:style w:type="paragraph" w:styleId="Normal">
+            <w:name w:val="Normal"/>
+          </w:style>
+        </w:styles>
+    """)
+    document = textwrap.dedent("""\
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:body>
+            <w:p>
+              <w:pPr><w:pStyle w:val="Heading1"/></w:pPr>
+              <w:r><w:t>合同标题</w:t></w:r>
+            </w:p>
+            <w:p>
+              <w:r><w:t>第一段内容</w:t></w:r>
+            </w:p>
+          </w:body>
+        </w:document>
+    """)
+
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("[Content_Types].xml", content_types)
+        archive.writestr("_rels/.rels", rels)
+        archive.writestr("word/document.xml", document)
+        archive.writestr("word/styles.xml", styles)
+
+
+@pytest.fixture(scope="module")
+def doc_parser_module():
+    module = _load_module()
+    yield module
+    ToolRegistry._tools.pop("doc_parser", None)
+
+
+def test_default_output_path_uses_workspace_outputs(tmp_path, monkeypatch, doc_parser_module):
+    previous_instance = WorkspaceManager._instance
+    WorkspaceManager._instance = None
+    monkeypatch.setenv("FLOCKS_WORKSPACE_DIR", str(tmp_path / "workspace"))
+    try:
+        output_path = doc_parser_module._default_output_path(Path("/tmp/合同 Final.docx"))
+    finally:
+        WorkspaceManager._instance = previous_instance
+
+    expected_dir = tmp_path / "workspace" / "outputs" / dt.date.today().isoformat()
+    assert output_path.parent == expected_dir
+    assert output_path.name == "Final_docx.md"
+
+
+@pytest.mark.asyncio
+async def test_doc_parser_writes_docx_markdown(tmp_path, doc_parser_module):
+    source = tmp_path / "sample.docx"
+    _write_minimal_docx(source)
+
+    output = tmp_path / "sample.md"
+    result = await doc_parser_module.doc_parser(
+        ToolContext(session_id="test", message_id="test"),
+        input_path=str(source),
+        output_path=str(output),
+    )
+
+    assert result.success is True
+    assert output.exists()
+    content = output.read_text(encoding="utf-8")
+    assert "# 合同标题" in content
+    assert "第一段内容" in content
+    assert result.output["output_path"] == str(output)
+    assert result.output["parser"] in {"markitdown", "docx-xml", "pandoc"}
+
+
+@pytest.mark.asyncio
+async def test_doc_parser_rejects_unsupported_file(tmp_path, doc_parser_module):
+    source = tmp_path / "sample.txt"
+    source.write_text("hello", encoding="utf-8")
+
+    result = await doc_parser_module.doc_parser(
+        ToolContext(session_id="test", message_id="test"),
+        input_path=str(source),
+    )
+
+    assert result.success is False
+    assert "Unsupported file type" in (result.error or "")
+
+
+def test_normalize_markdown_preserves_fenced_code_block(doc_parser_module):
+    normalized = doc_parser_module._normalize_markdown(
+        "```python\n    print(1)\n\n    print(2)\n```\n"
+    )
+
+    assert "    print(1)" in normalized
+    assert "    print(2)" in normalized
+
+
+def test_doc_fallback_prefers_pandoc_before_olefile(monkeypatch, tmp_path, doc_parser_module):
+    source = tmp_path / "sample.doc"
+    source.write_bytes(b"not-a-real-doc")
+
+    calls: list[str] = []
+
+    def fake_markitdown(_: Path) -> str:
+        calls.append("markitdown")
+        return ""
+
+    def fake_pandoc(_: Path) -> str:
+        calls.append("pandoc")
+        return "converted"
+
+    def fake_olefile(_: Path) -> str:
+        calls.append("olefile")
+        return "should-not-be-used"
+
+    monkeypatch.setattr(doc_parser_module, "_extract_with_markitdown", fake_markitdown)
+    monkeypatch.setattr(doc_parser_module, "_extract_with_pandoc", fake_pandoc)
+    monkeypatch.setattr(doc_parser_module, "_extract_doc_with_olefile", fake_olefile)
+
+    content, parser_name, errors = doc_parser_module._run_extractors(source)
+
+    assert content == "converted"
+    assert parser_name == "pandoc"
+    assert errors == ["markitdown: extracted empty content"]
+    assert calls == ["markitdown", "pandoc"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform != 'win32'",
+]
 
 [[package]]
 name = "aiofiles"
@@ -167,6 +171,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "cattrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -267,6 +284,18 @@ wheels = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.5"
 source = { registry = "https://pypi.org/simple" }
@@ -351,6 +380,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -422,6 +460,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "flocks"
 version = "2026.3.31"
 source = { editable = "." }
@@ -442,11 +488,14 @@ dependencies = [
     { name = "lark-oapi" },
     { name = "litellm" },
     { name = "lsprotocol" },
+    { name = "markitdown" },
     { name = "mcp" },
+    { name = "olefile" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygls" },
+    { name = "pymupdf" },
     { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -493,11 +542,14 @@ requires-dist = [
     { name = "lark-oapi", specifier = ">=1.3.0" },
     { name = "litellm", specifier = ">=1.30.0" },
     { name = "lsprotocol", specifier = ">=2023.0.0" },
+    { name = "markitdown", specifier = ">=0.1.5" },
     { name = "mcp", specifier = ">=1.26.0" },
+    { name = "olefile", specifier = ">=0.47" },
     { name = "openai", specifier = ">=1.12.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "pygls", specifier = ">=1.3.0" },
+    { name = "pymupdf", specifier = ">=1.27.2.2" },
     { name = "pypdf", specifier = ">=6.8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
@@ -755,6 +807,18 @@ wheels = [
 ]
 
 [[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -986,6 +1050,24 @@ wheels = [
 ]
 
 [[package]]
+name = "magika"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e4/35c323beb3280482c94299d61626116856ac2d4ec16ecef50afc4fdd4291/magika-0.6.3-py3-none-any.whl", hash = "sha256:eda443d08006ee495e02083b32e51b98cb3696ab595a7d13900d8e2ef506ec9d", size = 2969474, upload-time = "2025-10-30T15:22:25.298Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/132b0d7cd51c02c39fd52658a5896276c30c8cc2fd453270b19db8c40f7e/magika-0.6.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:86901e64b05dde5faff408c9b8245495b2e1fd4c226e3393d3d2a3fee65c504b", size = 13358841, upload-time = "2025-10-30T15:22:27.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/03/5ed859be502903a68b7b393b17ae0283bf34195cfcca79ce2dc25b9290e7/magika-0.6.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3d9661eedbdf445ac9567e97e7ceefb93545d77a6a32858139ea966b5806fb64", size = 15367335, upload-time = "2025-10-30T15:22:29.907Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/9e/f8ee7d644affa3b80efdd623a3d75865c8f058f3950cb87fb0c48e3559bc/magika-0.6.3-py3-none-win_amd64.whl", hash = "sha256:e57f75674447b20cab4db928ae58ab264d7d8582b55183a0b876711c2b2787f3", size = 12692831, upload-time = "2025-10-30T15:22:32.063Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -995,6 +1077,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
+name = "markitdown"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "defusedxml" },
+    { name = "magika" },
+    { name = "markdownify" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/93/3b93c291c99d09f64f7535ba74c1c6a3507cf49cffd38983a55de6f834b6/markitdown-0.1.5.tar.gz", hash = "sha256:4c956ff1528bf15e1814542035ec96e989206d19d311bb799f4df973ecafc31a", size = 45099, upload-time = "2026-02-20T19:45:23.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/8b/fd7e042455a829a1ede0bc8e9e3061aa6c7c4cf745385526ef62ff1b5a5b/markitdown-0.1.5-py3-none-any.whl", hash = "sha256:5180a9a841e20fc01c2c09dbc5d039638429bbebcdc2af1b2615c3c427840434", size = 63402, upload-time = "2026-02-20T19:45:27.195Z" },
 ]
 
 [[package]]
@@ -1063,6 +1175,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1117,6 +1238,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+]
+
+[[package]]
+name = "olefile"
+version = "0.47"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/1b/077b508e3e500e1629d366249c3ccb32f95e50258b231705c09e3c7a4366/olefile-0.47.zip", hash = "sha256:599383381a0bf3dfbd932ca0ca6515acd174ed48870cbf7fee123d698c192c1c", size = 112240, upload-time = "2023-12-01T16:22:53.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/d3/b64c356a907242d719fc668b71befd73324e47ab46c8ebbbede252c154b2/olefile-0.47-py2.py3-none-any.whl", hash = "sha256:543c7da2a7adadf21214938bb79c83ea12b473a4b6ee4ad4bf854e7715e13d1f", size = 114565, upload-time = "2023-12-01T16:22:51.518Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/39/9335e0874f68f7d27103cbffc0e235e32e26759202df6085716375c078bb/onnxruntime-1.20.1-cp312-cp312-macosx_13_0_universal2.whl", hash = "sha256:22b0655e2bf4f2161d52706e31f517a0e54939dc393e92577df51808a7edc8c9", size = 31007580, upload-time = "2024-11-21T00:49:07.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/9d/a42a84e10f1744dd27c6f2f9280cc3fb98f869dd19b7cd042e391ee2ab61/onnxruntime-1.20.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f56e898815963d6dc4ee1c35fc6c36506466eff6d16f3cb9848cea4e8c8172", size = 11952833, upload-time = "2024-11-21T00:49:10.563Z" },
+    { url = "https://files.pythonhosted.org/packages/47/42/2f71f5680834688a9c81becbe5c5bb996fd33eaed5c66ae0606c3b1d6a02/onnxruntime-1.20.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb71a814f66517a65628c9e4a2bb530a6edd2cd5d87ffa0af0f6f773a027d99e", size = 13333903, upload-time = "2024-11-21T00:49:12.984Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/aabfdf91d013320aa2fc46cf43c88ca0182860ff15df872b4552254a9680/onnxruntime-1.20.1-cp312-cp312-win32.whl", hash = "sha256:bd386cc9ee5f686ee8a75ba74037750aca55183085bf1941da8efcfe12d5b120", size = 9814562, upload-time = "2024-11-21T00:49:15.453Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/80/76979e0b744307d488c79e41051117634b956612cc731f1028eb17ee7294/onnxruntime-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:19c2d843eb074f385e8bbb753a40df780511061a63f9def1b216bf53860223fb", size = 11331482, upload-time = "2024-11-21T00:49:19.412Z" },
 ]
 
 [[package]]
@@ -1252,7 +1421,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1482,12 +1651,36 @@ crypto = [
 ]
 
 [[package]]
+name = "pymupdf"
+version = "1.27.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/32/f6b645c51d79a188a4844140c5dabca7b487ad56c4be69c4bc782d0d11a9/pymupdf-1.27.2.2.tar.gz", hash = "sha256:ea8fdc3ab6671ca98f629d5ec3032d662c8cf1796b146996b7ad306ac7ed3335", size = 85354380, upload-time = "2026-03-20T09:47:58.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/88/d01992a50165e22dec057a1129826846c547feb4ba07f42720ac030ce438/pymupdf-1.27.2.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:800f43e60a6f01f644343c2213b8613db02eaf4f4ba235b417b3351fa99e01c0", size = 23987563, upload-time = "2026-03-19T12:35:42.989Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0e/9f526bc1d49d8082eff0d1547a69d541a0c5a052e71da625559efaba46a6/pymupdf-1.27.2.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e2e4299ef1ac0c9dff9be096cbd22783699673abecfa7c3f73173ae06421d73", size = 23263089, upload-time = "2026-03-20T09:44:16.982Z" },
+    { url = "https://files.pythonhosted.org/packages/42/be/984f0d6343935b5dd30afaed6be04fc753146bf55709e63ef28bf9ef7497/pymupdf-1.27.2.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5e3d54922db1c7da844f1208ac1db05704770988752311f81dd36694ae0a07b", size = 24318817, upload-time = "2026-03-20T09:44:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8e/85e9d9f11dbf34036eb1df283805ef6b885f2005a56d6533bb58ab0b8a11/pymupdf-1.27.2.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:892698c9768457eb0991c102c96a856c0a7062539371df5e6bee0816f3ef498e", size = 24948135, upload-time = "2026-03-20T09:44:51.012Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e6/386edb017e5b93f1ab0bf6653ae32f3dd8dfc834ed770212e10ca62f4af9/pymupdf-1.27.2.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b4bbfa6ef347fade678771a93f6364971c51a2cdc44cd2400dc4eeed1ddb4e6", size = 25169585, upload-time = "2026-03-20T09:45:05.393Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/fd/f1ebe24fcd31aaea8b85b3a7ac4c3fc96e20388be5466ace27c9a3c546d9/pymupdf-1.27.2.2-cp310-abi3-win32.whl", hash = "sha256:0b8e924433b7e0bd46be820899300259235997d5a747638471fb2762baa8ee30", size = 18008861, upload-time = "2026-03-20T09:45:21.353Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b6/2a9a8556000199bbf80a5915dcd15d550d1e5288894316445c54726aaf53/pymupdf-1.27.2.2-cp310-abi3-win_amd64.whl", hash = "sha256:09bb53f9486ccb5297030cbc2dbdae845ba1c3c5126e96eb2d16c4f118de0b5b", size = 19238032, upload-time = "2026-03-20T09:45:37.941Z" },
+]
+
+[[package]]
 name = "pypdf"
 version = "6.9.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/83/691bdb309306232362503083cb15777491045dd54f45393a317dc7d8082f/pypdf-6.9.2.tar.gz", hash = "sha256:7f850faf2b0d4ab936582c05da32c52214c2b089d61a316627b5bfb5b0dab46c", size = 5311837, upload-time = "2026-03-23T14:53:27.983Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/7e/c85f41243086a8fe5d1baeba527cb26a1918158a565932b41e0f7c0b32e9/pypdf-6.9.2-py3-none-any.whl", hash = "sha256:662cf29bcb419a36a1365232449624ab40b7c2d0cfc28e54f42eeecd1fd7e844", size = 333744, upload-time = "2026-03-23T14:53:26.573Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
 ]
 
 [[package]]
@@ -1763,6 +1956,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
@@ -1829,6 +2031,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/86/7154b7c625a3ff704581dab70c05389e1de90233b7a751f79f712c2ca0e9/striprtf-0.0.29.tar.gz", hash = "sha256:5a822d075e17417934ed3add6fc79b5fc8fb544fe4370b2f894cdd28f0ddd78e", size = 7533, upload-time = "2025-03-27T22:55:56.874Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/3e/1418afacc4aae04690cff282078f22620c89a99490499878ececc3021654/striprtf-0.0.29-py3-none-any.whl", hash = "sha256:0fc6a41999d015358d19627776b616424dd501ad698105c81d76734d1e14d91b", size = 7879, upload-time = "2025-03-27T22:55:55.977Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a built-in doc_parser tool for converting PDF, DOCX, and DOC files to Markdown with workspace-aware output paths. Include parser fallbacks and focused tests to protect markdown preservation and DOC fallback behavior.

Made-with: Cursor