### PR TITLE
fix(cli): avoid os.kill probe on Windows

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -5,6 +5,7 @@ Service lifecycle helpers for local Flocks daemon commands.
 from __future__ import annotations
 
 import contextlib
+import ctypes
 import datetime
 import importlib.util
 import json
@@ -408,10 +409,43 @@ def _unix_pid_is_zombie(pid: int | None) -> bool:
     return bool(stat and stat.startswith("Z"))
 
 
+def _windows_pid_is_running(pid: int) -> bool:
+    """Return True when a Windows process id is still alive."""
+    if sys.platform != "win32" or pid <= 0:
+        return False
+
+    process_query_limited_information = 0x1000
+    still_active = 259
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    open_process = kernel32.OpenProcess
+    open_process.argtypes = [ctypes.c_uint32, ctypes.c_int, ctypes.c_uint32]
+    open_process.restype = ctypes.c_void_p
+    get_exit_code_process = kernel32.GetExitCodeProcess
+    get_exit_code_process.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32)]
+    get_exit_code_process.restype = ctypes.c_int
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [ctypes.c_void_p]
+    close_handle.restype = ctypes.c_int
+
+    handle = open_process(process_query_limited_information, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == 5
+
+    try:
+        exit_code = ctypes.c_uint32()
+        if not get_exit_code_process(handle, ctypes.byref(exit_code)):
+            return ctypes.get_last_error() == 5
+        return exit_code.value == still_active
+    finally:
+        close_handle(handle)
+
+
 def pid_is_running(pid: int | None) -> bool:
     """Return True if a pid exists and is still alive."""
-    if pid is None:
+    if pid is None or pid <= 0:
         return False
+    if sys.platform == "win32":
+        return _windows_pid_is_running(pid)
 
     try:
         os.kill(pid, 0)

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -38,6 +38,19 @@ def test_cleanup_stale_pid_file_removes_dead_pid(tmp_path: Path) -> None:
     assert not pid_file.exists()
 
 
+def test_pid_is_running_uses_windows_probe(monkeypatch) -> None:
+    monkeypatch.setattr(service_manager.sys, "platform", "win32")
+    monkeypatch.setattr(service_manager, "_windows_pid_is_running", lambda pid: pid == 123)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("os.kill should not be used on Windows")
+
+    monkeypatch.setattr(service_manager.os, "kill", fail_if_called)
+
+    assert service_manager.pid_is_running(123) is True
+    assert service_manager.pid_is_running(456) is False
+
+
 def test_read_runtime_record_supports_legacy_pid_file(tmp_path: Path) -> None:
     pid_file = tmp_path / "backend.pid"
     pid_file.write_text("12345\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- replace the Windows pid liveness probe with a Win32 API check instead of `os.kill(pid, 0)`
- prevent `flocks stop` and `flocks restart` from failing during stale pid cleanup with `WinError 87`
- add a regression test to ensure the Windows code path does not fall back to `os.kill`
