### PR TITLE
fix/delegate button disabled during subagent

### DIFF
--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -1647,6 +1647,8 @@ export const ChatMessageBubble = memo(ChatMessageBubbleInner, (prev, next) => {
   return (
     prevLast?.text === nextLast?.text &&
     prevLast?.thinking === nextLast?.thinking &&
-    prevLast?.state?.status === nextLast?.state?.status
+    prevLast?.state?.status === nextLast?.state?.status &&
+    JSON.stringify(prevLast?.state?.metadata) ===
+      JSON.stringify(nextLast?.state?.metadata)
   );
 });


### PR DESCRIPTION
fix(webui): use deep comparison for metadata in ChatMessageBubble memo

- The previous fix used reference equality (===) to compare state.metadata,
which is unreliable: SSE events produce a new object on every JSON.parse,
causing unnecessary re-renders when metadata has not actually changed;
conversely, an in-place mutation would be silently missed.

- Switch to JSON.stringify for a stable content-based comparison. For the
common case where metadata is undefined, JSON.stringify returns undefined
on both sides with zero extra cost. For DelegateTaskCard parts the
payload is small (sessionId, steps, stepCount, currentText, elapsed), so
the serialisation overhead is negligible.