### PR TITLE
feat(usage): unify CLI stats, API, and WebUI on usage_records

### DIFF
--- a/flocks/cli/commands/stats.py
+++ b/flocks/cli/commands/stats.py
@@ -1,44 +1,42 @@
-"""
-Stats CLI command
+"""Stats CLI command backed by usage_records."""
 
-Shows token usage and cost statistics
-Ported from original cli/cmd/stats.ts
-"""
+from __future__ import annotations
 
 import asyncio
-import json
 import os
 from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Any, Optional, Dict, List
+from datetime import UTC, datetime, timedelta
+from typing import Dict, List, Optional, Sequence
 
 import typer
 from rich.console import Console
 
-from flocks.session.session import Session, SessionInfo
-from flocks.session.message import Message
-from flocks.session.prompt import SessionPrompt
 from flocks.project.project import Project
+from flocks.provider.usage_service import (
+    BackfillUsageResult,
+    backfill_usage_records,
+    get_usage_records,
+    get_usage_stats,
+)
+from flocks.session.message import Message
+from flocks.session.session import Session, SessionInfo
 from flocks.storage.storage import Storage
 
 
-stats_app = typer.Typer(
-    name="stats",
-    help="Show usage statistics",
-)
-
+stats_app = typer.Typer(name="stats", help="Show usage statistics")
 console = Console()
 
 
 @dataclass
 class TokenStats:
-    """Token usage statistics"""
+    """Token usage statistics."""
+
     input: int = 0
     output: int = 0
     reasoning: int = 0
     cache_read: int = 0
     cache_write: int = 0
-    
+
     @property
     def total(self) -> int:
         return self.input + self.output + self.reasoning
@@ -46,296 +44,207 @@ class TokenStats:
 
 @dataclass
 class ModelUsage:
-    """Usage statistics per model"""
+    """Usage statistics per model."""
+
     messages: int = 0
     tokens_input: int = 0
     tokens_output: int = 0
-    cost: float = 0.0
+    cost_by_currency: Dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
 class SessionStats:
-    """Aggregated session statistics"""
+    """Aggregated session statistics."""
+
     total_sessions: int = 0
     total_messages: int = 0
-    total_cost: float = 0.0
+    total_cost_by_currency: Dict[str, float] = field(default_factory=dict)
+    cost_per_day_by_currency: Dict[str, float] = field(default_factory=dict)
     total_tokens: TokenStats = field(default_factory=TokenStats)
     tool_usage: Dict[str, int] = field(default_factory=dict)
     model_usage: Dict[str, ModelUsage] = field(default_factory=dict)
-    date_range_earliest: int = 0
-    date_range_latest: int = 0
     days: int = 0
-    cost_per_day: float = 0.0
     tokens_per_day: float = 0.0
     tokens_per_session: float = 0.0
     median_tokens_per_session: float = 0.0
-    has_reasoning_tokens: bool = False
-
-
-def _count_tokens(text: str) -> int:
-    """Count tokens using the shared prompt tokenizer fallback."""
-    return SessionPrompt.count_tokens(text)
-
-
-def _stringify_payload(payload: Any) -> str:
-    """Convert tool payloads to text for token estimation."""
-    if payload is None:
-        return ""
-    if isinstance(payload, str):
-        return payload
-    try:
-        return json.dumps(payload, ensure_ascii=False, sort_keys=True)
-    except TypeError:
-        return str(payload)
-
-
-def _estimate_message_context_tokens(msg: Message) -> int:
-    """Estimate how many tokens this message adds to future prompts."""
-    total = 0
-    for part in msg.parts:
-        if part.type in {"text", "reasoning"}:
-            total += _count_tokens(getattr(part, "text", ""))
-            continue
-
-        if part.type != "tool":
-            continue
-
-        state = getattr(part, "state", None)
-        if state is None:
-            continue
-
-        total += _count_tokens(_stringify_payload(getattr(state, "input", None)))
-
-        time_info = getattr(state, "time", None)
-        is_compacted = isinstance(time_info, dict) and time_info.get("compacted")
-        if is_compacted:
-            total += 10
-        else:
-            total += _count_tokens(_stringify_payload(getattr(state, "output", None)))
-
-    return total
-
-
-def _estimate_assistant_tokens(msg: Message, prior_context_tokens: int) -> TokenStats:
-    """Estimate assistant token usage when providers persisted no usage data."""
-    estimated_output = 0
-    estimated_reasoning = 0
-
-    for part in msg.parts:
-        if part.type == "text":
-            estimated_output += _count_tokens(getattr(part, "text", ""))
-            continue
-
-        if part.type == "reasoning":
-            estimated_reasoning += _count_tokens(getattr(part, "text", ""))
-            continue
-
-        if part.type != "tool":
-            continue
-
-        state = getattr(part, "state", None)
-        if state is None:
-            continue
-        estimated_output += _count_tokens(_stringify_payload(getattr(state, "input", None)))
-
-    if estimated_output == 0 and estimated_reasoning == 0:
-        return TokenStats()
-
-    return TokenStats(
-        input=prior_context_tokens + 800,
-        output=estimated_output,
-        reasoning=estimated_reasoning,
-    )
 
 
 def _format_number(num: int) -> str:
-    """Format number with K/M suffixes"""
+    """Format number with K/M suffixes."""
     if num >= 1_000_000:
         return f"{num / 1_000_000:.1f}M"
-    elif num >= 1_000:
+    if num >= 1_000:
         return f"{num / 1_000:.1f}K"
     return str(num)
 
 
 def _render_row(label: str, value: str, width: int = 56) -> str:
-    """Render a table row"""
+    """Render a table row."""
     available_width = width - 1
     padding_needed = available_width - len(label) - len(value)
     padding = max(0, padding_needed)
     return f"│{label}{' ' * padding}{value} │"
 
 
+def _format_currency(currency: str, amount: float) -> str:
+    """Format a currency amount for display."""
+    symbol_map = {"USD": "$", "CNY": "¥"}
+    symbol = symbol_map.get(currency)
+    if symbol:
+        return f"{symbol}{amount:.4f}"
+    return f"{currency} {amount:.4f}"
+
+
 async def _get_all_sessions() -> List[SessionInfo]:
-    """Get all sessions across all projects"""
+    """Get all sessions across all projects."""
     return await Session.list_all()
 
 
-async def _aggregate_stats(
-    days: Optional[int],
-    project_filter: Optional[str]
-) -> SessionStats:
-    """Aggregate statistics from sessions"""
-    all_sessions = await _get_all_sessions()
-    
-    MS_IN_DAY = 24 * 60 * 60 * 1000
-    
-    # Calculate cutoff time
+def _resolve_time_window(days: Optional[int]) -> tuple[Optional[str], Optional[str], int]:
+    """Translate a CLI day filter into query bounds."""
+    now = datetime.now(UTC)
     if days is None:
-        cutoff_time = 0
-    elif days == 0:
-        # Today only
-        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        cutoff_time = int(today.timestamp() * 1000)
-    else:
-        cutoff_time = int(datetime.now().timestamp() * 1000) - days * MS_IN_DAY
-    
-    # Filter sessions
-    filtered_sessions = all_sessions
-    
-    if cutoff_time > 0:
-        filtered_sessions = [s for s in filtered_sessions if s.time.updated >= cutoff_time]
-    
-    if project_filter is not None:
-        if project_filter == "":
-            # Current project
-            result = await Project.from_directory(os.getcwd())
-            current_project_id = result["project"].id
-            filtered_sessions = [s for s in filtered_sessions if s.project_id == current_project_id]
-        else:
-            filtered_sessions = [s for s in filtered_sessions if s.project_id == project_filter]
-    
-    # Initialize stats
-    stats = SessionStats()
-    stats.total_sessions = len(filtered_sessions)
-    
-    if not filtered_sessions:
-        stats.days = days or 0
-        return stats
-    
-    earliest_time = int(datetime.now().timestamp() * 1000)
-    latest_time = 0
-    session_total_tokens: List[int] = []
-    
-    # Process each session
-    for session in filtered_sessions:
-        messages = await Message.list_with_parts(session.id)
-        stats.total_messages += len(messages)
-        prior_context_tokens = 0
-        session_tokens = TokenStats()
+        return None, None, 0
+    if days == 0:
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        return start.isoformat(), now.isoformat(), 1
+    start = now - timedelta(days=days)
+    return start.isoformat(), now.isoformat(), max(days, 1)
 
+
+async def _resolve_project_sessions(project_filter: Optional[str]) -> List[SessionInfo]:
+    """Resolve session scope for a project filter."""
+    sessions = await _get_all_sessions()
+    if project_filter is None:
+        return sessions
+    if project_filter == "":
+        result = await Project.from_directory(os.getcwd())
+        project_filter = result["project"].id
+    return [session for session in sessions if session.project_id == project_filter]
+
+
+async def _collect_message_metrics(session_ids: Sequence[str]) -> tuple[int, Dict[str, int]]:
+    """Count messages and tool usage for the selected sessions."""
+    total_messages = 0
+    tool_usage: Dict[str, int] = {}
+    for session_id in session_ids:
+        messages = await Message.list_with_parts(session_id)
+        total_messages += len(messages)
         for msg in messages:
-            info = msg.info
-
-            if info.role == "assistant":
-                cost = getattr(info, "cost", 0.0) or 0.0
-                provider_id = getattr(info, "providerID", None)
-                model_id = getattr(info, "modelID", None)
-                tokens = getattr(info, "tokens", None)
-                cache = getattr(tokens, "cache", None) if tokens else None
-                cache_read = getattr(cache, "read", 0) if cache else 0
-                cache_write = getattr(cache, "write", 0) if cache else 0
-                total_recorded_tokens = (
-                    (getattr(tokens, "input", 0) if tokens else 0)
-                    + (getattr(tokens, "output", 0) if tokens else 0)
-                    + (getattr(tokens, "reasoning", 0) if tokens else 0)
-                    + cache_read
-                    + cache_write
-                )
-                tokens_to_add = tokens
-
-                stats.total_cost += cost
-
-                # Model usage
-                if provider_id and model_id:
-                    model_key = f"{provider_id}/{model_id}"
-                    if model_key not in stats.model_usage:
-                        stats.model_usage[model_key] = ModelUsage()
-
-                    stats.model_usage[model_key].messages += 1
-                    stats.model_usage[model_key].cost += cost
-
-                if total_recorded_tokens == 0:
-                    tokens_to_add = _estimate_assistant_tokens(msg, prior_context_tokens)
-
-                # Token usage
-                if tokens_to_add:
-                    cache = getattr(tokens_to_add, "cache", None)
-                    cache_read = getattr(cache, "read", 0) if cache else 0
-                    cache_write = getattr(cache, "write", 0) if cache else 0
-
-                    session_tokens.input += tokens_to_add.input
-                    session_tokens.output += tokens_to_add.output
-                    session_tokens.reasoning += tokens_to_add.reasoning
-                    session_tokens.cache_read += cache_read
-                    session_tokens.cache_write += cache_write
-                    if tokens_to_add.reasoning > 0:
-                        stats.has_reasoning_tokens = True
-
-                    if provider_id and model_id:
-                        model_key = f"{provider_id}/{model_id}"
-                        stats.model_usage[model_key].tokens_input += tokens_to_add.input
-                        stats.model_usage[model_key].tokens_output += (
-                            tokens_to_add.output + tokens_to_add.reasoning
-                        )
-            
-            # Tool usage
             for part in msg.parts:
-                if part.type == "tool":
-                    tool_name = getattr(part, "tool", None) or "unknown"
-                    stats.tool_usage[tool_name] = stats.tool_usage.get(tool_name, 0) + 1
+                if part.type != "tool":
+                    continue
+                tool_name = getattr(part, "tool", None) or "unknown"
+                tool_usage[tool_name] = tool_usage.get(tool_name, 0) + 1
+    return total_messages, tool_usage
 
