### PR TITLE
fix(onboarding): update global activation URL

### DIFF
--- a/webui/src/components/common/OnboardingModal.tsx
+++ b/webui/src/components/common/OnboardingModal.tsx
@@ -19,7 +19,7 @@ const ONBOARDING_DISMISSED_KEY = 'flocks_onboarding_dismissed';
 
 const TBCLOUD_LINKS = {
   cn: 'https://x.threatbook.com/flocks/activate',
-  global: 'https://threatbook.io/flocks/activate',
+  global: 'https://i.threatbook.io/flocks/activate',
 };
 
 const THREATBOOK_PROVIDER_IDS = ['threatbook-cn-llm', 'threatbook-io-llm'] as const;


### PR DESCRIPTION
Point the global ThreatBook onboarding link to the new activation endpoint so users are sent to the correct key retrieval page.