### PR TITLE
docs: improve China install pointer and Docker notes; bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ If automatic `npm` installation fails during setup, please install `npm` manuall
 
 ### Install with one command
 
-> **Users in mainland China**: If GitHub or `raw.githubusercontent.com` is slow or unreachable, clone from a Gitee mirror and follow the Source install instructions below.
+> [!NOTE]
+> **Users in mainland China**: Please follow the installation instructions in the [简体中文](README_zh.md), which provides a mirror-accelerated installation method specifically optimized for users in China.
 
 The recommended host installation entrypoint is the GitHub bootstrap installer. It downloads the repository source archive to a temporary directory, copies it into a `flocks/` subdirectory under your current working directory by default, then installs backend and WebUI dependencies and exposes the `flocks` CLI on your PATH. You can still override the destination with `FLOCKS_INSTALL_DIR`.
 
@@ -119,7 +120,7 @@ Flocks cli useage:  `flocks --help`
 ## Option 2: Docker Installation
 
 > [!NOTE]
-> docker 模式下暂时 agent-browser headed 模式不可用
+> In the Docker installation, the agent-browser headed mode is currently unavailable.
 
 ### Pull image
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -113,7 +113,7 @@ flocks stop
 ## 方案 2：Docker 安装
 
 > [!NOTE]
-> docker 模式下暂时 agent-browser headed 模式不可用
+> docker 版本暂时 agent-browser headed 模式不可用
 
 ### 拉取镜像
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.4.7"
+version = "v2026.4.9"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}


### PR DESCRIPTION
- README: point mainland users to README_zh for mirror-accelerated install
- README: translate Docker agent-browser headed note to English
- README_zh: clarify Docker headed-mode limitation wording
- pyproject: set version to v2026.4.9
