### PR TITLE
fix: record streaming usage for stats and WebUI

### DIFF
--- a/flocks/provider/provider.py
+++ b/flocks/provider/provider.py
@@ -134,9 +134,6 @@ class StreamChunk(BaseModel):
     tool_input: Optional[Dict[str, Any]] = None  # Incremental tool input
     metadata: Optional[Dict[str, Any]] = None  # Provider-specific metadata
     usage: Optional[Dict[str, int]] = None  # Token usage from provider (prompt_tokens, completion_tokens, total_tokens)
-    
-    # Token usage (if available)
-    usage: Optional[Dict[str, int]] = None
 
 
 class Provider:

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -28,16 +28,10 @@ def _normalize_stream_usage(raw_usage: Any) -> Optional[Dict[str, int]]:
     if not raw_usage:
         return None
 
-    prompt_tokens = (
-        getattr(raw_usage, "prompt_tokens", None)
-        if getattr(raw_usage, "prompt_tokens", None) is not None
-        else getattr(raw_usage, "input_tokens", 0)
-    ) or 0
-    completion_tokens = (
-        getattr(raw_usage, "completion_tokens", None)
-        if getattr(raw_usage, "completion_tokens", None) is not None
-        else getattr(raw_usage, "output_tokens", 0)
-    ) or 0
+    _pt = getattr(raw_usage, "prompt_tokens", None)
+    prompt_tokens = (_pt if _pt is not None else getattr(raw_usage, "input_tokens", 0)) or 0
+    _ct = getattr(raw_usage, "completion_tokens", None)
+    completion_tokens = (_ct if _ct is not None else getattr(raw_usage, "output_tokens", 0)) or 0
     reasoning_tokens = getattr(raw_usage, "reasoning_tokens", 0) or 0
     total_tokens = getattr(raw_usage, "total_tokens", 0) or (
         prompt_tokens + completion_tokens + reasoning_tokens

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -23,6 +23,70 @@ from flocks.utils.log import Log
 log = Log.create(service="provider.openai_base")
 
 
+def _normalize_stream_usage(raw_usage: Any) -> Optional[Dict[str, int]]:
+    """Normalize provider usage objects to a shared stream usage schema."""
+    if not raw_usage:
+        return None
+
+    prompt_tokens = (
+        getattr(raw_usage, "prompt_tokens", None)
+        if getattr(raw_usage, "prompt_tokens", None) is not None
+        else getattr(raw_usage, "input_tokens", 0)
+    ) or 0
+    completion_tokens = (
+        getattr(raw_usage, "completion_tokens", None)
+        if getattr(raw_usage, "completion_tokens", None) is not None
+        else getattr(raw_usage, "output_tokens", 0)
+    ) or 0
+    reasoning_tokens = getattr(raw_usage, "reasoning_tokens", 0) or 0
+    total_tokens = getattr(raw_usage, "total_tokens", 0) or (
+        prompt_tokens + completion_tokens + reasoning_tokens
+    )
+    cache_read_tokens = getattr(raw_usage, "cache_read_input_tokens", 0) or 0
+    cache_write_tokens = getattr(raw_usage, "cache_creation_input_tokens", 0) or 0
+
+    if not any(
+        [
+            prompt_tokens,
+            completion_tokens,
+            reasoning_tokens,
+            total_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+        ]
+    ):
+        return None
+
+    usage = {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+    }
+    if reasoning_tokens:
+        usage["reasoning_tokens"] = reasoning_tokens
+    if cache_read_tokens:
+        usage["cache_read_input_tokens"] = cache_read_tokens
+    if cache_write_tokens:
+        usage["cache_creation_input_tokens"] = cache_write_tokens
+    return usage
+
+
+def _supports_include_usage_fallback(exc: Exception) -> bool:
+    """Return True when the provider rejects OpenAI stream usage options."""
+    message = str(exc).lower()
+    return any(
+        marker in message
+        for marker in (
+            "stream_options",
+            "include_usage",
+            "unknown parameter",
+            "unsupported parameter",
+            "extra inputs are not permitted",
+            "extra fields not permitted",
+        )
+    )
+
+
 class ThinkTagExtractor:
     """Extract reasoning content from streaming LLM output.
 
@@ -434,6 +498,7 @@ class OpenAIBaseProvider(BaseProvider):
             "model": model_id,
             "messages": openai_messages,
             "stream": True,
+            "stream_options": {"include_usage": True},
         }
 
         extra_body = dict(kwargs.get("extra_body") or {})
@@ -458,17 +523,33 @@ class OpenAIBaseProvider(BaseProvider):
             "has_tools": bool(kwargs.get("tools")),
             "max_tokens": kwargs.get("max_tokens"),
             "has_temperature": "temperature" in params,
+            "include_usage": True,
         })
 
-        stream = await client.chat.completions.create(**params)
+        try:
+            stream = await client.chat.completions.create(**params)
+        except Exception as exc:
+            if not _supports_include_usage_fallback(exc):
+                raise
+            log.warn("openai_base.stream.include_usage_unsupported", {
+                "model": model_id,
+                "error": str(exc),
+            })
+            params_without_usage = dict(params)
+            params_without_usage.pop("stream_options", None)
+            stream = await client.chat.completions.create(**params_without_usage)
         tool_calls: Dict[int, Dict[str, Any]] = {}
         emitted_substantive_chunk = False
+        stream_usage: Optional[Dict[str, int]] = None
 
         # Stateful extractor to separate <think>...</think> from content.
         think_extractor = ThinkTagExtractor()
         _first_delta_logged = False
 
         async for chunk in stream:
+            normalized_usage = _normalize_stream_usage(getattr(chunk, "usage", None))
+            if normalized_usage:
+                stream_usage = normalized_usage
             if not chunk.choices:
                 continue
             choice = chunk.choices[0]
@@ -567,9 +648,14 @@ class OpenAIBaseProvider(BaseProvider):
                         delta="",
                         finish_reason=choice.finish_reason,
                         tool_calls=sorted_calls,
+                        usage=stream_usage,
                     )
                 else:
-                    yield StreamChunk(delta="", finish_reason=choice.finish_reason)
+                    yield StreamChunk(
+                        delta="",
+                        finish_reason=choice.finish_reason,
+                        usage=stream_usage,
+                    )
 
         if not emitted_substantive_chunk:
             log.warn("openai_base.stream.empty_response", {
@@ -581,7 +667,11 @@ class OpenAIBaseProvider(BaseProvider):
                 fallback = await self.chat(model_id, messages, **kwargs)
                 fallback_content = fallback.content or ""
                 if fallback_content:
-                    yield StreamChunk(delta=fallback_content, finish_reason=fallback.finish_reason or "stop")
+                    yield StreamChunk(
+                        delta=fallback_content,
+                        finish_reason=fallback.finish_reason or "stop",
+                        usage=fallback.usage or None,
+                    )
                     return
             except Exception as exc:
                 fallback_error = exc
@@ -597,7 +687,11 @@ class OpenAIBaseProvider(BaseProvider):
                     fallback = await self.chat(model_id, messages, **no_tool_kwargs)
                     fallback_content = fallback.content or ""
                     if fallback_content:
-                        yield StreamChunk(delta=fallback_content, finish_reason=fallback.finish_reason or "stop")
+                        yield StreamChunk(
+                            delta=fallback_content,
+                            finish_reason=fallback.finish_reason or "stop",
+                            usage=fallback.usage or None,
+                        )
                         return
                 except Exception as exc:
                     if fallback_error is None:

--- a/flocks/provider/sdk/openai_compatible.py
+++ b/flocks/provider/sdk/openai_compatible.py
@@ -287,7 +287,7 @@ class OpenAICompatibleProvider(BaseProvider):
             if chunk.choices:
                 choice = chunk.choices[0]
                 delta = choice.delta
-                emitted_terminal_chunk = False
+                yielded_finish_for_this_chunk = False
 
                 if delta is not None:
                     if not _first_delta_logged:
@@ -336,11 +336,8 @@ class OpenAICompatibleProvider(BaseProvider):
                                     emitted_substantive_chunk = True
                                 yield StreamChunk(
                                     delta=seg_text,
-                                    finish_reason=choice.finish_reason,
-                                    usage=stream_usage if choice.finish_reason else None,
+                                    finish_reason=None,
                                 )
-                                if choice.finish_reason:
-                                    emitted_terminal_chunk = True
 
                 # Flush think extractor on finish (before tool-call chunks; matches prior behavior)
                 if choice.finish_reason:
@@ -392,9 +389,9 @@ class OpenAICompatibleProvider(BaseProvider):
                                 tool_calls=tool_calls,
                                 usage=stream_usage,
                             )
-                            emitted_terminal_chunk = True
+                            yielded_finish_for_this_chunk = True
 
-                if choice.finish_reason and not emitted_terminal_chunk:
+                if choice.finish_reason and not yielded_finish_for_this_chunk:
                     yield StreamChunk(
                         delta="",
                         finish_reason=choice.finish_reason,

--- a/flocks/provider/sdk/openai_compatible.py
+++ b/flocks/provider/sdk/openai_compatible.py
@@ -10,7 +10,7 @@ Supports any API that implements OpenAI's chat completions API, including:
 """
 
 import asyncio
-from typing import List, AsyncIterator, Optional, Any
+from typing import Dict, List, AsyncIterator, Optional, Any
 import os
 
 from flocks.provider.provider import (
@@ -21,7 +21,12 @@ from flocks.provider.provider import (
     ChatResponse,
     StreamChunk,
 )
-from flocks.provider.sdk.openai_base import extract_reasoning_content, ThinkTagExtractor
+from flocks.provider.sdk.openai_base import (
+    ThinkTagExtractor,
+    _normalize_stream_usage,
+    _supports_include_usage_fallback,
+    extract_reasoning_content,
+)
 from flocks.utils.log import Log
 
 log = Log.create(service="provider.openai_compatible")
@@ -229,6 +234,7 @@ class OpenAICompatibleProvider(BaseProvider):
             "model": model_id,
             "messages": formatted_messages,
             "stream": True,
+            "stream_options": {"include_usage": True},
         }
 
         if thinking:
@@ -252,19 +258,36 @@ class OpenAICompatibleProvider(BaseProvider):
             "thinking_enabled": bool(thinking),
             "has_tools": bool(tools),
             "max_tokens": max_tokens,
+            "include_usage": True,
         })
 
