### PR TITLE
fix(installer): prefer Gitee repository archive for zh bootstrap

### DIFF
--- a/install_zh.ps1
+++ b/install_zh.ps1
@@ -96,6 +96,7 @@ function Invoke-WorkspaceInstaller {
 
 function Get-ArchiveCandidateUrls {
     return @(
+        "https://gitee.com/$RepoSlug/repository/archive/$Version.zip",
         "https://gitee.com/$RepoSlug/archive/refs/heads/$Version.zip",
         "https://gitee.com/$RepoSlug/archive/refs/tags/$Version.zip"
     )

--- a/install_zh.sh
+++ b/install_zh.sh
@@ -15,7 +15,7 @@ RAW_INSTALL_ZH_SH_URL="${FLOCKS_RAW_INSTALL_ZH_SH_URL:-https://gitee.com/flocks/
 RAW_INSTALL_ZH_PS1_URL="${FLOCKS_RAW_INSTALL_ZH_PS1_URL:-https://gitee.com/flocks/flocks/raw/main/install_zh.ps1}"
 
 info() {
-  printf '[flocks-bootstrap-zh] %s\n' "$1"
+  printf '[flocks-bootstrap-zh] %s\n' "$1" >&2
 }
 
 fail() {
@@ -90,6 +90,7 @@ ensure_dependencies() {
 }
 
 build_candidate_urls() {
+  printf 'https://gitee.com/%s/repository/archive/%s.zip\n' "$REPO_SLUG" "$VERSION"
   printf 'https://gitee.com/%s/archive/refs/heads/%s.zip\n' "$REPO_SLUG" "$VERSION"
   printf 'https://gitee.com/%s/archive/refs/tags/%s.zip\n' "$REPO_SLUG" "$VERSION"
 }

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -7,7 +7,9 @@ SCRIPT_DIR = REPO_ROOT / "scripts"
 def test_install_zh_bash_bootstrap_uses_gitee_archive_and_delegates_to_zh_workspace_installer() -> None:
     script = (REPO_ROOT / "install_zh.sh").read_text(encoding="utf-8")
 
+    assert 'https://gitee.com/%s/repository/archive/%s.zip' in script
     assert 'https://gitee.com/%s/archive/refs/tags/%s.zip' in script
+    assert "printf '[flocks-bootstrap-zh] %s\\n' \"$1\" >&2" in script
     assert 'has_cmd unzip || fail "缺少 unzip，无法解压 Gitee zip 源码包。"' in script
     assert 'archive_path="$TMP_DIR/flocks.zip"' in script
     assert 'unzip -q "$archive_path" -d "$TMP_DIR"' in script
@@ -21,6 +23,7 @@ def test_install_zh_bash_bootstrap_uses_gitee_archive_and_delegates_to_zh_worksp
 def test_install_zh_powershell_bootstrap_uses_gitee_archive_and_delegates_to_zh_workspace_installer() -> None:
     script = (REPO_ROOT / "install_zh.ps1").read_text(encoding="utf-8-sig")
 
+    assert 'https://gitee.com/$RepoSlug/repository/archive/$Version.zip' in script
     assert 'https://gitee.com/$RepoSlug/archive/refs/tags/$Version.zip' in script
     assert 'scripts\\install_zh.ps1' in script
     assert 'https://gitee.com/flocks/flocks/raw/main/install_zh.sh' in script


### PR DESCRIPTION
Use Gitee's repository archive endpoint before legacy archive refs URLs so the zh bootstrap can download source zips reliably. Send bootstrap info logs to stderr to keep the reported download source clean.
