### PR TITLE
feat(webui): clipboard fallback and toast feedback

### DIFF
--- a/webui/src/components/common/CopyButton.tsx
+++ b/webui/src/components/common/CopyButton.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Copy, Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { useToast } from './Toast';
+import { copyText } from '@/utils/clipboard';
 
 interface CopyButtonProps {
   text: string;
@@ -11,11 +13,19 @@ interface CopyButtonProps {
 export default function CopyButton({ text, size = 'w-3.5 h-3.5' }: CopyButtonProps) {
   const { t } = useTranslation('common');
   const [copied, setCopied] = useState(false);
+  const toast = useToast();
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await copyText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      toast.error(
+        t('clipboard.copyFailedTitle'),
+        error instanceof Error ? error.message : t('clipboard.copyFailedDescription'),
+      );
+    }
   };
 
   return (

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMessageBubbleClassName } from './SessionChat';
+
+describe('getMessageBubbleClassName', () => {
+  it('keeps non-editing user bubbles auto-sized in full layout', () => {
+    const className = getMessageBubbleClassName({
+      compact: false,
+      isUser: true,
+      isEditing: false,
+    });
+
+    expect(className).toContain('max-w-2xl w-auto');
+  });
+
+  it('expands editing user bubbles to full width in full layout', () => {
+    const className = getMessageBubbleClassName({
+      compact: false,
+      isUser: true,
+      isEditing: true,
+    });
+
+    expect(className).toContain('max-w-2xl w-full');
+    expect(className).not.toContain('w-auto');
+  });
+
+  it('keeps assistant bubbles full width regardless of editing state', () => {
+    const className = getMessageBubbleClassName({
+      compact: false,
+      isUser: false,
+      isEditing: true,
+    });
+
+    expect(className).toContain('max-w-2xl w-full');
+  });
+});

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -21,6 +21,7 @@ import { Send, Loader2, ChevronDown, Square, Copy, User, Plus, FileText, AlertCi
 import { StreamingMarkdown } from './StreamingMarkdown';
 import { useTranslation } from 'react-i18next';
 import LoadingSpinner from './LoadingSpinner';
+import { useToast } from './Toast';
 import { QuestionTool } from './QuestionTool';
 import DelegateTaskCard, { isDelegateTool } from './DelegateTaskCard';
 import CommandDropdown, { parseSlashCommand } from './CommandDropdown';
@@ -32,6 +33,7 @@ import { sessionApi } from '@/api/session';
 import client from '@/api/client';
 import { commandAPI, type Command } from '@/api/skill';
 import { workspaceAPI } from '@/api/workspace';
+import { copyText } from '@/utils/clipboard';
 import { formatSmartTime } from '@/utils/time';
 import type { Message, MessagePart, ToolState } from '@/types';
 
@@ -161,6 +163,34 @@ export function mergeConsecutiveAssistantMessages(messages: Message[]): MergedMe
   return result;
 }
 
+export function getMessageBubbleClassName({
+  compact,
+  isUser,
+  isEditing,
+}: {
+  compact: boolean;
+  isUser: boolean;
+  isEditing: boolean;
+}): string {
+  if (compact) {
+    return `max-w-[90%] px-4 py-3 rounded-xl text-sm break-words ${
+      isUser
+        ? 'bg-gradient-to-br from-slate-50 to-gray-100 border border-slate-200 text-gray-900 shadow-sm'
+        : 'bg-white border border-gray-200 shadow-sm'
+    }`;
+  }
+
+  const widthClass = isUser
+    ? (isEditing ? 'max-w-2xl w-full' : 'max-w-2xl w-auto')
+    : 'max-w-2xl w-full';
+
+  return `${widthClass} px-6 py-4 rounded-2xl text-sm break-words ${
+    isUser
+      ? 'bg-gradient-to-br from-slate-50 to-gray-100 border border-slate-200 text-gray-900 shadow-sm'
+      : 'bg-white border border-gray-200 shadow-sm hover:shadow-md transition-shadow duration-200'
+  }`;
+}
+
 // ============================================================================
 // Main component
 // ============================================================================
@@ -206,6 +236,8 @@ export default function SessionChat({
   onInitialMessageConsumed,
 }: SessionChatProps) {
   const { t } = useTranslation('session');
+  const { t: tCommon } = useTranslation('common');
+  const toast = useToast();
   const compact = display?.compact ?? true;
   const showActions = display?.showActions ?? false;
   const showTimestamp = display?.showTimestamp ?? false;
@@ -913,9 +945,17 @@ export default function SessionChat({
   }, [isStreaming, sessionId, refetch]);
 
   // Copy text to clipboard
-  const handleCopy = useCallback((text: string) => {
-    navigator.clipboard.writeText(text).catch(() => {});
-  }, []);
+  const handleCopy = useCallback(async (text: string) => {
+    try {
+      await copyText(text);
+      toast.success(tCommon('clipboard.copySuccessTitle'));
+    } catch (error) {
+      toast.error(
+        tCommon('clipboard.copyFailedTitle'),
+        error instanceof Error ? error.message : tCommon('clipboard.copyFailedDescription'),
+      );
+    }
+  }, [tCommon, toast]);
 
   const resetEditingState = useCallback(() => {
     setEditingMessageId(null);
@@ -1519,17 +1559,7 @@ function ChatMessageBubbleInner({
   const isEditing = !!targetPartId && editingMessageId === targetMessageId;
   const isActionPending = actionMessageId === targetMessageId;
 
-  const bubbleClass = compact
-    ? `max-w-[90%] px-4 py-3 rounded-xl text-sm break-words ${
-        isUser
-          ? 'bg-gradient-to-br from-slate-50 to-gray-100 border border-slate-200 text-gray-900 shadow-sm'
-          : 'bg-white border border-gray-200 shadow-sm'
-      }`
-    : `${isUser ? 'max-w-2xl w-auto' : 'max-w-2xl w-full'} px-6 py-4 rounded-2xl text-sm break-words ${
-        isUser
-          ? 'bg-gradient-to-br from-slate-50 to-gray-100 border border-slate-200 text-gray-900 shadow-sm'
-          : 'bg-white border border-gray-200 shadow-sm hover:shadow-md transition-shadow duration-200'
-      }`;
+  const bubbleClass = getMessageBubbleClassName({ compact, isUser, isEditing });
   const actionBarClass = `absolute bottom-0 z-10 flex items-center gap-1.5 transition-all duration-150 ${
     isUser ? 'right-3 translate-x-0.5 translate-y-1/2' : 'left-3 -translate-x-0.5 translate-y-1/2'
   } ${

--- a/webui/src/locales/en-US/common.json
+++ b/webui/src/locales/en-US/common.json
@@ -20,6 +20,11 @@
     "installing": "Installing...",
     "copy": "Copy"
   },
+  "clipboard": {
+    "copySuccessTitle": "Copied to clipboard",
+    "copyFailedTitle": "Copy failed",
+    "copyFailedDescription": "Automatic copy is unavailable in this environment. Please select and copy manually."
+  },
   "status": {
     "loading": "Loading...",
     "healthy": "Healthy",

--- a/webui/src/locales/zh-CN/common.json
+++ b/webui/src/locales/zh-CN/common.json
@@ -20,6 +20,11 @@
     "installing": "安装中...",
     "copy": "复制"
   },
+  "clipboard": {
+    "copySuccessTitle": "已复制到剪贴板",
+    "copyFailedTitle": "复制失败",
+    "copyFailedDescription": "当前环境不支持自动复制，请手动选择后复制"
+  },
   "status": {
     "loading": "加载中...",
     "healthy": "运行正常",

--- a/webui/src/utils/clipboard.test.ts
+++ b/webui/src/utils/clipboard.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { copyText, fallbackCopyText } from './clipboard';
+
+function setExecCommand(fn?: (commandId: string) => boolean) {
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    value: fn,
+  });
+}
+
+describe('clipboard helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setExecCommand(undefined);
+  });
+
+  it('uses async clipboard in secure contexts', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await copyText('hello');
+
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('falls back to execCommand when async clipboard is unavailable', async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    setExecCommand(execCommand);
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+
+    await copyText('fallback text');
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('falls back to execCommand when async clipboard write fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('not allowed'));
+    const execCommand = vi.fn().mockReturnValue(true);
+    setExecCommand(execCommand);
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await copyText('fallback after failure');
+
+    expect(writeText).toHaveBeenCalledWith('fallback after failure');
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('throws when both clipboard strategies fail', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('blocked'));
+    setExecCommand(vi.fn().mockReturnValue(false));
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await expect(copyText('nope')).rejects.toThrow('blocked');
+  });
+
+  it('returns false when execCommand is unavailable', () => {
+    setExecCommand(undefined);
+    expect(fallbackCopyText('text')).toBe(false);
+  });
+});

--- a/webui/src/utils/clipboard.ts
+++ b/webui/src/utils/clipboard.ts
@@ -1,0 +1,88 @@
+type SelectionSnapshot = {
+  ranges: Range[];
+  activeElement: HTMLElement | null;
+};
+
+function captureSelection(): SelectionSnapshot {
+  const selection = document.getSelection();
+  const ranges: Range[] = [];
+  if (selection) {
+    for (let index = 0; index < selection.rangeCount; index += 1) {
+      ranges.push(selection.getRangeAt(index).cloneRange());
+    }
+  }
+
+  return {
+    ranges,
+    activeElement: document.activeElement instanceof HTMLElement ? document.activeElement : null,
+  };
+}
+
+function restoreSelection(snapshot: SelectionSnapshot) {
+  const selection = document.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+    snapshot.ranges.forEach((range) => selection.addRange(range));
+  }
+
+  snapshot.activeElement?.focus?.();
+}
+
+export function fallbackCopyText(text: string): boolean {
+  if (typeof document === 'undefined' || typeof document.execCommand !== 'function') {
+    return false;
+  }
+
+  const textarea = document.createElement('textarea');
+  const snapshot = captureSelection();
+
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.setAttribute('aria-hidden', 'true');
+  textarea.tabIndex = -1;
+  textarea.style.position = 'fixed';
+  textarea.style.top = '0';
+  textarea.style.left = '-9999px';
+  textarea.style.opacity = '0';
+  textarea.style.pointerEvents = 'none';
+  textarea.style.whiteSpace = 'pre';
+
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  try {
+    return document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+    restoreSelection(snapshot);
+  }
+}
+
+export async function copyText(text: string): Promise<void> {
+  const normalizedText = String(text ?? '');
+  let clipboardError: unknown;
+
+  if (
+    typeof window !== 'undefined' &&
+    window.isSecureContext &&
+    typeof navigator !== 'undefined' &&
+    typeof navigator.clipboard?.writeText === 'function'
+  ) {
+    try {
+      await navigator.clipboard.writeText(normalizedText);
+      return;
+    } catch (error) {
+      clipboardError = error;
+    }
+  }
+
+  if (fallbackCopyText(normalizedText)) {
+    return;
+  }
+
+  throw clipboardError instanceof Error
+    ? clipboardError
+    : new Error('Clipboard copy failed');
+}


### PR DESCRIPTION
## Summary
- Add `copyText` utility: Clipboard API in secure context with `execCommand` fallback
- Show success/error toasts in SessionChat and CopyButton when copying
- Extract `getMessageBubbleClassName`; user bubbles use full width while editing in full layout
- i18n: clipboard strings for en-US and zh-CN
- Unit tests for clipboard helper and bubble class names