### PR TITLE
docs: remove optional TUI install steps from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ The recommended host installation entrypoint is the GitHub bootstrap installer. 
 # One-click install backend + WebUI
 curl -fsSL https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.sh | bash
 # Creates ./flocks under the current directory
-
-# Optional: also install TUI dependencies
-curl -fsSL https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.sh | bash -s -- --with-tui
 ```
 
 #### Windows PowerShell (Administrator)
@@ -67,9 +64,6 @@ curl -fsSL https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.sh 
 ```powershell
 # One-click install backend + WebUI
 powershell -c "irm https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.ps1 | iex"
-
-# Optional: also install TUI dependencies
-powershell -c "& ([scriptblock]::Create((irm https://raw.githubusercontent.com/AgentFlocks/flocks/main/install.ps1))) -InstallTui"
 ```
 
 ### Install from source code
@@ -78,9 +72,6 @@ If you prefer to inspect the repository before installation, clone it locally an
 
 ```bash
 git clone https://github.com/AgentFlocks/Flocks.git flocks
-
-# Alternative for users in China (Gitee mirror)
-# git clone https://gitee.com/flocks/flocks.git flocks
 
 cd flocks
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -54,9 +54,6 @@ Flocks 支持两种部署方式：
 # 一键安装后端 + WebUI
 curl -fsSL https://gitee.com/flocks/flocks/raw/main/install_zh.sh | bash
 # 默认会在当前目录下创建 ./flocks
-
-# 可选：同时安装 TUI 依赖
-curl -fsSL https://gitee.com/flocks/flocks/raw/main/install_zh.sh | bash -s -- --with-tui
 ```
 
 #### Windows PowerShell (Administrator)
@@ -64,9 +61,6 @@ curl -fsSL https://gitee.com/flocks/flocks/raw/main/install_zh.sh | bash -s -- -
 ```powershell
 # 一键安装后端 + WebUI
 powershell -c "irm https://gitee.com/flocks/flocks/raw/main/install_zh.ps1 | iex"
-
-# 可选：同时安装 TUI 依赖
-powershell -c "& ([scriptblock]::Create((irm https://gitee.com/flocks/flocks/raw/main/install_zh.ps1))) -InstallTui"
 ```
 
 ### github源码安装


### PR DESCRIPTION
- Drop --with-tui / -InstallTui snippets from EN/ZH install sections
- Remove Gitee mirror clone comment from English README