### PR TITLE
fix/defer session creation

### DIFF
--- a/webui/src/components/common/ChatDialog.tsx
+++ b/webui/src/components/common/ChatDialog.tsx
@@ -2,9 +2,10 @@
  * ChatDialog - 统一的对话弹窗组件
  *
  * 使用 useSessionChat 创建会话，通过 SessionChat 展示对话并支持追问。
+ * 会话在用户首次发送消息时才创建，避免空会话污染会话列表。
  */
-import { useEffect } from 'react';
-import { X, Sparkles, Loader2 } from 'lucide-react';
+import { useEffect, useCallback } from 'react';
+import { X, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import SessionChat from './SessionChat';
 import { useSessionChat } from '@/hooks/useSessionChat';
@@ -34,14 +35,23 @@ export default function ChatDialog({
   width = 'max-w-2xl',
 }: ChatDialogProps) {
   const { t } = useTranslation('common');
-  const { sessionId, loading, create, reset } = useSessionChat({
+  const { sessionId, createAndSend, reset } = useSessionChat({
     title,
   });
 
   useEffect(() => {
-    if (open) create().catch(() => {});
-    else reset();
-  }, [open, create, reset]);
+    if (open && initialPrompt) {
+      createAndSend(initialPrompt).catch(() => {});
+    }
+    if (!open) reset();
+  }, [open, reset, initialPrompt, createAndSend]);
+
+  const handleCreateAndSend = useCallback(
+    async (text: string) => {
+      await createAndSend(text);
+    },
+    [createAndSend],
+  );
 
   if (!open) return null;
 
@@ -70,32 +80,22 @@ export default function ChatDialog({
         </div>
 
         {/* Body */}
-        {loading ? (
-          <div className="flex-1 flex items-center justify-center bg-gray-50">
-            <div className="text-center">
-              <Loader2 className="w-8 h-8 text-red-500 animate-spin mx-auto mb-3" />
-              <p className="text-sm text-gray-500">{t('chat.creating')}</p>
-            </div>
-          </div>
-        ) : sessionId ? (
-          <SessionChat
-            sessionId={sessionId}
-            live
-            placeholder={placeholder ?? t('chat.inputPlaceholder')}
-            className="flex-1 min-h-0 rounded-b-xl"
-            emptyText={t('chat.starting')}
-            suggestions={suggestions}
-            initialMessage={initialPrompt}
-          />
-        ) : (
-          <div className="flex-1 flex items-center justify-center bg-gray-50 rounded-b-xl">
+        <SessionChat
+          sessionId={sessionId}
+          live={!!sessionId}
+          placeholder={placeholder ?? t('chat.inputPlaceholder')}
+          className="flex-1 min-h-0 rounded-b-xl"
+          emptyText={t('chat.starting')}
+          suggestions={suggestions}
+          onCreateAndSend={!sessionId ? handleCreateAndSend : undefined}
+          welcomeContent={!sessionId ? (
             <div className="text-center max-w-md">
               <Sparkles className="w-10 h-10 text-red-500 mx-auto mb-3" />
               <h3 className="text-lg font-semibold text-gray-900 mb-2">{t('chat.talkToRex')}</h3>
               <p className="text-sm text-gray-500">{t('chat.talkToRexHint')}</p>
             </div>
-          </div>
-        )}
+          ) : undefined}
+        />
       </div>
     </div>
   );

--- a/webui/src/components/common/EntitySheet.tsx
+++ b/webui/src/components/common/EntitySheet.tsx
@@ -167,6 +167,7 @@ export default function EntitySheet({
     loading: sessionLoading,
     error: sessionError,
     create: createRexSession,
+    createAndSend: createAndSendRex,
     retry: retryRexSession,
     reset: resetRexSession,
   } = useSessionChat({
@@ -211,23 +212,13 @@ export default function EntitySheet({
     }
   }, [open, mode, defaultTestPrompt, resetRexSession, initialWidth, showTabs, hideRex, hideForm, initialTab]);
 
-  // ── Auto-create Rex session on mount when starting on the rex tab ─────────
-
-  useEffect(() => {
-    if (activeTab === 'rex') {
-      createRexSession().catch(() => {});
-    }
-    // Only run on mount; activeTab and createRexSession are stable at this point
-  }, []);
-
   // ── Tab handling ──────────────────────────────────────────────────────────
 
   const handleTabChange = useCallback(
     (tab: Tab) => {
       setActiveTab(tab);
-      if (tab === 'rex') createRexSession().catch(() => {});
     },
-    [createRexSession],
+    [],
   );
 
   // ── Drawer width resizing ───────────────────────────────────────────────
@@ -268,12 +259,11 @@ export default function EntitySheet({
         client.post(`/api/session/${sessionId}/prompt_async`, {
           parts: [{ type: 'text', text: msg }],
         });
-      } else {
-        if (msg) setRexInitialMessage(msg);
-        createRexSession().catch(() => {});
+      } else if (msg) {
+        createAndSendRex(msg).catch(() => {});
       }
     },
-    [sessionId, createRexSession],
+    [sessionId, createAndSendRex],
   );
 
   // ── openTest (exposed via context) ────────────────────────────────────────
@@ -479,12 +469,6 @@ export default function EntitySheet({
           {/* Rex Tab */}
           {activeTab === 'rex' && (
             <div className="h-full flex flex-col">
-              {sessionLoading && !sessionId && (
-                <div className="flex flex-col items-center justify-center flex-1 gap-3">
-                  <Loader2 className="w-6 h-6 text-red-500 animate-spin" />
-                  <p className="text-sm text-gray-500">{t('entity.startingRex')}</p>
-                </div>
-              )}
               {sessionError && (
                 <div className="flex flex-col items-center justify-center flex-1 gap-4 p-6 text-center">
                   <div className="flex items-center gap-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3 w-full">
@@ -499,14 +483,22 @@ export default function EntitySheet({
                   </button>
                 </div>
               )}
-              {sessionId && (
+              {!sessionError && (
                 <SessionChat
                   sessionId={sessionId}
-                  live
+                  live={!!sessionId}
                   placeholder={t('entity.rexInputPlaceholder')}
                   className="flex-1"
                   emptyText={t('entity.rexReady')}
                   initialMessage={rexInitialMessage}
+                  onCreateAndSend={!sessionId ? async (text: string) => { await createAndSendRex(text); } : undefined}
+                  welcomeContent={!sessionId ? (
+                    <div className="text-center max-w-md">
+                      <MessageSquare className="w-10 h-10 text-red-500 mx-auto mb-3" />
+                      <h3 className="text-lg font-semibold text-gray-900 mb-2">{t('entity.rexAssist')}</h3>
+                      <p className="text-sm text-gray-500">{t('entity.rexReady')}</p>
+                    </div>
+                  ) : undefined}
                 />
               )}
             </div>

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -1647,6 +1647,7 @@ export const ChatMessageBubble = memo(ChatMessageBubbleInner, (prev, next) => {
   return (
     prevLast?.text === nextLast?.text &&
     prevLast?.thinking === nextLast?.thinking &&
-    prevLast?.state?.status === nextLast?.state?.status
+    prevLast?.state?.status === nextLast?.state?.status &&
+    prevLast?.state?.metadata === nextLast?.state?.metadata
   );
 });

--- a/webui/src/hooks/useSessionChat.ts
+++ b/webui/src/hooks/useSessionChat.ts
@@ -92,9 +92,22 @@ export function useSessionChat({
     setError(null);
   }, []);
 
+  const createAndSend = useCallback(
+    async (text: string, agent?: string): Promise<string> => {
+      const sid = await create();
+      const payload: Record<string, unknown> = {
+        parts: [{ type: 'text', text }],
+      };
+      if (agent) payload.agent = agent;
+      client.post(`/api/session/${sid}/prompt_async`, payload).catch(() => {});
+      return sid;
+    },
+    [create],
+  );
+
   useEffect(() => {
     if (autoCreate) create().catch(() => {});
   }, []);
 
-  return { sessionId, loading, error, create, retry, reset };
+  return { sessionId, loading, error, create, createAndSend, retry, reset };
 }

--- a/webui/src/pages/Agent/CreateAgentChat.tsx
+++ b/webui/src/pages/Agent/CreateAgentChat.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { X, Bot, Loader2, AlertCircle } from 'lucide-react';
+import { useEffect, useCallback } from 'react';
+import { X, Bot } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import SessionChat from '@/components/common/SessionChat';
 import { useSessionChat } from '@/hooks/useSessionChat';
@@ -48,7 +48,7 @@ interface CreateAgentChatProps {
 export default function CreateAgentChat({ open, onClose }: CreateAgentChatProps) {
   const { t } = useTranslation(['agent', 'common']);
 
-  const { sessionId, loading, error, create, retry, reset } = useSessionChat({
+  const { sessionId, createAndSend, reset } = useSessionChat({
     title: t('agent:chat.createTitle'),
     category: 'agent',
     contextMessage: buildContext(),
@@ -56,9 +56,15 @@ export default function CreateAgentChat({ open, onClose }: CreateAgentChatProps)
   });
 
   useEffect(() => {
-    if (open) create().catch(() => {});
-    else reset();
-  }, [open, create, reset]);
+    if (!open) reset();
+  }, [open, reset]);
+
+  const handleCreateAndSend = useCallback(
+    async (text: string) => {
+      await createAndSend(text);
+    },
+    [createAndSend],
+  );
 
   if (!open) return null;
 
@@ -88,35 +94,21 @@ export default function CreateAgentChat({ open, onClose }: CreateAgentChatProps)
         </div>
 
         {/* Body */}
-        {loading ? (
-          <div className="flex-1 flex items-center justify-center bg-gray-50/50">
-            <div className="text-center">
-              <Loader2 className="w-8 h-8 text-purple-500 animate-spin mx-auto mb-3" />
-              <p className="text-sm text-gray-500">{t('agent:chat.preparing')}</p>
+        <SessionChat
+          sessionId={sessionId}
+          live={!!sessionId}
+          placeholder={t('agent:chat.placeholder')}
+          className="flex-1 min-h-0"
+          suggestions={SUGGESTIONS}
+          onCreateAndSend={!sessionId ? handleCreateAndSend : undefined}
+          welcomeContent={!sessionId ? (
+            <div className="text-center max-w-md">
+              <Bot className="w-10 h-10 text-purple-500 mx-auto mb-3" />
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">{t('agent:chat.createTitle')}</h3>
+              <p className="text-sm text-gray-500">{t('agent:chat.subtitle')}</p>
             </div>
-          </div>
-        ) : error ? (
-          <div className="flex-1 flex flex-col items-center justify-center gap-4 p-6 bg-gray-50/50">
-            <div className="flex items-center gap-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
-              <AlertCircle className="w-4 h-4 flex-shrink-0" />
-              {error}
-            </div>
-            <button
-              onClick={retry}
-              className="px-4 py-2 bg-purple-600 text-white text-sm rounded-lg hover:bg-purple-700 transition-colors"
-            >
-              {t('common:button.retry')}
-            </button>
-          </div>
-        ) : sessionId ? (
-          <SessionChat
-            sessionId={sessionId}
-            live
-            placeholder={t('agent:chat.placeholder')}
-            className="flex-1 min-h-0"
-            suggestions={SUGGESTIONS}
-          />
-        ) : null}
+          ) : undefined}
+        />
       </div>
     </div>
   );

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -22,11 +22,11 @@ export default function SessionPage() {
   // Capture params on mount only — avoids re-running when setSearchParams clears the URL.
   const initialSearchParamsRef = useRef(searchParams);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const isCreatingNewRef = useRef(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState('rex');
   const [showAgentOptions, setShowAgentOptions] = useState(false);
   const [sseStatus, setSseStatus] = useState<SSEConnectionStatus>('disconnected');
-  const [creating, setCreating] = useState(false);
   const [pendingInitialMessage, setPendingInitialMessage] = useState<string | null>(null);
   const [selectMode, setSelectMode] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
@@ -76,9 +76,9 @@ export default function SessionPage() {
     }
   }, []);
 
-  // Auto select first session
+  // Auto select first session (skip when user intentionally started a new session)
   useEffect(() => {
-    if (!selectedSessionId && sessions.length > 0) {
+    if (!selectedSessionId && sessions.length > 0 && !isCreatingNewRef.current) {
       setSelectedSessionId(sessions[0].id);
     }
   }, [sessions, selectedSessionId]);
@@ -94,19 +94,10 @@ export default function SessionPage() {
     return () => document.removeEventListener('mousedown', handle);
   }, [showAgentOptions]);
 
-  const handleCreateSession = useCallback(async () => {
-    if (creating) return;
-    setCreating(true);
-    try {
-      const response = await client.post('/api/session', { title: 'New Session' });
-      addSession(response.data);
-      setSelectedSessionId(response.data.id);
-    } catch (err: any) {
-      toast.error(t('createFailed'), err.message);
-    } finally {
-      setCreating(false);
-    }
-  }, [creating, addSession, toast, t]);
+  const handleCreateSession = useCallback(() => {
+    isCreatingNewRef.current = true;
+    setSelectedSessionId(null);
+  }, []);
 
   const handleCreateAndSend = useCallback(async (text: string) => {
     try {
@@ -114,6 +105,7 @@ export default function SessionPage() {
       const newSessionId = response.data.id;
 
       // Show the new session in the sidebar and switch to it immediately.
+      isCreatingNewRef.current = false;
       addSession(response.data);
       setSelectedSessionId(newSessionId);
 
@@ -246,12 +238,9 @@ export default function SessionPage() {
             <>
               <button
                 onClick={handleCreateSession}
-                disabled={creating}
-                className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 hover:border-gray-300 transition-colors disabled:opacity-60 disabled:cursor-not-allowed shadow-sm"
+                className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 hover:border-gray-300 transition-colors shadow-sm"
               >
-                {creating
-                  ? <Loader2 className="w-5 h-5 animate-spin" />
-                  : <Plus className="w-5 h-5" />}
+                <Plus className="w-5 h-5" />
                 <span className="font-medium">{t('newSession')}</span>
               </button>
               <button
@@ -275,7 +264,7 @@ export default function SessionPage() {
             sessions.map((session) => (
               <div
                 key={session.id}
-                onClick={() => selectMode ? handleToggleCheck(session.id) : setSelectedSessionId(session.id)}
+                onClick={() => { if (selectMode) { handleToggleCheck(session.id); } else { isCreatingNewRef.current = false; setSelectedSessionId(session.id); } }}
                 className={`group p-3 rounded-xl cursor-pointer transition-all duration-200 ${
                   !selectMode && selectedSessionId === session.id
                     ? 'bg-gray-100 border-2 border-gray-300 shadow-sm'

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -22,11 +22,11 @@ export default function SessionPage() {
   // Capture params on mount only — avoids re-running when setSearchParams clears the URL.
   const initialSearchParamsRef = useRef(searchParams);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
-  const isCreatingNewRef = useRef(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState('rex');
   const [showAgentOptions, setShowAgentOptions] = useState(false);
   const [sseStatus, setSseStatus] = useState<SSEConnectionStatus>('disconnected');
+  const [creating, setCreating] = useState(false);
   const [pendingInitialMessage, setPendingInitialMessage] = useState<string | null>(null);
   const [selectMode, setSelectMode] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
@@ -76,9 +76,9 @@ export default function SessionPage() {
     }
   }, []);
 
-  // Auto select first session (skip when user intentionally started a new session)
+  // Auto select first session
   useEffect(() => {
-    if (!selectedSessionId && sessions.length > 0 && !isCreatingNewRef.current) {
+    if (!selectedSessionId && sessions.length > 0) {
       setSelectedSessionId(sessions[0].id);
     }
   }, [sessions, selectedSessionId]);
@@ -94,23 +94,28 @@ export default function SessionPage() {
     return () => document.removeEventListener('mousedown', handle);
   }, [showAgentOptions]);
 
-  const handleCreateSession = useCallback(() => {
-    isCreatingNewRef.current = true;
-    setSelectedSessionId(null);
-  }, []);
+  const handleCreateSession = useCallback(async () => {
+    if (creating) return;
+    setCreating(true);
+    try {
+      const response = await client.post('/api/session', { title: 'New Session' });
+      addSession(response.data);
+      setSelectedSessionId(response.data.id);
+    } catch (err: any) {
+      toast.error(t('createFailed'), err.message);
+    } finally {
+      setCreating(false);
+    }
+  }, [creating, addSession, toast, t]);
 
   const handleCreateAndSend = useCallback(async (text: string) => {
     try {
       const response = await client.post('/api/session', { title: 'New Session' });
       const newSessionId = response.data.id;
 
-      // Show the new session in the sidebar and switch to it immediately.
-      isCreatingNewRef.current = false;
       addSession(response.data);
       setSelectedSessionId(newSessionId);
 
-      // Fire-and-forget: prompt_async returns 202 instantly; no need to await.
-      // The response streams in via SSE once the backend picks it up.
       const payload: Record<string, unknown> = { parts: [{ type: 'text', text }] };
       if (selectedAgent) payload.agent = selectedAgent;
       client.post(`/api/session/${newSessionId}/prompt_async`, payload).catch((err: any) => {
@@ -238,9 +243,12 @@ export default function SessionPage() {
             <>
               <button
                 onClick={handleCreateSession}
-                className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 hover:border-gray-300 transition-colors shadow-sm"
+                disabled={creating}
+                className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 hover:border-gray-300 transition-colors disabled:opacity-60 disabled:cursor-not-allowed shadow-sm"
               >
-                <Plus className="w-5 h-5" />
+                {creating
+                  ? <Loader2 className="w-5 h-5 animate-spin" />
+                  : <Plus className="w-5 h-5" />}
                 <span className="font-medium">{t('newSession')}</span>
               </button>
               <button
@@ -264,7 +272,7 @@ export default function SessionPage() {
             sessions.map((session) => (
               <div
                 key={session.id}
-                onClick={() => { if (selectMode) { handleToggleCheck(session.id); } else { isCreatingNewRef.current = false; setSelectedSessionId(session.id); } }}
+                onClick={() => selectMode ? handleToggleCheck(session.id) : setSelectedSessionId(session.id)}
                 className={`group p-3 rounded-xl cursor-pointer transition-all duration-200 ${
                   !selectMode && selectedSessionId === session.id
                     ? 'bg-gray-100 border-2 border-gray-300 shadow-sm'

--- a/webui/src/pages/WorkflowCreate/CreateChatTab.tsx
+++ b/webui/src/pages/WorkflowCreate/CreateChatTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import SessionChat, { type SSEChatEvent } from '@/components/common/SessionChat';
 import { useSessionChat } from '@/hooks/useSessionChat';
@@ -15,14 +15,12 @@ export default function CreateChatTab({ onWorkflowCreated }: CreateChatTabProps)
   const { t } = useTranslation('workflow');
 
   const exampleQuestions = t('create.chat.exampleQuestions', { returnObjects: true }) as string[];
-  const welcomeMessage = t('create.chat.welcomeMessage');
 
-  const { sessionId, loading, error, retry } = useSessionChat({
+  const { sessionId, error, createAndSend, retry } = useSessionChat({
     title: t('create.chat.sessionTitle'),
     category: 'workflow',
     contextMessage: t('create.chat.contextMessage'),
-    welcomeMessage,
-    autoCreate: true,
+    welcomeMessage: t('create.chat.welcomeMessage'),
   });
 
   const knownIdsRef = useRef<Set<string>>(new Set());
@@ -85,14 +83,12 @@ export default function CreateChatTab({ onWorkflowCreated }: CreateChatTabProps)
     return () => clearInterval(timer);
   }, [sessionId, snapshotReady, detectNewWorkflow]);
 
-  if (loading || (!sessionId && !error)) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full gap-3">
-        <Loader2 className="w-7 h-7 text-red-500 animate-spin" />
-        <p className="text-xs text-gray-500">{t('create.chat.preparing')}</p>
-      </div>
-    );
-  }
+  const handleCreateAndSend = useCallback(
+    async (text: string) => {
+      await createAndSend(text);
+    },
+    [createAndSend],
+  );
 
   if (error) {
     return (
@@ -113,13 +109,14 @@ export default function CreateChatTab({ onWorkflowCreated }: CreateChatTabProps)
 
   return (
     <SessionChat
-      sessionId={sessionId!}
-      live
+      sessionId={sessionId}
+      live={!!sessionId}
       placeholder={t('create.chat.inputPlaceholder')}
       className="h-full"
       suggestions={exampleQuestions}
       onStreamingDone={handleStreamingDone}
       onSSEEvent={handleSSEEvent}
+      onCreateAndSend={!sessionId ? handleCreateAndSend : undefined}
     />
   );
 }


### PR DESCRIPTION
fix(webui): restore immediate session creation on Session page

- The previous commit deferred session creation globally, but the Session
management page needs to create real sessions on button click so users
can batch-create empty sessions. Revert the deferral for this page only;
ChatDialog and CreateAgentChat still use deferred creation.