-            prior_context_tokens += _estimate_message_context_tokens(msg)
-        
-        # Aggregate token stats
-        stats.total_tokens.input += session_tokens.input
-        stats.total_tokens.output += session_tokens.output
-        stats.total_tokens.reasoning += session_tokens.reasoning
-        stats.total_tokens.cache_read += session_tokens.cache_read
-        stats.total_tokens.cache_write += session_tokens.cache_write
-        
-        if session_tokens.total > 0:
-            session_total_tokens.append(session_tokens.total)
-        
-        # Update time range
-        session_time = session.time.updated if cutoff_time > 0 else session.time.created
-        earliest_time = min(earliest_time, session_time)
-        latest_time = max(latest_time, session.time.updated)
-    
-    # Calculate derived stats
-    stats.date_range_earliest = earliest_time
-    stats.date_range_latest = latest_time
-    
-    range_days = max(1, (latest_time - earliest_time) // MS_IN_DAY)
-    stats.days = days if days is not None else range_days
-    
+
+async def _aggregate_stats(days: Optional[int], project_filter: Optional[str]) -> SessionStats:
+    """Aggregate statistics from usage_records."""
+    sessions = await _resolve_project_sessions(project_filter)
+    session_ids = [session.id for session in sessions]
+    start_date, end_date, requested_days = _resolve_time_window(days)
+    records = await get_usage_records(
+        start_date=start_date,
+        end_date=end_date,
+        session_ids=session_ids,
+    )
+    usage_stats = await get_usage_stats(
+        start_date=start_date,
+        end_date=end_date,
+        session_ids=session_ids,
+    )
+
+    stats = SessionStats()
+    stats.total_cost_by_currency = {
+        item.currency: item.total_cost for item in usage_stats.summary.cost_by_currency
+    }
+
+    if not records:
+        stats.days = requested_days
+        return stats
+
+    session_token_totals: Dict[str, int] = {}
+    active_session_ids: set[str] = set()
+    created_at_values: List[datetime] = []
+
+    for record in records:
+        stats.total_tokens.input += record.input_tokens
+        stats.total_tokens.output += record.output_tokens
+        stats.total_tokens.reasoning += record.reasoning_tokens
+        stats.total_tokens.cache_read += record.cached_tokens
+        stats.total_tokens.cache_write += getattr(record, "cache_write_tokens", 0)
+
+        if record.session_id:
+            active_session_ids.add(record.session_id)
+            session_token_totals[record.session_id] = (
+                session_token_totals.get(record.session_id, 0) + record.total_tokens
+            )
+
+        created_at_values.append(record.created_at)
+
+        model_key = f"{record.provider_id}/{record.model_id}"
+        model_usage = stats.model_usage.setdefault(model_key, ModelUsage())
+        model_usage.messages += 1
+        model_usage.tokens_input += record.input_tokens
+        model_usage.tokens_output += record.output_tokens + record.reasoning_tokens
+        model_usage.cost_by_currency[record.currency] = (
+            model_usage.cost_by_currency.get(record.currency, 0.0) + record.total_cost
+        )
+
+    stats.total_sessions = len(active_session_ids)
+    stats.total_messages, stats.tool_usage = await _collect_message_metrics(sorted(active_session_ids))
+
+    if requested_days:
+        stats.days = requested_days
+    else:
+        earliest = min(created_at_values)
+        latest = max(created_at_values)
+        stats.days = max(1, (latest.date() - earliest.date()).days + 1)
+
     if stats.days > 0:
-        stats.cost_per_day = stats.total_cost / stats.days
         stats.tokens_per_day = stats.total_tokens.total / stats.days
-    
+        stats.cost_per_day_by_currency = {
+            currency: total_cost / stats.days
+            for currency, total_cost in stats.total_cost_by_currency.items()
+        }
+
     if stats.total_sessions > 0:
         stats.tokens_per_session = stats.total_tokens.total / stats.total_sessions
-    
-    # Calculate median
-    if session_total_tokens:
-        session_total_tokens.sort()
-        mid = len(session_total_tokens) // 2
-        if len(session_total_tokens) % 2 == 0:
-            stats.median_tokens_per_session = (session_total_tokens[mid - 1] + session_total_tokens[mid]) / 2
+
+    if session_token_totals:
+        sorted_totals = sorted(session_token_totals.values())
+        mid = len(sorted_totals) // 2
+        if len(sorted_totals) % 2 == 0:
+            stats.median_tokens_per_session = (
+                sorted_totals[mid - 1] + sorted_totals[mid]
+            ) / 2
         else:
-            stats.median_tokens_per_session = session_total_tokens[mid]
-    
+            stats.median_tokens_per_session = sorted_totals[mid]
+
     return stats
 
 
-def _display_stats(
-    stats: SessionStats,
-    tool_limit: Optional[int],
-    model_limit: Optional[int]
-):
-    """Display statistics in formatted output"""
+def _display_cost_section(stats: SessionStats, width: int) -> None:
+    """Render grouped cost totals."""
+    console.print("┌" + "─" * width + "┐")
+    console.print("│" + "COSTS".center(width) + "│")
+    console.print("├" + "─" * width + "┤")
+    if stats.total_cost_by_currency:
+        for currency, total_cost in sorted(stats.total_cost_by_currency.items()):
+            console.print(_render_row(f"Total ({currency})", _format_currency(currency, total_cost), width + 2))
+            avg_per_day = stats.cost_per_day_by_currency.get(currency, 0.0)
+            console.print(_render_row(f"Avg/Day ({currency})", _format_currency(currency, avg_per_day), width + 2))
+    else:
+        console.print(_render_row("Total", "0", width + 2))
+    console.print("└" + "─" * width + "┘")
+    console.print()
+
+
+def _display_stats(stats: SessionStats, tool_limit: Optional[int], model_limit: Optional[int]) -> None:
+    """Display statistics in formatted output."""
     width = 56
-    
-    # Overview section
+
     console.print("┌" + "─" * width + "┐")
     console.print("│" + "OVERVIEW".center(width) + "│")
     console.print("├" + "─" * width + "┤")
@@ -344,20 +253,14 @@ def _display_stats(
     console.print(_render_row("Days", str(stats.days), width + 2))
     console.print("└" + "─" * width + "┘")
     console.print()
-    
-    # Tokens section
+
     console.print("┌" + "─" * width + "┐")
     console.print("│" + "TOKENS".center(width) + "│")
     console.print("├" + "─" * width + "┤")
-    
-    total_tokens = 0 if stats.total_tokens.total != stats.total_tokens.total else stats.total_tokens.total
-    tokens_per_day = 0 if stats.tokens_per_day != stats.tokens_per_day else stats.tokens_per_day
-    tokens_per_session = 0 if stats.tokens_per_session != stats.tokens_per_session else stats.tokens_per_session
-    median_tokens = 0 if stats.median_tokens_per_session != stats.median_tokens_per_session else stats.median_tokens_per_session
-    console.print(_render_row("Total Tokens", _format_number(int(total_tokens)), width + 2))
-    console.print(_render_row("Avg Tokens/Day", _format_number(int(tokens_per_day)), width + 2))
-    console.print(_render_row("Avg Tokens/Session", _format_number(int(tokens_per_session)), width + 2))
-    console.print(_render_row("Median Tokens/Active Session", _format_number(int(median_tokens)), width + 2))
+    console.print(_render_row("Total Tokens", _format_number(stats.total_tokens.total), width + 2))
+    console.print(_render_row("Avg Tokens/Day", _format_number(int(stats.tokens_per_day)), width + 2))
+    console.print(_render_row("Avg Tokens/Session", _format_number(int(stats.tokens_per_session)), width + 2))
+    console.print(_render_row("Median Tokens/Active Session", _format_number(int(stats.median_tokens_per_session)), width + 2))
     console.print(_render_row("Input", _format_number(stats.total_tokens.input), width + 2))
     console.print(_render_row("Output", _format_number(stats.total_tokens.output), width + 2))
     if stats.total_tokens.reasoning > 0:
@@ -366,97 +269,95 @@ def _display_stats(
     console.print(_render_row("Cache Write", _format_number(stats.total_tokens.cache_write), width + 2))
     console.print("└" + "─" * width + "┘")
     console.print()
-    
-    # Model Usage section
+
+    _display_cost_section(stats, width)
+
     if model_limit is not None and stats.model_usage:
         sorted_models = sorted(
             stats.model_usage.items(),
-            key=lambda x: x[1].messages,
-            reverse=True
+            key=lambda item: item[1].messages,
+            reverse=True,
         )
-        
-        if model_limit != float('inf'):
+        if model_limit != float("inf"):
             sorted_models = sorted_models[:model_limit]
-        
+
         console.print("┌" + "─" * width + "┐")
         console.print("│" + "MODEL USAGE".center(width) + "│")
         console.print("├" + "─" * width + "┤")
-        
+
         for model, usage in sorted_models:
             console.print(f"│ {model:<{width-2}} │")
             console.print(_render_row("  Messages", f"{usage.messages:,}", width + 2))
             console.print(_render_row("  Input Tokens", _format_number(usage.tokens_input), width + 2))
             console.print(_render_row("  Output Tokens", _format_number(usage.tokens_output), width + 2))
-            console.print(_render_row("  Cost", f"${usage.cost:.4f}", width + 2))
+            if usage.cost_by_currency:
+                for currency, total_cost in sorted(usage.cost_by_currency.items()):
+                    console.print(_render_row(f"  Cost ({currency})", _format_currency(currency, total_cost), width + 2))
+            else:
+                console.print(_render_row("  Cost", "0", width + 2))
             console.print("├" + "─" * width + "┤")
-        
-        # Remove last separator
+
         console.print("\033[1A└" + "─" * width + "┘")
         console.print()
-    
-    # Tool Usage section
+
     if stats.tool_usage:
         sorted_tools = sorted(
             stats.tool_usage.items(),
-            key=lambda x: x[1],
-            reverse=True
+            key=lambda item: item[1],
+            reverse=True,
         )
-        
         if tool_limit:
             sorted_tools = sorted_tools[:tool_limit]
-        
+
         console.print("┌" + "─" * width + "┐")
         console.print("│" + "TOOL USAGE".center(width) + "│")
         console.print("├" + "─" * width + "┤")
-        
-        if sorted_tools:
-            max_count = max(count for _, count in sorted_tools)
-            total_tool_usage = sum(stats.tool_usage.values())
-            
-            for tool, count in sorted_tools:
-                bar_length = max(1, int((count / max_count) * 20))
-                bar = "█" * bar_length
-                percentage = (count / total_tool_usage) * 100
-                
-                tool_name = tool[:18] + ".." if len(tool) > 18 else tool
-                content = f" {tool_name:<18} {bar:<20} {count:>3} ({percentage:>4.1f}%)"
-                padding = max(0, width - len(content) - 1)
-                console.print(f"│{content}{' ' * padding} │")
-        
+        max_count = max(count for _, count in sorted_tools)
+        total_tool_usage = sum(stats.tool_usage.values())
+        for tool, count in sorted_tools:
+            bar_length = max(1, int((count / max_count) * 20))
+            bar = "█" * bar_length
+            percentage = (count / total_tool_usage) * 100
+            tool_name = tool[:18] + ".." if len(tool) > 18 else tool
+            content = f" {tool_name:<18} {bar:<20} {count:>3} ({percentage:>4.1f}%)"
+            padding = max(0, width - len(content) - 1)
+            console.print(f"│{content}{' ' * padding} │")
         console.print("└" + "─" * width + "┘")
-    
+
     console.print()
 
 
 @stats_app.callback(invoke_without_command=True)
 def show_stats(
+    ctx: typer.Context,
     days: Optional[int] = typer.Option(
-        None, "-d", "--days",
-        help="Show stats for the last N days (default: all time). Use 0 for today."
+        None,
+        "-d",
+        "--days",
+        help="Show stats for the last N days (default: all time). Use 0 for today.",
     ),
     tools: int = typer.Option(
-        5, "-t", "--tools",
-        help="Number of tools to show (default: top 5; use 0 for all)"
+        5,
+        "-t",
+        "--tools",
+        help="Number of tools to show (default: top 5; use 0 for all)",
     ),
     models: Optional[int] = typer.Option(
-        None, "-m", "--models",
-        help="Show model statistics. Pass a number to limit, or 0 for all."
+        None,
+        "-m",
+        "--models",
+        help="Show model statistics. Pass a number to limit, or 0 for all.",
     ),
     project: Optional[str] = typer.Option(
-        None, "-p", "--project",
-        help="Filter by project (empty string for current project)"
+        None,
+        "-p",
+        "--project",
+        help="Filter by project (empty string for current project)",
     ),
-):
-    """
-    Show token usage and cost statistics
-    
-    Aggregates statistics across sessions including:
-    - Session and message counts
-    - Token usage (input, output, cache)
-    - Cost breakdown
-    - Tool usage frequency
-    - Model usage statistics
-    """
+) -> None:
+    """Show token usage and cost statistics."""
+    if ctx.invoked_subcommand:
+        return
     asyncio.run(_show_stats(days, tools, models, project))
 
 
@@ -464,18 +365,55 @@ async def _show_stats(
     days: Optional[int],
     tools: Optional[int],
     models: Optional[int],
-    project: Optional[str]
-):
-    """Internal stats implementation"""
+    project: Optional[str],
+) -> None:
+    """Internal stats implementation."""
     await Storage.init()
-    
     console.print("[dim]Aggregating statistics...[/dim]")
-    
     stats = await _aggregate_stats(days, project)
-    
-    # Determine model limit
-    model_limit = None
-    if models is not None:
-        model_limit = float('inf') if models == 0 else models
-    
+    model_limit = None if models is None else (float("inf") if models == 0 else models)
     _display_stats(stats, tools, model_limit)
+
+
+@stats_app.command("backfill")
+def backfill_stats(
+    days: Optional[int] = typer.Option(
+        None,
+        "-d",
+        "--days",
+        help="Backfill usage for the last N days (default: all time). Use 0 for today.",
+    ),
+    project: Optional[str] = typer.Option(
+        None,
+        "-p",
+        "--project",
+        help="Filter by project (empty string for current project)",
+    ),
+) -> None:
+    """Backfill usage_records from historical assistant message metadata."""
+    asyncio.run(_backfill_stats(days, project))
+
+
+async def _backfill_stats(days: Optional[int], project: Optional[str]) -> BackfillUsageResult:
+    """Run historical usage backfill and report the result."""
+    await Storage.init()
+    sessions = await _resolve_project_sessions(project)
+    session_ids = [session.id for session in sessions]
+    start_date, end_date, _ = _resolve_time_window(days)
+    result = await backfill_usage_records(
+        session_ids=session_ids,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    width = 56
+    console.print("┌" + "─" * width + "┐")
+    console.print("│" + "USAGE BACKFILL".center(width) + "│")
+    console.print("├" + "─" * width + "┤")
+    console.print(_render_row("Scanned Assistant Messages", f"{result.scanned_messages:,}", width + 2))
+    console.print(_render_row("Inserted Records", f"{result.inserted_records:,}", width + 2))
+    console.print(_render_row("Skipped Existing", f"{result.skipped_existing:,}", width + 2))
+    console.print(_render_row("Skipped Missing Data", f"{result.skipped_missing_data:,}", width + 2))
+    console.print("└" + "─" * width + "┘")
+    console.print()
+    return result

--- a/flocks/provider/cost_calculator.py
+++ b/flocks/provider/cost_calculator.py
@@ -22,6 +22,7 @@ class CostCalculator:
         output_tokens: int,
         pricing: PriceConfig,
         cached_tokens: int = 0,
+        cache_write_tokens: int = 0,
     ) -> UsageCost:
         """
         Calculate cost from token usage and pricing.
@@ -30,7 +31,8 @@ class CostCalculator:
             input_tokens: Number of input tokens (excluding cached).
             output_tokens: Number of output tokens.
             pricing: Model price configuration.
-            cached_tokens: Number of cached input tokens.
+            cached_tokens: Number of cache-read input tokens.
+            cache_write_tokens: Number of cache-write input tokens.
 
         Returns:
             Computed costs.
@@ -48,6 +50,8 @@ class CostCalculator:
         cache_cost = 0.0
         if cached_tokens > 0 and pricing.cache_read is not None:
             cache_cost = (cached_tokens / unit) * pricing.cache_read
+        if cache_write_tokens > 0 and pricing.cache_write is not None:
+            cache_cost += (cache_write_tokens / unit) * pricing.cache_write
 
         total_cost = input_cost + output_cost + cache_cost
 

--- a/flocks/provider/types.py
+++ b/flocks/provider/types.py
@@ -310,9 +310,11 @@ class UsageRecord(BaseModel):
     model_id: str
     credential_id: Optional[str] = None
     session_id: Optional[str] = None
+    message_id: Optional[str] = None
     input_tokens: int = 0
     output_tokens: int = 0
     cached_tokens: int = 0
+    cache_write_tokens: int = 0
     reasoning_tokens: int = 0
     total_tokens: int = 0
     input_cost: float = 0.0
@@ -320,7 +322,9 @@ class UsageRecord(BaseModel):
     total_cost: float = 0.0
     currency: str = "USD"
     latency_ms: Optional[int] = None
+    source: str = "live"
     created_at: datetime
+    backfilled_at: Optional[datetime] = None
 
 
 class UsageCost(BaseModel):

--- a/flocks/provider/usage_service.py
+++ b/flocks/provider/usage_service.py
@@ -1,0 +1,762 @@
+"""
+Shared usage tracking service.
+
+Provides a single source of truth for usage persistence, aggregation,
+and historical backfill without depending on HTTP route modules.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import aiosqlite
+from pydantic import BaseModel, Field
+
+from flocks.provider.cost_calculator import CostCalculator
+from flocks.provider.provider import Provider
+from flocks.provider.types import PriceConfig, UsageCost, UsageRecord
+from flocks.session.message import Message
+from flocks.session.session import Session
+from flocks.storage.storage import Storage
+from flocks.utils.log import Log
+
+log = Log.create(service="usage-service")
+_auto_backfill_complete = False
+_auto_backfill_lock = asyncio.Lock()
+
+
+class RecordUsageRequest(BaseModel):
+    """Usage write request."""
+
+    provider_id: str
+    model_id: str
+    credential_id: Optional[str] = None
+    session_id: Optional[str] = None
+    message_id: Optional[str] = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+    cache_write_tokens: int = 0
+    reasoning_tokens: int = 0
+    latency_ms: Optional[int] = None
+    pricing: Optional[PriceConfig] = None
+    cost_override: Optional[UsageCost] = None
+    source: str = "live"
+    created_at: Optional[datetime] = None
+    backfilled_at: Optional[datetime] = None
+
+
+class CurrencyCostSummary(BaseModel):
+    """Usage cost grouped by currency."""
+
+    currency: str
+    total_cost: float = 0.0
+
+
+class UsageSummary(BaseModel):
+    """Aggregated usage summary."""
+
+    total_tokens: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cost: float = 0.0
+    total_requests: int = 0
+    currency: str = "USD"
+    cost_by_currency: List[CurrencyCostSummary] = Field(default_factory=list)
+
+
+class ProviderUsageSummary(BaseModel):
+    """Usage summary per provider."""
+
+    provider_id: str
+    total_tokens: int = 0
+    total_cost: float = 0.0
+    request_count: int = 0
+    currency: str = "USD"
+    cost_by_currency: List[CurrencyCostSummary] = Field(default_factory=list)
+
+
+class ModelUsageSummary(BaseModel):
+    """Usage summary per model."""
+
+    provider_id: str
+    model_id: str
+    total_tokens: int = 0
+    total_cost: float = 0.0
+    request_count: int = 0
+    currency: str = "USD"
+    cost_by_currency: List[CurrencyCostSummary] = Field(default_factory=list)
+
+
+class DailyUsageSummary(BaseModel):
+    """Usage summary per day."""
+
+    date: str
+    total_tokens: int = 0
+    total_cost: float = 0.0
+    request_count: int = 0
+    currency: str = "USD"
+    cost_by_currency: List[CurrencyCostSummary] = Field(default_factory=list)
+
+
+class UsageStatsResponse(BaseModel):
+    """Full usage statistics."""
+
+    summary: UsageSummary
+    by_provider: List[ProviderUsageSummary]
+    by_model: List[ModelUsageSummary]
+    daily: List[DailyUsageSummary]
+
+
+class BackfillUsageResult(BaseModel):
+    """Historical usage backfill summary."""
+
+    scanned_messages: int = 0
+    inserted_records: int = 0
+    skipped_existing: int = 0
+    skipped_missing_data: int = 0
+
+
+def resolve_usage_pricing(provider_id: str, model_id: str) -> Optional[PriceConfig]:
+    """Resolve runtime pricing for a provider/model pair."""
+    model_info = None
+    provider = Provider.get(provider_id)
+    if provider:
+        for candidate in getattr(provider, "_config_models", []):
+            if candidate.id == model_id:
+                model_info = candidate
+                break
+
+    if model_info is None:
+        model_info = Provider.get_model(model_id)
+
+    pricing = getattr(model_info, "pricing", None) if model_info else None
+    if pricing is None:
+        return None
+
+    if isinstance(pricing, PriceConfig):
+        return pricing
+
+    if hasattr(pricing, "input") and hasattr(pricing, "output"):
+        return PriceConfig(
+            input=getattr(pricing, "input", 0.0),
+            output=getattr(pricing, "output", 0.0),
+            unit=getattr(pricing, "unit", 1_000_000),
+            currency=getattr(pricing, "currency", "USD"),
+            cache_read=getattr(pricing, "cache_read", None),
+            cache_write=getattr(pricing, "cache_write", None),
+        )
+
+    if isinstance(pricing, dict):
+        return PriceConfig(
+            input=pricing.get("input", 0.0),
+            output=pricing.get("output", 0.0),
+            unit=pricing.get("unit", 1_000_000),
+            currency=pricing.get("currency", "USD"),
+            cache_read=pricing.get("cache_read"),
+            cache_write=pricing.get("cache_write"),
+        )
+
+    return None
+
+
+def _currency_rollup(cost_rows: Sequence[Tuple[str, float]]) -> tuple[float, str, List[CurrencyCostSummary]]:
+    """Return legacy single-currency fields plus grouped totals."""
+    grouped = [
+        CurrencyCostSummary(currency=currency, total_cost=round(total_cost, 6))
+        for currency, total_cost in cost_rows
+    ]
+    if len(grouped) == 1:
+        return grouped[0].total_cost, grouped[0].currency, grouped
+    if len(grouped) == 0:
+        return 0.0, "USD", []
+    return 0.0, "MIXED", grouped
+
+
+def _usage_record_from_row(row: aiosqlite.Row) -> UsageRecord:
+    """Convert a database row into a UsageRecord."""
+    created_at = datetime.fromisoformat(row["created_at"])
+    backfilled_at = (
+        datetime.fromisoformat(row["backfilled_at"])
+        if row["backfilled_at"]
+        else None
+    )
+    return UsageRecord(
+        id=row["id"],
+        provider_id=row["provider_id"],
+        model_id=row["model_id"],
+        credential_id=row["credential_id"],
+        session_id=row["session_id"],
+        message_id=row["message_id"],
+        input_tokens=row["input_tokens"],
+        output_tokens=row["output_tokens"],
+        cached_tokens=row["cached_tokens"],
+        cache_write_tokens=row["cache_write_tokens"],
+        reasoning_tokens=row["reasoning_tokens"],
+        total_tokens=row["total_tokens"],
+        input_cost=row["input_cost"],
+        output_cost=row["output_cost"],
+        total_cost=row["total_cost"],
+        currency=row["currency"],
+        latency_ms=row["latency_ms"],
+        source=row["source"],
+        created_at=created_at,
+        backfilled_at=backfilled_at,
+    )
+
+
+def _build_filters(
+    *,
+    start_date: Optional[str],
+    end_date: Optional[str],
+    provider_id: Optional[str],
+    model_id: Optional[str],
+    session_ids: Optional[Sequence[str]],
+) -> tuple[str, List[str]]:
+    """Build SQL filters for usage queries."""
+    clauses: List[str] = []
+    params: List[str] = []
+
+    if start_date:
+        clauses.append("created_at >= ?")
+        params.append(start_date)
+    if end_date:
+        clauses.append("created_at <= ?")
+        params.append(end_date)
+    if provider_id:
+        clauses.append("provider_id = ?")
+        params.append(provider_id)
+    if model_id:
+        clauses.append("model_id = ?")
+        params.append(model_id)
+    if session_ids is not None:
+        if not session_ids:
+            clauses.append("1 = 0")
+        else:
+            placeholders = ", ".join("?" for _ in session_ids)
+            clauses.append(f"session_id IN ({placeholders})")
+            params.extend(session_ids)
+
+    where_sql = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+    return where_sql, params
+
+
+async def _get_existing_usage_record(
+    db: aiosqlite.Connection,
+    *,
+    session_id: Optional[str],
+    message_id: Optional[str],
+) -> Optional[UsageRecord]:
+    """Look up an existing usage record for an assistant message."""
+    if not session_id or not message_id:
+        return None
+    async with db.execute(
+        """SELECT id, provider_id, model_id, credential_id, session_id, message_id,
+                  input_tokens, output_tokens, cached_tokens, cache_write_tokens, reasoning_tokens,
+                  total_tokens, input_cost, output_cost, total_cost, currency,
+                  latency_ms, source, created_at, backfilled_at
+           FROM usage_records
+           WHERE session_id = ? AND message_id = ?
+           LIMIT 1""",
+        (session_id, message_id),
+    ) as cursor:
+        row = await cursor.fetchone()
+    return _usage_record_from_row(row) if row else None
+
+
+async def usage_record_exists(*, session_id: str, message_id: str) -> bool:
+    """Check whether a usage row already exists for a message."""
+    await Storage._ensure_init()
+    async with aiosqlite.connect(Storage._db_path) as db:
+        async with db.execute(
+            "SELECT 1 FROM usage_records WHERE session_id = ? AND message_id = ? LIMIT 1",
+            (session_id, message_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+    return row is not None
+
+
+async def _get_recorded_message_ids(session_id: str) -> set[str]:
+    """Return all assistant message ids already present in usage_records."""
+    await Storage._ensure_init()
+    async with aiosqlite.connect(Storage._db_path) as db:
+        async with db.execute(
+            "SELECT message_id FROM usage_records WHERE session_id = ? AND message_id IS NOT NULL",
+            (session_id,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+    return {row[0] for row in rows if row[0]}
+
+
+async def ensure_usage_backfilled() -> None:
+    """Run a one-time historical backfill before serving stats."""
+    global _auto_backfill_complete
+    if _auto_backfill_complete:
+        return
+    async with _auto_backfill_lock:
+        if _auto_backfill_complete:
+            return
+        result = await backfill_usage_records()
+        log.info("usage.backfill.auto_complete", result.model_dump())
+        _auto_backfill_complete = True
+
+
+async def record_usage(req: RecordUsageRequest) -> UsageRecord:
+    """Record a usage entry in SQLite."""
+    await Storage._ensure_init()
+
+    total_tokens = req.input_tokens + req.output_tokens + req.reasoning_tokens
+    created_at = req.created_at or datetime.now(UTC)
+
+    if req.cost_override:
+        input_cost = req.cost_override.input_cost
+        output_cost = req.cost_override.output_cost
+        total_cost = req.cost_override.total_cost
+        currency = req.cost_override.currency
+    elif req.pricing:
+        computed_cost = CostCalculator.calculate(
+            input_tokens=req.input_tokens,
+            output_tokens=req.output_tokens,
+            pricing=req.pricing,
+            cached_tokens=req.cached_tokens,
+            cache_write_tokens=req.cache_write_tokens,
+        )
+        input_cost = computed_cost.input_cost
+        output_cost = computed_cost.output_cost
+        total_cost = computed_cost.total_cost
+        currency = computed_cost.currency
+    else:
+        input_cost = 0.0
+        output_cost = 0.0
+        total_cost = 0.0
+        currency = "USD"
+
+    async with aiosqlite.connect(Storage._db_path) as db:
+        db.row_factory = aiosqlite.Row
+        existing = await _get_existing_usage_record(
+            db,
+            session_id=req.session_id,
+            message_id=req.message_id,
+        )
+        if existing is not None:
+            return existing
+
+        record_id = str(uuid.uuid4())
+        await db.execute(
+            """INSERT INTO usage_records
+               (id, provider_id, model_id, credential_id, session_id, message_id,
+                input_tokens, output_tokens, cached_tokens, cache_write_tokens, reasoning_tokens,
+                total_tokens, input_cost, output_cost, total_cost, currency,
+                latency_ms, source, created_at, backfilled_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                record_id,
+                req.provider_id,
+                req.model_id,
+                req.credential_id,
+                req.session_id,
+                req.message_id,
+                req.input_tokens,
+                req.output_tokens,
+                req.cached_tokens,
+                req.cache_write_tokens,
+                req.reasoning_tokens,
+                total_tokens,
+                input_cost,
+                output_cost,
+                total_cost,
+                currency,
+                req.latency_ms,
+                req.source,
+                created_at.isoformat(),
+                req.backfilled_at.isoformat() if req.backfilled_at else None,
+            ),
+        )
+        await db.commit()
+
+    return UsageRecord(
+        id=record_id,
+        provider_id=req.provider_id,
+        model_id=req.model_id,
+        credential_id=req.credential_id,
+        session_id=req.session_id,
+        message_id=req.message_id,
+        input_tokens=req.input_tokens,
+        output_tokens=req.output_tokens,
+        cached_tokens=req.cached_tokens,
+        cache_write_tokens=req.cache_write_tokens,
+        reasoning_tokens=req.reasoning_tokens,
+        total_tokens=total_tokens,
+        input_cost=input_cost,
+        output_cost=output_cost,
+        total_cost=total_cost,
+        currency=currency,
+        latency_ms=req.latency_ms,
+        source=req.source,
+        created_at=created_at,
+        backfilled_at=req.backfilled_at,
+    )
+
+
+async def get_usage_records(
+    *,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    provider_id: Optional[str] = None,
+    model_id: Optional[str] = None,
+    session_ids: Optional[Sequence[str]] = None,
+) -> List[UsageRecord]:
+    """Return raw usage rows for callers that need custom aggregation."""
+    await ensure_usage_backfilled()
+    await Storage._ensure_init()
+    where_sql, params = _build_filters(
+        start_date=start_date,
+        end_date=end_date,
+        provider_id=provider_id,
+        model_id=model_id,
+        session_ids=session_ids,
+    )
+    async with aiosqlite.connect(Storage._db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            f"""SELECT id, provider_id, model_id, credential_id, session_id, message_id,
+                       input_tokens, output_tokens, cached_tokens, cache_write_tokens, reasoning_tokens,
+                       total_tokens, input_cost, output_cost, total_cost, currency,
+                       latency_ms, source, created_at, backfilled_at
+                FROM usage_records{where_sql}
+                ORDER BY created_at ASC""",
+            params,
+        ) as cursor:
+            rows = await cursor.fetchall()
+    return [_usage_record_from_row(row) for row in rows]
+
+
+async def get_usage_stats(
+    *,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    provider_id: Optional[str] = None,
+    model_id: Optional[str] = None,
+    session_ids: Optional[Sequence[str]] = None,
+) -> UsageStatsResponse:
+    """Query aggregated usage stats from SQLite."""
+    await ensure_usage_backfilled()
+    await Storage._ensure_init()
+    where_sql, params = _build_filters(
+        start_date=start_date,
+        end_date=end_date,
+        provider_id=provider_id,
+        model_id=model_id,
+        session_ids=session_ids,
+    )
+
+    async with aiosqlite.connect(Storage._db_path) as db:
+        db.row_factory = aiosqlite.Row
+
+        async with db.execute(
+            f"""SELECT
+                    COALESCE(SUM(total_tokens), 0) AS total_tokens,
+                    COALESCE(SUM(input_tokens), 0) AS total_input,
+                    COALESCE(SUM(output_tokens), 0) AS total_output,
+                    COUNT(*) AS total_requests
+                FROM usage_records{where_sql}""",
+            params,
+        ) as cursor:
+            totals_row = await cursor.fetchone()
+
+        async with db.execute(
+            f"""SELECT currency, COALESCE(SUM(total_cost), 0) AS total_cost
+                FROM usage_records{where_sql}
+                GROUP BY currency
+                ORDER BY currency ASC""",
+            params,
+        ) as cursor:
+            summary_cost_rows = await cursor.fetchall()
+
+        summary_total_cost, summary_currency, summary_cost_by_currency = _currency_rollup(
+            [(row["currency"], row["total_cost"]) for row in summary_cost_rows]
+        )
+        summary = UsageSummary(
+            total_tokens=totals_row["total_tokens"],
+            total_input_tokens=totals_row["total_input"],
+            total_output_tokens=totals_row["total_output"],
+            total_cost=summary_total_cost,
+            total_requests=totals_row["total_requests"],
+            currency=summary_currency,
+            cost_by_currency=summary_cost_by_currency,
+        )
+
+        async with db.execute(
+            f"""SELECT provider_id, currency,
+                       COALESCE(SUM(total_tokens), 0) AS total_tokens,
+                       COALESCE(SUM(total_cost), 0) AS total_cost,
+                       COUNT(*) AS request_count
+                FROM usage_records{where_sql}
+                GROUP BY provider_id, currency
+                ORDER BY provider_id ASC, currency ASC""",
+            params,
+        ) as cursor:
+            provider_rows = await cursor.fetchall()
+
+        provider_agg: Dict[str, Dict[str, object]] = {}
+        for row in provider_rows:
+            aggregate = provider_agg.setdefault(
+                row["provider_id"],
+                {
+                    "provider_id": row["provider_id"],
+                    "total_tokens": 0,
+                    "request_count": 0,
+                    "cost_rows": [],
+                },
+            )
+            aggregate["total_tokens"] += row["total_tokens"]
+            aggregate["request_count"] += row["request_count"]
+            aggregate["cost_rows"].append((row["currency"], row["total_cost"]))
+
+        by_provider: List[ProviderUsageSummary] = []
+        for provider_key, aggregate in sorted(provider_agg.items()):
+            total_cost, currency, cost_by_currency = _currency_rollup(aggregate["cost_rows"])
+            by_provider.append(
+                ProviderUsageSummary(
+                    provider_id=provider_key,
+                    total_tokens=aggregate["total_tokens"],
+                    total_cost=total_cost,
+                    request_count=aggregate["request_count"],
+                    currency=currency,
+                    cost_by_currency=cost_by_currency,
+                )
+            )
+
+        async with db.execute(
+            f"""SELECT provider_id, model_id, currency,
+                       COALESCE(SUM(total_tokens), 0) AS total_tokens,
+                       COALESCE(SUM(total_cost), 0) AS total_cost,
+                       COUNT(*) AS request_count
+                FROM usage_records{where_sql}
+                GROUP BY provider_id, model_id, currency
+                ORDER BY provider_id ASC, model_id ASC, currency ASC""",
+            params,
+        ) as cursor:
+            model_rows = await cursor.fetchall()
+
+        model_agg: Dict[tuple[str, str], Dict[str, object]] = {}
+        for row in model_rows:
+            model_key = (row["provider_id"], row["model_id"])
+            aggregate = model_agg.setdefault(
+                model_key,
+                {
+                    "provider_id": row["provider_id"],
+                    "model_id": row["model_id"],
+                    "total_tokens": 0,
+                    "request_count": 0,
+                    "cost_rows": [],
+                },
+            )
+            aggregate["total_tokens"] += row["total_tokens"]
+            aggregate["request_count"] += row["request_count"]
+            aggregate["cost_rows"].append((row["currency"], row["total_cost"]))
+
+        by_model: List[ModelUsageSummary] = []
+        for (_, _), aggregate in sorted(model_agg.items()):
+            total_cost, currency, cost_by_currency = _currency_rollup(aggregate["cost_rows"])
+            by_model.append(
+                ModelUsageSummary(
+                    provider_id=aggregate["provider_id"],
+                    model_id=aggregate["model_id"],
+                    total_tokens=aggregate["total_tokens"],
+                    total_cost=total_cost,
+                    request_count=aggregate["request_count"],
+                    currency=currency,
+                    cost_by_currency=cost_by_currency,
+                )
+            )
+
+        async with db.execute(
+            f"""SELECT DATE(created_at) AS date, currency,
+                       COALESCE(SUM(total_tokens), 0) AS total_tokens,
+                       COALESCE(SUM(total_cost), 0) AS total_cost,
+                       COUNT(*) AS request_count
+                FROM usage_records{where_sql}
+                GROUP BY DATE(created_at), currency
+                ORDER BY date DESC, currency ASC
+                LIMIT 180""",
+            params,
+        ) as cursor:
+            daily_rows = await cursor.fetchall()
+
+        daily_agg: Dict[str, Dict[str, object]] = {}
+        for row in daily_rows:
+            aggregate = daily_agg.setdefault(
+                row["date"],
+                {
+                    "date": row["date"],
+                    "total_tokens": 0,
+                    "request_count": 0,
+                    "cost_rows": [],
+                },
+            )
+            aggregate["total_tokens"] += row["total_tokens"]
+            aggregate["request_count"] += row["request_count"]
+            aggregate["cost_rows"].append((row["currency"], row["total_cost"]))
+
+        daily: List[DailyUsageSummary] = []
+        for date_key in sorted(daily_agg.keys(), reverse=True)[:90]:
+            aggregate = daily_agg[date_key]
+            total_cost, currency, cost_by_currency = _currency_rollup(aggregate["cost_rows"])
+            daily.append(
+                DailyUsageSummary(
+                    date=date_key,
+                    total_tokens=aggregate["total_tokens"],
+                    total_cost=total_cost,
+                    request_count=aggregate["request_count"],
+                    currency=currency,
+                    cost_by_currency=cost_by_currency,
+                )
+            )
+
+    return UsageStatsResponse(
+        summary=summary,
+        by_provider=by_provider,
+        by_model=by_model,
+        daily=daily,
+    )
+
+
+def _token_fields(tokens) -> tuple[int, int, int, int, int]:
+    """Extract token counts from message metadata."""
+    if not tokens:
+        return 0, 0, 0, 0, 0
+    cache = getattr(tokens, "cache", None)
+    return (
+        getattr(tokens, "input", 0) or 0,
+        getattr(tokens, "output", 0) or 0,
+        getattr(tokens, "reasoning", 0) or 0,
+        getattr(cache, "read", 0) if cache else 0,
+        getattr(cache, "write", 0) if cache else 0,
+    )
+
+
+def _message_timestamp_ms(info) -> Optional[int]:
+    """Return the best available message timestamp."""
+    time_info = getattr(info, "time", None) or {}
+    return time_info.get("completed") or time_info.get("created")
+
+
+async def backfill_usage_records(
+    *,
+    session_ids: Optional[Sequence[str]] = None,
+    project_id: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> BackfillUsageResult:
+    """Backfill usage records from persisted assistant message metadata."""
+    await Storage._ensure_init()
+    result = BackfillUsageResult()
+    backfilled_at = datetime.now(UTC)
+    start_dt = datetime.fromisoformat(start_date) if start_date else None
+    end_dt = datetime.fromisoformat(end_date) if end_date else None
+
+    sessions = await Session.list_all()
+    selected_session_ids = set(session_ids) if session_ids is not None else None
+
+    for session in sessions:
+        if selected_session_ids is not None and session.id not in selected_session_ids:
+            continue
+        if project_id is not None and session.project_id != project_id:
+            continue
+
+        existing_message_ids = await _get_recorded_message_ids(session.id)
+        messages = await Message.list_with_parts(session.id)
+        for msg in messages:
+            info = msg.info
+            if getattr(info, "role", None) != "assistant":
+                continue
+
+            result.scanned_messages += 1
+            backfill_status = await _backfill_message_if_needed(
+                session_id=session.id,
+                message=msg,
+                existing_message_ids=existing_message_ids,
+                backfilled_at=backfilled_at,
+                start_dt=start_dt,
+                end_dt=end_dt,
+            )
+            if backfill_status == "inserted":
+                result.inserted_records += 1
+                message_id = getattr(msg.info, "id", None)
+                if message_id:
+                    existing_message_ids.add(message_id)
+            elif backfill_status == "existing":
+                result.skipped_existing += 1
+            elif backfill_status == "missing":
+                result.skipped_missing_data += 1
+
+    return result
+
+
+async def _backfill_message_if_needed(
+    *,
+    session_id: str,
+    message,
+    existing_message_ids: set[str],
+    backfilled_at: datetime,
+    start_dt: Optional[datetime],
+    end_dt: Optional[datetime],
+) -> str:
+    """Backfill one assistant message if it is not already recorded."""
+    info = message.info
+    message_id = getattr(info, "id", None)
+    provider_id = getattr(info, "providerID", None)
+    model_id = getattr(info, "modelID", None)
+    if not message_id or not provider_id or not model_id:
+        return "missing"
+
+    if message_id in existing_message_ids:
+        return "existing"
+
+    timestamp_ms = _message_timestamp_ms(info)
+    created_at = (
+        datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC)
+        if timestamp_ms
+        else None
+    )
+    if created_at and start_dt and created_at < start_dt:
+        return "filtered"
+    if created_at and end_dt and created_at > end_dt:
+        return "filtered"
+
+    tokens = getattr(info, "tokens", None)
+    input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_write_tokens = _token_fields(tokens)
+    has_tokens = any((input_tokens, output_tokens, reasoning_tokens, cached_tokens, cache_write_tokens))
+    cost = getattr(info, "cost", 0.0) or 0.0
+    if not has_tokens and cost <= 0:
+        return "missing"
+
+    pricing = resolve_usage_pricing(provider_id, model_id)
+    cost_override = None
+    if cost > 0:
+        currency = pricing.currency if pricing else "USD"
+        cost_override = UsageCost(total_cost=cost, currency=currency)
+
+    await record_usage(
+        RecordUsageRequest(
+            provider_id=provider_id,
+            model_id=model_id,
+            session_id=session_id,
+            message_id=message_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=cached_tokens,
+            cache_write_tokens=cache_write_tokens,
+            reasoning_tokens=reasoning_tokens,
+            pricing=pricing if cost_override is None else None,
+            cost_override=cost_override,
+            source="backfill",
+            created_at=created_at,
+            backfilled_at=backfilled_at,
+        )
+    )
+    return "inserted"

--- a/flocks/server/routes/usage.py
+++ b/flocks/server/routes/usage.py
@@ -1,154 +1,18 @@
-"""
-Usage tracking API routes
+"""Usage tracking API routes."""
 
-Provides endpoints for recording and querying LLM usage and costs.
-"""
+from typing import Optional
 
-import uuid
-from datetime import UTC, datetime
-from typing import Any, Dict, List, Optional
+from fastapi import APIRouter, Query
 
-import aiosqlite
-from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel, Field
-
-from flocks.provider.cost_calculator import CostCalculator
-from flocks.provider.types import PriceConfig, UsageCost, UsageRecord
-from flocks.storage.storage import Storage
-from flocks.utils.log import Log
+from flocks.provider.types import UsageRecord
+from flocks.provider.usage_service import (
+    RecordUsageRequest,
+    UsageStatsResponse,
+    get_usage_stats,
+    record_usage,
+)
 
 router = APIRouter()
-log = Log.create(service="routes.usage")
-
-
-# ==================== Request / Response Models ====================
-
-
-class RecordUsageRequest(BaseModel):
-    """Record a usage entry"""
-    provider_id: str
-    model_id: str
-    credential_id: Optional[str] = None
-    session_id: Optional[str] = None
-    input_tokens: int = 0
-    output_tokens: int = 0
-    cached_tokens: int = 0
-    reasoning_tokens: int = 0
-    latency_ms: Optional[int] = None
-    # Optional: pass pricing to auto-calculate cost
-    pricing: Optional[PriceConfig] = None
-
-
-class UsageSummary(BaseModel):
-    """Aggregated usage summary"""
-    total_tokens: int = 0
-    total_input_tokens: int = 0
-    total_output_tokens: int = 0
-    total_cost: float = 0.0
-    total_requests: int = 0
-    currency: str = "USD"
-
-
-class ProviderUsageSummary(BaseModel):
-    """Usage summary per provider"""
-    provider_id: str
-    total_tokens: int = 0
-    total_cost: float = 0.0
-    request_count: int = 0
-
-
-class ModelUsageSummary(BaseModel):
-    """Usage summary per model"""
-    provider_id: str
-    model_id: str
-    total_tokens: int = 0
-    total_cost: float = 0.0
-    request_count: int = 0
-
-
-class DailyUsageSummary(BaseModel):
-    """Usage summary per day"""
-    date: str
-    total_tokens: int = 0
-    total_cost: float = 0.0
-    request_count: int = 0
-
-
-class UsageStatsResponse(BaseModel):
-    """Full usage statistics"""
-    summary: UsageSummary
-    by_provider: List[ProviderUsageSummary]
-    by_model: List[ModelUsageSummary]
-    daily: List[DailyUsageSummary]
-
-
-# ==================== Service Functions ====================
-
-
-async def record_usage(req: RecordUsageRequest) -> UsageRecord:
-    """Record a usage entry to the database."""
-    await Storage._ensure_init()
-
-    record_id = str(uuid.uuid4())
-    now = datetime.now(UTC).isoformat()
-
-    total_tokens = req.input_tokens + req.output_tokens + req.reasoning_tokens
-
-    # Calculate cost if pricing provided
-    input_cost = 0.0
-    output_cost = 0.0
-    total_cost = 0.0
-    currency = "USD"
-
-    if req.pricing:
-        cost = CostCalculator.calculate(
-            input_tokens=req.input_tokens,
-            output_tokens=req.output_tokens,
-            pricing=req.pricing,
-            cached_tokens=req.cached_tokens,
-        )
-        input_cost = cost.input_cost
-        output_cost = cost.output_cost
-        total_cost = cost.total_cost
-        currency = cost.currency
-
-    async with aiosqlite.connect(Storage._db_path) as db:
-        await db.execute(
-            """INSERT INTO usage_records
-               (id, provider_id, model_id, credential_id, session_id,
-                input_tokens, output_tokens, cached_tokens, reasoning_tokens,
-                total_tokens, input_cost, output_cost, total_cost, currency,
-                latency_ms, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                record_id, req.provider_id, req.model_id,
-                req.credential_id, req.session_id,
-                req.input_tokens, req.output_tokens, req.cached_tokens,
-                req.reasoning_tokens, total_tokens,
-                input_cost, output_cost, total_cost, currency,
-                req.latency_ms, now,
-            ),
-        )
-        await db.commit()
-
-    return UsageRecord(
-        id=record_id,
-        provider_id=req.provider_id,
-        model_id=req.model_id,
-        credential_id=req.credential_id,
-        session_id=req.session_id,
-        input_tokens=req.input_tokens,
-        output_tokens=req.output_tokens,
-        cached_tokens=req.cached_tokens,
-        reasoning_tokens=req.reasoning_tokens,
-        total_tokens=total_tokens,
-        input_cost=input_cost,
-        output_cost=output_cost,
-        total_cost=total_cost,
-        currency=currency,
-        latency_ms=req.latency_ms,
-        created_at=datetime.fromisoformat(now),
-    )
 
 
 # ==================== Routes ====================
@@ -165,140 +29,6 @@ async def api_record_usage(body: RecordUsageRequest) -> UsageRecord:
     return await record_usage(body)
 
 
-async def _query_usage_stats(
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
-    provider_id: Optional[str] = None,
-    model_id: Optional[str] = None,
-) -> UsageStatsResponse:
-    """Internal usage stats query (decoupled from FastAPI Query objects)."""
-    await Storage._ensure_init()
-
-    where_clauses = []
-    params = []
-
-    if start_date:
-        where_clauses.append("created_at >= ?")
-        params.append(start_date)
-    if end_date:
-        where_clauses.append("created_at <= ?")
-        params.append(end_date)
-    if provider_id:
-        where_clauses.append("provider_id = ?")
-        params.append(provider_id)
-    if model_id:
-        where_clauses.append("model_id = ?")
-        params.append(model_id)
-
-    where_sql = (" WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
-
-    async with aiosqlite.connect(Storage._db_path) as db:
-        db.row_factory = aiosqlite.Row
-
-        # Overall summary
-        async with db.execute(
-            f"""SELECT
-                COALESCE(SUM(total_tokens), 0) as total_tokens,
-                COALESCE(SUM(input_tokens), 0) as total_input,
-                COALESCE(SUM(output_tokens), 0) as total_output,
-                COALESCE(SUM(total_cost), 0) as total_cost,
-                COUNT(*) as total_requests
-            FROM usage_records{where_sql}""",
-            params,
-        ) as cursor:
-            row = await cursor.fetchone()
-
-        summary = UsageSummary(
-            total_tokens=row["total_tokens"],
-            total_input_tokens=row["total_input"],
-            total_output_tokens=row["total_output"],
-            total_cost=round(row["total_cost"], 6),
-            total_requests=row["total_requests"],
-        )
-
-        # By provider
-        async with db.execute(
-            f"""SELECT provider_id,
-                COALESCE(SUM(total_tokens), 0) as total_tokens,
-                COALESCE(SUM(total_cost), 0) as total_cost,
-                COUNT(*) as cnt
-            FROM usage_records{where_sql}
-            GROUP BY provider_id
-            ORDER BY total_cost DESC""",
-            params,
-        ) as cursor:
-            rows = await cursor.fetchall()
-
-        by_provider = [
-            ProviderUsageSummary(
-                provider_id=r["provider_id"],
-                total_tokens=r["total_tokens"],
-                total_cost=round(r["total_cost"], 6),
-                request_count=r["cnt"],
-            )
-            for r in rows
-        ]
-
-        # By model
-        async with db.execute(
-            f"""SELECT provider_id, model_id,
-                COALESCE(SUM(total_tokens), 0) as total_tokens,
-                COALESCE(SUM(total_cost), 0) as total_cost,
-                COUNT(*) as cnt
-            FROM usage_records{where_sql}
-            GROUP BY provider_id, model_id
-            ORDER BY total_cost DESC""",
-            params,
-        ) as cursor:
-            rows = await cursor.fetchall()
-
-        by_model = [
-            ModelUsageSummary(
-                provider_id=r["provider_id"],
-                model_id=r["model_id"],
-                total_tokens=r["total_tokens"],
-                total_cost=round(r["total_cost"], 6),
-                request_count=r["cnt"],
-            )
-            for r in rows
-        ]
-
-        # Daily
-        async with db.execute(
-            f"""SELECT DATE(created_at) as date,
-                COALESCE(SUM(total_tokens), 0) as total_tokens,
-                COALESCE(SUM(total_cost), 0) as total_cost,
-                COUNT(*) as cnt
-            FROM usage_records{where_sql}
-            GROUP BY DATE(created_at)
-            ORDER BY date DESC
-            LIMIT 90""",
-            params,
-        ) as cursor:
-            rows = await cursor.fetchall()
-
-        daily = [
-            DailyUsageSummary(
-                date=r["date"],
-                total_tokens=r["total_tokens"],
-                total_cost=round(r["total_cost"], 6),
-                request_count=r["cnt"],
-            )
-            for r in rows
-        ]
-
-    return UsageStatsResponse(
-        summary=summary,
-        by_provider=by_provider,
-        by_model=by_model,
-        daily=daily,
-    )
-
-
-# Public alias for direct (non-FastAPI) callers
-get_usage_stats = _query_usage_stats
-
-
 @router.get(
     "/summary",
     response_model=UsageStatsResponse,
@@ -312,7 +42,7 @@ async def api_get_usage_stats(
     model_id: Optional[str] = Query(None, description="Filter by model"),
 ) -> UsageStatsResponse:
     """Get aggregated usage statistics (HTTP route handler)."""
-    return await _query_usage_stats(
+    return await get_usage_stats(
         start_date=start_date, end_date=end_date,
         provider_id=provider_id, model_id=model_id,
     )

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -880,7 +880,7 @@ Please address this message and continue with your tasks.
                         # Record usage for this empty attempt even though we are
                         # about to retry – the provider may have already charged
                         # for the tokens returned in this response.
-                        await self._record_usage_if_available(result.usage)
+                        await self._record_usage_if_available(result.usage, message_id=assistant_msg.id)
                         delay_ms = SessionRetry.delay(empty_attempt)
                         next_retry_time = int(asyncio.get_event_loop().time() * 1000) + delay_ms
                         log.warn("runner.step.empty_response_retry", {
@@ -934,7 +934,7 @@ Please address this message and continue with your tasks.
                 # Success! Update finish reason
                 finish = "tool-calls" if result.tool_calls else "stop"
                 await Message.update(self.session.id, assistant_msg.id, finish=finish)
-                await self._record_usage_if_available(result.usage)
+                await self._record_usage_if_available(result.usage, message_id=assistant_msg.id)
                 
                 # Note: Compaction check is now done in the main loop (run()) before processing step
                 # This matches Flocks's logic: check lastFinished.tokens at loop start
@@ -1029,81 +1029,41 @@ Please address this message and continue with your tasks.
 
     def _resolve_usage_pricing(self) -> Optional[Any]:
         """Resolve pricing config for the current provider/model pair."""
-        from flocks.provider.types import PriceConfig
+        from flocks.provider.usage_service import resolve_usage_pricing
 
-        model_info = None
-        provider = Provider.get(self.provider_id)
-        if provider:
-            for candidate in getattr(provider, "_config_models", []):
-                if candidate.id == self.model_id:
-                    model_info = candidate
-                    break
+        return resolve_usage_pricing(self.provider_id, self.model_id)
 
-        if model_info is None:
-            model_info = Provider.get_model(self.model_id)
-
-        pricing = getattr(model_info, "pricing", None) if model_info else None
-        if pricing is None:
-            return None
-
-        if isinstance(pricing, PriceConfig):
-            # Already the correct type – returned as-is.
-            return pricing
-
-        if hasattr(pricing, "input") and hasattr(pricing, "output"):
-            # Defensive branch: handles any duck-typed object with input/output
-            # attributes (e.g. legacy dataclass or proxy object). In practice
-            # ModelInfo.pricing is typed as Optional[Dict[str, Any]], so this
-            # branch is unlikely to be hit at runtime.
-            return PriceConfig(
-                input=getattr(pricing, "input", 0.0),
-                output=getattr(pricing, "output", 0.0),
-                unit=getattr(pricing, "unit", 1_000_000),
-                currency=getattr(pricing, "currency", "USD"),
-                cache_read=getattr(pricing, "cache_read", None),
-                cache_write=getattr(pricing, "cache_write", None),
-            )
-
-        if isinstance(pricing, dict):
-            # Standard runtime path: ModelInfo.pricing is a plain dict from JSON.
-            return PriceConfig(
-                input=pricing.get("input", 0.0),
-                output=pricing.get("output", 0.0),
-                unit=pricing.get("unit", 1_000_000),
-                currency=pricing.get("currency", "USD"),
-                cache_read=pricing.get("cache_read"),
-                cache_write=pricing.get("cache_write"),
-            )
-
-        return None
-
-    async def _record_usage_if_available(self, usage: Optional[Dict[str, int]]) -> None:
+    async def _record_usage_if_available(
+        self,
+        usage: Optional[Dict[str, int]],
+        *,
+        message_id: Optional[str] = None,
+    ) -> None:
         """Persist usage records without blocking successful session steps.
 
         All exceptions – including ImportError when server routes are absent
         in CLI-only environments – are caught here so that a usage-recording
         failure can never corrupt an already-successful step result.
 
-        Note: This imports from flocks.server.routes.usage, creating a
-        core→server-routes dependency.
-        TODO: Move record_usage logic to a provider-layer service
-        (e.g. flocks.provider.usage_service) to remove the architectural
-        inversion.
+        Uses the shared provider-layer usage service so that CLI and HTTP
+        callers rely on the same persistence and aggregation path.
         """
         if not usage:
             return
 
         try:
-            from flocks.server.routes.usage import RecordUsageRequest, record_usage
+            from flocks.provider.usage_service import RecordUsageRequest, record_usage
 
             await record_usage(
                 RecordUsageRequest(
                     provider_id=self.provider_id,
                     model_id=self.model_id,
                     session_id=self.session.id,
+                    message_id=message_id,
                     input_tokens=usage.get("prompt_tokens", 0),
                     output_tokens=usage.get("completion_tokens", 0),
                     cached_tokens=usage.get("cache_read_input_tokens", 0),
+                    cache_write_tokens=usage.get("cache_creation_input_tokens", 0),
                     reasoning_tokens=usage.get("reasoning_tokens", 0),
                     pricing=self._resolve_usage_pricing(),
                 )

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -175,9 +175,11 @@ class Storage:
                     model_id TEXT NOT NULL,
                     credential_id TEXT,
                     session_id TEXT,
+                    message_id TEXT,
                     input_tokens INTEGER NOT NULL DEFAULT 0,
                     output_tokens INTEGER NOT NULL DEFAULT 0,
                     cached_tokens INTEGER NOT NULL DEFAULT 0,
+                    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
                     reasoning_tokens INTEGER NOT NULL DEFAULT 0,
                     total_tokens INTEGER NOT NULL DEFAULT 0,
                     input_cost REAL NOT NULL DEFAULT 0,
@@ -185,14 +187,32 @@ class Storage:
                     total_cost REAL NOT NULL DEFAULT 0,
                     currency TEXT NOT NULL DEFAULT 'USD',
                     latency_ms INTEGER,
-                    created_at TEXT NOT NULL
+                    source TEXT NOT NULL DEFAULT 'live',
+                    created_at TEXT NOT NULL,
+                    backfilled_at TEXT
                 );
             """)
+
+            async with db.execute("PRAGMA table_info(usage_records)") as cursor:
+                existing_columns = {row[1] for row in await cursor.fetchall()}
+
+            schema_additions = [
+                ("message_id", "ALTER TABLE usage_records ADD COLUMN message_id TEXT"),
+                ("cache_write_tokens", "ALTER TABLE usage_records ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0"),
+                ("source", "ALTER TABLE usage_records ADD COLUMN source TEXT NOT NULL DEFAULT 'live'"),
+                ("backfilled_at", "ALTER TABLE usage_records ADD COLUMN backfilled_at TEXT"),
+            ]
+            for column_name, statement in schema_additions:
+                if column_name in existing_columns:
+                    continue
+                await db.execute(statement)
 
             index_statements = [
                 "CREATE INDEX IF NOT EXISTS idx_usage_provider ON usage_records(provider_id, model_id)",
                 "CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_records(session_id)",
                 "CREATE INDEX IF NOT EXISTS idx_usage_time ON usage_records(created_at)",
+                "CREATE INDEX IF NOT EXISTS idx_usage_message ON usage_records(session_id, message_id)",
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_usage_unique_message ON usage_records(session_id, message_id) WHERE message_id IS NOT NULL",
             ]
             for stmt in index_statements:
                 try:

--- a/tests/cli/test_stats_command.py
+++ b/tests/cli/test_stats_command.py
@@ -3,27 +3,16 @@ from typer.testing import CliRunner
 
 import flocks.cli.commands.stats as stats_cmd
 from flocks.cli.commands.stats import ModelUsage, SessionStats, TokenStats
-from flocks.session.message import (
-    AssistantMessageInfo,
-    MessagePath,
-    MessageWithParts,
-    PartTime,
-    ReasoningPart,
-    TextPart,
-    TokenCache,
-    TokenUsage,
-    ToolPart,
-    ToolStatePending,
-    UserMessageInfo,
-)
+from flocks.provider.usage_service import BackfillUsageResult
+from flocks.provider.types import UsageRecord
 from flocks.session.session import SessionInfo, SessionTime
 
 runner = CliRunner()
 
 
-def _build_session() -> SessionInfo:
+def _build_session(session_id: str = "ses_stats_test") -> SessionInfo:
     return SessionInfo(
-        id="ses_stats_test",
+        id=session_id,
         projectID="proj_stats",
         directory="/tmp/stats-project",
         title="Stats Session",
@@ -31,262 +20,136 @@ def _build_session() -> SessionInfo:
     )
 
 
-def _build_messages(session_id: str) -> list[MessageWithParts]:
-    user = UserMessageInfo(
-        id="msg_user_stats",
-        sessionID=session_id,
-        role="user",
-        time={"created": 1_000},
-        agent="rex",
-        model={"providerID": "anthropic", "modelID": "claude-sonnet"},
-    )
-    assistant = AssistantMessageInfo(
-        id="msg_assistant_stats",
-        sessionID=session_id,
-        role="assistant",
-        time={"created": 1_100, "completed": 1_200},
-        parentID=user.id,
-        modelID="claude-sonnet",
-        providerID="anthropic",
-        mode="standard",
-        agent="rex",
-        path=MessagePath(cwd="/tmp/stats-project", root="/tmp/stats-project"),
-        tokens=TokenUsage(
-            input=11,
-            output=7,
-            reasoning=3,
-            cache=TokenCache(read=5, write=2),
-        ),
-        cost=1.25,
-    )
-    return [
-        MessageWithParts(
-            info=user,
-            parts=[
-                TextPart(
-                    id="part_user_text",
-                    sessionID=session_id,
-                    messageID=user.id,
-                    text="How many tool calls?",
-                )
-            ],
-        ),
-        MessageWithParts(
-            info=assistant,
-            parts=[
-                TextPart(
-                    id="part_assistant_text",
-                    sessionID=session_id,
-                    messageID=assistant.id,
-                    text="One bash call.",
-                ),
-                ToolPart(
-                    id="part_assistant_tool",
-                    sessionID=session_id,
-                    messageID=assistant.id,
-                    callID="call_stats",
-                    tool="bash",
-                    state=ToolStatePending(input={"command": "echo hi"}, raw='{"command":"echo hi"}'),
-                ),
-            ],
-        ),
-    ]
-
-
-def _build_zero_token_messages(session_id: str) -> list[MessageWithParts]:
-    user = UserMessageInfo(
-        id=f"{session_id}_user_zero",
-        sessionID=session_id,
-        role="user",
-        time={"created": 2_000},
-        agent="rex",
-        model={"providerID": "anthropic", "modelID": "claude-sonnet"},
-    )
-    assistant = AssistantMessageInfo(
-        id=f"{session_id}_assistant_zero",
-        sessionID=session_id,
-        role="assistant",
-        time={"created": 2_100, "completed": 2_200},
-        parentID=user.id,
-        modelID="claude-sonnet",
-        providerID="anthropic",
-        mode="standard",
-        agent="rex",
-        path=MessagePath(cwd="/tmp/stats-project", root="/tmp/stats-project"),
-        tokens=TokenUsage(),
-        cost=0.0,
-    )
-    return [
-        MessageWithParts(
-            info=user,
-            parts=[TextPart(id=f"{session_id}_user_text", sessionID=session_id, messageID=user.id, text="hi")],
-        ),
-        MessageWithParts(
-            info=assistant,
-            parts=[],
-        ),
-    ]
-
-
-def _build_estimated_token_messages(session_id: str) -> list[MessageWithParts]:
-    user = UserMessageInfo(
-        id=f"{session_id}_user_estimate",
-        sessionID=session_id,
-        role="user",
-        time={"created": 3_000},
-        agent="rex",
-        model={"providerID": "anthropic", "modelID": "claude-sonnet"},
-    )
-    assistant = AssistantMessageInfo(
-        id=f"{session_id}_assistant_estimate",
-        sessionID=session_id,
-        role="assistant",
-        time={"created": 3_100, "completed": 3_200},
-        parentID=user.id,
-        modelID="claude-sonnet",
-        providerID="anthropic",
-        mode="standard",
-        agent="rex",
-        path=MessagePath(cwd="/tmp/stats-project", root="/tmp/stats-project"),
-        tokens=TokenUsage(),
-        cost=0.0,
-    )
-    return [
-        MessageWithParts(
-            info=user,
-            parts=[
-                TextPart(
-                    id=f"{session_id}_user_estimate_text",
-                    sessionID=session_id,
-                    messageID=user.id,
-                    text="Please investigate the issue carefully.",
-                )
-            ],
-        ),
-        MessageWithParts(
-            info=assistant,
-            parts=[
-                TextPart(
-                    id=f"{session_id}_assistant_estimate_text",
-                    sessionID=session_id,
-                    messageID=assistant.id,
-                    text="Estimated assistant answer.",
-                ),
-                ReasoningPart(
-                    id=f"{session_id}_assistant_estimate_reasoning",
-                    sessionID=session_id,
-                    messageID=assistant.id,
-                    text="Hidden chain of thought summary.",
-                    time=PartTime(start=3_120),
-                ),
-                ToolPart(
-                    id=f"{session_id}_assistant_estimate_tool",
-                    sessionID=session_id,
-                    messageID=assistant.id,
-                    callID=f"{session_id}_tool_call",
-                    tool="bash",
-                    state=ToolStatePending(
-                        input={"command": "echo estimated"},
-                        raw='{"command":"echo estimated"}',
-                    ),
-                ),
-            ],
-        ),
-    ]
-
-
 @pytest.mark.asyncio
-async def test_aggregate_stats_uses_current_message_model(monkeypatch) -> None:
+async def test_aggregate_stats_uses_usage_records(monkeypatch) -> None:
     session = _build_session()
-    messages = _build_messages(session.id)
+    record = UsageRecord(
+        id="usage-1",
+        provider_id="anthropic",
+        model_id="claude-sonnet",
+        session_id=session.id,
+        message_id="msg-1",
+        input_tokens=11,
+        output_tokens=7,
+        cached_tokens=5,
+        cache_write_tokens=2,
+        reasoning_tokens=3,
+        total_tokens=21,
+        total_cost=1.25,
+        currency="USD",
+        source="live",
+        created_at=stats_cmd.datetime.now(stats_cmd.UTC),
+    )
 
-    async def fake_get_all_sessions():
+    async def fake_resolve_project_sessions(project_filter):
+        assert project_filter is None
         return [session]
 
-    async def fake_list_with_parts(session_id: str, include_archived: bool = False):
-        assert session_id == session.id
-        assert include_archived is False
-        return messages
+    async def fake_get_usage_records(**kwargs):
+        assert kwargs["session_ids"] == [session.id]
+        return [record]
 
-    monkeypatch.setattr(stats_cmd, "_get_all_sessions", fake_get_all_sessions)
-    monkeypatch.setattr(stats_cmd.Message, "list_with_parts", fake_list_with_parts)
+    async def fake_get_usage_stats(**kwargs):
+        assert kwargs["session_ids"] == [session.id]
+        return type("UsageStats", (), {
+            "summary": type("Summary", (), {
+                "cost_by_currency": [type("CurrencyCost", (), {"currency": "USD", "total_cost": 1.25})()],
+            })(),
+        })()
+
+    async def fake_collect_message_metrics(session_ids):
+        assert session_ids == [session.id]
+        return 2, {"bash": 1}
+
+    monkeypatch.setattr(stats_cmd, "_resolve_project_sessions", fake_resolve_project_sessions)
+    monkeypatch.setattr(stats_cmd, "get_usage_records", fake_get_usage_records)
+    monkeypatch.setattr(stats_cmd, "get_usage_stats", fake_get_usage_stats)
+    monkeypatch.setattr(stats_cmd, "_collect_message_metrics", fake_collect_message_metrics)
 
     result = await stats_cmd._aggregate_stats(days=None, project_filter=None)
 
     assert result.total_sessions == 1
     assert result.total_messages == 2
-    assert result.total_cost == 1.25
     assert result.total_tokens.input == 11
     assert result.total_tokens.output == 7
     assert result.total_tokens.reasoning == 3
     assert result.total_tokens.cache_read == 5
     assert result.total_tokens.cache_write == 2
+    assert result.total_cost_by_currency == {"USD": 1.25}
     assert result.tool_usage == {"bash": 1}
     assert result.model_usage["anthropic/claude-sonnet"].messages == 1
     assert result.model_usage["anthropic/claude-sonnet"].tokens_input == 11
     assert result.model_usage["anthropic/claude-sonnet"].tokens_output == 10
+    assert result.model_usage["anthropic/claude-sonnet"].cost_by_currency == {"USD": 1.25}
 
 
 @pytest.mark.asyncio
-async def test_aggregate_stats_median_ignores_zero_token_sessions(monkeypatch) -> None:
-    session_with_tokens = _build_session()
-    zero_session = SessionInfo(
-        id="ses_stats_zero",
-        projectID="proj_stats",
-        directory="/tmp/stats-project",
-        title="Zero Session",
-        time=SessionTime(created=2_000, updated=3_000),
-    )
+async def test_aggregate_stats_uses_active_session_median(monkeypatch) -> None:
+    first = _build_session("ses_first")
+    second = _build_session("ses_second")
+    records = [
+        UsageRecord(
+            id="usage-1",
+            provider_id="anthropic",
+            model_id="m1",
+            session_id=first.id,
+            message_id="msg-1",
+            input_tokens=10,
+            output_tokens=5,
+            cached_tokens=0,
+            cache_write_tokens=0,
+            reasoning_tokens=0,
+            total_tokens=15,
+            total_cost=0.5,
+            currency="USD",
+            source="live",
+            created_at=stats_cmd.datetime.now(stats_cmd.UTC),
+        ),
+        UsageRecord(
+            id="usage-2",
+            provider_id="anthropic",
+            model_id="m1",
+            session_id=second.id,
+            message_id="msg-2",
+            input_tokens=20,
+            output_tokens=10,
+            cached_tokens=0,
+            cache_write_tokens=0,
+            reasoning_tokens=0,
+            total_tokens=30,
+            total_cost=1.0,
+            currency="USD",
+            source="live",
+            created_at=stats_cmd.datetime.now(stats_cmd.UTC),
+        ),
+    ]
 
-    async def fake_get_all_sessions():
-        return [session_with_tokens, zero_session]
+    async def fake_resolve_project_sessions(project_filter):
+        return [first, second]
 
-    async def fake_list_with_parts(session_id: str, include_archived: bool = False):
-        assert include_archived is False
-        if session_id == session_with_tokens.id:
-            return _build_messages(session_id)
-        return _build_zero_token_messages(session_id)
+    async def fake_get_usage_records(**kwargs):
+        return records
 
-    monkeypatch.setattr(stats_cmd, "_get_all_sessions", fake_get_all_sessions)
-    monkeypatch.setattr(stats_cmd.Message, "list_with_parts", fake_list_with_parts)
+    async def fake_get_usage_stats(**kwargs):
+        return type("UsageStats", (), {
+            "summary": type("Summary", (), {
+                "cost_by_currency": [type("CurrencyCost", (), {"currency": "USD", "total_cost": 1.5})()],
+            })(),
+        })()
+
+    async def fake_collect_message_metrics(session_ids):
+        return 4, {}
+
+    monkeypatch.setattr(stats_cmd, "_resolve_project_sessions", fake_resolve_project_sessions)
+    monkeypatch.setattr(stats_cmd, "get_usage_records", fake_get_usage_records)
+    monkeypatch.setattr(stats_cmd, "get_usage_stats", fake_get_usage_stats)
+    monkeypatch.setattr(stats_cmd, "_collect_message_metrics", fake_collect_message_metrics)
 
     result = await stats_cmd._aggregate_stats(days=None, project_filter=None)
 
     assert result.total_sessions == 2
-    assert result.median_tokens_per_session == 21
-
-
-@pytest.mark.asyncio
-async def test_aggregate_stats_estimates_missing_assistant_tokens(monkeypatch) -> None:
-    session = _build_session()
-    messages = _build_estimated_token_messages(session.id)
-
-    async def fake_get_all_sessions():
-        return [session]
-
-    async def fake_list_with_parts(session_id: str, include_archived: bool = False):
-        assert session_id == session.id
-        assert include_archived is False
-        return messages
-
-    monkeypatch.setattr(stats_cmd, "_get_all_sessions", fake_get_all_sessions)
-    monkeypatch.setattr(stats_cmd.Message, "list_with_parts", fake_list_with_parts)
-
-    result = await stats_cmd._aggregate_stats(days=None, project_filter=None)
-
-    expected_input = 800 + stats_cmd._estimate_message_context_tokens(messages[0])
-    expected_output = (
-        stats_cmd._count_tokens("Estimated assistant answer.")
-        + stats_cmd._count_tokens(stats_cmd._stringify_payload({"command": "echo estimated"}))
-    )
-    expected_reasoning = stats_cmd._count_tokens("Hidden chain of thought summary.")
-
-    assert result.total_tokens.input == expected_input
-    assert result.total_tokens.output == expected_output
-    assert result.total_tokens.reasoning == expected_reasoning
-    assert result.has_reasoning_tokens is True
-    assert result.model_usage["anthropic/claude-sonnet"].tokens_input == expected_input
-    assert result.model_usage["anthropic/claude-sonnet"].tokens_output == expected_output + expected_reasoning
+    assert result.tokens_per_session == 22.5
+    assert result.median_tokens_per_session == 22.5
 
 
 def test_stats_command_renders_output(monkeypatch) -> None:
@@ -299,16 +162,22 @@ def test_stats_command_renders_output(monkeypatch) -> None:
         return SessionStats(
             total_sessions=2,
             total_messages=4,
-            total_cost=2.5,
+            total_cost_by_currency={"USD": 2.5, "CNY": 1.2},
+            cost_per_day_by_currency={"USD": 2.5, "CNY": 1.2},
             total_tokens=TokenStats(input=20, output=10, reasoning=5, cache_read=3, cache_write=1),
             tool_usage={"bash": 2},
-            model_usage={"anthropic/claude-sonnet": ModelUsage(messages=2, tokens_input=20, tokens_output=15, cost=2.5)},
+            model_usage={
+                "anthropic/claude-sonnet": ModelUsage(
+                    messages=2,
+                    tokens_input=20,
+                    tokens_output=15,
+                    cost_by_currency={"USD": 2.5},
+                )
+            },
             days=1,
-            cost_per_day=2.5,
             tokens_per_day=35.0,
             tokens_per_session=17.5,
             median_tokens_per_session=17.5,
-            has_reasoning_tokens=True,
         )
 
     monkeypatch.setattr(stats_cmd.Storage, "init", fake_storage_init)
@@ -319,12 +188,12 @@ def test_stats_command_renders_output(monkeypatch) -> None:
     assert result.exit_code == 0
     assert "OVERVIEW" in result.stdout
     assert "TOKENS" in result.stdout
-    assert "Total Tokens" in result.stdout
-    assert "Avg Tokens/Day" in result.stdout
-    assert "Median Tokens/Active Session" in result.stdout
+    assert "COSTS" in result.stdout
     assert "MODEL USAGE" in result.stdout
     assert "TOOL USAGE" in result.stdout
     assert "anthropic/claude-sonnet" in result.stdout
+    assert "$2.5000" in result.stdout
+    assert "¥1.2000" in result.stdout
 
 
 def test_stats_command_defaults_tools_to_five(monkeypatch) -> None:
@@ -372,7 +241,6 @@ def test_stats_command_hides_reasoning_when_zero(monkeypatch) -> None:
             tokens_per_day=30.0,
             tokens_per_session=30.0,
             median_tokens_per_session=30.0,
-            has_reasoning_tokens=False,
         )
 
     monkeypatch.setattr(stats_cmd.Storage, "init", fake_storage_init)
@@ -382,3 +250,31 @@ def test_stats_command_hides_reasoning_when_zero(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert "Reasoning" not in result.stdout
+
+
+def test_stats_backfill_command_renders_summary(monkeypatch) -> None:
+    async def fake_storage_init(*args, **kwargs) -> None:
+        return None
+
+    async def fake_resolve_project_sessions(project_filter):
+        return [_build_session()]
+
+    async def fake_backfill_usage_records(**kwargs):
+        assert kwargs["session_ids"] == ["ses_stats_test"]
+        return BackfillUsageResult(
+            scanned_messages=10,
+            inserted_records=4,
+            skipped_existing=5,
+            skipped_missing_data=1,
+        )
+
+    monkeypatch.setattr(stats_cmd.Storage, "init", fake_storage_init)
+    monkeypatch.setattr(stats_cmd, "_resolve_project_sessions", fake_resolve_project_sessions)
+    monkeypatch.setattr(stats_cmd, "backfill_usage_records", fake_backfill_usage_records)
+
+    result = runner.invoke(stats_cmd.stats_app, ["backfill"])
+
+    assert result.exit_code == 0
+    assert "USAGE BACKFILL" in result.stdout
+    assert "Inserted Records" in result.stdout
+    assert "4" in result.stdout

--- a/tests/provider/test_model_management_p2p3.py
+++ b/tests/provider/test_model_management_p2p3.py
@@ -376,6 +376,31 @@ class TestCostCalculator:
         assert abs(cost.cache_cost - 0.0024) < 0.0001
         assert abs(cost.total_cost - 0.0234) < 0.0001
 
+    def test_with_cache_write(self):
+        from flocks.provider.cost_calculator import CostCalculator
+        pricing = PriceConfig(
+            input=3.0,
+            output=15.0,
+            cache_read=0.3,
+            cache_write=3.75,
+        )
+
+        cost = CostCalculator.calculate(
+            input_tokens=10000,
+            output_tokens=1000,
+            pricing=pricing,
+            cached_tokens=8000,
+            cache_write_tokens=2000,
+        )
+        # Billable input: 10000 - 8000 = 2000 => 0.006
+        # output: 1000 / 1M * 15.0 = 0.015
+        # cache read: 8000 / 1M * 0.3 = 0.0024
+        # cache write: 2000 / 1M * 3.75 = 0.0075
+        assert abs(cost.input_cost - 0.006) < 0.0001
+        assert abs(cost.output_cost - 0.015) < 0.0001
+        assert abs(cost.cache_cost - 0.0099) < 0.0001
+        assert abs(cost.total_cost - 0.0309) < 0.0001
+
     def test_zero_tokens(self):
         from flocks.provider.cost_calculator import CostCalculator
         pricing = PriceConfig(input=3.0, output=15.0)
@@ -420,12 +445,97 @@ class TestUsageTracking:
             input_tokens=10000,
             output_tokens=2000,
             cached_tokens=5000,
-            pricing=PriceConfig(input=3.0, output=15.0, cache_read=0.3),
+            cache_write_tokens=1000,
+            pricing=PriceConfig(input=3.0, output=15.0, cache_read=0.3, cache_write=3.75),
         )
         record = run_async(record_usage(req))
         assert record.total_cost > 0
         assert record.input_cost > 0
         assert record.output_cost > 0
+        assert abs(record.total_cost - 0.05025) < 0.0001
+
+    def test_backfill_skips_existing_live_record_with_same_message_id(self, setup_storage, monkeypatch):
+        from flocks.provider import usage_service
+        from flocks.provider.usage_service import (
+            RecordUsageRequest,
+            backfill_usage_records,
+            get_usage_records,
+            record_usage,
+        )
+        from flocks.session.message import (
+            AssistantMessageInfo,
+            MessagePath,
+            MessageWithParts,
+            TokenCache,
+            TokenUsage,
+            UserMessageInfo,
+        )
+        from flocks.session.session import SessionInfo, SessionTime
+
+        usage_service._auto_backfill_complete = False
+
+        session = SessionInfo(
+            id="ses_backfill_live",
+            projectID="proj_backfill_live",
+            directory="/tmp/backfill-live",
+            title="Backfill Live Session",
+            time=SessionTime(created=1_000, updated=2_000),
+        )
+        user = UserMessageInfo(
+            id="msg_user_live",
+            sessionID=session.id,
+            role="user",
+            time={"created": 1_000},
+            agent="rex",
+            model={"providerID": "anthropic", "modelID": "claude-sonnet"},
+        )
+        assistant = AssistantMessageInfo(
+            id="msg_assistant_live",
+            sessionID=session.id,
+            role="assistant",
+            time={"created": 1_100, "completed": 1_200},
+            parentID=user.id,
+            modelID="claude-sonnet",
+            providerID="anthropic",
+            mode="standard",
+            agent="rex",
+            path=MessagePath(cwd="/tmp/backfill-live", root="/tmp/backfill-live"),
+            tokens=TokenUsage(input=11, output=7, reasoning=3, cache=TokenCache(read=5, write=2)),
+            cost=1.25,
+        )
+        message = MessageWithParts(info=assistant, parts=[])
+
+        run_async(record_usage(RecordUsageRequest(
+            provider_id="anthropic",
+            model_id="claude-sonnet",
+            session_id=session.id,
+            message_id=assistant.id,
+            input_tokens=11,
+            output_tokens=7,
+            cached_tokens=5,
+            cache_write_tokens=2,
+            reasoning_tokens=3,
+            pricing=PriceConfig(input=3.0, output=15.0, cache_read=0.3, cache_write=3.75),
+        )))
+
+        async def fake_list_all():
+            return [session]
+
+        async def fake_list_with_parts(session_id: str, include_archived: bool = False):
+            assert session_id == session.id
+            assert include_archived is False
+            return [MessageWithParts(info=user, parts=[]), message]
+
+        monkeypatch.setattr(usage_service.Session, "list_all", fake_list_all)
+        monkeypatch.setattr(usage_service.Message, "list_with_parts", fake_list_with_parts)
+
+        result = run_async(backfill_usage_records())
+        records = run_async(get_usage_records(session_ids=[session.id]))
+
+        assert result.inserted_records == 0
+        assert result.skipped_existing == 1
+        assert len(records) == 1
+        assert records[0].source == "live"
 
     def test_record_multiple_and_query(self, setup_storage):
         from flocks.server.routes.usage import RecordUsageRequest, record_usage
@@ -481,3 +591,98 @@ class TestUsageTracking:
         assert stats.summary.total_requests == 1
         assert len(stats.by_provider) == 1
         assert stats.by_provider[0].provider_id == "anthropic"
+
+    def test_query_groups_costs_by_currency(self, setup_storage):
+        from flocks.server.routes.usage import RecordUsageRequest, record_usage, get_usage_stats
+
+        run_async(record_usage(RecordUsageRequest(
+            provider_id="anthropic",
+            model_id="m1",
+            input_tokens=1000,
+            output_tokens=500,
+            pricing=PriceConfig(input=3.0, output=15.0, currency="USD"),
+        )))
+        run_async(record_usage(RecordUsageRequest(
+            provider_id="threatbook",
+            model_id="m2",
+            input_tokens=1000,
+            output_tokens=500,
+            pricing=PriceConfig(input=2.1, output=8.4, currency="CNY"),
+        )))
+
+        stats = run_async(get_usage_stats())
+
+        assert stats.summary.currency == "MIXED"
+        assert stats.summary.total_cost == 0.0
+        assert {(item.currency, item.total_cost > 0) for item in stats.summary.cost_by_currency} == {
+            ("USD", True),
+            ("CNY", True),
+        }
+
+    def test_backfill_usage_records_is_idempotent(self, setup_storage, monkeypatch):
+        from flocks.provider import usage_service
+        from flocks.provider.usage_service import backfill_usage_records, get_usage_records
+        from flocks.session.message import (
+            AssistantMessageInfo,
+            MessagePath,
+            MessageWithParts,
+            TokenCache,
+            TokenUsage,
+            UserMessageInfo,
+        )
+        from flocks.session.session import SessionInfo, SessionTime
+
+        usage_service._auto_backfill_complete = False
+
+        session = SessionInfo(
+            id="ses_backfill",
+            projectID="proj_backfill",
+            directory="/tmp/backfill",
+            title="Backfill Session",
+            time=SessionTime(created=1_000, updated=2_000),
+        )
+        user = UserMessageInfo(
+            id="msg_user",
+            sessionID=session.id,
+            role="user",
+            time={"created": 1_000},
+            agent="rex",
+            model={"providerID": "anthropic", "modelID": "claude-sonnet"},
+        )
+        assistant = AssistantMessageInfo(
+            id="msg_assistant",
+            sessionID=session.id,
+            role="assistant",
+            time={"created": 1_100, "completed": 1_200},
+            parentID=user.id,
+            modelID="claude-sonnet",
+            providerID="anthropic",
+            mode="standard",
+            agent="rex",
+            path=MessagePath(cwd="/tmp/backfill", root="/tmp/backfill"),
+            tokens=TokenUsage(input=11, output=7, reasoning=3, cache=TokenCache(read=5, write=2)),
+            cost=1.25,
+        )
+        message = MessageWithParts(info=assistant, parts=[])
+
+        async def fake_list_all():
+            return [session]
+
+        async def fake_list_with_parts(session_id: str, include_archived: bool = False):
+            assert session_id == session.id
+            assert include_archived is False
+            return [MessageWithParts(info=user, parts=[]), message]
+
+        monkeypatch.setattr(usage_service.Session, "list_all", fake_list_all)
+        monkeypatch.setattr(usage_service.Message, "list_with_parts", fake_list_with_parts)
+
+        first = run_async(backfill_usage_records())
+        second = run_async(backfill_usage_records())
+        records = run_async(get_usage_records(session_ids=[session.id]))
+
+        assert first.inserted_records == 1
+        assert second.skipped_existing == 1
+        assert len(records) == 1
+        assert records[0].message_id == assistant.id
+        assert records[0].cache_write_tokens == 2
+        assert records[0].source == "backfill"

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -766,7 +766,7 @@ async def test_process_step_records_usage_after_success(monkeypatch):
     result = await runner._process_step([last_user], last_user)
 
     assert result.content == "done"
-    record_mock.assert_awaited_once_with(usage)
+    record_mock.assert_awaited_once_with(usage, message_id=assistant_msg.id)
     update_mock.assert_any_await(runner.session.id, assistant_msg.id, finish="stop")
 
 
@@ -828,21 +828,49 @@ async def test_process_step_empty_retry_records_usage_per_attempt(monkeypatch):
     # Both the empty attempt and the successful attempt must be recorded so
     # that provider charges are not silently dropped during retries.
     assert record_mock.await_count == 2
-    record_mock.assert_any_await(first_usage)
-    record_mock.assert_any_await(second_usage)
+    record_mock.assert_any_await(first_usage, message_id=assistant_msg.id)
+    record_mock.assert_any_await(second_usage, message_id=assistant_msg.id)
 
 
 @pytest.mark.asyncio
 async def test_record_usage_if_available_swallows_import_error():
-    """ImportError from the server-routes import must not propagate out of
+    """ImportError from the usage service import must not propagate out of
     _record_usage_if_available so that a CLI-only environment (where fastapi /
     server deps may be absent) never turns a successful step into an error."""
     runner = _make_runner("ses_runner_import_error")
     usage = {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
 
-    with patch.dict("sys.modules", {"flocks.server.routes.usage": None}):
+    with patch.dict("sys.modules", {"flocks.provider.usage_service": None}):
         # Should complete without raising, even though the import will fail.
         await runner._record_usage_if_available(usage)
+
+
+@pytest.mark.asyncio
+async def test_record_usage_if_available_passes_message_id():
+    runner = _make_runner("ses_runner_message_id")
+    usage = {
+        "prompt_tokens": 3,
+        "completion_tokens": 2,
+        "total_tokens": 5,
+        "cache_creation_input_tokens": 4,
+    }
+    request_cls = MagicMock(return_value=SimpleNamespace())
+    record_usage_mock = AsyncMock(return_value=None)
+    fake_module = SimpleNamespace(
+        RecordUsageRequest=request_cls,
+        record_usage=record_usage_mock,
+    )
+    runner._resolve_usage_pricing = MagicMock(return_value=None)
+
+    with patch.dict("sys.modules", {"flocks.provider.usage_service": fake_module}):
+        await runner._record_usage_if_available(usage, message_id="msg_assistant")
+
+    request_cls.assert_called_once()
+    kwargs = request_cls.call_args.kwargs
+    assert kwargs["session_id"] == runner.session.id
+    assert kwargs["message_id"] == "msg_assistant"
+    assert kwargs["cache_write_tokens"] == 4
+    record_usage_mock.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -856,5 +884,5 @@ async def test_record_usage_if_available_swallows_runtime_error():
         RecordUsageRequest=MagicMock(return_value=SimpleNamespace()),
         record_usage=AsyncMock(side_effect=RuntimeError("db unavailable")),
     )
-    with patch.dict("sys.modules", {"flocks.server.routes.usage": fake_module}):
+    with patch.dict("sys.modules", {"flocks.provider.usage_service": fake_module}):
         await runner._record_usage_if_available(usage)

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.4.7"
+version = "2026.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/webui/src/locales/en-US/model.json
+++ b/webui/src/locales/en-US/model.json
@@ -12,7 +12,11 @@
     "connected": "Connected Provider",
     "availableModels": "Available Models",
     "totalUsage": "Total Usage",
-    "noUsage": "None"
+    "totalTokens": "Total Tokens",
+    "totalCost": "Total Cost",
+    "noUsage": "None",
+    "noCost": "No cost",
+    "toggleCurrency": "Click to switch between USD and CNY"
   },
   "providerList": {
     "empty": "No providers configured",

--- a/webui/src/locales/zh-CN/model.json
+++ b/webui/src/locales/zh-CN/model.json
@@ -12,7 +12,11 @@
     "connected": "已连接 Provider",
     "availableModels": "可用模型",
     "totalUsage": "总用量",
-    "noUsage": "暂无"
+    "totalTokens": "总 Tokens",
+    "totalCost": "总费用",
+    "noUsage": "暂无",
+    "noCost": "暂无费用",
+    "toggleCurrency": "点击切换人民币 / 美元"
   },
   "providerList": {
     "empty": "尚未添加模型供应商",

--- a/webui/src/pages/Model/index.tsx
+++ b/webui/src/pages/Model/index.tsx
@@ -21,6 +21,12 @@ import {
   customAPI, modelSettingsAPI, catalogAPI, defaultModelAPI,
 } from '@/api/provider';
 import { hasPendingProviderCredentialChanges } from './providerCredentialUtils';
+import {
+  formatTokenMillions,
+  getConvertedTotalCost,
+  getDefaultDashboardCurrency,
+  toggleDashboardCurrency,
+} from './usageDisplay';
 import type {
   ProviderCredentials, ModelDefinitionV2, UsageStats,
   CatalogProvider, CatalogModel, CatalogCredentialField, ModelSettingV2,
@@ -600,12 +606,21 @@ function DashboardStrip({
   defaultModel: { provider_id: string; model_id: string } | null;
   onEditDefault: () => void;
 }) {
-  const { t } = useTranslation('model');
-  const todayCost = usageStats?.summary?.total_cost ?? 0;
-  const currency = usageStats?.summary?.currency ?? 'USD';
+  const { t, i18n } = useTranslation('model');
+  const totalTokens = usageStats?.summary?.total_tokens ?? 0;
+  const defaultCurrency = getDefaultDashboardCurrency(i18n.language);
+  const [displayCurrency, setDisplayCurrency] = useState(defaultCurrency);
+  const totalCost = useMemo(
+    () => getConvertedTotalCost(usageStats, displayCurrency),
+    [displayCurrency, usageStats],
+  );
+
+  useEffect(() => {
+    setDisplayCurrency(getDefaultDashboardCurrency(i18n.language));
+  }, [i18n.language]);
 
   return (
-    <div className="grid grid-cols-4 gap-3 mb-4">
+    <div className="grid grid-cols-5 gap-3 mb-4">
       {/* Default Model Card */}
       <div className="rounded-lg border p-3 bg-purple-50 text-purple-700 border-purple-200">
         <div className="flex items-center justify-between mb-1 opacity-70">
@@ -630,13 +645,32 @@ function DashboardStrip({
       </div>
       <StatCard icon={<Link2 className="w-5 h-5" />} label={t('dashboard.connected')} value={String(connectedCount)} color="green" />
       <StatCard icon={<Cpu className="w-5 h-5" />} label={t('dashboard.availableModels')} value={String(totalModels)} color="blue" />
-      <StatCard icon={<DollarSign className="w-5 h-5" />} label={t('dashboard.totalUsage')} value={todayCost > 0 ? `${currency === 'USD' ? '$' : '¥'}${todayCost.toFixed(4)}` : t('dashboard.noUsage')} color="amber" />
+      <StatCard
+        icon={<Brain className="w-5 h-5" />}
+        label={t('dashboard.totalTokens')}
+        value={totalTokens > 0 ? formatTokenMillions(totalTokens) : t('dashboard.noUsage')}
+        color="blue"
+      />
+      <StatCard
+        icon={<DollarSign className="w-5 h-5" />}
+        label={t('dashboard.totalCost')}
+        value={totalCost ?? t('dashboard.noCost')}
+        color="amber"
+        onClick={() => setDisplayCurrency(current => toggleDashboardCurrency(current))}
+        title={t('dashboard.toggleCurrency')}
+      />
     </div>
   );
 }
 
-function StatCard({ icon, label, value, color, small }: {
-  icon: React.ReactNode; label: string; value: string; color: string; small?: boolean;
+function StatCard({ icon, label, value, color, small, onClick, title }: {
+  icon: React.ReactNode;
+  label: string;
+  value: React.ReactNode;
+  color: string;
+  small?: boolean;
+  onClick?: () => void;
+  title?: string;
 }) {
   const colorMap: Record<string, string> = {
     green: 'bg-green-50 text-green-700 border-green-200',
@@ -645,7 +679,19 @@ function StatCard({ icon, label, value, color, small }: {
     amber: 'bg-amber-50 text-amber-700 border-amber-200',
   };
   return (
-    <div className={`rounded-lg border p-3 ${colorMap[color] || colorMap.blue}`}>
+    <div
+      className={`rounded-lg border p-3 ${colorMap[color] || colorMap.blue} ${onClick ? 'cursor-pointer transition-opacity hover:opacity-90' : ''}`}
+      onClick={onClick}
+      title={title}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick();
+        }
+      } : undefined}
+    >
       <div className="flex items-center gap-2 mb-1 opacity-70">
         {icon}
         <span className="text-xs font-medium">{label}</span>

--- a/webui/src/pages/Model/usageDisplay.test.ts
+++ b/webui/src/pages/Model/usageDisplay.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatTokenMillions,
+  getConvertedTotalCost,
+  getDefaultDashboardCurrency,
+  toggleDashboardCurrency,
+} from './usageDisplay';
+import type { UsageStats } from '@/types';
+
+const usageStats: UsageStats = {
+  summary: {
+    total_tokens: 1_234_567,
+    total_input_tokens: 1_000_000,
+    total_output_tokens: 234_567,
+    total_cost: 0,
+    total_requests: 2,
+    currency: 'MIXED',
+    cost_by_currency: [
+      { currency: 'USD', total_cost: 1.25 },
+      { currency: 'CNY', total_cost: 14 },
+    ],
+  },
+  by_provider: [],
+  by_model: [],
+  daily: [],
+};
+
+describe('usageDisplay helpers', () => {
+  it('formats tokens in millions', () => {
+    expect(formatTokenMillions(1_234_567)).toBe('1.23M');
+  });
+
+  it('uses locale-based default currency', () => {
+    expect(getDefaultDashboardCurrency('zh-CN')).toBe('CNY');
+    expect(getDefaultDashboardCurrency('en-US')).toBe('USD');
+  });
+
+  it('converts grouped costs to the target currency', () => {
+    expect(getConvertedTotalCost(usageStats, 'CNY')).toBe('¥22.7500');
+    expect(getConvertedTotalCost(usageStats, 'USD')).toBe('$3.2500');
+  });
+
+  it('toggles dashboard currency', () => {
+    expect(toggleDashboardCurrency('USD')).toBe('CNY');
+    expect(toggleDashboardCurrency('CNY')).toBe('USD');
+  });
+});

--- a/webui/src/pages/Model/usageDisplay.ts
+++ b/webui/src/pages/Model/usageDisplay.ts
@@ -1,0 +1,55 @@
+import type { UsageStats } from '@/types';
+
+const USD_TO_CNY = 7;
+
+export type DashboardCurrency = 'USD' | 'CNY';
+
+function formatCurrencyAmount(currency: string, amount: number): string {
+  if (currency === 'USD') {
+    return `$${amount.toFixed(4)}`;
+  }
+  if (currency === 'CNY') {
+    return `¥${amount.toFixed(4)}`;
+  }
+  return `${currency} ${amount.toFixed(4)}`;
+}
+
+export function formatTokenMillions(totalTokens: number): string {
+  return `${(totalTokens / 1_000_000).toFixed(2)}M`;
+}
+
+export function getDefaultDashboardCurrency(language: string | undefined): DashboardCurrency {
+  return language?.toLowerCase().startsWith('zh') ? 'CNY' : 'USD';
+}
+
+export function getConvertedTotalCost(
+  usageStats: UsageStats | null,
+  targetCurrency: DashboardCurrency,
+): string | null {
+  const buckets = usageStats?.summary?.cost_by_currency ?? [];
+  if (buckets.length === 0) {
+    return null;
+  }
+
+  const total = buckets.reduce((sum, bucket) => {
+    if (bucket.currency === targetCurrency) {
+      return sum + bucket.total_cost;
+    }
+    if (bucket.currency === 'USD' && targetCurrency === 'CNY') {
+      return sum + (bucket.total_cost * USD_TO_CNY);
+    }
+    if (bucket.currency === 'CNY' && targetCurrency === 'USD') {
+      return sum + (bucket.total_cost / USD_TO_CNY);
+    }
+    return sum;
+  }, 0);
+
+  if (total <= 0) {
+    return null;
+  }
+  return formatCurrencyAmount(targetCurrency, total);
+}
+
+export function toggleDashboardCurrency(currency: DashboardCurrency): DashboardCurrency {
+  return currency === 'USD' ? 'CNY' : 'USD';
+}

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -480,10 +480,33 @@ export interface UsageStats {
     total_cost: number;
     total_requests: number;
     currency: string;
+    cost_by_currency: { currency: string; total_cost: number }[];
   };
-  by_provider: { provider_id: string; total_tokens: number; total_cost: number; request_count: number }[];
-  by_model: { provider_id: string; model_id: string; total_tokens: number; total_cost: number; request_count: number }[];
-  daily: { date: string; total_tokens: number; total_cost: number; request_count: number }[];
+  by_provider: {
+    provider_id: string;
+    total_tokens: number;
+    total_cost: number;
+    request_count: number;
+    currency: string;
+    cost_by_currency: { currency: string; total_cost: number }[];
+  }[];
+  by_model: {
+    provider_id: string;
+    model_id: string;
+    total_tokens: number;
+    total_cost: number;
+    request_count: number;
+    currency: string;
+    cost_by_currency: { currency: string; total_cost: number }[];
+  }[];
+  daily: {
+    date: string;
+    total_tokens: number;
+    total_cost: number;
+    request_count: number;
+    currency: string;
+    cost_by_currency: { currency: string; total_cost: number }[];
+  }[];
 }
 
 /** Custom provider creation */


### PR DESCRIPTION
- Add shared usage_service for aggregation, query, and idempotent backfill
- Refactor flocks stats to read from usage_records with consistent metrics
- Delegate /api/usage routes to the service; simplify runner usage recording
- WebUI Model page: display token usage and costs by currency from summary API
- Extend storage/types/cost calculator; add CLI, provider, runner, and WebUI tests