### PR TITLE
feat/onboarding default qwen3 max

### DIFF
--- a/flocks/server/routes/onboarding.py
+++ b/flocks/server/routes/onboarding.py
@@ -141,7 +141,7 @@ ONBOARDING_REGION_PRESETS: Dict[Region, Dict[str, Any]] = {
     "cn": {
         "activation_url": "https://x.threatbook.com/flocks/activate",
         "threatbook_llm_provider_id": "threatbook-cn-llm",
-        "threatbook_default_model_id": "qwen3.6-plus",
+        "threatbook_default_model_id": "qwen3-max",
         "threatbook_api_service_id": "threatbook-cn",
         "threatbook_mcp_name": "threatbook_mcp",
         "threatbook_mcp_url": "https://mcp.threatbook.cn/mcp?apikey={api_key}",
@@ -151,7 +151,7 @@ ONBOARDING_REGION_PRESETS: Dict[Region, Dict[str, Any]] = {
     "global": {
         "activation_url": "https://threatbook.io/flocks/activate",
         "threatbook_llm_provider_id": "threatbook-io-llm",
-        "threatbook_default_model_id": "qwen3.6-plus",
+        "threatbook_default_model_id": "qwen3-max",
         "threatbook_api_service_id": "threatbook-io",
         "threatbook_mcp_name": None,
         "threatbook_mcp_url": None,

--- a/tests/server/routes/test_onboarding_routes.py
+++ b/tests/server/routes/test_onboarding_routes.py
@@ -42,7 +42,7 @@ class TestOnboardingStatusRoutes:
         self, client, monkeypatch: pytest.MonkeyPatch
     ):
         async def fake_resolve():
-            return {"provider_id": "threatbook-cn-llm", "model_id": "qwen3.6-plus"}
+            return {"provider_id": "threatbook-cn-llm", "model_id": "qwen3-max"}
 
         monkeypatch.setattr(onboarding_routes.Config, "resolve_default_llm", fake_resolve)
         monkeypatch.setattr(onboarding_routes, "_llm_provider_has_usable_credentials", lambda _pid: True)

--- a/tests/skill/test_onboarding_status.py
+++ b/tests/skill/test_onboarding_status.py
@@ -38,7 +38,7 @@ async def test_onboarding_status_uses_default_model_services_and_channels(isolat
             "default_models": {
                 "llm": {
                     "provider_id": "threatbook-cn-llm",
-                    "model_id": "qwen3.6-plus",
+                    "model_id": "qwen3-max",
                 }
             },
             "api_services": {

--- a/webui/src/components/common/OnboardingModal.test.tsx
+++ b/webui/src/components/common/OnboardingModal.test.tsx
@@ -112,11 +112,11 @@ describe('OnboardingModal', () => {
         providers: [
           makeProvider('threatbook-cn-llm', 'ThreatBook CN', [
             { id: 'minimax-m2.7', name: 'MiniMax M2.7' },
-            { id: 'qwen3.6-plus', name: 'Qwen 3.6 Plus' },
+            { id: 'qwen3-max', name: 'Qwen 3 Max' },
           ]),
           makeProvider('threatbook-io-llm', 'ThreatBook Global', [
             { id: 'minimax-m2.7', name: 'MiniMax M2.7' },
-            { id: 'qwen3.6-plus', name: 'Qwen 3.6 Plus' },
+            { id: 'qwen3-max', name: 'Qwen 3 Max' },
           ]),
           makeProvider('openai-compatible', 'OpenAI Compatible', []),
           makeProvider('deepseek', 'DeepSeek', [{ id: 'deepseek-chat', name: 'DeepSeek V3.2' }]),
@@ -173,7 +173,7 @@ describe('OnboardingModal', () => {
     defaultModelAPI.getResolved.mockResolvedValue({
       data: {
         provider_id: 'threatbook-cn-llm',
-        model_id: 'qwen3.6-plus',
+        model_id: 'qwen3-max',
       },
     });
 
@@ -195,7 +195,7 @@ describe('OnboardingModal', () => {
     defaultModelAPI.getResolved.mockResolvedValue({
       data: {
         provider_id: 'threatbook-cn-llm',
-        model_id: 'qwen3.6-plus',
+        model_id: 'qwen3-max',
       },
     });
 
@@ -290,7 +290,7 @@ describe('OnboardingModal', () => {
         skipped: [],
         default_model: {
           provider_id: 'threatbook-cn-llm',
-          model_id: 'qwen3.6-plus',
+          model_id: 'qwen3-max',
         },
       },
     });
@@ -304,7 +304,7 @@ describe('OnboardingModal', () => {
     await screen.findByText('onboarding.bootstrap.primaryConfiguredSummary');
     await user.click(screen.getByText('onboarding.bootstrap.primaryTitle'));
 
-    expect(screen.getByText('Qwen 3.6 Plus')).toBeInTheDocument();
+    expect(screen.getByText('Qwen 3 Max')).toBeInTheDocument();
     expect(screen.queryByText('MiniMax M2.7')).not.toBeInTheDocument();
   });
 });

--- a/webui/src/components/layout/Layout.test.tsx
+++ b/webui/src/components/layout/Layout.test.tsx
@@ -165,7 +165,7 @@ describe('Layout onboarding entry', () => {
     defaultModelAPI.getResolved.mockResolvedValue({
       data: {
         provider_id: 'threatbook-cn-llm',
-        model_id: 'qwen3.6-plus',
+        model_id: 'qwen3-max',
       },
     });
 
@@ -174,11 +174,11 @@ describe('Layout onboarding entry', () => {
         providers: [
           makeProvider('threatbook-cn-llm', 'ThreatBook CN', [
             { id: 'minimax-m2.7', name: 'MiniMax M2.7' },
-            { id: 'qwen3.6-plus', name: 'Qwen 3.6 Plus' },
+            { id: 'qwen3-max', name: 'Qwen 3 Max' },
           ]),
           makeProvider('threatbook-io-llm', 'ThreatBook Global', [
             { id: 'minimax-m2.7', name: 'MiniMax M2.7' },
-            { id: 'qwen3.6-plus', name: 'Qwen 3.6 Plus' },
+            { id: 'qwen3-max', name: 'Qwen 3 Max' },
           ]),
           makeProvider('openai-compatible', 'OpenAI Compatible', []),
           makeProvider('deepseek', 'DeepSeek', [{ id: 'deepseek-chat', name: 'DeepSeek V3.2' }]),


### PR DESCRIPTION
- Default ThreatBook preset to qwen3-max\n\nSwitch the onboarding ThreatBook default model to qwen3-max so new setups use the updated preset and the related tests stay aligned.