### PR TITLE
feat(onboarding): change default ThreatBook model to qwen3.6-plus

### DIFF
--- a/flocks/server/routes/onboarding.py
+++ b/flocks/server/routes/onboarding.py
@@ -141,7 +141,7 @@ ONBOARDING_REGION_PRESETS: Dict[Region, Dict[str, Any]] = {
     "cn": {
         "activation_url": "https://x.threatbook.com/flocks/activate",
         "threatbook_llm_provider_id": "threatbook-cn-llm",
-        "threatbook_default_model_id": "minimax-m2.7",
+        "threatbook_default_model_id": "qwen3.6-plus",
         "threatbook_api_service_id": "threatbook-cn",
         "threatbook_mcp_name": "threatbook_mcp",
         "threatbook_mcp_url": "https://mcp.threatbook.cn/mcp?apikey={api_key}",
@@ -151,7 +151,7 @@ ONBOARDING_REGION_PRESETS: Dict[Region, Dict[str, Any]] = {
     "global": {
         "activation_url": "https://threatbook.io/flocks/activate",
         "threatbook_llm_provider_id": "threatbook-io-llm",
-        "threatbook_default_model_id": "minimax-m2.7",
+        "threatbook_default_model_id": "qwen3.6-plus",
         "threatbook_api_service_id": "threatbook-io",
         "threatbook_mcp_name": None,
         "threatbook_mcp_url": None,

--- a/tests/server/routes/test_onboarding_routes.py
+++ b/tests/server/routes/test_onboarding_routes.py
@@ -42,7 +42,7 @@ class TestOnboardingStatusRoutes:
         self, client, monkeypatch: pytest.MonkeyPatch
     ):
         async def fake_resolve():
-            return {"provider_id": "threatbook-cn-llm", "model_id": "minimax-m2.7"}
+            return {"provider_id": "threatbook-cn-llm", "model_id": "qwen3.6-plus"}
 
         monkeypatch.setattr(onboarding_routes.Config, "resolve_default_llm", fake_resolve)
         monkeypatch.setattr(onboarding_routes, "_llm_provider_has_usable_credentials", lambda _pid: True)

--- a/tests/skill/test_onboarding_status.py
+++ b/tests/skill/test_onboarding_status.py
@@ -38,7 +38,7 @@ async def test_onboarding_status_uses_default_model_services_and_channels(isolat
             "default_models": {
                 "llm": {
                     "provider_id": "threatbook-cn-llm",
-                    "model_id": "minimax-m2.7",
+                    "model_id": "qwen3.6-plus",
                 }
             },
             "api_services": {

--- a/webui/src/components/common/OnboardingModal.test.tsx
+++ b/webui/src/components/common/OnboardingModal.test.tsx
@@ -111,11 +111,11 @@ describe('OnboardingModal', () => {
       data: {
         providers: [
           makeProvider('threatbook-cn-llm', 'ThreatBook CN', [
-            { id: 'minimax-m2.7', name: 'MiniMax M2.7' },
+            { id: 'qwen3.6-plus', name: 'Qwen3.6 Plus' },
             { id: 'qwen3-max', name: 'Qwen 3 Max' },
           ]),
           makeProvider('threatbook-io-llm', 'ThreatBook Global', [
-            { id: 'minimax-m2.7', name: 'MiniMax M2.7' },
+            { id: 'qwen3.6-plus', name: 'Qwen3.6 Plus' },
             { id: 'qwen3-max', name: 'Qwen 3 Max' },
           ]),
           makeProvider('openai-compatible', 'OpenAI Compatible', []),
@@ -173,7 +173,7 @@ describe('OnboardingModal', () => {
     defaultModelAPI.getResolved.mockResolvedValue({
       data: {
         provider_id: 'threatbook-cn-llm',
-        model_id: 'minimax-m2.7',
+        model_id: 'qwen3.6-plus',
       },
     });
 
@@ -195,7 +195,7 @@ describe('OnboardingModal', () => {
     defaultModelAPI.getResolved.mockResolvedValue({
       data: {
         provider_id: 'threatbook-cn-llm',
-        model_id: 'minimax-m2.7',
+        model_id: 'qwen3.6-plus',
       },
     });
 
@@ -290,7 +290,7 @@ describe('OnboardingModal', () => {
         skipped: [],
         default_model: {
           provider_id: 'threatbook-cn-llm',
-          model_id: 'minimax-m2.7',
+          model_id: 'qwen3.6-plus',
         },
       },
     });
@@ -304,7 +304,7 @@ describe('OnboardingModal', () => {
     await screen.findByText('onboarding.bootstrap.primaryConfiguredSummary');
     await user.click(screen.getByText('onboarding.bootstrap.primaryTitle'));
 
-    expect(screen.getByText('MiniMax M2.7')).toBeInTheDocument();
+    expect(screen.getByText('Qwen3.6 Plus')).toBeInTheDocument();
     expect(screen.queryByText('Qwen 3 Max')).not.toBeInTheDocument();
   });
 });

--- a/webui/src/components/layout/Layout.test.tsx
+++ b/webui/src/components/layout/Layout.test.tsx
@@ -165,7 +165,7 @@ describe('Layout onboarding entry', () => {
     defaultModelAPI.getResolved.mockResolvedValue({
       data: {
         provider_id: 'threatbook-cn-llm',
-        model_id: 'minimax-m2.7',
+        model_id: 'qwen3.6-plus',
       },
     });
 
@@ -173,11 +173,11 @@ describe('Layout onboarding entry', () => {
       data: {
         providers: [
           makeProvider('threatbook-cn-llm', 'ThreatBook CN', [
-            { id: 'minimax-m2.7', name: 'MiniMax M2.7' },
+            { id: 'qwen3.6-plus', name: 'Qwen3.6 Plus' },
             { id: 'qwen3-max', name: 'Qwen 3 Max' },
           ]),
           makeProvider('threatbook-io-llm', 'ThreatBook Global', [
-            { id: 'minimax-m2.7', name: 'MiniMax M2.7' },
+            { id: 'qwen3.6-plus', name: 'Qwen3.6 Plus' },
             { id: 'qwen3-max', name: 'Qwen 3 Max' },
           ]),
           makeProvider('openai-compatible', 'OpenAI Compatible', []),


### PR DESCRIPTION
Replace minimax-m2.7 with qwen3.6-plus as the default LLM for both cn and global regions in the onboarding preset. Update all related tests to reflect the new default.