### PR TITLE
fix(context): reduce tool output truncation limits to 10K chars

### DIFF
--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -55,8 +55,8 @@ log = Log.create(service="session.runner")
 
 TOOL_RESULT_CHAR_BUDGET_RATIO = 0.70
 TOOL_RESULT_TURN_BUDGET_RATIO = 0.35
-TOOL_RESULT_MIN_CHAR_BUDGET = 12_000
-TOOL_RESULT_MIN_TURN_BUDGET = 6_000
+TOOL_RESULT_MIN_CHAR_BUDGET = 8_000
+TOOL_RESULT_MIN_TURN_BUDGET = 4_000
 TOOL_RESULT_PREVIEW_CHARS = 160
 
 # Maximum seconds to wait for the *first* chunk from the LLM stream.
@@ -1641,10 +1641,18 @@ Please address this message and continue with your tasks.
                                     except (TypeError, ValueError):
                                         tool_output_str = str(tool_output)
 
-                                from flocks.tool.truncation import truncate_tool_result_dynamic
-                                tool_output_str, was_dyn_truncated = truncate_tool_result_dynamic(
-                                    tool_output_str, ctx_window_tokens,
+                                from flocks.tool.truncation import truncate_tool_result_dynamic, HARD_MAX_TOOL_RESULT_CHARS
+                                already_truncated = (
+                                    isinstance(getattr(part.state, 'metadata', None), dict)
+                                    and part.state.metadata.get("truncated")
+                                    and len(tool_output_str) <= HARD_MAX_TOOL_RESULT_CHARS * 2
                                 )
+                                if not already_truncated:
+                                    tool_output_str, was_dyn_truncated = truncate_tool_result_dynamic(
+                                        tool_output_str, ctx_window_tokens,
+                                    )
+                                else:
+                                    was_dyn_truncated = False
                                 if was_dyn_truncated:
                                     log.info("runner.tool_result_dynamic_truncated", {
                                         "tool_name": tool_name,

--- a/flocks/tool/file/read.py
+++ b/flocks/tool/file/read.py
@@ -24,10 +24,10 @@ from flocks.utils.id import Identifier
 
 log = Log.create(service="tool.read")
 
-# Constants matching Flocks
-DEFAULT_READ_LIMIT = 2000
-MAX_LINE_LENGTH = 2000
-MAX_BYTES = 50 * 1024
+# Constants — keep output within the 10 K-char tool result budget
+DEFAULT_READ_LIMIT = 200
+MAX_LINE_LENGTH = 500
+MAX_BYTES = 8 * 1024  # 8 KB
 
 # Binary file extensions
 BINARY_EXTENSIONS = {
@@ -47,9 +47,9 @@ Assume this tool is able to read all files on the machine. If the User provides 
 
 Usage:
 - The filePath parameter must be an absolute path, not a relative path
-- By default, it reads up to 2000 lines starting from the beginning of the file
-- You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
-- Any lines longer than 2000 characters will be truncated
+- By default, it reads up to 200 lines starting from the beginning of the file
+- For files longer than 200 lines, you MUST use offset and limit to read in segments (e.g. offset=0 limit=200, then offset=200 limit=200, etc.)
+- Any lines longer than 500 characters will be truncated
 - Results are returned using cat -n format, with line numbers starting at 1
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.
@@ -194,7 +194,7 @@ async def _resolve_sandbox_file_path(ctx: ToolContext, filepath: str) -> tuple[O
         ToolParameter(
             name="limit",
             type=ParameterType.INTEGER,
-            description="The number of lines to read (defaults to 2000)",
+            description="The number of lines to read (defaults to 200)",
             required=False,
             default=DEFAULT_READ_LIMIT
         ),

--- a/flocks/tool/truncation.py
+++ b/flocks/tool/truncation.py
@@ -27,12 +27,12 @@ from flocks.workspace.manager import WorkspaceManager
 
 log = Log.create(service="tool.truncation")
 
-MAX_LINES = 2000
-MAX_BYTES = 50 * 1024  # 50 KB
+MAX_LINES = 200
+MAX_BYTES = 10 * 1024  # 10 KB
 
 MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3
-HARD_MAX_TOOL_RESULT_CHARS = 400_000
-MIN_KEEP_CHARS = 2_000
+HARD_MAX_TOOL_RESULT_CHARS = 10_000
+MIN_KEEP_CHARS = 1_000
 
 _OUTPUT_DIR: Optional[Path] = None
 
@@ -202,7 +202,11 @@ _IMPORTANT_TAIL_RE = re.compile(
 
 
 def _has_important_tail(text: str) -> bool:
-    """Check if the last ~2000 chars contain error/result patterns worth keeping."""
+    """Check if the tail contains error/result patterns worth keeping.
+
+    The detection window (2000 chars) matches the tail_budget cap in
+    truncate_tool_result_text so we only flag content we can actually retain.
+    """
     tail = text[-2000:]
     if _IMPORTANT_TAIL_RE.search(tail):
         return True
@@ -239,7 +243,7 @@ def truncate_tool_result_text(
     budget = max(min_keep_chars, max_chars - len(suffix))
 
     if _has_important_tail(text) and budget > min_keep_chars * 2:
-        tail_budget = min(int(budget * 0.3), 4_000)
+        tail_budget = min(int(budget * 0.3), 2_000)
         middle_marker = "\n\n[... middle content omitted - showing head and tail ...]\n\n"
         head_budget = budget - tail_budget - len(middle_marker)
 


### PR DESCRIPTION
Tighten tool output size limits to reduce context window pressure:

- truncation.py: MAX_LINES 2000→200, MAX_BYTES 50KB→10KB, HARD_MAX_TOOL_RESULT_CHARS 400K→10K, MIN_KEEP_CHARS 2K→1K, tail_budget cap 4K→2K
- runner.py: align MIN_CHAR_BUDGET 12K→8K, MIN_TURN_BUDGET 6K→4K to stay consistent with the new per-tool hard cap
- runner.py: skip dynamic truncation for outputs already truncated by the static first-gate, preventing the hint (with the persisted file path) from being cut off by the second-gate 10K limit
- read.py: align read tool limits (DEFAULT_READ_LIMIT 2000→200, MAX_LINE_LENGTH 2000→500, MAX_BYTES 50KB→8KB) to stay within the 10K-char result budget

Full tool output is still persisted to workspace/tool-output/ so agents can access it via Grep/Read with offset/limit.