-        stream = await client.chat.completions.create(**request_params)
+        try:
+            stream = await client.chat.completions.create(**request_params)
+        except Exception as exc:
+            if not _supports_include_usage_fallback(exc):
+                raise
+            self.log.warn("openai_compatible.stream.include_usage_unsupported", {
+                "model": model_id,
+                "error": str(exc),
+            })
+            request_params = dict(request_params)
+            request_params.pop("stream_options", None)
+            stream = await client.chat.completions.create(**request_params)
 
         # Stateful extractor to separate <think>...</think> from content.
         think_extractor = ThinkTagExtractor()
         _first_delta_logged = False
         emitted_substantive_chunk = False
+        stream_usage: Optional[Dict[str, int]] = None
 
         async for chunk in stream:
+            normalized_usage = _normalize_stream_usage(getattr(chunk, "usage", None))
+            if normalized_usage:
+                stream_usage = normalized_usage
             if chunk.choices:
                 choice = chunk.choices[0]
                 delta = choice.delta
+                emitted_terminal_chunk = False
 
                 if delta is not None:
                     if not _first_delta_logged:
@@ -314,7 +337,10 @@ class OpenAICompatibleProvider(BaseProvider):
                                 yield StreamChunk(
                                     delta=seg_text,
                                     finish_reason=choice.finish_reason,
+                                    usage=stream_usage if choice.finish_reason else None,
                                 )
