### PR TITLE
fix(updater): improve non-Windows upgrade stability

### DIFF
--- a/flocks/cli/commands/update.py
+++ b/flocks/cli/commands/update.py
@@ -92,6 +92,17 @@ async def _update(check: bool, yes: bool, force: bool = False, region: str | Non
     total_steps = 6
     seen_stages: set[str] = set()
     step = 0
+    active_stage: str | None = None
+
+    def _finish_active(success: bool = True) -> None:
+        """Mark the currently displayed line as done or failed."""
+        nonlocal active_stage
+        if active_stage is not None:
+            if success:
+                console.print("[green]✓[/green]")
+            else:
+                console.print("[red]✗[/red]")
+            active_stage = None
 
     async for progress in perform_update(
         version_to_apply,
@@ -101,21 +112,24 @@ async def _update(check: bool, yes: bool, force: bool = False, region: str | Non
         region=region,
     ):
         if progress.stage == "error":
+            _finish_active(success=False)
             console.print(f"\n[red]✗ 升级失败：{progress.message}[/red]")
             raise typer.Exit(1)
 
         if progress.stage == "done":
+            _finish_active(success=True)
             step += 1
             console.print(f"[cyan][{step}/{total_steps}] 完成[/cyan]  ", end="")
             console.print("[green]✓[/green]")
             continue
 
         if progress.stage not in seen_stages:
+            _finish_active(success=True)
             seen_stages.add(progress.stage)
             step += 1
             label = stage_labels.get(progress.stage, progress.stage)
             console.print(f"[cyan][{step}/{total_steps}] {label}...[/cyan]  ", end="")
-            console.print("[green]✓[/green]")
+            active_stage = progress.stage
 
     console.print(f"\n[green]✓ 升级完成 → v{version_to_apply}[/green]")
     console.print("[dim]如有后台服务正在运行，请执行 [bold]flocks restart[/bold] 重启服务[/dim]")

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -230,6 +230,31 @@ async def _validate_windows_restart_runtime(
     return f"Windows restart runtime validation failed: {last_error}"
 
 
+def _build_uv_sync_env() -> dict[str, str] | None:
+    """Build supplementary env vars for ``uv sync``.
+
+    On Linux/macOS under systemd or other minimal-PATH environments, the
+    inherited PATH may not include directories where ``uv`` or managed
+    Python interpreters live.  We augment PATH with well-known locations
+    so that ``uv sync`` can reliably locate its own toolchain.
+    """
+    if sys.platform == "win32":
+        return None
+
+    home = str(Path.home())
+    extra_dirs = [
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".cargo", "bin"),
+        "/usr/local/bin",
+    ]
+    current_path = os.environ.get("PATH", "")
+    current_entries = set(current_path.split(os.pathsep))
+    missing = [d for d in extra_dirs if d not in current_entries]
+    if not missing:
+        return None
+    return {"PATH": os.pathsep.join([current_path] + missing)}
+
+
 # ------------------------------------------------------------------ #
 # Async subprocess helpers
 # ------------------------------------------------------------------ #
@@ -1919,7 +1944,7 @@ async def perform_update(
     yield UpdateProgress(stage="syncing", message="Syncing dependencies...")
 
     uv_path = _find_executable("uv")
-    if sys.platform == "win32" and not uv_path:
+    if not uv_path:
         shutil.rmtree(tmp_dir, ignore_errors=True)
         if backup_path is not None:
             await asyncio.to_thread(
@@ -1928,28 +1953,32 @@ async def perform_update(
                 install_root,
                 current_version,
             )
-        yield UpdateProgress(
-            stage="error",
-            message="Dependency sync failed: uv is required to refresh the Windows project runtime.",
-            success=False,
+        hint = (
+            "Dependency sync failed: uv is required but was not found. "
+            "Please install uv (https://docs.astral.sh/uv/) and ensure it "
+            "is in PATH (e.g. add ~/.local/bin to PATH for systemd services)."
         )
+        if sys.platform == "win32":
+            hint = "Dependency sync failed: uv is required to refresh the Windows project runtime."
+        yield UpdateProgress(stage="error", message=hint, success=False)
         return
 
-    if uv_path:
-        log.info("updater.dependencies.sync", {"tool": "uv sync", "path": uv_path})
-        uv_cmd = [uv_path, "sync"]
-        if profile.uv_default_index:
-            uv_cmd.extend(["--default-index", profile.uv_default_index])
-        code, _, err = await _run_async(uv_cmd, cwd=install_root, timeout=120)
-    else:
-        log.warning("updater.dependencies.sync_fallback", {"tool": "pip"})
-        pip_env = {"PIP_INDEX_URL": profile.pip_index_url} if profile.pip_index_url else None
+    log.info("updater.dependencies.sync", {"tool": "uv sync", "path": uv_path})
+    uv_cmd = [uv_path, "sync"]
+    if profile.uv_default_index:
+        uv_cmd.extend(["--default-index", profile.uv_default_index])
+
+    sync_env = _build_uv_sync_env()
+    code, _, err = await _run_async(
+        uv_cmd, cwd=install_root, timeout=180, env=sync_env,
+    )
+    if code != 0:
+        log.warning("updater.dependencies.sync_retry", {"first_error": err})
+        await asyncio.sleep(3)
         code, _, err = await _run_async(
-            [sys.executable, "-m", "pip", "install", "-e", ".", "--quiet"],
-            cwd=install_root,
-            timeout=120,
-            env=pip_env,
+            uv_cmd, cwd=install_root, timeout=180, env=sync_env,
         )
+
     if code != 0:
         shutil.rmtree(tmp_dir, ignore_errors=True)
         if backup_path is not None:
@@ -2201,4 +2230,28 @@ def _find_executable(name: str) -> str | None:
     for candidate in venv_candidates:
         if candidate.exists():
             return str(candidate)
+
+    # When running inside a uv-tool-managed environment (e.g. systemd service
+    # where PATH is minimal), shutil.which may miss uv.  Probe well-known
+    # user-level and system-level locations so the updater can still call
+    # ``uv sync`` instead of falling back to pip (which doesn't exist in uv
+    # tool venvs).
+    if name == "uv" and sys.platform != "win32":
+        extra_paths: list[Path] = []
+        home = Path.home()
+        extra_paths.append(home / ".local" / "bin" / "uv")
+        extra_paths.append(home / ".cargo" / "bin" / "uv")
+        # If the running interpreter lives inside a uv tools tree, the uv
+        # binary that created it is usually in ~/.local/bin.  Also try the
+        # bin dir adjacent to the tools dir.
+        exe = Path(sys.executable).resolve()
+        uv_tools_marker = os.sep + os.path.join(".local", "share", "uv", "tools") + os.sep
+        if uv_tools_marker in str(exe):
+            uv_share = str(exe).split(uv_tools_marker)[0]
+            extra_paths.append(Path(uv_share) / ".local" / "bin" / "uv")
+        extra_paths.append(Path("/usr/local/bin/uv"))
+        for p in extra_paths:
+            if p.is_file() and os.access(p, os.X_OK):
+                return str(p)
+
     return None

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import sys
@@ -150,6 +151,108 @@ def test_find_executable_ignores_wsl_mnt_paths(
     monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path)
 
     assert updater._find_executable("uv") == str(uv_bin)
+
+
+def test_find_executable_probes_user_local_bin_for_uv(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When shutil.which fails (e.g. systemd with minimal PATH) and the
+    interpreter is inside a uv-tool venv, _find_executable should still
+    locate uv in ~/.local/bin/."""
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    uv_bin = local_bin / "uv"
+    uv_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    uv_bin.chmod(0o755)
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    assert updater._find_executable("uv") == str(uv_bin)
+
+
+def test_find_executable_probes_cargo_bin_for_uv(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """uv installed via cargo should be found at ~/.cargo/bin/uv."""
+    cargo_bin = tmp_path / ".cargo" / "bin"
+    cargo_bin.mkdir(parents=True)
+    uv_bin = cargo_bin / "uv"
+    uv_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    uv_bin.chmod(0o755)
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    assert updater._find_executable("uv") == str(uv_bin)
+
+
+def test_find_executable_does_not_probe_extra_paths_for_non_uv(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The extra path probing should only apply to the 'uv' name."""
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    npm_bin = local_bin / "npm"
+    npm_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    npm_bin.chmod(0o755)
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    assert updater._find_executable("npm") is None
+
+
+def test_build_uv_sync_env_augments_path_with_missing_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    result = updater._build_uv_sync_env()
+
+    assert result is not None
+    parts = result["PATH"].split(os.pathsep)
+    assert "/usr/bin" in parts
+    assert str(tmp_path / ".local" / "bin") in parts
+    assert str(tmp_path / ".cargo" / "bin") in parts
+    assert "/usr/local/bin" in parts
+
+
+def test_build_uv_sync_env_returns_none_when_all_dirs_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = str(tmp_path)
+    full_path = os.pathsep.join([
+        os.path.join(home, ".local", "bin"),
+        os.path.join(home, ".cargo", "bin"),
+        "/usr/local/bin",
+        "/usr/bin",
+    ])
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("PATH", full_path)
+
+    assert updater._build_uv_sync_env() is None
+
+
+def test_build_uv_sync_env_returns_none_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    assert updater._build_uv_sync_env() is None
 
 
 def test_upgrade_page_html_contains_marker_and_version() -> None:
@@ -1119,6 +1222,7 @@ async def test_perform_update_uses_cn_mirror_profile_for_sources_and_dependency_
         "_find_executable",
         lambda name: "/usr/bin/npm" if name in {"npm", "npm.cmd"} else "/usr/bin/uv",
     )
+    monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
     monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
 
@@ -1150,10 +1254,12 @@ async def test_perform_update_uses_cn_mirror_profile_for_sources_and_dependency_
 
 
 @pytest.mark.asyncio
-async def test_perform_update_uses_cn_pip_index_when_uv_is_unavailable(
+async def test_perform_update_errors_when_uv_not_found(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """When uv is not found, the updater should fail immediately with a clear
+    message telling the user to install uv."""
     archive_path = tmp_path / "flocks.tar.gz"
     archive_path.write_text("archive", encoding="utf-8")
     staged_root = tmp_path / "staged"
@@ -1161,7 +1267,7 @@ async def test_perform_update_uses_cn_pip_index_when_uv_is_unavailable(
     async def fake_get_updater_config():
         return SimpleNamespace(
             archive_format="tar.gz",
-            sources=["github", "gitee"],
+            sources=["github"],
             repo="AgentFlocks/Flocks",
             token=None,
             gitee_token=None,
@@ -1170,42 +1276,150 @@ async def test_perform_update_uses_cn_pip_index_when_uv_is_unavailable(
             gitee_repo=None,
         )
 
-    captured: list[tuple[list[str], dict[str, str] | None]] = []
-
-    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
-        captured.append((list(cmd), env))
-        return 0, "", ""
-
     monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
     monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
     monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+
     async def fake_download_with_fallback(**_kwargs):
         return archive_path
 
     monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
     monkeypatch.setattr(updater, "_extract_archive", lambda *_args, **_kwargs: staged_root)
-    monkeypatch.setattr(updater, "_run_async", fake_run_async)
     monkeypatch.setattr(updater, "_find_executable", lambda _name: None)
     monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
 
     progresses = [
         step
-        async for step in updater.perform_update(
-            "2026.4.1",
-            restart=False,
-            region="cn",
+        async for step in updater.perform_update("2026.4.1", restart=False)
+    ]
+
+    error_events = [p for p in progresses if p.stage == "error"]
+    assert len(error_events) == 1
+    assert "uv is required but was not found" in error_events[0].message
+    assert "PATH" in error_events[0].message
+
+
+@pytest.mark.asyncio
+async def test_perform_update_retries_uv_sync_on_first_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """uv sync should retry once after a transient failure."""
+    archive_path = tmp_path / "flocks.tar.gz"
+    archive_path.write_text("archive", encoding="utf-8")
+    staged_root = tmp_path / "staged"
+
+    call_count = 0
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            archive_format="tar.gz",
+            sources=["github"],
+            repo="AgentFlocks/Flocks",
+            token=None,
+            gitee_token=None,
+            backup_retain_count=3,
+            base_url=None,
+            gitee_repo=None,
         )
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        nonlocal call_count
+        if "sync" in cmd:
+            call_count += 1
+            if call_count == 1:
+                return 1, "", "network timeout"
+            return 0, "", ""
+        return 0, "", ""
+
+    async def fake_download(**_kw):
+        return archive_path
+
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater, "_download_with_fallback", fake_download)
+    monkeypatch.setattr(updater, "_backup_current_version", lambda *_a, **_kw: tmp_path / "backup.tar.gz")
+    monkeypatch.setattr(updater, "_extract_archive", lambda *_a, **_kw: staged_root)
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(updater, "_find_executable", lambda _name: "/usr/bin/uv")
+    async def fake_sleep(_s):
+        pass
+
+    monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
+    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_a, **_kw: None)
+    monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
+    monkeypatch.setattr(updater.asyncio, "sleep", fake_sleep)
+
+    progresses = [
+        step async for step in updater.perform_update("2026.4.1", restart=False)
     ]
 
     assert progresses[-1].stage == "done"
-    assert captured == [
-        (
-            [sys.executable, "-m", "pip", "install", "-e", ".", "--quiet"],
-            {"PIP_INDEX_URL": "https://mirrors.aliyun.com/pypi/simple"},
-        ),
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_perform_update_fails_after_uv_sync_retry_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When uv sync fails twice, the updater should give up and rollback."""
+    archive_path = tmp_path / "flocks.tar.gz"
+    archive_path.write_text("archive", encoding="utf-8")
+    staged_root = tmp_path / "staged"
+    rolled_back = False
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            archive_format="tar.gz",
+            sources=["github"],
+            repo="AgentFlocks/Flocks",
+            token=None,
+            gitee_token=None,
+            backup_retain_count=3,
+            base_url=None,
+            gitee_repo=None,
+        )
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        if "sync" in cmd:
+            return 1, "", "resolution failed"
+        return 0, "", ""
+
+    async def fake_download(**_kw):
+        return archive_path
+
+    def fake_restore(*_args):
+        nonlocal rolled_back
+        rolled_back = True
+
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater, "_download_with_fallback", fake_download)
+    monkeypatch.setattr(updater, "_backup_current_version", lambda *_a, **_kw: tmp_path / "backup.tar.gz")
+    monkeypatch.setattr(updater, "_extract_archive", lambda *_a, **_kw: staged_root)
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(updater, "_find_executable", lambda _name: "/usr/bin/uv")
+    monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
+    async def fake_sleep(_s):
+        pass
+
+    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_a, **_kw: None)
+    monkeypatch.setattr(updater, "_restore_backup_if_possible", fake_restore)
+    monkeypatch.setattr(updater.asyncio, "sleep", fake_sleep)
+
+    progresses = [
+        step async for step in updater.perform_update("2026.4.1", restart=False)
     ]
+
+    error_events = [p for p in progresses if p.stage == "error"]
+    assert len(error_events) == 1
+    assert "resolution failed" in error_events[0].message
+    assert rolled_back
 
 
 @pytest.mark.asyncio
@@ -1583,7 +1797,8 @@ async def test_perform_update_yields_error_when_build_restart_argv_fails(
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
     monkeypatch.setattr(updater, "_extract_archive", lambda *_args, **_kwargs: staged_root)
     monkeypatch.setattr(updater, "_run_async", fake_run_async)
-    monkeypatch.setattr(updater, "_find_executable", lambda _name: None)
+    monkeypatch.setattr(updater, "_find_executable", lambda _name: "/usr/bin/uv")
+    monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
     monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(updater, "_write_version_marker", lambda _v: events.append("marker"))
     monkeypatch.setattr(


### PR DESCRIPTION
- Augment PATH for uv sync on Unix under minimal environments (systemd)
- Probe ~/.local/bin, ~/.cargo/bin, /usr/local for uv when which misses
- Require uv on all platforms; remove pip fallback; clearer error hints
- Retry uv sync once after transient failure; extend sync timeout to 180s
- CLI: defer stage checkmark until step completes for accurate progress