### PR TITLE
feat(provider): configurable TLS verification for OpenAI clients

### DIFF
--- a/.flocks/flocks.json.example
+++ b/.flocks/flocks.json.example
@@ -1,6 +1,20 @@
 {
-
-  "provider": {},
+  "provider": {
+    "custom-openai": {
+      "name": "Internal OpenAI Gateway",
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "apiKey": "{secret:internal-openai_llm_key}",
+        "baseURL": "https://llm-gateway.example.internal/v1",
+        "verify_ssl": false
+      },
+      "models": {
+        "gpt-4o": {
+          "name": "gpt-4o"
+        }
+      }
+    }
+  },
   "mcp": {},
   "channels": {},
   "api_services": {

--- a/README_zh.md
+++ b/README_zh.md
@@ -53,7 +53,7 @@ Flocks 支持两种部署方式：
 ```bash
 curl -fsSL https://gitee.com/flocks/flocks/raw/main/install_zh.sh | bash
 ```
-# 默认会在当前目录下创建 ./flocks
+默认会在当前目录下创建 ./flocks
 
 #### Windows PowerShell (Administrator)
 

--- a/flocks/provider/sdk/openai.py
+++ b/flocks/provider/sdk/openai.py
@@ -16,7 +16,11 @@ from flocks.provider.provider import (
     ChatResponse,
     StreamChunk,
 )
-from flocks.provider.sdk.openai_base import extract_reasoning_content, resolve_verify_ssl
+from flocks.provider.sdk.openai_base import (
+    _coerce_bool,
+    extract_reasoning_content,
+    resolve_verify_ssl,
+)
 from flocks.utils.log import Log
 
 log = Log.create(service="provider.openai")
@@ -27,16 +31,6 @@ def _env_bool(name: str, default: bool) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _coerce_bool(value: Any, default: bool) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return default
 
 
 class OpenAIProvider(BaseProvider):

--- a/flocks/provider/sdk/openai.py
+++ b/flocks/provider/sdk/openai.py
@@ -16,7 +16,7 @@ from flocks.provider.provider import (
     ChatResponse,
     StreamChunk,
 )
-from flocks.provider.sdk.openai_base import extract_reasoning_content
+from flocks.provider.sdk.openai_base import extract_reasoning_content, resolve_verify_ssl
 from flocks.utils.log import Log
 
 log = Log.create(service="provider.openai")
@@ -82,7 +82,12 @@ class OpenAIProvider(BaseProvider):
                 cfg_settings = getattr(self._config, "custom_settings", None) or {}
                 if isinstance(cfg_settings, dict) and "trust_env" in cfg_settings:
                     trust_env = _coerce_bool(cfg_settings.get("trust_env"), trust_env)
-                http_client = httpx.AsyncClient(trust_env=trust_env, timeout=120.0)
+                verify_ssl = resolve_verify_ssl(cfg_settings, default=True)
+                http_client = httpx.AsyncClient(
+                    trust_env=trust_env,
+                    verify=verify_ssl,
+                    timeout=120.0,
+                )
 
                 if base_url:
                     self._client = AsyncOpenAI(
@@ -92,11 +97,18 @@ class OpenAIProvider(BaseProvider):
                     )
                     self.log.info(
                         "openai.client.created",
-                        {"base_url": base_url, "trust_env": trust_env},
+                        {
+                            "base_url": base_url,
+                            "trust_env": trust_env,
+                            "verify_ssl": verify_ssl,
+                        },
                     )
                 else:
                     self._client = AsyncOpenAI(api_key=api_key, http_client=http_client)
-                    self.log.info("openai.client.created", {"trust_env": trust_env})
+                    self.log.info(
+                        "openai.client.created",
+                        {"trust_env": trust_env, "verify_ssl": verify_ssl},
+                    )
                     
             except ImportError:
                 raise ImportError("openai package not installed. Install with: pip install openai")

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -23,6 +23,29 @@ from flocks.utils.log import Log
 log = Log.create(service="provider.openai_base")
 
 
+def _coerce_bool(value: Any, default: bool) -> bool:
+    """Coerce loosely-typed config values to bool."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return default
+
+
+def resolve_verify_ssl(custom_settings: Any, default: bool = True) -> bool:
+    """Resolve the SSL verification flag from provider custom settings."""
+    if not isinstance(custom_settings, dict):
+        return default
+
+    if "verify_ssl" in custom_settings:
+        return _coerce_bool(custom_settings.get("verify_ssl"), default)
+    if "ssl_verify" in custom_settings:
+        return _coerce_bool(custom_settings.get("ssl_verify"), default)
+    return default
+
+
 def _normalize_stream_usage(raw_usage: Any) -> Optional[Dict[str, int]]:
     """Normalize provider usage objects to a shared stream usage schema."""
     if not raw_usage:
@@ -366,6 +389,7 @@ class OpenAIBaseProvider(BaseProvider):
         """Get or create AsyncOpenAI client."""
         if self._client is None:
             from openai import AsyncOpenAI
+            import httpx
 
             api_key = self._config.api_key if self._config else self._api_key
             if not api_key:
@@ -380,7 +404,15 @@ class OpenAIBaseProvider(BaseProvider):
                 else self._base_url
             )
 
-            self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+            custom_settings = getattr(self._config, "custom_settings", None) or {}
+            verify_ssl = resolve_verify_ssl(custom_settings, default=True)
+            http_client = httpx.AsyncClient(verify=verify_ssl, timeout=120.0)
+
+            self._client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                http_client=http_client,
+            )
         return self._client
 
     # ==================== Catalog Integration ====================

--- a/flocks/provider/sdk/openai_compatible.py
+++ b/flocks/provider/sdk/openai_compatible.py
@@ -26,6 +26,7 @@ from flocks.provider.sdk.openai_base import (
     _normalize_stream_usage,
     _supports_include_usage_fallback,
     extract_reasoning_content,
+    resolve_verify_ssl,
 )
 from flocks.utils.log import Log
 
@@ -52,6 +53,7 @@ class OpenAICompatibleProvider(BaseProvider):
         if self._client is None:
             try:
                 from openai import AsyncOpenAI
+                import httpx
                 
                 # Get API key (many local services don't need one)
                 api_key = self._config.api_key if self._config else self._api_key
@@ -67,13 +69,21 @@ class OpenAICompatibleProvider(BaseProvider):
                 
                 if not base_url:
                     raise ValueError("OpenAI Compatible base URL not configured. Set OPENAI_COMPATIBLE_BASE_URL environment variable.")
-                
+
+                custom_settings = getattr(self._config, "custom_settings", None) or {}
+                verify_ssl = resolve_verify_ssl(custom_settings, default=True)
+                http_client = httpx.AsyncClient(verify=verify_ssl, timeout=120.0)
+
                 # Create client
                 self._client = AsyncOpenAI(
                     api_key=api_key,
                     base_url=base_url,
+                    http_client=http_client,
                 )
-                self.log.info("openai_compatible.client.created", {"base_url": base_url})
+                self.log.info(
+                    "openai_compatible.client.created",
+                    {"base_url": base_url, "verify_ssl": verify_ssl},
+                )
                     
             except ImportError:
                 raise ImportError("openai package not installed. Install with: pip install openai")

--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -107,6 +107,13 @@ def _get_inline_provider_api_key(provider_id: str) -> Optional[str]:
     return api_key
 
 
+def _get_provider_custom_settings(provider: Any) -> Dict[str, Any]:
+    """Return the currently applied provider custom settings, if any."""
+    provider_config = getattr(provider, "_config", None)
+    custom_settings = getattr(provider_config, "custom_settings", None) or {}
+    return dict(custom_settings) if isinstance(custom_settings, dict) else {}
+
+
 def _model_to_api_format(model: ProviderModelInfo) -> Dict[str, Any]:
     """Convert internal ModelInfo to Flocks-compatible dict format.
 
@@ -1718,10 +1725,12 @@ async def set_provider_credentials(provider_id: str, request: ProviderCredential
                 if raw:
                     effective_base_url = raw.get("options", {}).get("baseURL")
 
+            custom_settings = _get_provider_custom_settings(provider)
             provider.configure(ProviderConfig(
                 provider_id=provider_id,
                 api_key=request.api_key,
                 base_url=effective_base_url,
+                custom_settings=custom_settings,
             ))
             # Reset client so it picks up new base_url/key
             if hasattr(provider, "_client"):
@@ -2100,10 +2109,12 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
                 base_url_attr = getattr(provider, "_base_url", None)
                 if isinstance(base_url_attr, str) and base_url_attr:
                     effective_base_url = base_url_attr
+            custom_settings = _get_provider_custom_settings(provider)
             provider.configure(ProviderConfig(
                 provider_id=provider_id,
                 api_key=api_key,
                 base_url=effective_base_url,
+                custom_settings=custom_settings,
             ))
             if hasattr(provider, '_client'):
                 provider._client = None

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -332,6 +332,33 @@ class TestOpenAIBaseProviderConfiguration:
         
         assert provider._base_url == "https://api.test.com/v1"
 
+    @patch("httpx.AsyncClient")
+    @patch("openai.AsyncOpenAI")
+    def test_get_client_respects_verify_ssl_false(self, mock_async_openai, mock_http_client):
+        """verify_ssl=false should disable certificate verification for self-hosted gateways."""
+        provider = MockProviderWithCatalog()
+        provider.configure(
+            ProviderConfig(
+                provider_id=provider.id,
+                api_key="test-api-key",
+                base_url="https://gateway.internal/v1",
+                custom_settings={"verify_ssl": False},
+            )
+        )
+
+        http_client = MagicMock()
+        mock_http_client.return_value = http_client
+        mock_async_openai.return_value = MagicMock()
+
+        provider._get_client()
+
+        mock_http_client.assert_called_once_with(verify=False, timeout=120.0)
+        mock_async_openai.assert_called_once_with(
+            api_key="test-api-key",
+            base_url="https://gateway.internal/v1",
+            http_client=http_client,
+        )
+
 
 class TestOpenAIBaseProviderTemperature:
     def _build_provider_with_client(self):

--- a/tests/provider/test_openai_compatible_provider.py
+++ b/tests/provider/test_openai_compatible_provider.py
@@ -1,9 +1,10 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from types import SimpleNamespace
 
 import pytest
 
 from flocks.provider.provider import ChatMessage, ChatResponse
+from flocks.provider.provider import ProviderConfig
 from flocks.provider.sdk.openai_compatible import OpenAICompatibleProvider
 
 
@@ -25,6 +26,34 @@ def _mock_chat_response(content: str = "Paris"):
     choice.message = MagicMock(content=content)
     response.choices = [choice]
     return response
+
+
+class TestOpenAICompatibleProviderConfiguration:
+    @patch("httpx.AsyncClient")
+    @patch("openai.AsyncOpenAI")
+    def test_get_client_respects_verify_ssl_false(self, mock_async_openai, mock_http_client):
+        provider = OpenAICompatibleProvider()
+        provider.configure(
+            ProviderConfig(
+                provider_id=provider.id,
+                api_key="test-api-key",
+                base_url="https://gateway.internal/v1",
+                custom_settings={"verify_ssl": False},
+            )
+        )
+
+        http_client = MagicMock()
+        mock_http_client.return_value = http_client
+        mock_async_openai.return_value = MagicMock()
+
+        provider._get_client()
+
+        mock_http_client.assert_called_once_with(verify=False, timeout=120.0)
+        mock_async_openai.assert_called_once_with(
+            api_key="test-api-key",
+            base_url="https://gateway.internal/v1",
+            http_client=http_client,
+        )
 
 
 def _chat_response(content: str, model: str = "MiniMax-M2.5") -> ChatResponse:

--- a/tests/provider/test_openai_provider.py
+++ b/tests/provider/test_openai_provider.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock, patch
+
+from flocks.provider.provider import ProviderConfig
+from flocks.provider.sdk.openai import OpenAIProvider
+
+
+class TestOpenAIProviderConfiguration:
+    @patch("httpx.AsyncClient")
+    @patch("openai.AsyncOpenAI")
+    def test_get_client_respects_verify_ssl_false(self, mock_async_openai, mock_http_client):
+        provider = OpenAIProvider()
+        provider.configure(
+            ProviderConfig(
+                provider_id=provider.id,
+                api_key="test-api-key",
+                base_url="https://gateway.internal/v1",
+                custom_settings={"verify_ssl": False},
+            )
+        )
+
+        http_client = MagicMock()
+        mock_http_client.return_value = http_client
+        mock_async_openai.return_value = MagicMock()
+
+        provider._get_client()
+
+        mock_http_client.assert_called_once_with(
+            trust_env=True,
+            verify=False,
+            timeout=120.0,
+        )
+        mock_async_openai.assert_called_once_with(
+            api_key="test-api-key",
+            base_url="https://gateway.internal/v1",
+            http_client=http_client,
+        )

--- a/tests/provider/test_test_credentials.py
+++ b/tests/provider/test_test_credentials.py
@@ -417,3 +417,42 @@ class TestTestCredentialsInlineConfigFallback:
             provider.configure.assert_called_once()
             configured = provider.configure.call_args.args[0]
             assert configured.api_key == "inline-qianfan-key"
+
+    @pytest.mark.asyncio
+    async def test_existing_custom_settings_are_preserved_during_provider_test(self):
+        from flocks.server.routes.provider import test_provider_credentials
+
+        provider = MagicMock()
+        provider._config = MagicMock(
+            custom_settings={"verify_ssl": False},
+            base_url="https://gateway.internal/v1",
+        )
+        provider.chat = AsyncMock(return_value=MagicMock(content="Paris"))
+
+        model = MagicMock()
+        model.id = "gateway-model"
+
+        mock_secrets = MagicMock()
+        mock_secrets.get.return_value = "gateway-api-key"
+
+        mock_config = MagicMock()
+
+        with (
+            patch(_PATCH_SECRET_MGR, return_value=mock_secrets),
+            patch(_PATCH_CONFIG_GET, new_callable=AsyncMock, return_value=mock_config),
+            patch(_PATCH_PROVIDER) as mock_provider_cls,
+        ):
+            mock_provider_cls._ensure_initialized = MagicMock()
+            mock_provider_cls._load_dynamic_providers = MagicMock()
+            mock_provider_cls.apply_config = AsyncMock()
+            mock_provider_cls.get.return_value = provider
+            mock_provider_cls.list_models.return_value = [model]
+
+            result = await test_provider_credentials("internal-openai")
+
+            assert result["success"] is True, result
+            provider.configure.assert_called_once()
+            configured = provider.configure.call_args.args[0]
+            assert configured.api_key == "gateway-api-key"
+            assert configured.base_url == "https://gateway.internal/v1"
+            assert configured.custom_settings["verify_ssl"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.4.9"
+version = "2026.4.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/webui/README.md
+++ b/webui/README.md
@@ -90,7 +90,3 @@ VITE_WS_BASE_URL=ws://127.0.0.1:8000
 VITE_API_BASE_URL=http://127.0.0.1:9000
 VITE_WS_BASE_URL=ws://127.0.0.1:9000
 ```
-
-## License
-
-MIT


### PR DESCRIPTION
## Summary

Adds configurable TLS certificate verification for OpenAI, OpenAI Base, and OpenAI Compatible providers via `custom_settings` (`verify_ssl` / `ssl_verify`).

## Changes

- Resolve `verify_ssl` from provider custom settings and pass `verify=` to `httpx.AsyncClient` used by the OpenAI SDK.
- Preserve `custom_settings` when setting or testing provider credentials in API routes.
- Extend `.flocks/flocks.json.example` with an internal gateway example.
- Add unit tests for OpenAI, OpenAI Base, OpenAI Compatible, and credential test flow.

## Testing

`uv run pytest` on the new/updated provider tests (verify_ssl and custom_settings preservation).