+                                if choice.finish_reason:
+                                    emitted_terminal_chunk = True
 
                 # Flush think extractor on finish (before tool-call chunks; matches prior behavior)
                 if choice.finish_reason:
@@ -364,7 +390,16 @@ class OpenAICompatibleProvider(BaseProvider):
                                 delta="",  # Empty string, not None
                                 finish_reason=choice.finish_reason,
                                 tool_calls=tool_calls,
+                                usage=stream_usage,
                             )
+                            emitted_terminal_chunk = True
+
+                if choice.finish_reason and not emitted_terminal_chunk:
+                    yield StreamChunk(
+                        delta="",
+                        finish_reason=choice.finish_reason,
+                        usage=stream_usage,
+                    )
 
         if not emitted_substantive_chunk:
             self.log.warn("openai_compatible.stream.empty_response", {
@@ -416,6 +451,7 @@ class OpenAICompatibleProvider(BaseProvider):
                     yield StreamChunk(
                         delta=fallback_content,
                         finish_reason=fallback.finish_reason or "stop",
+                        usage=fallback.usage or None,
                     )
                     return
                 if minimax_empty_response_target:
@@ -479,6 +515,7 @@ class OpenAICompatibleProvider(BaseProvider):
                     yield StreamChunk(
                         delta=fallback_content,
                         finish_reason=fallback.finish_reason or "stop",
+                        usage=fallback.usage or None,
                     )
                     return
                 if minimax_empty_response_target:

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -105,6 +105,7 @@ class StepResult:
     content: str = ""
     tool_calls: List[ToolCall] = field(default_factory=list)
     error: Optional[str] = None
+    usage: Optional[Dict[str, int]] = None
 
 
 @dataclass
@@ -929,6 +930,7 @@ Please address this message and continue with your tasks.
                 # Success! Update finish reason
                 finish = "tool-calls" if result.tool_calls else "stop"
                 await Message.update(self.session.id, assistant_msg.id, finish=finish)
+                await self._record_usage_if_available(result.usage)
                 
                 # Note: Compaction check is now done in the main loop (run()) before processing step
                 # This matches Flocks's logic: check lastFinished.tokens at loop start
@@ -1005,6 +1007,93 @@ Please address this message and continue with your tasks.
         
         # Aborted
         return StepResult(action="stop", error="Aborted")
+
+    @staticmethod
+    def _build_tokens_update(stream_usage: Optional[Dict[str, int]]) -> Optional[Dict[str, Any]]:
+        """Normalize runner token updates from provider usage."""
+        if not stream_usage:
+            return None
+        return {
+            "input": stream_usage.get("prompt_tokens", 0),
+            "output": stream_usage.get("completion_tokens", 0),
+            "reasoning": stream_usage.get("reasoning_tokens", 0),
+            "cache": {
+                "read": stream_usage.get("cache_read_input_tokens", 0),
+                "write": stream_usage.get("cache_creation_input_tokens", 0),
+            },
+        }
+
+    def _resolve_usage_pricing(self) -> Optional[Any]:
+        """Resolve pricing config for the current provider/model pair."""
+        from flocks.provider.types import PriceConfig
+
+        model_info = None
+        provider = Provider.get(self.provider_id)
+        if provider:
+            for candidate in getattr(provider, "_config_models", []):
+                if candidate.id == self.model_id:
+                    model_info = candidate
+                    break
+
+        if model_info is None:
+            model_info = Provider.get_model(self.model_id)
+
+        pricing = getattr(model_info, "pricing", None) if model_info else None
+        if pricing is None:
+            return None
+
+        if isinstance(pricing, PriceConfig):
+            return pricing
+
+        if hasattr(pricing, "input") and hasattr(pricing, "output"):
+            return PriceConfig(
+                input=getattr(pricing, "input", 0.0),
+                output=getattr(pricing, "output", 0.0),
+                unit=getattr(pricing, "unit", 1_000_000),
+                currency=getattr(pricing, "currency", "USD"),
+                cache_read=getattr(pricing, "cache_read", None),
+                cache_write=getattr(pricing, "cache_write", None),
+            )
+
+        if isinstance(pricing, dict):
+            return PriceConfig(
+                input=pricing.get("input", 0.0),
+                output=pricing.get("output", 0.0),
+                unit=pricing.get("unit", 1_000_000),
+                currency=pricing.get("currency", "USD"),
+                cache_read=pricing.get("cache_read"),
+                cache_write=pricing.get("cache_write"),
+            )
+
+        return None
+
+    async def _record_usage_if_available(self, usage: Optional[Dict[str, int]]) -> None:
+        """Persist usage records without blocking successful session steps."""
+        if not usage:
+            return
+
+        from flocks.server.routes.usage import RecordUsageRequest, record_usage
+
+        try:
+            await record_usage(
+                RecordUsageRequest(
+                    provider_id=self.provider_id,
+                    model_id=self.model_id,
+                    session_id=self.session.id,
+                    input_tokens=usage.get("prompt_tokens", 0),
+                    output_tokens=usage.get("completion_tokens", 0),
+                    cached_tokens=usage.get("cache_read_input_tokens", 0),
+                    reasoning_tokens=usage.get("reasoning_tokens", 0),
+                    pricing=self._resolve_usage_pricing(),
+                )
+            )
+        except Exception as exc:
+            log.warn("runner.usage_record_failed", {
+                "session_id": self.session.id,
+                "provider_id": self.provider_id,
+                "model_id": self.model_id,
+                "error": str(exc),
+            })
     
     async def _build_system_prompts(self, agent: AgentInfo) -> List[str]:
         """Build system prompts."""
@@ -1930,16 +2019,8 @@ Please address this message and continue with your tasks.
         reasoning = processor.get_reasoning_content()
         
         # Update message tokens if provider reported usage
-        if stream_usage:
-            tokens_update = {
-                "input": stream_usage.get("prompt_tokens", 0),
-                "output": stream_usage.get("completion_tokens", 0),
-                "reasoning": 0,
-                "cache": {
-                    "read": stream_usage.get("cache_read_input_tokens", 0),
-                    "write": stream_usage.get("cache_creation_input_tokens", 0),
-                },
-            }
+        tokens_update = self._build_tokens_update(stream_usage)
+        if tokens_update:
             try:
                 await Message.update(
                     self.session.id,
@@ -2007,6 +2088,7 @@ Please address this message and continue with your tasks.
                 action="continue",
                 content=content,
                 tool_calls=tool_calls_for_result,
+                usage=stream_usage,
             )
         
         self._end_observability(
@@ -2028,7 +2110,7 @@ Please address this message and continue with your tasks.
                 "finish_reason": processor.get_finish_reason(),
             },
         )
-        return StepResult(action="stop", content=content)
+        return StepResult(action="stop", content=content, usage=stream_usage)
     
     @staticmethod
     def _end_observability(

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -877,6 +877,10 @@ Please address this message and continue with your tasks.
                         and not result.content and not result.tool_calls):
                     empty_attempt += 1
                     if empty_attempt <= MAX_EMPTY_RETRIES:
+                        # Record usage for this empty attempt even though we are
+                        # about to retry – the provider may have already charged
+                        # for the tokens returned in this response.
+                        await self._record_usage_if_available(result.usage)
                         delay_ms = SessionRetry.delay(empty_attempt)
                         next_retry_time = int(asyncio.get_event_loop().time() * 1000) + delay_ms
                         log.warn("runner.step.empty_response_retry", {
@@ -1043,9 +1047,14 @@ Please address this message and continue with your tasks.
             return None
 
         if isinstance(pricing, PriceConfig):
+            # Already the correct type – returned as-is.
             return pricing
 
         if hasattr(pricing, "input") and hasattr(pricing, "output"):
+            # Defensive branch: handles any duck-typed object with input/output
+            # attributes (e.g. legacy dataclass or proxy object). In practice
+            # ModelInfo.pricing is typed as Optional[Dict[str, Any]], so this
+            # branch is unlikely to be hit at runtime.
             return PriceConfig(
                 input=getattr(pricing, "input", 0.0),
                 output=getattr(pricing, "output", 0.0),
@@ -1056,6 +1065,7 @@ Please address this message and continue with your tasks.
             )
 
         if isinstance(pricing, dict):
+            # Standard runtime path: ModelInfo.pricing is a plain dict from JSON.
             return PriceConfig(
                 input=pricing.get("input", 0.0),
                 output=pricing.get("output", 0.0),
@@ -1068,13 +1078,24 @@ Please address this message and continue with your tasks.
         return None
 
     async def _record_usage_if_available(self, usage: Optional[Dict[str, int]]) -> None:
-        """Persist usage records without blocking successful session steps."""
+        """Persist usage records without blocking successful session steps.
+
+        All exceptions – including ImportError when server routes are absent
+        in CLI-only environments – are caught here so that a usage-recording
+        failure can never corrupt an already-successful step result.
+
+        Note: This imports from flocks.server.routes.usage, creating a
+        core→server-routes dependency.
+        TODO: Move record_usage logic to a provider-layer service
+        (e.g. flocks.provider.usage_service) to remove the architectural
+        inversion.
+        """
         if not usage:
             return
 
-        from flocks.server.routes.usage import RecordUsageRequest, record_usage
-
         try:
+            from flocks.server.routes.usage import RecordUsageRequest, record_usage
+
             await record_usage(
                 RecordUsageRequest(
                     provider_id=self.provider_id,

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -9,6 +9,7 @@ Tests various scenarios:
 """
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
 from flocks.provider.sdk.openai_base import OpenAIBaseProvider, extract_reasoning_content
 from flocks.provider.provider import ModelInfo, ModelCapabilities, ProviderConfig
@@ -42,141 +43,130 @@ class TestOpenAIBaseProviderGetModels:
     """Test suite for get_models() method."""
     
     def test_get_models_with_catalog_success(self):
-        """Test get_models() with valid catalog data."""
+        """Test get_models() returns configured models."""
         provider = MockProviderWithCatalog()
-        
-        # Mock catalog model definition
-        mock_model_def = Mock()
-        mock_model_def.id = "test-model-1"
-        mock_model_def.name = "Test Model 1"
-        mock_model_def.capabilities = Mock(
-            supports_tools=True,
-            supports_vision=False,
-            supports_streaming=True,
-            supports_reasoning=False
-        )
-        mock_model_def.limits = Mock(
-            context_window=128000,
-            max_tokens=4096
-        )
-        
-        # Mock the catalog function
-        with patch('flocks.provider.model_catalog.get_provider_model_definitions') as mock_get_defs:
-            mock_get_defs.return_value = [mock_model_def]
-            
-            models = provider.get_models()
-            
-            # Verify the call
-            mock_get_defs.assert_called_once_with("test-provider")
-            
-            # Verify returned models
-            assert len(models) == 1
-            assert isinstance(models[0], ModelInfo)
-            assert models[0].id == "test-model-1"
-            assert models[0].name == "Test Model 1"
-            assert models[0].provider_id == "test-provider"
-            assert models[0].capabilities.supports_tools is True
-            assert models[0].capabilities.supports_vision is False
-            assert models[0].capabilities.supports_streaming is True
-            assert models[0].capabilities.context_window == 128000
-            assert models[0].capabilities.max_tokens == 4096
-    
+
+        provider._config_models = [
+            ModelInfo(
+                id="test-model-1",
+                name="Test Model 1",
+                provider_id="test-provider",
+                capabilities=ModelCapabilities(
+                    supports_tools=True,
+                    supports_vision=False,
+                    supports_streaming=True,
+                    supports_reasoning=False,
+                    context_window=128000,
+                    max_tokens=4096,
+                ),
+            )
+        ]
+
+        models = provider.get_models()
+
+        assert len(models) == 1
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "test-model-1"
+        assert models[0].name == "Test Model 1"
+        assert models[0].provider_id == "test-provider"
+        assert models[0].capabilities.supports_tools is True
+        assert models[0].capabilities.supports_vision is False
+        assert models[0].capabilities.supports_streaming is True
+        assert models[0].capabilities.context_window == 128000
+        assert models[0].capabilities.max_tokens == 4096
+
     def test_get_models_with_multiple_models(self):
-        """Test get_models() returns multiple models from catalog."""
+        """Test get_models() returns multiple configured models."""
         provider = MockProviderWithCatalog()
-        
-        # Create multiple mock models
-        mock_models = []
-        for i in range(3):
-            mock_model = Mock()
-            mock_model.id = f"test-model-{i}"
-            mock_model.name = f"Test Model {i}"
-            mock_model.capabilities = Mock(
-                supports_tools=True,
-                supports_vision=i == 2,  # Only last model has vision
-                supports_streaming=True,
-                supports_reasoning=False
+
+        provider._config_models = [
+            ModelInfo(
+                id=f"test-model-{i}",
+                name=f"Test Model {i}",
+                provider_id="test-provider",
+                capabilities=ModelCapabilities(
+                    supports_tools=True,
+                    supports_vision=i == 2,
+                    supports_streaming=True,
+                    supports_reasoning=False,
+                    context_window=100000,
+                    max_tokens=4096,
+                ),
             )
-            mock_model.limits = Mock(
-                context_window=100000,
-                max_tokens=4096
-            )
-            mock_models.append(mock_model)
-        
-        with patch('flocks.provider.model_catalog.get_provider_model_definitions') as mock_get_defs:
-            mock_get_defs.return_value = mock_models
-            
-            models = provider.get_models()
-            
-            assert len(models) == 3
-            assert models[0].id == "test-model-0"
-            assert models[1].id == "test-model-1"
-            assert models[2].id == "test-model-2"
-            assert models[2].capabilities.supports_vision is True
-            assert models[0].capabilities.supports_vision is False
-    
+            for i in range(3)
+        ]
+
+        models = provider.get_models()
+
+        assert len(models) == 3
+        assert models[0].id == "test-model-0"
+        assert models[1].id == "test-model-1"
+        assert models[2].id == "test-model-2"
+        assert models[2].capabilities.supports_vision is True
+        assert models[0].capabilities.supports_vision is False
+
     def test_get_models_without_catalog(self):
         """Test get_models() for provider without CATALOG_ID."""
         provider = MockProviderWithoutCatalog()
-        
+
         models = provider.get_models()
-        
-        # Should return empty list when no catalog ID
+
+        # Should return empty list when no configured models
         assert models == []
         assert isinstance(models, list)
-    
+
     def test_get_models_catalog_import_error(self):
-        """Test get_models() handles import errors gracefully."""
+        """Test get_models() is independent of catalog imports."""
         provider = MockProviderWithCatalog()
-        
+
         with patch('flocks.provider.model_catalog.get_provider_model_definitions') as mock_get_defs:
             mock_get_defs.side_effect = ImportError("Cannot import module")
-            
+
             models = provider.get_models()
-            
-            # Should return empty list and not raise
+
             assert models == []
-    
+            mock_get_defs.assert_not_called()
+
     def test_get_models_catalog_returns_none(self):
-        """Test get_models() when catalog returns None."""
+        """Test get_models() ignores catalog results when not configured."""
         provider = MockProviderWithCatalog()
-        
+
         with patch('flocks.provider.model_catalog.get_provider_model_definitions') as mock_get_defs:
             mock_get_defs.return_value = None
-            
+
             models = provider.get_models()
-            
-            # Should return empty list
+
             assert models == []
-    
+            mock_get_defs.assert_not_called()
+
     def test_get_models_catalog_returns_empty_list(self):
-        """Test get_models() when catalog returns empty list."""
+        """Test get_models() ignores empty catalog results."""
         provider = MockProviderWithCatalog()
-        
+
         with patch('flocks.provider.model_catalog.get_provider_model_definitions') as mock_get_defs:
             mock_get_defs.return_value = []
-            
+
             models = provider.get_models()
-            
-            # Should return empty list
+
             assert models == []
-    
+            mock_get_defs.assert_not_called()
+
     def test_get_models_catalog_generic_exception(self):
-        """Test get_models() handles generic exceptions gracefully."""
+        """Test get_models() does not depend on catalog lookups."""
         provider = MockProviderWithCatalog()
-        
+
         with patch('flocks.provider.model_catalog.get_provider_model_definitions') as mock_get_defs:
             mock_get_defs.side_effect = ValueError("Invalid catalog data")
-            
+
             models = provider.get_models()
-            
-            # Should return empty list and not raise
+
             assert models == []
-    
+            mock_get_defs.assert_not_called()
+
     def test_get_models_with_config_models(self):
         """Test get_models() when provider has config models loaded."""
         provider = MockProviderWithoutCatalog()
-        
+
         # Simulate Provider.apply_config() loading models into _config_models
         from flocks.provider.provider import ModelInfo, ModelCapabilities
         provider._config_models = [
@@ -207,9 +197,9 @@ class TestOpenAIBaseProviderGetModels:
                 )
             )
         ]
-        
+
         models = provider.get_models()
-        
+
         # Should return config models
         assert len(models) == 2
         assert models[0].id == "custom-model-1"
@@ -217,63 +207,57 @@ class TestOpenAIBaseProviderGetModels:
         assert models[1].id == "custom-model-2"
         assert models[1].name == "Custom Model 2"
         assert models[1].capabilities.supports_vision is True
-    
+
     def test_get_models_missing_supports_reasoning(self):
-        """Test get_models() handles missing supports_reasoning attribute."""
+        """Test get_models() preserves configured models without reasoning support."""
         provider = MockProviderWithCatalog()
-        
-        # Mock model without supports_reasoning - spec_set to control attributes
-        mock_capabilities = Mock(spec=['supports_tools', 'supports_vision', 'supports_streaming'])
-        mock_capabilities.supports_tools = True
-        mock_capabilities.supports_vision = False
-        mock_capabilities.supports_streaming = True
-        # supports_reasoning will raise AttributeError
-        
-        mock_model = Mock()
-        mock_model.id = "old-model"
-        mock_model.name = "Old Model"
-        mock_model.capabilities = mock_capabilities
-        mock_model.limits = Mock(
-            context_window=4096,
-            max_tokens=2048
-        )
-        
-        with patch('flocks.provider.model_catalog.get_provider_model_definitions') as mock_get_defs:
-            mock_get_defs.return_value = [mock_model]
-            
-            models = provider.get_models()
-            
-            # Should default to False for supports_reasoning
-            assert len(models) == 1
-            assert models[0].capabilities.supports_reasoning is False
-    
+
+        provider._config_models = [
+            ModelInfo(
+                id="old-model",
+                name="Old Model",
+                provider_id="test-provider",
+                capabilities=ModelCapabilities(
+                    supports_tools=True,
+                    supports_vision=False,
+                    supports_streaming=True,
+                    supports_reasoning=False,
+                    context_window=4096,
+                    max_tokens=2048,
+                ),
+            )
+        ]
+
+        models = provider.get_models()
+
+        assert len(models) == 1
+        assert models[0].capabilities.supports_reasoning is False
+
     def test_get_models_with_reasoning_support(self):
-        """Test get_models() with models that support reasoning."""
+        """Test get_models() preserves configured reasoning support."""
         provider = MockProviderWithCatalog()
-        
-        # Mock model with reasoning support
-        mock_model = Mock()
-        mock_model.id = "reasoning-model"
-        mock_model.name = "Reasoning Model"
-        mock_model.capabilities = Mock(
-            supports_tools=True,
-            supports_vision=True,
-            supports_streaming=True,
-            supports_reasoning=True
-        )
-        mock_model.limits = Mock(
-            context_window=200000,
-            max_tokens=8192
-        )
-        
-        with patch('flocks.provider.model_catalog.get_provider_model_definitions') as mock_get_defs:
-            mock_get_defs.return_value = [mock_model]
-            
-            models = provider.get_models()
-            
-            assert len(models) == 1
-            assert models[0].capabilities.supports_reasoning is True
-            assert models[0].capabilities.supports_vision is True
+
+        provider._config_models = [
+            ModelInfo(
+                id="reasoning-model",
+                name="Reasoning Model",
+                provider_id="test-provider",
+                capabilities=ModelCapabilities(
+                    supports_tools=True,
+                    supports_vision=True,
+                    supports_streaming=True,
+                    supports_reasoning=True,
+                    context_window=200000,
+                    max_tokens=8192,
+                ),
+            )
+        ]
+
+        models = provider.get_models()
+
+        assert len(models) == 1
+        assert models[0].capabilities.supports_reasoning is True
+        assert models[0].capabilities.supports_vision is True
 
 
 class TestOpenAIBaseProviderConfiguration:
@@ -409,6 +393,100 @@ class TestExtractReasoningContent:
 
     def test_extract_reasoning_content_none_delta(self):
         assert extract_reasoning_content(None) is None
+
+
+async def _stream_from_chunks(*chunks):
+    for chunk in chunks:
+        yield chunk
+
+
+class TestOpenAIBaseProviderStreamingUsage:
+    @staticmethod
+    def _build_provider_with_stream():
+        provider = MockProviderWithoutCatalog()
+        create = AsyncMock()
+        provider._client = MagicMock()
+        provider._client.chat.completions.create = create
+        return provider, create
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_includes_usage_and_attaches_to_terminal_chunk(self):
+        provider, create = self._build_provider_with_stream()
+
+        content_chunk = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(content="hello", tool_calls=None),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        )
+        usage_chunk = SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+        )
+        finish_chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=None, finish_reason="stop")],
+            usage=None,
+        )
+        create.return_value = _stream_from_chunks(content_chunk, usage_chunk, finish_chunk)
+
+        from flocks.provider.provider import ChatMessage
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "kimi-k2.5",
+                [ChatMessage(role="user", content="hello")],
+            )
+        ]
+
+        kwargs = create.await_args.kwargs
+        assert kwargs["stream_options"] == {"include_usage": True}
+        assert chunks[-1].finish_reason == "stop"
+        assert chunks[-1].usage == {
+            "prompt_tokens": 11,
+            "completion_tokens": 7,
+            "total_tokens": 18,
+        }
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_retries_without_stream_options_when_unsupported(self):
+        provider, create = self._build_provider_with_stream()
+
+        content_chunk = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(content="hello", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+        )
+        create.side_effect = [
+            ValueError("unknown parameter: stream_options.include_usage"),
+            _stream_from_chunks(content_chunk),
+        ]
+
+        from flocks.provider.provider import ChatMessage
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "kimi-k2.5",
+                [ChatMessage(role="user", content="hello")],
+            )
+        ]
+
+        assert create.await_count == 2
+        assert "stream_options" in create.await_args_list[0].kwargs
+        assert "stream_options" not in create.await_args_list[1].kwargs
+        assert chunks[-1].usage == {
+            "prompt_tokens": 5,
+            "completion_tokens": 3,
+            "total_tokens": 8,
+        }
 
 
 if __name__ == "__main__":

--- a/tests/provider/test_openai_compatible_provider.py
+++ b/tests/provider/test_openai_compatible_provider.py
@@ -1,4 +1,5 @@
 from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
 
 import pytest
 
@@ -39,6 +40,11 @@ def _chat_response(content: str, model: str = "MiniMax-M2.5") -> ChatResponse:
 async def _empty_stream():
     if False:
         yield None
+
+
+async def _stream_from_chunks(*chunks):
+    for chunk in chunks:
+        yield chunk
 
 
 class TestOpenAICompatibleProviderTemperature:
@@ -167,3 +173,75 @@ class TestOpenAICompatibleProviderMiniMaxFallback:
 
         assert [chunk.delta for chunk in chunks] == ["Recovered generic fallback"]
         sleep_mock.assert_not_awaited()
+
+
+class TestOpenAICompatibleProviderStreamingUsage:
+    @pytest.mark.asyncio
+    async def test_chat_stream_includes_usage_in_terminal_chunk(self):
+        provider, create = _build_provider_with_client()
+        create.return_value = _stream_from_chunks(
+            SimpleNamespace(
+                choices=[],
+                usage=SimpleNamespace(prompt_tokens=13, completion_tokens=8, total_tokens=21),
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="hello", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=None,
+            ),
+        )
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "kimi-k2.5",
+                [ChatMessage(role="user", content="hello")],
+            )
+        ]
+
+        assert create.await_args.kwargs["stream_options"] == {"include_usage": True}
+        assert chunks[-1].finish_reason == "stop"
+        assert chunks[-1].usage == {
+            "prompt_tokens": 13,
+            "completion_tokens": 8,
+            "total_tokens": 21,
+        }
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_retries_without_stream_options_when_unsupported(self):
+        provider, create = _build_provider_with_client()
+        create.side_effect = [
+            ValueError("unsupported parameter: include_usage"),
+            _stream_from_chunks(
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(content="hello", tool_calls=None),
+                            finish_reason="stop",
+                        )
+                    ],
+                    usage=SimpleNamespace(prompt_tokens=5, completion_tokens=2, total_tokens=7),
+                )
+            ),
+        ]
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "kimi-k2.5",
+                [ChatMessage(role="user", content="hello")],
+            )
+        ]
+
+        assert create.await_count == 2
+        assert "stream_options" in create.await_args_list[0].kwargs
+        assert "stream_options" not in create.await_args_list[1].kwargs
+        assert chunks[-1].usage == {
+            "prompt_tokens": 5,
+            "completion_tokens": 2,
+            "total_tokens": 7,
+        }

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -771,7 +771,9 @@ async def test_process_step_records_usage_after_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_process_step_empty_retry_records_usage_only_once(monkeypatch):
+async def test_process_step_empty_retry_records_usage_per_attempt(monkeypatch):
+    """Each empty-response attempt records its own usage so that provider
+    charges are not lost when the model returns tokens but no content."""
     runner = _make_runner("ses_runner_usage_retry")
     runner.callbacks = RunnerCallbacks(on_error=AsyncMock())
 
@@ -823,4 +825,36 @@ async def test_process_step_empty_retry_records_usage_only_once(monkeypatch):
 
     assert result.content == "recovered"
     sleep_mock.assert_awaited_once()
-    record_mock.assert_awaited_once_with(second_usage)
+    # Both the empty attempt and the successful attempt must be recorded so
+    # that provider charges are not silently dropped during retries.
+    assert record_mock.await_count == 2
+    record_mock.assert_any_await(first_usage)
+    record_mock.assert_any_await(second_usage)
+
+
+@pytest.mark.asyncio
+async def test_record_usage_if_available_swallows_import_error():
+    """ImportError from the server-routes import must not propagate out of
+    _record_usage_if_available so that a CLI-only environment (where fastapi /
+    server deps may be absent) never turns a successful step into an error."""
+    runner = _make_runner("ses_runner_import_error")
+    usage = {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+    with patch.dict("sys.modules", {"flocks.server.routes.usage": None}):
+        # Should complete without raising, even though the import will fail.
+        await runner._record_usage_if_available(usage)
+
+
+@pytest.mark.asyncio
+async def test_record_usage_if_available_swallows_runtime_error():
+    """Any exception raised by record_usage() itself must also be silently
+    swallowed so that usage-recording failures never corrupt step results."""
+    runner = _make_runner("ses_runner_record_error")
+    usage = {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+    fake_module = SimpleNamespace(
+        RecordUsageRequest=MagicMock(return_value=SimpleNamespace()),
+        record_usage=AsyncMock(side_effect=RuntimeError("db unavailable")),
+    )
+    with patch.dict("sys.modules", {"flocks.server.routes.usage": fake_module}):
+        await runner._record_usage_if_available(usage)

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -705,7 +705,7 @@ async def test_process_step_creates_assistant_message_with_provider_and_model(mo
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
     monkeypatch.setattr(runner, "_build_system_prompts", AsyncMock(return_value=[]))
-    monkeypatch.setattr(runner, "_build_tools", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         runner,
         "_to_chat_messages",
@@ -719,3 +719,108 @@ async def test_process_step_creates_assistant_message_with_provider_and_model(mo
 
     assert captured_kwargs["model_id"] == runner.model_id
     assert captured_kwargs["provider_id"] == runner.provider_id
+
+
+@pytest.mark.asyncio
+async def test_process_step_records_usage_after_success(monkeypatch):
+    runner = _make_runner("ses_runner_usage_success")
+    runner.callbacks = RunnerCallbacks(on_error=AsyncMock())
+
+    last_user = UserMessageInfo(
+        id="msg_user_usage_success",
+        sessionID=runner.session.id,
+        role="user",
+        time={"created": 1_000},
+        agent="rex",
+        model={"providerID": "anthropic", "modelID": "claude-sonnet"},
+    )
+
+    agent = SimpleNamespace(name="rex", steps=None, mode="primary", prompt="", tools=[])
+    provider = MagicMock()
+    provider.is_configured.return_value = True
+    assistant_msg = SimpleNamespace(id="msg_assistant_usage_success")
+    update_mock = AsyncMock(return_value=None)
+    record_mock = AsyncMock(return_value=None)
+    usage = {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20}
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
+    monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner, "_build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        runner,
+        "_to_chat_messages",
+        AsyncMock(return_value=[SimpleNamespace(role="user", content="hi")]),
+    )
+    monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="hi"))
+    monkeypatch.setattr(runner_mod.Message, "create", AsyncMock(return_value=assistant_msg))
+    monkeypatch.setattr(runner_mod.Message, "update", update_mock)
+    monkeypatch.setattr(
+        runner,
+        "_call_llm",
+        AsyncMock(return_value=StepResult(action="stop", content="done", usage=usage)),
+    )
+    monkeypatch.setattr(runner, "_record_usage_if_available", record_mock)
+
+    result = await runner._process_step([last_user], last_user)
+
+    assert result.content == "done"
+    record_mock.assert_awaited_once_with(usage)
+    update_mock.assert_any_await(runner.session.id, assistant_msg.id, finish="stop")
+
+
+@pytest.mark.asyncio
+async def test_process_step_empty_retry_records_usage_only_once(monkeypatch):
+    runner = _make_runner("ses_runner_usage_retry")
+    runner.callbacks = RunnerCallbacks(on_error=AsyncMock())
+
+    last_user = UserMessageInfo(
+        id="msg_user_usage_retry",
+        sessionID=runner.session.id,
+        role="user",
+        time={"created": 1_000},
+        agent="rex",
+        model={"providerID": "anthropic", "modelID": "claude-sonnet"},
+    )
+
+    agent = SimpleNamespace(name="rex", steps=None, mode="primary", prompt="", tools=[])
+    provider = MagicMock()
+    provider.is_configured.return_value = True
+    assistant_msg = SimpleNamespace(id="msg_assistant_usage_retry")
+    record_mock = AsyncMock(return_value=None)
+    sleep_mock = AsyncMock(return_value=None)
+    first_usage = {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+    second_usage = {"prompt_tokens": 9, "completion_tokens": 4, "total_tokens": 13}
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
+    monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner, "_build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        runner,
+        "_to_chat_messages",
+        AsyncMock(return_value=[SimpleNamespace(role="user", content="hi")]),
+    )
+    monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="hi"))
+    monkeypatch.setattr(runner_mod.Message, "create", AsyncMock(return_value=assistant_msg))
+    monkeypatch.setattr(runner_mod.Message, "update", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        runner,
+        "_call_llm",
+        AsyncMock(
+            side_effect=[
+                StepResult(action="stop", content="", usage=first_usage),
+                StepResult(action="stop", content="recovered", usage=second_usage),
+            ]
+        ),
+    )
+    monkeypatch.setattr(runner, "_record_usage_if_available", record_mock)
+    monkeypatch.setattr(runner_mod.SessionRetry, "sleep", sleep_mock)
+
+    result = await runner._process_step([last_user], last_user)
+
+    assert result.content == "recovered"
+    sleep_mock.assert_awaited_once()
+    record_mock.assert_awaited_once_with(second_usage)


### PR DESCRIPTION
Fixes #63
Capture streaming usage from OpenAI-compatible providers, persist successful session usage records, and add regression coverage so stats and the WebUI usage summary stay in sync without affecting session retries or tool flows.
