### PR TITLE
fix(webui): Vite allowedHosts from env (custom domain after restart)

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# 本地开发脚本：支持单独启动前端、后端，或同时启动。
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_HOST="${FRONTEND_HOST:-127.0.0.1}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+
+BACKEND_ACCESS_HOST="${BACKEND_HOST}"
+if [ "${BACKEND_ACCESS_HOST}" = "0.0.0.0" ] || [ "${BACKEND_ACCESS_HOST}" = "::" ]; then
+    BACKEND_ACCESS_HOST="127.0.0.1"
+fi
+
+BACKEND_BASE_URL="http://${BACKEND_ACCESS_HOST}:${BACKEND_PORT}"
+BACKEND_WS_URL="ws://${BACKEND_ACCESS_HOST}:${BACKEND_PORT}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/dev.sh              同时启动后端和前端
+  ./scripts/dev.sh all          同时启动后端和前端
+  ./scripts/dev.sh backend      只启动后端
+  ./scripts/dev.sh frontend     只启动前端
+
+Environment variables:
+  BACKEND_HOST   默认 127.0.0.1
+  BACKEND_PORT   默认 8000
+  FRONTEND_HOST  默认 127.0.0.1
+  FRONTEND_PORT  默认 5173
+EOF
+}
+
+start_backend() {
+    echo -e "${GREEN}🔧 启动后端服务: http://${BACKEND_HOST}:${BACKEND_PORT}${NC}"
+    cd "${PROJECT_ROOT}"
+    uv run uvicorn flocks.server.app:app \
+        --host "${BACKEND_HOST}" \
+        --port "${BACKEND_PORT}" \
+        --reload \
+        --reload-dir flocks
+}
+
+start_frontend() {
+    echo -e "${GREEN}🎨 启动前端服务: http://${FRONTEND_HOST}:${FRONTEND_PORT}${NC}"
+    cd "${PROJECT_ROOT}/webui"
+    VITE_API_BASE_URL="${BACKEND_BASE_URL}" \
+    VITE_WS_BASE_URL="${BACKEND_WS_URL}" \
+    npm run dev -- --host "${FRONTEND_HOST}" --port "${FRONTEND_PORT}"
+}
+
+start_all() {
+    echo -e "${BLUE}🚀 同时启动前后端开发环境...${NC}"
+    cd "${PROJECT_ROOT}"
+    uv run uvicorn flocks.server.app:app \
+        --host "${BACKEND_HOST}" \
+        --port "${BACKEND_PORT}" \
+        --reload \
+        --reload-dir flocks &
+
+    BACKEND_PID=$!
+    trap 'echo -e "${YELLOW}\n🛑 停止后端服务...${NC}"; kill "${BACKEND_PID}" 2>/dev/null || true' EXIT
+
+    echo -e "${YELLOW}后端 PID: ${BACKEND_PID}${NC}"
+    echo -e "${YELLOW}前端将连接到: ${BACKEND_BASE_URL}${NC}"
+
+    start_frontend
+}
+
+MODE="${1:-all}"
+
+case "${MODE}" in
+    all)
+        start_all
+        ;;
+    backend)
+        start_backend
+        ;;
+    frontend)
+        start_frontend
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        echo -e "${RED}不支持的模式: ${MODE}${NC}"
+        usage
+        exit 1
+        ;;
+esac

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -615,6 +615,7 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
     monkeypatch.setattr(service_manager, "node_version_satisfies_requirement", lambda: True)
     monkeypatch.setattr(service_manager.subprocess, "run", fake_run)
     monkeypatch.setattr(service_manager, "_spawn_process", fake_spawn)
