### PR TITLE
fix(security): enable SSL verification by default for SkyEye/TDP

### DIFF
--- a/.flocks/plugins/skills/skyeye-sensor-data-fetch/scripts/config.py
+++ b/.flocks/plugins/skills/skyeye-sensor-data-fetch/scripts/config.py
@@ -26,4 +26,4 @@ DEFAULT_HEADERS = {
 }
 
 TIMEOUT = 30
-SSL_VERIFY = os.getenv("SKYEYE_SENSOR_SSL_VERIFY", "false").lower() in ("1", "true", "yes")
+SSL_VERIFY = os.getenv("SKYEYE_SENSOR_SSL_VERIFY", "true").lower() in ("1", "true", "yes")

--- a/.flocks/plugins/skills/skyeye-use/scripts/config.py
+++ b/.flocks/plugins/skills/skyeye-use/scripts/config.py
@@ -19,4 +19,4 @@ DEFAULT_HEADERS = {
 }
 
 TIMEOUT = 30
-SSL_VERIFY = os.getenv("SKYEYE_SSL_VERIFY", "false").lower() in ("1", "true", "yes")
+SSL_VERIFY = os.getenv("SKYEYE_SSL_VERIFY", "true").lower() in ("1", "true", "yes")

--- a/.flocks/plugins/tools/api/skyeye_api/skyeye.handler.py
+++ b/.flocks/plugins/tools/api/skyeye_api/skyeye.handler.py
@@ -112,7 +112,7 @@ def _resolve_username(raw_service: dict[str, Any]) -> str:
 def _verify_ssl(raw_service: dict[str, Any]) -> bool:
     raw_value = raw_service.get("verify_ssl")
     if raw_value is None:
-        raw_value = _get_custom_setting(raw_service, "verify_ssl", False)
+        raw_value = _get_custom_setting(raw_service, "verify_ssl", True)
     if isinstance(raw_value, bool):
         return raw_value
     if isinstance(raw_value, str):

--- a/.flocks/plugins/tools/api/tdp_api/tdp.handler.py
+++ b/.flocks/plugins/tools/api/tdp_api/tdp.handler.py
@@ -68,7 +68,7 @@ def _resolve_verify_ssl(raw: dict[str, Any]) -> bool:
     if value is None:
         custom_settings = raw.get("custom_settings", {})
         if isinstance(custom_settings, dict):
-            value = custom_settings.get("verify_ssl", False)
+            value = custom_settings.get("verify_ssl", True)
     if isinstance(value, bool):
         return value
     if isinstance(value, str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.4.3"
+version = "v2026.4.7"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/tests/tool/test_tdp_skyeye_api_plugins.py
+++ b/tests/tool/test_tdp_skyeye_api_plugins.py
@@ -314,3 +314,17 @@ def test_skyeye_alarm_list_yaml_loads_with_provider():
 
     assert tool.info.name == "skyeye_alarm_list"
     assert tool.info.provider == "skyeye_api"
+
+
+def test_skyeye_verify_ssl_defaults_true_when_unset():
+    module = _load_module("test_skyeye_handler_verify_ssl", _SKYEYE_HANDLER)
+    assert module._verify_ssl({}) is True
+    assert module._verify_ssl({"custom_settings": {}}) is True
+    assert module._verify_ssl({"verify_ssl": False}) is False
+
+
+def test_tdp_resolve_verify_ssl_defaults_true_when_unset():
+    module = _load_module("test_tdp_handler_verify_ssl", _TDP_HANDLER)
+    assert module._resolve_verify_ssl({}) is True
+    assert module._resolve_verify_ssl({"custom_settings": {}}) is True
+    assert module._resolve_verify_ssl({"verify_ssl": False}) is False


### PR DESCRIPTION
- Default SKYEYE_SSL_VERIFY and SKYEYE_SENSOR_SSL_VERIFY to true in skill configs
- Default verify_ssl to true in skyeye_api and tdp_api handlers when unset
- Add unit tests for default SSL verify resolution
