### PR TITLE
feat(install): macOS Node install falls back to nvm without Homebrew

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,7 @@ PATH_REFRESH_HINT_REQUIRED=0
 UV_DEFAULT_INDEX="${FLOCKS_UV_DEFAULT_INDEX:-https://pypi.org/simple}"
 NPM_REGISTRY="${FLOCKS_NPM_REGISTRY:-https://registry.npmjs.org/}"
 NODEJS_MANUAL_DOWNLOAD_URL="${FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL:-https://nodejs.org/en/download}"
+NVM_INSTALL_SCRIPT_URL="${FLOCKS_NVM_INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh}"
 
 info() {
   printf '[flocks] %s\n' "$1"
@@ -319,11 +320,35 @@ node_version_satisfies_requirement() {
   [[ "$major" -ge "$MIN_NODE_MAJOR" ]]
 }
 
-install_nodejs_macos() {
-  has_cmd brew || fail "A compatible npm installation was not found. Homebrew is required to install or upgrade Node.js 22+ automatically on macOS. Install Homebrew first and retry: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"$(nodejs_manual_download_hint)"
+load_nvm() {
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  [[ -s "$NVM_DIR/nvm.sh" ]] || return 1
 
-  info "Trying to install or upgrade Node.js with Homebrew..."
-  brew install node
+  # shellcheck disable=SC1090
+  . "$NVM_DIR/nvm.sh"
+  command -v nvm >/dev/null 2>&1
+}
+
+install_nodejs_macos() {
+  if has_cmd brew; then
+    info "Trying to install or upgrade Node.js with Homebrew..."
+    brew install node
+    return
+  fi
+
+  has_cmd curl || fail "A compatible npm installation was not found. Homebrew is not installed, and curl is required to install nvm automatically on macOS. Install Homebrew first and retry: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"$(nodejs_manual_download_hint)"
+
+  if load_nvm; then
+    info "Homebrew was not found. Using the existing nvm installation..."
+  else
+    info "Homebrew was not found. Trying to install nvm..."
+    curl -o- "$NVM_INSTALL_SCRIPT_URL" | bash
+    load_nvm || fail "nvm was installed, but it could not be loaded from $NVM_DIR/nvm.sh. Open a new shell and retry.$(nodejs_manual_download_hint)"
+  fi
+
+  info "Trying to install Node.js ${MIN_NODE_MAJOR} with nvm..."
+  nvm install "$MIN_NODE_MAJOR"
+  nvm use "$MIN_NODE_MAJOR" >/dev/null
 }
 
 install_nodejs_linux() {

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -1,3 +1,6 @@
+import re
+import subprocess
+import textwrap
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -86,6 +89,118 @@ def test_main_bash_installer_uses_configured_default_sources_without_probing() -
     assert "FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL" in script
     assert "https://nodejs.org/en/download" in script
     assert "nodejs_manual_download_hint" in script
+    assert "FLOCKS_NVM_INSTALL_SCRIPT_URL" in script
+    assert "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh" in script
+    assert "load_nvm()" in script
+    assert 'curl -o- "$NVM_INSTALL_SCRIPT_URL" | bash' in script
+    assert 'nvm install "$MIN_NODE_MAJOR"' in script
+    assert 'nvm use "$MIN_NODE_MAJOR" >/dev/null' in script
+    assert "Homebrew was not found. Trying to install nvm..." in script
+    assert "Homebrew was not found. Using the existing nvm installation..." in script
+
+
+def test_main_bash_installer_falls_back_to_nvm_when_brew_is_missing_on_macos() -> None:
+    script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
+    script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)
+    test_script = script_without_main + textwrap.dedent(
+        r"""
+
+        export HOME="$(mktemp -d)"
+        unset NVM_DIR
+        export TEST_LOG="$HOME/install-node.log"
+
+        info() {
+          printf '%s\n' "$1" >> "$TEST_LOG"
+        }
+
+        fail() {
+          printf 'FAIL:%s\n' "$1" >&2
+          exit 1
+        }
+
+        has_cmd() {
+          case "$1" in
+            brew)
+              return 1
+              ;;
+            curl)
+              return 0
+              ;;
+            *)
+              command -v "$1" >/dev/null 2>&1
+              ;;
+          esac
+        }
+
+        curl() {
+          cat <<'EOF'
+        mkdir -p "$HOME/.nvm"
+        cat > "$HOME/.nvm/nvm.sh" <<'EOS'
+        nvm() {
+          printf '%s\n' "$*" >> "$HOME/nvm-commands.log"
+          if [[ "$1" == "install" ]]; then
+            mkdir -p "$HOME/.nvm/versions/node/v22.22.2/bin"
+            cat > "$HOME/.nvm/versions/node/v22.22.2/bin/node" <<'EON'
+        #!/usr/bin/env bash
+        printf 'v22.22.2\n'
+        EON
+            cat > "$HOME/.nvm/versions/node/v22.22.2/bin/npm" <<'EON'
+        #!/usr/bin/env bash
+        printf '10.9.7\n'
+        EON
+            chmod +x "$HOME/.nvm/versions/node/v22.22.2/bin/node" "$HOME/.nvm/versions/node/v22.22.2/bin/npm"
+            export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+            return 0
+          fi
+          if [[ "$1" == "use" ]]; then
+            export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+            return 0
+          fi
+          return 0
+        }
+        EOS
+        EOF
+        }
+
+        install_nodejs_macos
+
+        node_version="$(node -v)"
+        npm_version="$(npm -v)"
+        nvm_commands="$(<"$HOME/nvm-commands.log")"
+        install_log="$(<"$TEST_LOG")"
+
+        [[ "$node_version" == "v22.22.2" ]] || {
+          printf 'unexpected node version: %s\n' "$node_version" >&2
+          exit 1
+        }
+        [[ "$npm_version" == "10.9.7" ]] || {
+          printf 'unexpected npm version: %s\n' "$npm_version" >&2
+          exit 1
+        }
+        [[ "$nvm_commands" == *"install 22"* ]] || {
+          printf 'nvm install was not called: %s\n' "$nvm_commands" >&2
+          exit 1
+        }
+        [[ "$nvm_commands" == *"use 22"* ]] || {
+          printf 'nvm use was not called: %s\n' "$nvm_commands" >&2
+          exit 1
+        }
+        [[ "$install_log" == *"Trying to install nvm"* ]] || {
+          printf 'nvm install message missing: %s\n' "$install_log" >&2
+          exit 1
+        }
+        """
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", test_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
 
 
 def test_main_powershell_installer_uses_configured_default_sources_without_probing() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.4.9"
+version = "2026.4.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

When Homebrew is not installed on macOS, the installer now falls back to **nvm** (via configurable `FLOCKS_NVM_INSTALL_SCRIPT_URL`) to satisfy the minimum Node.js major version, instead of failing immediately.

## Changes

- Add `NVM_INSTALL_SCRIPT_URL` / `FLOCKS_NVM_INSTALL_SCRIPT_URL` and `load_nvm()`.
- `install_nodejs_macos`: try Homebrew first; if `brew` is missing, use curl + nvm install/use `MIN_NODE_MAJOR`.
- Extend `test_install_script_sources.py` with source assertions and a bash harness test for the nvm path.
