### PR TITLE
fix(provider): preserve trailing stream usage chunks

### DIFF
--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -567,6 +567,7 @@ class OpenAIBaseProvider(BaseProvider):
         tool_calls: Dict[int, Dict[str, Any]] = {}
         emitted_substantive_chunk = False
         stream_usage: Optional[Dict[str, int]] = None
+        usage_emitted = False
 
         # Stateful extractor to separate <think>...</think> from content.
         think_extractor = ThinkTagExtractor()
@@ -670,18 +671,28 @@ class OpenAIBaseProvider(BaseProvider):
                     tool_calls.clear()
                     # Preserve real finish_reason (e.g. "length" when max_tokens
                     # hit) so the runner can detect truncated tool arguments.
-                    yield StreamChunk(
+                    terminal_chunk = StreamChunk(
                         delta="",
                         finish_reason=choice.finish_reason,
                         tool_calls=sorted_calls,
                         usage=stream_usage,
                     )
+                    yield terminal_chunk
+                    usage_emitted = usage_emitted or terminal_chunk.usage is not None
                 else:
-                    yield StreamChunk(
+                    terminal_chunk = StreamChunk(
                         delta="",
                         finish_reason=choice.finish_reason,
                         usage=stream_usage,
                     )
+                    yield terminal_chunk
+                    usage_emitted = usage_emitted or terminal_chunk.usage is not None
+
+        # OpenAI-compatible APIs may send the usage-only chunk after the
+        # terminal finish chunk. Surface that trailing usage so the runner can
+        # persist it into message metadata and usage_records.
+        if emitted_substantive_chunk and stream_usage and not usage_emitted:
+            yield StreamChunk(delta="", finish_reason=None, usage=stream_usage)
 
         if not emitted_substantive_chunk:
             log.warn("openai_base.stream.empty_response", {

--- a/flocks/provider/sdk/openai_compatible.py
+++ b/flocks/provider/sdk/openai_compatible.py
@@ -289,6 +289,7 @@ class OpenAICompatibleProvider(BaseProvider):
         _first_delta_logged = False
         emitted_substantive_chunk = False
         stream_usage: Optional[Dict[str, int]] = None
+        usage_emitted = False
 
         async for chunk in stream:
             normalized_usage = _normalize_stream_usage(getattr(chunk, "usage", None))
@@ -393,20 +394,29 @@ class OpenAICompatibleProvider(BaseProvider):
                             tool_calls.append(tc_dict)
 
                         if tool_calls:
-                            yield StreamChunk(
+                            terminal_chunk = StreamChunk(
                                 delta="",  # Empty string, not None
                                 finish_reason=choice.finish_reason,
                                 tool_calls=tool_calls,
                                 usage=stream_usage,
                             )
+                            yield terminal_chunk
+                            usage_emitted = usage_emitted or terminal_chunk.usage is not None
                             yielded_finish_for_this_chunk = True
 
                 if choice.finish_reason and not yielded_finish_for_this_chunk:
-                    yield StreamChunk(
+                    terminal_chunk = StreamChunk(
                         delta="",
                         finish_reason=choice.finish_reason,
                         usage=stream_usage,
                     )
+                    yield terminal_chunk
+                    usage_emitted = usage_emitted or terminal_chunk.usage is not None
+
+        # Some routers emit the OpenAI usage-only frame after the finish chunk.
+        # Re-emit that trailing usage so downstream stats persistence sees it.
+        if emitted_substantive_chunk and stream_usage and not usage_emitted:
+            yield StreamChunk(delta="", finish_reason=None, usage=stream_usage)
 
         if not emitted_substantive_chunk:
             self.log.warn("openai_compatible.stream.empty_response", {

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -479,6 +479,47 @@ class TestOpenAIBaseProviderStreamingUsage:
         }
 
     @pytest.mark.asyncio
+    async def test_chat_stream_emits_trailing_usage_when_usage_only_chunk_arrives_after_finish(self):
+        provider, create = self._build_provider_with_stream()
+
+        content_chunk = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(content="hello", tool_calls=None),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        )
+        finish_chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=None, finish_reason="stop")],
+            usage=None,
+        )
+        usage_chunk = SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+        )
+        create.return_value = _stream_from_chunks(content_chunk, finish_chunk, usage_chunk)
+
+        from flocks.provider.provider import ChatMessage
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "kimi-k2.5",
+                [ChatMessage(role="user", content="hello")],
+            )
+        ]
+
+        assert any(chunk.finish_reason == "stop" for chunk in chunks)
+        assert chunks[-1].usage == {
+            "prompt_tokens": 11,
+            "completion_tokens": 7,
+            "total_tokens": 18,
+        }
+        assert chunks[-1].finish_reason is None
+
+    @pytest.mark.asyncio
     async def test_chat_stream_retries_without_stream_options_when_unsupported(self):
         provider, create = self._build_provider_with_stream()
 

--- a/tests/provider/test_openai_compatible_provider.py
+++ b/tests/provider/test_openai_compatible_provider.py
@@ -241,6 +241,41 @@ class TestOpenAICompatibleProviderStreamingUsage:
         }
 
     @pytest.mark.asyncio
+    async def test_chat_stream_emits_trailing_usage_when_usage_only_chunk_arrives_after_finish(self):
+        provider, create = _build_provider_with_client()
+        create.return_value = _stream_from_chunks(
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="hello", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[],
+                usage=SimpleNamespace(prompt_tokens=13, completion_tokens=8, total_tokens=21),
+            ),
+        )
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "kimi-k2.5",
+                [ChatMessage(role="user", content="hello")],
+            )
+        ]
+
+        assert any(chunk.finish_reason == "stop" for chunk in chunks)
+        assert chunks[-1].usage == {
+            "prompt_tokens": 13,
+            "completion_tokens": 8,
+            "total_tokens": 21,
+        }
+        assert chunks[-1].finish_reason is None
+
+    @pytest.mark.asyncio
     async def test_chat_stream_retries_without_stream_options_when_unsupported(self):
         provider, create = _build_provider_with_client()
         create.side_effect = [


### PR DESCRIPTION
## Summary
- preserve trailing usage-only stream chunks when OpenAI-compatible APIs send usage after the terminal finish chunk
- apply the same handling to both `OpenAIBaseProvider` and `OpenAICompatibleProvider`
- add provider tests covering the finish-then-usage ordering