+    monkeypatch.setenv("__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS", "preview.example.com")
 
     config = service_manager.ServiceConfig(
         backend_host="10.0.0.8",
@@ -626,6 +627,7 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
 
     assert build_calls[0]["command"] == ["/usr/bin/npm", "run", "build"]
     assert build_calls[0]["kwargs"]["env"]["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
+    assert build_calls[0]["kwargs"]["env"]["__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS"] == "preview.example.com"
     assert "VITE_API_BASE_URL" not in build_calls[0]["kwargs"]["env"]
 
     assert preview_calls[0]["command"] == [
@@ -639,6 +641,7 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
         "5174",
     ]
     assert preview_calls[0]["kwargs"]["env"]["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
+    assert preview_calls[0]["kwargs"]["env"]["__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS"] == "preview.example.com"
     assert "VITE_API_BASE_URL" not in preview_calls[0]["kwargs"]["env"]
     record = service_manager.read_runtime_record(paths.frontend_pid)
     assert record is not None

--- a/webui/src/config/viteHosts.test.ts
+++ b/webui/src/config/viteHosts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { ADDITIONAL_ALLOWED_HOSTS_ENV, getAdditionalAllowedHosts } from './viteHosts.ts';
+
+describe('vite host helpers', () => {
+  it('keeps Vite defaults when no extra hosts are configured', () => {
+    expect(getAdditionalAllowedHosts({})).toBeUndefined();
+  });
+
+  it('returns unique configured custom hosts', () => {
+    expect(getAdditionalAllowedHosts({
+      [ADDITIONAL_ALLOWED_HOSTS_ENV]: 'preview.example.com, .example.org, preview.example.com',
+    })).toEqual(['preview.example.com', '.example.org']);
+  });
+
+  it('ignores empty custom host entries', () => {
+    expect(getAdditionalAllowedHosts({
+      [ADDITIONAL_ALLOWED_HOSTS_ENV]: ' , custom.example.com ,, .example.org ',
+    })).toEqual(['custom.example.com', '.example.org']);
+  });
+
+  it('returns undefined when the extra-host list is empty after trimming', () => {
+    expect(getAdditionalAllowedHosts({
+      [ADDITIONAL_ALLOWED_HOSTS_ENV]: ' , ,, ',
+    })).toBeUndefined();
+  });
+});

--- a/webui/src/config/viteHosts.ts
+++ b/webui/src/config/viteHosts.ts
@@ -1,0 +1,17 @@
+export type EnvLike = Record<string, string | undefined>;
+
+export const ADDITIONAL_ALLOWED_HOSTS_ENV = '__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS';
+
+export function getAdditionalAllowedHosts(env: EnvLike): string[] | undefined {
+  const configuredHosts = env[ADDITIONAL_ALLOWED_HOSTS_ENV];
+  if (!configuredHosts) {
+    return undefined;
+  }
+
+  const extraHosts = Array.from(new Set(configuredHosts
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean)));
+
+  return extraHosts.length > 0 ? extraHosts : undefined;
+}

--- a/webui/tsconfig.node.json
+++ b/webui/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "src/config/apiProxy.ts"]
+  "include": ["vite.config.ts", "src/config/apiProxy.ts", "src/config/viteHosts.ts"]
 }

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -3,8 +3,10 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 import fs from 'fs'
 import { createApiProxy, getApiProxyTarget } from './src/config/apiProxy'
+import { getAdditionalAllowedHosts } from './src/config/viteHosts'
 
 const apiProxyTarget = getApiProxyTarget(process.env)
+const allowedHosts = getAdditionalAllowedHosts(process.env)
 
 // Windows 8.3 短路径名（如 THREAT~1）会导致 Vite build-html 插件
 // 内部 path.relative() 计算出错，需规范化为完整长路径
@@ -74,11 +76,13 @@ export default defineConfig({
   server: {
     port: 5173,
     host: '127.0.0.1',
+    ...(allowedHosts ? { allowedHosts } : {}),
     proxy: createApiProxy(apiProxyTarget),
   },
   preview: {
     port: 5173,
     host: '127.0.0.1',
+    ...(allowedHosts ? { allowedHosts } : {}),
     proxy: createApiProxy(apiProxyTarget),
   },
 })


### PR DESCRIPTION
## Summary
- Read `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` in `vite.config.ts` and pass to Vite `server.allowedHosts` / `preview.allowedHosts` so custom domains work consistently after restarts when the variable is set.
- Add `webui/src/config/viteHosts.ts` + Vitest coverage; extend `tsconfig.node.json` include.
- Assert frontend build/preview subprocess env passes the variable in `test_service_manager.py`.
- Add `scripts/dev.sh` for local backend/frontend dev.