### PR TITLE
Try Gitee archive refs/heads before refs/tags in installers

### DIFF
--- a/install_zh.ps1
+++ b/install_zh.ps1
@@ -95,7 +95,10 @@ function Invoke-WorkspaceInstaller {
 }
 
 function Get-ArchiveCandidateUrls {
-    return @("https://gitee.com/$RepoSlug/archive/refs/tags/$Version.zip")
+    return @(
+        "https://gitee.com/$RepoSlug/archive/refs/heads/$Version.zip",
+        "https://gitee.com/$RepoSlug/archive/refs/tags/$Version.zip"
+    )
 }
 
 function Download-Archive {

--- a/install_zh.sh
+++ b/install_zh.sh
@@ -90,6 +90,7 @@ ensure_dependencies() {
 }
 
 build_candidate_urls() {
+  printf 'https://gitee.com/%s/archive/refs/heads/%s.zip\n' "$REPO_SLUG" "$VERSION"
   printf 'https://gitee.com/%s/archive/refs/tags/%s.zip\n' "$REPO_SLUG" "$VERSION"
 }
 


### PR DESCRIPTION
Prefer branch archive URLs so installs work when VERSION is a branch name; fall back to tag archives for tagged releases.
