### PR TITLE
chore(agents): extend plugin subagent tool lists

### DIFF
--- a/.flocks/plugins/agents/asset-survey/agent.yaml
+++ b/.flocks/plugins/agents/asset-survey/agent.yaml
@@ -17,6 +17,18 @@ tags:
   - security
   - asset-survey
 tools:
+  - read
+  - list
+  - glob
+  - grep
+  - edit
+  - write
+  - bash
+  - todoread
+  - todowrite
+  - file_search
+  - websearch
+  - webfetch
   - threatbook_mcp_hrti_query
   - threatbook_mcp_internet_assets_query
   - threatbook_mcp_web_search

--- a/.flocks/plugins/agents/host-forensics/agent.yaml
+++ b/.flocks/plugins/agents/host-forensics/agent.yaml
@@ -23,6 +23,15 @@ color: "#E74C3C"
 temperature: 0.3
 
 tools:
+  - read
+  - list
+  - glob
+  - grep
+  - edit
+  - write
+  - bash
+  - todoread
+  - todowrite
   - tool_search
   - ssh_run_script
   - ssh_host_cmd
@@ -35,8 +44,7 @@ tools:
   - virustotal_domain_query
   - virustotal_file_query
   - virustotal_url_query
-  - bash
-  - read
+  - file_search
   - websearch
   - webfetch
 

--- a/.flocks/plugins/agents/hrti_threat_intelligence/agent.yaml
+++ b/.flocks/plugins/agents/hrti_threat_intelligence/agent.yaml
@@ -17,15 +17,22 @@ tags:
   - security
   - threat-intelligence
 tools:
+  - read
+  - list
+  - glob
+  - grep
+  - edit
+  - write
+  - bash
+  - todoread
+  - todowrite
   - tool_search
   - threatbook_mcp_hrti_list_query
   - threatbook_mcp_hrti_query
   - threatbook_mcp_web_search
+  - file_search
   - websearch
   - webfetch
-  - read
-  - grep
-  - glob
   - virustotal_ip_query
   - virustotal_domain_query
   - virustotal_url_query

--- a/.flocks/plugins/agents/ndr-analyst/agent.yaml
+++ b/.flocks/plugins/agents/ndr-analyst/agent.yaml
@@ -16,10 +16,17 @@ color: "#3498DB"
 temperature: 0.3
 
 tools:
-  - tool_search
   - read
-  - grep
+  - list
   - glob
+  - grep
+  - edit
+  - write
+  - bash
+  - todoread
+  - todowrite
+  - tool_search
+  - file_search
   - codesearch
   - websearch
   - webfetch

--- a/.flocks/plugins/agents/phishing-detector/agent.yaml
+++ b/.flocks/plugins/agents/phishing-detector/agent.yaml
@@ -14,10 +14,19 @@ color: "#E74C3C"
 temperature: 0.3
 
 tools:
-  - tool_search
   - read
-  - grep
+  - list
   - glob
+  - grep
+  - edit
+  - write
+  - bash
+  - todoread
+  - todowrite
+  - tool_search
+  - file_search
+  - websearch
+  - webfetch
   - virustotal_ip_query
   - virustotal_domain_query
   - virustotal_url_query

--- a/.flocks/plugins/agents/ti-analyst/agent.yaml
+++ b/.flocks/plugins/agents/ti-analyst/agent.yaml
@@ -18,6 +18,15 @@ tags:
   - threat-intelligence
   - ioc-analysis
 tools:
+  - read
+  - list
+  - glob
+  - grep
+  - edit
+  - write
+  - bash
+  - todoread
+  - todowrite
   - tool_search
   - threatbook_mcp_ip_query
   - threatbook_mcp_ip_attribution
@@ -29,12 +38,10 @@ tools:
   - threatbook_mcp_vuln_query
   - threatbook_mcp_vuln_vendors_products_match
   - threatbook_mcp_hrti_query
-  - websearch
-  - webfetch
-  - read
-  - grep
-  - glob
   - virustotal_ip_query
   - virustotal_domain_query
   - virustotal_url_query
   - virustotal_file_query
+  - file_search
+  - websearch
+  - webfetch

--- a/.flocks/plugins/agents/vul_threat_intelligence/agent.yaml
+++ b/.flocks/plugins/agents/vul_threat_intelligence/agent.yaml
@@ -17,6 +17,15 @@ tags:
   - security
   - vulnerability
 tools:
+  - read
+  - list
+  - glob
+  - grep
+  - edit
+  - write
+  - bash
+  - todoread
+  - todowrite
   - tool_search
   - threatbook_mcp_vulnlist_query
   - threatbook_mcp_vuln_query
@@ -30,12 +39,9 @@ tools:
   - threatbook_mcp_threat_actor_query
   - threatbook_mcp_threat_actor_list_query
   - threatbook_mcp_hrti_query
+  - file_search
   - websearch
   - webfetch
-  - read
-  - grep
-  - glob
-  - codesearch
   - virustotal_ip_query
   - virustotal_domain_query
   - virustotal_url_query


### PR DESCRIPTION
Add core file/workspace tools, todos, file_search, websearch, webfetch, and VirusTotal queries to .flocks/plugins/agents; group VT tools after ThreatBook on ti-analyst.

Made-with: Cursor