### PR TITLE
fix(cli): process group running check after EPERM on macOS

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -492,13 +492,18 @@ def process_group_is_running(pgid: int | None) -> bool:
     except ProcessLookupError:
         return False
     except PermissionError:
-        return True
+        pass
     except OSError:
         return False
     members = _process_group_member_pids(pgid)
     if not members:
         return False
-    return any(pid_is_running(pid) for pid in members)
+    alive_members = [pid for pid in members if pid_is_running(pid)]
+    if alive_members:
+        return True
+    # macOS can raise EPERM for a defunct process-group leader even when no
+    # runnable members remain, so rely on member liveness as the source of truth.
+    return False
 
 
 def runtime_record_is_running(record: RuntimeRecord | None) -> bool:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -51,6 +51,31 @@ def test_pid_is_running_uses_windows_probe(monkeypatch) -> None:
     assert service_manager.pid_is_running(456) is False
 
 
+def test_process_group_is_running_ignores_permission_error_without_live_members(monkeypatch) -> None:
+    monkeypatch.setattr(service_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        service_manager.os,
+        "killpg",
+        lambda _pgid, _sig: (_ for _ in ()).throw(PermissionError(1, "Operation not permitted")),
+    )
+    monkeypatch.setattr(service_manager, "_process_group_member_pids", lambda _pgid: [])
+
+    assert service_manager.process_group_is_running(222) is False
+
+
+def test_process_group_is_running_checks_members_after_permission_error(monkeypatch) -> None:
+    monkeypatch.setattr(service_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        service_manager.os,
+        "killpg",
+        lambda _pgid, _sig: (_ for _ in ()).throw(PermissionError(1, "Operation not permitted")),
+    )
+    monkeypatch.setattr(service_manager, "_process_group_member_pids", lambda _pgid: [333, 444])
+    monkeypatch.setattr(service_manager, "pid_is_running", lambda pid: pid == 444)
+
+    assert service_manager.process_group_is_running(222) is True
+
+
 def test_read_runtime_record_supports_legacy_pid_file(tmp_path: Path) -> None:
     pid_file = tmp_path / "backend.pid"
     pid_file.write_text("12345\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
Fixes `process_group_is_running` so that when `os.killpg` raises `PermissionError` (e.g. macOS EPERM on a defunct group leader), we do not assume the process group is still running. We fall through to member PID checks and only return true if at least one member is alive.