### PR TITLE
feat(install): admin check, i18n, CN defaults

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -72,12 +72,12 @@ cd flocks
 
 Macos/Linux
 ```bash
-./scripts/install.sh # Macos/Linux
+./scripts/install_zh.sh # Macos/Linux
 ```
 
 Windows powershell (Administrator)
 ```bash
-powershell -ep Bypass -File .\scripts\install.ps1 # Windows powershell
+powershell -ep Bypass -File .\scripts\install_zh.ps1 # Windows powershell
 ```
 
 ### 启动服务

--- a/install.ps1
+++ b/install.ps1
@@ -15,6 +15,33 @@ $DefaultBranch = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_DEFAULT_BRANCH)) {
 $DefaultInstallDir = Join-Path (Get-Location) "flocks"
 $InstallDir = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_DIR)) { $DefaultInstallDir } else { $env:FLOCKS_INSTALL_DIR }
 
+function Test-IsWindowsPlatform {
+    return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+}
+
+function Test-IsAdministrator {
+    if (-not (Test-IsWindowsPlatform)) {
+        return $true
+    }
+
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Assert-Administrator {
+    if (Test-IsAdministrator) {
+        return
+    }
+
+    Fail "Administrator privileges are required. Reopen PowerShell as Administrator and rerun this installer."
+}
+
 function Write-Info {
     param([string]$Message)
     Write-Host "[flocks-bootstrap] $Message"
@@ -37,6 +64,7 @@ function Show-Usage {
     Write-Host "This script downloads the GitHub source archive to a temporary directory,"
     Write-Host "copies it to a persistent install location, and delegates to scripts/install.ps1."
     Write-Host "By default it creates a 'flocks' subdirectory under the current directory."
+    Write-Host "Run this installer in a PowerShell window opened as Administrator."
     Write-Host ""
     Write-Host "Remote usage:"
     Write-Host '  powershell -c "irm https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1 | iex"'
@@ -143,6 +171,8 @@ function Main {
         Show-Usage
         return
     }
+
+    Assert-Administrator
 
     $tempDir = New-TemporaryDirectory
     $archivePath = Join-Path $tempDir "flocks.zip"

--- a/install_zh.ps1
+++ b/install_zh.ps1
@@ -17,6 +17,33 @@ $InstallDir = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_DIR)) { $Defa
 $RawInstallZhShUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_RAW_INSTALL_ZH_SH_URL)) { "https://gitee.com/flocks/flocks/raw/main/install_zh.sh" } else { $env:FLOCKS_RAW_INSTALL_ZH_SH_URL }
 $RawInstallZhPs1Url = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_RAW_INSTALL_ZH_PS1_URL)) { "https://gitee.com/flocks/flocks/raw/main/install_zh.ps1" } else { $env:FLOCKS_RAW_INSTALL_ZH_PS1_URL }
 
+function Test-IsWindowsPlatform {
+    return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+}
+
+function Test-IsAdministrator {
+    if (-not (Test-IsWindowsPlatform)) {
+        return $true
+    }
+
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Assert-Administrator {
+    if (Test-IsAdministrator) {
+        return
+    }
+
+    Fail "安装需要管理员权限。请使用“以管理员身份运行”重新打开 PowerShell 后再执行。"
+}
+
 function Write-Info {
     param([string]$Message)
     Write-Host "[flocks-bootstrap-zh] $Message"
@@ -38,6 +65,7 @@ function Show-Usage {
     Write-Host "Flocks 中国用户一键安装脚本。"
     Write-Host "该脚本会从 Gitee 下载仓库源码压缩包到临时目录，复制到持久化安装目录后，转交 scripts/install_zh.ps1。"
     Write-Host "默认会在当前目录下创建 'flocks' 子目录。"
+    Write-Host "请在“以管理员身份运行”的 PowerShell 窗口中执行此安装脚本。"
     Write-Host ""
     Write-Host "远程使用："
     Write-Host "  curl -fsSL $RawInstallZhShUrl | bash"
@@ -138,6 +166,24 @@ function Resolve-ProjectRoot {
 }
 
 function Set-CnInstallerEnvironment {
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_LANGUAGE)) {
+        $env:FLOCKS_INSTALL_LANGUAGE = "zh-CN"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_DEFAULT_INDEX)) {
+        $env:FLOCKS_UV_DEFAULT_INDEX = "https://mirrors.aliyun.com/pypi/simple"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_SH_URL)) {
+        $env:FLOCKS_UV_INSTALL_SH_URL = "https://astral.org.cn/uv/install.sh"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) {
+        $env:FLOCKS_UV_INSTALL_PS1_URL = "https://astral.org.cn/uv/install.ps1"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) {
+        $env:FLOCKS_NPM_REGISTRY = "https://registry.npmmirror.com/"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL)) {
+        $env:FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL = "https://nodejs.org/zh-cn/download"
+    }
     if ([string]::IsNullOrWhiteSpace($env:PUPPETEER_CHROME_DOWNLOAD_BASE_URL)) {
         $env:PUPPETEER_CHROME_DOWNLOAD_BASE_URL = "https://cdn.npmmirror.com/binaries/chrome-for-testing"
     }
@@ -148,6 +194,8 @@ function Main {
         Show-Usage
         return
     }
+
+    Assert-Administrator
 
     $tempDir = New-TemporaryDirectory
     $archivePath = Join-Path $tempDir "flocks.zip"

--- a/install_zh.sh
+++ b/install_zh.sh
@@ -41,6 +41,8 @@ Flocks 中国用户一键安装脚本。
 该脚本会从 Gitee 下载仓库源码压缩包，解压到临时目录后复制到持久化安装目录，
 然后转交 scripts/install_zh.sh 继续安装。默认会在当前工作目录下创建 "flocks" 子目录。
 
+默认会为 install_zh 注入国内软件源与 uv 安装镜像。
+
 远程使用：
   curl -fsSL $RAW_INSTALL_ZH_SH_URL | bash
   curl -fsSL $RAW_INSTALL_ZH_SH_URL | bash -s -- --with-tui
@@ -126,6 +128,9 @@ resolve_project_dir() {
 }
 
 configure_cn_environment() {
+  export FLOCKS_INSTALL_LANGUAGE="${FLOCKS_INSTALL_LANGUAGE:-zh-CN}"
+  export FLOCKS_UV_INSTALL_SH_URL="${FLOCKS_UV_INSTALL_SH_URL:-https://astral.org.cn/uv/install.sh}"
+  export FLOCKS_UV_INSTALL_PS1_URL="${FLOCKS_UV_INSTALL_PS1_URL:-https://astral.org.cn/uv/install.ps1}"
   export PUPPETEER_CHROME_DOWNLOAD_BASE_URL="${PUPPETEER_CHROME_DOWNLOAD_BASE_URL:-https://cdn.npmmirror.com/binaries/chrome-for-testing}"
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -953,12 +953,14 @@ function Install-ChromeForTesting {
     $browserDir = Get-ChromeForTestingDir
 
     if (-not (Test-Command "npx.cmd")) {
-        Fail "npx was not found. Install Node.js (including npm) and retry.$(Get-NodejsManualDownloadHint)"
+        Write-Warning (Get-LocalizedText -English "npx was not found, so browser installation was skipped. This does not block Flocks startup; you can reinstall it later." -Chinese "未找到 npx，跳过浏览器安装；这不影响 Flocks 启动，可稍后重新安装。")
+        return $null
     }
 
     New-Item -ItemType Directory -Path $browserDir -Force | Out-Null
     Write-Info "System Chrome/Chromium was not found. Installing Chrome for Testing to: $browserDir"
-    Write-Info (Get-LocalizedText -English "Downloading Chrome for Testing (~200MB). The download progress will be shown below..." -Chinese "正在下载 Chrome for Testing（约 200MB），下方将显示下载进度...")
+    Write-Info (Get-LocalizedText -English "Downloading Chrome for Testing." -Chinese "正在下载 Chrome for Testing。")
+    Write-Warning (Get-LocalizedText -English "If browser installation fails, Flocks can still start and you can reinstall it later." -Chinese "如浏览器安装失败，不影响 Flocks 启动，可稍后重新安装。")
 
     $npxPath = Get-CommandPath "npx.cmd"
     if ([string]::IsNullOrWhiteSpace($npxPath)) {
@@ -976,7 +978,8 @@ function Install-ChromeForTesting {
             -Wait `
             -PassThru
         if ($process.ExitCode -ne 0) {
-            Fail "Chrome for Testing installation failed."
+            Write-Warning (Get-LocalizedText -English "Chrome for Testing installation failed. This does not block Flocks startup; you can reinstall it later." -Chinese "Chrome for Testing 安装失败，不影响 Flocks 启动，可稍后重新安装。")
+            return $null
         }
     }
     finally {
@@ -990,7 +993,8 @@ function Install-ChromeForTesting {
 
     $browserPath = Resolve-ChromeForTestingPath -BrowserDir $browserDir
     if ([string]::IsNullOrWhiteSpace($browserPath)) {
-        Fail "Chrome for Testing finished installing, but the browser executable could not be located under: $browserDir."
+        Write-Warning (Get-LocalizedText -English "Chrome for Testing finished installing, but the browser executable could not be located. This does not block Flocks startup; you can reinstall it later." -Chinese "Chrome for Testing 已安装，但未能在目录中找到浏览器可执行文件；这不影响 Flocks 启动，可稍后重新安装。")
+        return $null
     }
 
     return $browserPath
@@ -1000,8 +1004,19 @@ function Configure-AgentBrowserBrowser {
     $browserPath = Find-SystemBrowserPath
 
     if ([string]::IsNullOrWhiteSpace($browserPath)) {
-        $browserPath = Install-ChromeForTesting
-        Write-Info "Installed Chrome for Testing. agent-browser will use: $browserPath"
+        $browserPath = Resolve-ChromeForTestingPath -BrowserDir (Get-ChromeForTestingDir)
+        if ([string]::IsNullOrWhiteSpace($browserPath)) {
+            $browserPath = Install-ChromeForTesting
+            if (-not [string]::IsNullOrWhiteSpace($browserPath)) {
+                Write-Info "Installed Chrome for Testing. agent-browser will use: $browserPath"
+            }
+            else {
+                return
+            }
+        }
+        else {
+            Write-Info "Found existing Chrome for Testing. agent-browser will use: $browserPath"
+        }
     }
     else {
         Write-Info "Detected system Chrome/Chromium. agent-browser will use: $browserPath"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,7 +10,9 @@ $RawInstallShUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_RAW_INSTALL_SH_U
 $RawInstallPs1Url = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_RAW_INSTALL_PS1_URL)) { "https://raw.githubusercontent.com/AgentFlocks/Flocks/main/install.ps1" } else { $env:FLOCKS_RAW_INSTALL_PS1_URL }
 $RootDir = $null
 $MinNodeMajor = 22
+$script:InstallLanguage = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_LANGUAGE)) { "en" } else { $env:FLOCKS_INSTALL_LANGUAGE }
 $script:UvDefaultIndex = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_DEFAULT_INDEX)) { "https://pypi.org/simple" } else { $env:FLOCKS_UV_DEFAULT_INDEX }
+$script:UvInstallPs1Url = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) { "https://astral.sh/uv/install.ps1" } else { $env:FLOCKS_UV_INSTALL_PS1_URL }
 $script:NpmRegistry = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) { "https://registry.npmjs.org/" } else { $env:FLOCKS_NPM_REGISTRY }
 $script:NodejsManualDownloadUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL)) { "https://nodejs.org/en/download" } else { $env:FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL }
 
@@ -21,7 +23,12 @@ function Write-Info {
 
 function Fail {
     param([string]$Message)
-    Write-Host "[flocks] error: $Message" -ForegroundColor Red
+    if (Test-IsZhInstall) {
+        Write-Host "[flocks] 错误: $Message" -ForegroundColor Red
+    }
+    else {
+        Write-Host "[flocks] error: $Message" -ForegroundColor Red
+    }
     exit 1
 }
 
@@ -30,13 +37,58 @@ function Test-Command {
     return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Test-IsZhInstall {
+    return $script:InstallLanguage -like "zh*" -or $script:InstallLanguage -like "cn*"
+}
+
+function Get-LocalizedText {
+    param(
+        [string]$English,
+        [string]$Chinese
+    )
+
+    if (Test-IsZhInstall) {
+        return $Chinese
+    }
+
+    return $English
+}
+
+function Test-IsWindowsPlatform {
+    return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+}
+
+function Test-IsAdministrator {
+    if (-not (Test-IsWindowsPlatform)) {
+        return $true
+    }
+
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Assert-Administrator {
+    if (Test-IsAdministrator) {
+        return
+    }
+
+    Fail (Get-LocalizedText -English "Administrator privileges are required. Reopen PowerShell as Administrator and rerun this installer." -Chinese "安装需要管理员权限。请使用“以管理员身份运行”重新打开 PowerShell 后再执行。")
+}
+
 function Get-NodejsManualDownloadHint {
     return " Manual download: $script:NodejsManualDownloadUrl"
 }
 
 function Initialize-InstallSources {
-    Write-Info "Using PyPI index: $script:UvDefaultIndex"
-    Write-Info "Using npm registry: $script:NpmRegistry"
+    Write-Info (Get-LocalizedText -English "Using PyPI index: $script:UvDefaultIndex" -Chinese "使用 PyPI 源: $script:UvDefaultIndex")
+    Write-Info (Get-LocalizedText -English "Using npm registry: $script:NpmRegistry" -Chinese "使用 npm 源: $script:NpmRegistry")
+    Write-Info (Get-LocalizedText -English "Using uv install script: $script:UvInstallPs1Url" -Chinese "使用 uv 安装脚本: $script:UvInstallPs1Url")
 }
 
 function Get-NodeMajorVersion {
@@ -146,18 +198,34 @@ function Resolve-RootDir {
 }
 
 function Show-CloneHintAndExit {
-    Write-Host "[flocks] Flocks repository source was not found in the current location."
-    Write-Host ""
-    Write-Host "To install from source, clone the repository first and then run:"
-    Write-Host ""
-    Write-Host "  git clone $RepoUrl"
-    Write-Host "  cd Flocks"
-    Write-Host "  .\scripts\install.ps1"
-    Write-Host ""
-    Write-Host "Or use the one-line GitHub bootstrap installer:"
-    Write-Host ""
-    Write-Host "  curl -fsSL $RawInstallShUrl | bash"
-    Write-Host "  iwr -useb $RawInstallPs1Url | iex"
+    if (Test-IsZhInstall) {
+        Write-Host "[flocks] 当前目录未找到 Flocks 仓库源码。"
+        Write-Host ""
+        Write-Host "如需从源码安装，请先克隆仓库后再执行："
+        Write-Host ""
+        Write-Host "  git clone $RepoUrl"
+        Write-Host "  cd Flocks"
+        Write-Host "  .\scripts\install_zh.ps1"
+        Write-Host ""
+        Write-Host "或者使用一键安装脚本："
+        Write-Host ""
+        Write-Host "  curl -fsSL $RawInstallShUrl | bash"
+        Write-Host "  iwr -useb $RawInstallPs1Url | iex"
+    }
+    else {
+        Write-Host "[flocks] Flocks repository source was not found in the current location."
+        Write-Host ""
+        Write-Host "To install from source, clone the repository first and then run:"
+        Write-Host ""
+        Write-Host "  git clone $RepoUrl"
+        Write-Host "  cd Flocks"
+        Write-Host "  .\scripts\install.ps1"
+        Write-Host ""
+        Write-Host "Or use the one-line GitHub bootstrap installer:"
+        Write-Host ""
+        Write-Host "  curl -fsSL $RawInstallShUrl | bash"
+        Write-Host "  iwr -useb $RawInstallPs1Url | iex"
+    }
     exit 1
 }
 
@@ -302,12 +370,12 @@ function Install-Uv {
         return
     }
 
-    Write-Info "uv was not found. Installing it automatically..."
-    powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm https://astral.sh/uv/install.ps1 | iex"
+    Write-Info (Get-LocalizedText -English "uv was not found. Installing it automatically..." -Chinese "未检测到 uv，正在自动安装...")
+    powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm $script:UvInstallPs1Url | iex"
     Refresh-Path
 
     if (-not (Test-Command "uv")) {
-        Fail "uv finished installing, but it is still not available. Check PATH and retry."
+        Fail (Get-LocalizedText -English "uv finished installing, but it is still not available. Check PATH and retry." -Chinese "uv 安装已完成，但当前仍无法找到 uv。请检查 PATH 后重试。")
     }
 }
 
@@ -957,11 +1025,11 @@ function Install-DingtalkChannelDeps {
 
     $nodeModulesDir = Join-Path $connectorDir "node_modules"
     if (Test-Path $nodeModulesDir) {
-        Write-Info "DingTalk channel dependencies already exist. Skipping installation."
+        Write-Info (Get-LocalizedText -English "DingTalk channel dependencies already exist. Skipping installation." -Chinese "钉钉频道依赖已存在，跳过安装。")
         return
     }
 
-    Write-Info "Detected DingTalk channel plugin. Installing npm dependencies..."
+    Write-Info (Get-LocalizedText -English "Detected DingTalk channel plugin. Installing npm dependencies..." -Chinese "检测到钉钉频道插件，正在安装 npm 依赖...")
 
     Push-Location $connectorDir
     try {
@@ -977,7 +1045,7 @@ function Install-DingtalkChannelDeps {
         Pop-Location
     }
 
-    Write-Info "DingTalk channel dependencies installed."
+    Write-Info (Get-LocalizedText -English "DingTalk channel dependencies installed." -Chinese "钉钉频道依赖安装完成。")
 }
 
 function Write-RunCommandHint {
@@ -993,18 +1061,20 @@ function Main {
         return
     }
 
+    Assert-Administrator
+
     Refresh-Path
 
     if (-not (Resolve-RootDir)) {
         Show-CloneHintAndExit
     }
 
-    Write-Info "Project directory: $RootDir"
+    Write-Info (Get-LocalizedText -English "Project directory: $RootDir" -Chinese "项目目录: $RootDir")
     Install-Uv
     Ensure-NpmInstalled
     Initialize-InstallSources
 
-    Write-Info "Installing Python backend dependencies (including tests and lint tools) with uv sync --group dev..."
+    Write-Info (Get-LocalizedText -English "Installing Python backend dependencies (including tests and lint tools) with uv sync --group dev..." -Chinese "正在使用 uv sync --group dev 安装 Python 后端依赖（含测试与 lint 工具）...")
     Push-Location $RootDir
     try {
         Invoke-InstallerCommandWithLockRetry `
@@ -1020,7 +1090,7 @@ function Main {
 
     Install-FlocksCli
 
-    Write-Info "Installing WebUI dependencies..."
+    Write-Info (Get-LocalizedText -English "Installing WebUI dependencies..." -Chinese "正在安装 WebUI 依赖...")
     Push-Location (Join-Path $RootDir "webui")
     try {
         $null = Invoke-NativeCommandOrFail `
@@ -1039,7 +1109,7 @@ function Main {
 
     if ($InstallTui) {
         Install-Bun
-        Write-Info "Installing TUI dependencies..."
+        Write-Info (Get-LocalizedText -English "Installing TUI dependencies..." -Chinese "正在安装 TUI 依赖...")
         Push-Location (Join-Path $RootDir "tui")
         try {
             $null = Invoke-NativeCommandOrFail `
@@ -1054,26 +1124,45 @@ function Main {
         }
     }
     else {
-        Write-Info "Skipping TUI dependency installation. Re-run .\scripts\install.ps1 -InstallTui to install them."
+        Write-Info (Get-LocalizedText -English "Skipping TUI dependency installation. Re-run .\scripts\install_zh.ps1 -InstallTui to install them." -Chinese "已跳过 TUI 依赖安装。如需安装，请重新执行 .\scripts\install.ps1 -InstallTui。")
     }
 
     Install-AgentBrowser
 
     Write-Host ""
-    Write-Host "[flocks] Installation complete."
-    Write-Host ""
-    Write-Host "Start a new terminal session to load the updated environment and enable the installed commands."
-    Write-Host ""
-    Write-Host "Next commands:"
-    Write-Host "  1. Start the backend and WebUI in daemon mode"
-    Write-Host "     flocks start"
-    Write-Host ""
-    Write-Host "  2. Show command help"
-    Write-Host "     flocks --help"
-    Write-Host ""
-    if ($InstallTui) {
-        Write-Host "  3. Launch the TUI"
-        Write-Host "     flocks tui"
+    if (Test-IsZhInstall) {
+        Write-Host "[flocks] 安装完成。"
+        Write-Host ""
+        Write-Host "请打开新的终端会话，以加载更新后的环境变量并启用新安装的命令。"
+        Write-Host ""
+        Write-Host "接下来可以执行："
+        Write-Host "  1. 以守护进程模式启动后端和 WebUI"
+        Write-Host "     flocks start"
+        Write-Host ""
+        Write-Host "  2. 查看命令帮助"
+        Write-Host "     flocks --help"
+        Write-Host ""
+        if ($InstallTui) {
+            Write-Host "  3. 启动 TUI"
+            Write-Host "     flocks tui"
+        }
+    }
+    else {
+        Write-Host "[flocks] Installation complete."
+        Write-Host ""
+        Write-Host "Start a new terminal session to load the updated environment and enable the installed commands."
+        Write-Host ""
+        Write-Host "Next commands:"
+        Write-Host "  1. Start the backend and WebUI in daemon mode"
+        Write-Host "     flocks start"
+        Write-Host ""
+        Write-Host "  2. Show command help"
+        Write-Host "     flocks --help"
+        Write-Host ""
+        if ($InstallTui) {
+            Write-Host "  3. Launch the TUI"
+            Write-Host "     flocks tui"
+        }
     }
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -927,6 +927,28 @@ function Get-ChromeForTestingDir {
     return (Join-Path $HOME ".flocks\browser")
 }
 
+function Resolve-ChromeForTestingPath {
+    param([string]$BrowserDir)
+
+    if ([string]::IsNullOrWhiteSpace($BrowserDir) -or -not (Test-Path $BrowserDir)) {
+        return $null
+    }
+
+    $candidateNames = @("chrome.exe", "Google Chrome for Testing", "chrome")
+    $candidates = @(Get-ChildItem -Path $BrowserDir -Recurse -File -ErrorAction SilentlyContinue | Where-Object {
+        $candidateNames -contains $_.Name
+    })
+
+    foreach ($name in $candidateNames) {
+        $match = $candidates | Where-Object { $_.Name -eq $name } | Select-Object -First 1
+        if ($match) {
+            return $match.FullName
+        }
+    }
+
+    return $null
+}
+
 function Install-ChromeForTesting {
     $browserDir = Get-ChromeForTestingDir
 
@@ -936,46 +958,42 @@ function Install-ChromeForTesting {
 
     New-Item -ItemType Directory -Path $browserDir -Force | Out-Null
     Write-Info "System Chrome/Chromium was not found. Installing Chrome for Testing to: $browserDir"
+    Write-Info (Get-LocalizedText -English "Downloading Chrome for Testing (~200MB). The download progress will be shown below..." -Chinese "正在下载 Chrome for Testing（约 200MB），下方将显示下载进度...")
 
-    $result = Invoke-NativeCommandOrFail `
-        -Description "Chrome for Testing installation" `
-        -FilePath "npx.cmd" `
-        -ArgumentList @("--yes", "@puppeteer/browsers", "install", "chrome@stable", "--path", $browserDir) `
-        -WorkingDirectory $browserDir `
-        -Environment @{ npm_config_registry = $script:NpmRegistry } `
-        -StreamOutput
+    $npxPath = Get-CommandPath "npx.cmd"
+    if ([string]::IsNullOrWhiteSpace($npxPath)) {
+        Fail "npx was not found. Install Node.js (including npm) and retry.$(Get-NodejsManualDownloadHint)"
+    }
 
-    $browserPath = Resolve-ChromeForTestingPath -InstallOutputText (@($result.StdOut, $result.StdErr) -join [Environment]::NewLine)
+    $previousRegistry = $env:npm_config_registry
+    $env:npm_config_registry = $script:NpmRegistry
+    try {
+        $process = Start-Process `
+            -FilePath $npxPath `
+            -ArgumentList @("--yes", "@puppeteer/browsers", "install", "chrome@stable", "--path", $browserDir) `
+            -WorkingDirectory $browserDir `
+            -NoNewWindow `
+            -Wait `
+            -PassThru
+        if ($process.ExitCode -ne 0) {
+            Fail "Chrome for Testing installation failed."
+        }
+    }
+    finally {
+        if ($null -eq $previousRegistry) {
+            Remove-Item Env:npm_config_registry -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:npm_config_registry = $previousRegistry
+        }
+    }
+
+    $browserPath = Resolve-ChromeForTestingPath -BrowserDir $browserDir
     if ([string]::IsNullOrWhiteSpace($browserPath)) {
-        Fail "Chrome for Testing finished installing, but the browser path could not be parsed from the installer output."
+        Fail "Chrome for Testing finished installing, but the browser executable could not be located under: $browserDir."
     }
 
     return $browserPath
-}
-
-function Resolve-ChromeForTestingPath {
-    param([string]$InstallOutputText)
-
-    foreach ($line in ($InstallOutputText -split "\r?\n")) {
-        $line = $line.Trim()
-        if ([string]::IsNullOrWhiteSpace($line)) {
-            continue
-        }
-
-        if ($line -like "chrome@* *" -or $line -like "chromium@* *") {
-            $firstSpaceIndex = $line.IndexOf(' ')
-            if ($firstSpaceIndex -lt 0) {
-                continue
-            }
-
-            $candidate = $line.Substring($firstSpaceIndex + 1).Trim()
-            if (-not [string]::IsNullOrWhiteSpace($candidate) -and (Test-Path $candidate)) {
-                return $candidate
-            }
-        }
-    }
-
-    return $null
 }
 
 function Configure-AgentBrowserBrowser {
@@ -1122,9 +1140,6 @@ function Main {
         finally {
             Pop-Location
         }
-    }
-    else {
-        Write-Info (Get-LocalizedText -English "Skipping TUI dependency installation. Re-run .\scripts\install_zh.ps1 -InstallTui to install them." -Chinese "已跳过 TUI 依赖安装。如需安装，请重新执行 .\scripts\install.ps1 -InstallTui。")
     }
 
     Install-AgentBrowser

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -778,38 +778,54 @@ get_chrome_for_testing_dir() {
   printf '%s' "$HOME/.flocks/browser"
 }
 
+resolve_chrome_for_testing_path_from_dir() {
+  local browser_dir="$1" candidate restore_globstar=0 restore_nullglob=0
+  [[ -d "$browser_dir" ]] || return 1
+
+  shopt -q globstar || restore_globstar=1
+  shopt -q nullglob || restore_nullglob=1
+  shopt -s globstar nullglob
+
+  for candidate in \
+    "$browser_dir"/**/"Google Chrome for Testing" \
+    "$browser_dir"/**/chrome.exe \
+    "$browser_dir"/**/chrome; do
+    [[ -f "$candidate" && -x "$candidate" ]] || continue
+    printf '%s' "$candidate"
+    [[ "$restore_globstar" -eq 1 ]] && shopt -u globstar
+    [[ "$restore_nullglob" -eq 1 ]] && shopt -u nullglob
+    return 0
+  done
+
+  [[ "$restore_globstar" -eq 1 ]] && shopt -u globstar
+  [[ "$restore_nullglob" -eq 1 ]] && shopt -u nullglob
+  return 1
+}
+
 install_chrome_for_testing() {
-  local browser_dir install_output browser_path="" line candidate tmpfile
+  local browser_dir browser_path="" install_status
   has_cmd npx || fail "npx was not found. Install Node.js (including npm) and retry.$(nodejs_manual_download_hint)"
   browser_dir="$(get_chrome_for_testing_dir)"
   mkdir -p "$browser_dir"
 
   info "System Chrome/Chromium was not found. Installing Chrome for Testing to: $browser_dir" >&2
+  if is_zh_install; then
+    info "正在下载 Chrome for Testing（约 200MB），下方将显示下载进度..." >&2
+  else
+    info "Downloading Chrome for Testing (~200MB). The download progress will be shown below..." >&2
+  fi
 
-  tmpfile="$(mktemp)"
   set +e
-  npm_config_registry="$NPM_REGISTRY" npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir" 2>&1 | tee "$tmpfile" >&2
-  local install_status=${PIPESTATUS[0]}
+  npm_config_registry="$NPM_REGISTRY" npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir" 1>&2
+  install_status=$?
   set -e
-  install_output="$(<"$tmpfile")"
-  rm -f "$tmpfile"
 
   if [[ "$install_status" -ne 0 ]]; then
     fail "Chrome for Testing installation failed."
   fi
 
-  while IFS= read -r line; do
-    case "$line" in
-      chrome@*' '*|chromium@*' '*)
-        candidate="${line#* }"
-        if [[ "$candidate" = /* && -x "$candidate" ]]; then
-          browser_path="$candidate"
-        fi
-        ;;
-    esac
-  done <<< "$install_output"
-
-  [[ -n "$browser_path" ]] || fail "Chrome for Testing finished installing, but the browser path could not be parsed from the installer output."
+  browser_path="$(resolve_chrome_for_testing_path_from_dir "$browser_dir" || true)"
+  [[ -n "$browser_path" ]] || fail "Chrome for Testing finished installing, but the browser executable could not be located under: $browser_dir."
   printf '%s' "$browser_path"
 }
 
@@ -895,12 +911,6 @@ main() {
       cd "$ROOT_DIR/tui"
       bun install
     )
-  else
-    if is_zh_install; then
-      info "已跳过 TUI 依赖安装。如需安装，请重新执行 ./scripts/install_zh.sh --with-tui。"
-    else
-      info "Skipping TUI dependency installation. Re-run ./scripts/install.sh --with-tui to install them."
-    fi
   fi
 
   install_agent_browser

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,6 +34,14 @@ fail() {
   exit 1
 }
 
+warn() {
+  if is_zh_install; then
+    printf '[flocks] 警告: %s\n' "$1" >&2
+  else
+    printf '[flocks] warning: %s\n' "$1" >&2
+  fi
+}
+
 has_cmd() {
   command -v "$1" >/dev/null 2>&1
 }
@@ -804,15 +812,24 @@ resolve_chrome_for_testing_path_from_dir() {
 
 install_chrome_for_testing() {
   local browser_dir browser_path="" install_status
-  has_cmd npx || fail "npx was not found. Install Node.js (including npm) and retry.$(nodejs_manual_download_hint)"
+  if ! has_cmd npx; then
+    if is_zh_install; then
+      warn "未找到 npx，跳过浏览器安装；这不影响 Flocks 启动，可稍后重新安装。"
+    else
+      warn "npx was not found, so browser installation was skipped. This does not block Flocks startup; you can reinstall it later."
+    fi
+    return 1
+  fi
   browser_dir="$(get_chrome_for_testing_dir)"
   mkdir -p "$browser_dir"
 
   info "System Chrome/Chromium was not found. Installing Chrome for Testing to: $browser_dir" >&2
   if is_zh_install; then
-    info "正在下载 Chrome for Testing（约 200MB），下方将显示下载进度..." >&2
+    info "正在下载 Chrome for Testing。" >&2
+    warn "如浏览器安装失败，不影响 Flocks 启动，可稍后重新安装。" 
   else
-    info "Downloading Chrome for Testing (~200MB). The download progress will be shown below..." >&2
+    info "Downloading Chrome for Testing." >&2
+    warn "If browser installation fails, Flocks can still start and you can reinstall it later."
   fi
 
   set +e
@@ -821,23 +838,45 @@ install_chrome_for_testing() {
   set -e
 
   if [[ "$install_status" -ne 0 ]]; then
-    fail "Chrome for Testing installation failed."
+    if is_zh_install; then
+      warn "Chrome for Testing 安装失败，不影响 Flocks 启动，可稍后重新安装。"
+    else
+      warn "Chrome for Testing installation failed. This does not block Flocks startup; you can reinstall it later."
+    fi
+    return 1
   fi
 
   browser_path="$(resolve_chrome_for_testing_path_from_dir "$browser_dir" || true)"
-  [[ -n "$browser_path" ]] || fail "Chrome for Testing finished installing, but the browser executable could not be located under: $browser_dir."
+  if [[ -z "$browser_path" ]]; then
+    if is_zh_install; then
+      warn "Chrome for Testing 已安装，但未能在目录中找到浏览器可执行文件；这不影响 Flocks 启动，可稍后重新安装。"
+    else
+      warn "Chrome for Testing finished installing, but the browser executable could not be located. This does not block Flocks startup; you can reinstall it later."
+    fi
+    return 1
+  fi
   printf '%s' "$browser_path"
 }
 
 configure_agent_browser_browser() {
-  local browser_path=""
+  local browser_path="" browser_dir=""
 
   browser_path="$(detect_system_browser_path || true)"
   if [[ -n "$browser_path" ]]; then
     info "Detected system Chrome/Chromium. agent-browser will use: $browser_path"
   else
-    browser_path="$(install_chrome_for_testing)"
-    info "Installed Chrome for Testing. agent-browser will use: $browser_path"
+    browser_dir="$(get_chrome_for_testing_dir)"
+    browser_path="$(resolve_chrome_for_testing_path_from_dir "$browser_dir" || true)"
+    if [[ -n "$browser_path" ]]; then
+      info "Found existing Chrome for Testing. agent-browser will use: $browser_path"
+    else
+      browser_path="$(install_chrome_for_testing || true)"
+      if [[ -n "$browser_path" ]]; then
+        info "Installed Chrome for Testing. agent-browser will use: $browser_path"
+      else
+        return 0
+      fi
+    fi
   fi
 
   export AGENT_BROWSER_EXECUTABLE_PATH="$browser_path"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,9 @@ PATH_UPDATE_REQUIRED=0
 PATH_UPDATE_FILES=""
 PATH_UPDATE_DIRS=""
 PATH_REFRESH_HINT_REQUIRED=0
+INSTALL_LANGUAGE="${FLOCKS_INSTALL_LANGUAGE:-en}"
 UV_DEFAULT_INDEX="${FLOCKS_UV_DEFAULT_INDEX:-https://pypi.org/simple}"
+UV_INSTALL_SH_URL="${FLOCKS_UV_INSTALL_SH_URL:-https://astral.sh/uv/install.sh}"
 NPM_REGISTRY="${FLOCKS_NPM_REGISTRY:-https://registry.npmjs.org/}"
 NODEJS_MANUAL_DOWNLOAD_URL="${FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL:-https://nodejs.org/en/download}"
 NVM_INSTALL_SCRIPT_URL="${FLOCKS_NVM_INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh}"
@@ -24,7 +26,11 @@ info() {
 }
 
 fail() {
-  printf '[flocks] error: %s\n' "$1" >&2
+  if is_zh_install; then
+    printf '[flocks] 错误: %s\n' "$1" >&2
+  else
+    printf '[flocks] error: %s\n' "$1" >&2
+  fi
   exit 1
 }
 
@@ -32,13 +38,24 @@ has_cmd() {
   command -v "$1" >/dev/null 2>&1
 }
 
+is_zh_install() {
+  [[ "$INSTALL_LANGUAGE" == zh* || "$INSTALL_LANGUAGE" == cn* ]]
+}
+
 nodejs_manual_download_hint() {
   printf ' Manual download: %s' "$NODEJS_MANUAL_DOWNLOAD_URL"
 }
 
 select_install_sources() {
-  info "Using PyPI index: $UV_DEFAULT_INDEX"
-  info "Using npm registry: $NPM_REGISTRY"
+  if is_zh_install; then
+    info "使用 PyPI 源: $UV_DEFAULT_INDEX"
+    info "使用 npm 源: $NPM_REGISTRY"
+    info "使用 uv 安装脚本: $UV_INSTALL_SH_URL"
+  else
+    info "Using PyPI index: $UV_DEFAULT_INDEX"
+    info "Using npm registry: $NPM_REGISTRY"
+    info "Using uv install script: $UV_INSTALL_SH_URL"
+  fi
 }
 
 
@@ -206,7 +223,23 @@ resolve_root_dir() {
 }
 
 print_clone_hint_and_exit() {
-  cat <<EOF
+  if is_zh_install; then
+    cat <<EOF
+[flocks] 当前目录未找到 Flocks 仓库源码。
+
+如需从源码安装，请先克隆仓库后再执行：
+
+  git clone $REPO_URL
+  cd Flocks
+  ./scripts/install_zh.sh
+
+或者使用一键安装脚本：
+
+  curl -fsSL $RAW_INSTALL_SH_URL | bash
+  iwr -useb $RAW_INSTALL_PS1_URL | iex
+EOF
+  else
+    cat <<EOF
 [flocks] Flocks repository source was not found in the current location.
 
 To install from source, clone the repository first and then run:
@@ -220,6 +253,7 @@ Or use the one-line GitHub bootstrap installer:
   curl -fsSL $RAW_INSTALL_SH_URL | bash
   iwr -useb $RAW_INSTALL_PS1_URL | iex
 EOF
+  fi
   exit 1
 }
 
@@ -251,6 +285,22 @@ get_npm_prefix() {
   fi
 
   printf '%s' "$npm_prefix"
+}
+
+get_npm_global_write_check_dir() {
+  local npm_prefix="$1"
+  local candidate
+
+  [[ -n "$npm_prefix" ]] || return 1
+
+  for candidate in "$npm_prefix/lib/node_modules" "$npm_prefix/lib" "$npm_prefix"; do
+    if [[ -e "$candidate" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  printf '%s' "$npm_prefix/lib/node_modules"
 }
 
 ensure_agent_browser_user_path_if_needed() {
@@ -445,10 +495,7 @@ ensure_npm_global_prefix_writable() {
     return
   fi
 
-  target_dir="$npm_prefix"
-  if [[ -d "$npm_prefix/lib" ]]; then
-    target_dir="$npm_prefix/lib"
-  fi
+  target_dir="$(get_npm_global_write_check_dir "$npm_prefix")"
 
   if [[ -w "$target_dir" ]]; then
     return
@@ -466,12 +513,21 @@ install_uv() {
     return
   fi
 
-  has_cmd curl || fail "curl is required to install uv automatically."
-  info "uv was not found. Installing it automatically..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+  if is_zh_install; then
+    has_cmd curl || fail "自动安装 uv 需要 curl，请先安装 curl 后重试。"
+    info "未检测到 uv，正在自动安装..."
+  else
+    has_cmd curl || fail "curl is required to install uv automatically."
+    info "uv was not found. Installing it automatically..."
+  fi
+  curl -LsSf "$UV_INSTALL_SH_URL" | sh
   refresh_path
   ensure_path_persisted "$HOME/.local/bin"
-  has_cmd uv || fail "uv finished installing, but it is still not available. Check PATH and retry."
+  if is_zh_install; then
+    has_cmd uv || fail "uv 安装已完成，但当前仍无法找到 uv。请检查 PATH 后重试。"
+  else
+    has_cmd uv || fail "uv finished installing, but it is still not available. Check PATH and retry."
+  fi
 }
 
 is_lock_error_output() {
@@ -642,16 +698,28 @@ install_dingtalk_channel_deps() {
 
   local node_modules_dir="$connector_dir/node_modules"
   if [[ -d "$node_modules_dir" ]]; then
-    info "DingTalk channel dependencies already exist. Skipping installation."
+    if is_zh_install; then
+      info "钉钉频道依赖已存在，跳过安装。"
+    else
+      info "DingTalk channel dependencies already exist. Skipping installation."
+    fi
     return 0
   fi
 
-  info "Detected DingTalk channel plugin. Installing npm dependencies..."
+  if is_zh_install; then
+    info "检测到钉钉频道插件，正在安装 npm 依赖..."
+  else
+    info "Detected DingTalk channel plugin. Installing npm dependencies..."
+  fi
   (
     cd "$connector_dir"
     npm_config_registry="$NPM_REGISTRY" npm install
   )
-  info "DingTalk channel dependencies installed."
+  if is_zh_install; then
+    info "钉钉频道依赖安装完成。"
+  else
+    info "DingTalk channel dependencies installed."
+  fi
 }
 
 ensure_env_var_persisted() {
@@ -783,12 +851,20 @@ main() {
 
   resolve_root_dir || print_clone_hint_and_exit
 
-  info "Project directory: $ROOT_DIR"
+  if is_zh_install; then
+    info "项目目录: $ROOT_DIR"
+  else
+    info "Project directory: $ROOT_DIR"
+  fi
   install_uv
   ensure_npm_installed
   select_install_sources
 
-  info "Installing Python backend dependencies (including tests and lint tools) with uv sync --group dev..."
+  if is_zh_install; then
+    info "正在使用 uv sync --group dev 安装 Python 后端依赖（含测试与 lint 工具）..."
+  else
+    info "Installing Python backend dependencies (including tests and lint tools) with uv sync --group dev..."
+  fi
   (
     cd "$ROOT_DIR"
     run_with_lock_retry "Python backend dependency installation" uv sync --group dev --default-index "$UV_DEFAULT_INDEX"
@@ -796,7 +872,11 @@ main() {
 
   install_flocks_cli
 
-  info "Installing WebUI dependencies..."
+  if is_zh_install; then
+    info "正在安装 WebUI 依赖..."
+  else
+    info "Installing WebUI dependencies..."
+  fi
   (
     cd "$ROOT_DIR/webui"
     npm_config_registry="$NPM_REGISTRY" npm install
@@ -806,18 +886,41 @@ main() {
 
   if [[ "$INSTALL_TUI" -eq 1 ]]; then
     install_bun
-    info "Installing TUI dependencies..."
+    if is_zh_install; then
+      info "正在安装 TUI 依赖..."
+    else
+      info "Installing TUI dependencies..."
+    fi
     (
       cd "$ROOT_DIR/tui"
       bun install
     )
   else
-    info "Skipping TUI dependency installation. Re-run ./scripts/install.sh --with-tui to install them."
+    if is_zh_install; then
+      info "已跳过 TUI 依赖安装。如需安装，请重新执行 ./scripts/install_zh.sh --with-tui。"
+    else
+      info "Skipping TUI dependency installation. Re-run ./scripts/install.sh --with-tui to install them."
+    fi
   fi
 
   install_agent_browser
 
-  cat <<EOF
+  if is_zh_install; then
+    cat <<EOF
+
+[flocks] 安装完成。
+
+请打开新的终端会话，以加载更新后的环境变量并启用新安装的命令。
+
+接下来可以执行：
+  1. 以守护进程模式启动后端和 WebUI
+     flocks start
+
+  2. 查看命令帮助
+     flocks --help
+EOF
+  else
+    cat <<EOF
 
 [flocks] Installation complete.
 
@@ -830,12 +933,20 @@ Next commands:
   2. Show command help
      flocks --help
 EOF
+  fi
 
   if [[ "$INSTALL_TUI" -eq 1 ]]; then
-    cat <<EOF
+    if is_zh_install; then
+      cat <<EOF
+  3. 启动 TUI
+     flocks tui
+EOF
+    else
+      cat <<EOF
   3. Launch the TUI
      flocks tui
 EOF
+    fi
   fi
 
   # show_path_update_hint

--- a/scripts/install_zh.ps1
+++ b/scripts/install_zh.ps1
@@ -7,6 +7,33 @@ $ErrorActionPreference = "Stop"
 $RawInstallZhShUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_RAW_INSTALL_ZH_SH_URL)) { "https://gitee.com/flocks/flocks/raw/main/install_zh.sh" } else { $env:FLOCKS_RAW_INSTALL_ZH_SH_URL }
 $RawInstallZhPs1Url = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_RAW_INSTALL_ZH_PS1_URL)) { "https://gitee.com/flocks/flocks/raw/main/install_zh.ps1" } else { $env:FLOCKS_RAW_INSTALL_ZH_PS1_URL }
 
+function Test-IsWindowsPlatform {
+    return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+}
+
+function Test-IsAdministrator {
+    if (-not (Test-IsWindowsPlatform)) {
+        return $true
+    }
+
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Assert-Administrator {
+    if (Test-IsAdministrator) {
+        return
+    }
+
+    Fail "安装需要管理员权限。请使用“以管理员身份运行”重新打开 PowerShell 后再执行。"
+}
+
 function Show-Usage {
     Write-Host "用法: .\scripts\install_zh.ps1 [-InstallTui] [-Help]"
     Write-Host ""
@@ -16,6 +43,7 @@ function Show-Usage {
     Write-Host "默认软件源："
     Write-Host "  PyPI: https://mirrors.aliyun.com/pypi/simple"
     Write-Host "  npm : https://registry.npmmirror.com/"
+    Write-Host "  uv  : https://astral.org.cn/uv/install.ps1"
     Write-Host ""
     Write-Host "一键安装入口："
     Write-Host "  curl -fsSL $RawInstallZhShUrl | bash"
@@ -27,6 +55,9 @@ function Show-Usage {
 }
 
 function Set-CnInstallerEnvironment {
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_LANGUAGE)) {
+        $env:FLOCKS_INSTALL_LANGUAGE = "zh-CN"
+    }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_REPO_URL)) {
         $env:FLOCKS_INSTALL_REPO_URL = "https://gitee.com/flocks/flocks.git"
     }
@@ -38,6 +69,12 @@ function Set-CnInstallerEnvironment {
     }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_DEFAULT_INDEX)) {
         $env:FLOCKS_UV_DEFAULT_INDEX = "https://mirrors.aliyun.com/pypi/simple"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_SH_URL)) {
+        $env:FLOCKS_UV_INSTALL_SH_URL = "https://astral.org.cn/uv/install.sh"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) {
+        $env:FLOCKS_UV_INSTALL_PS1_URL = "https://astral.org.cn/uv/install.ps1"
     }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) {
         $env:FLOCKS_NPM_REGISTRY = "https://registry.npmmirror.com/"
@@ -56,6 +93,7 @@ function Main {
         return
     }
 
+    Assert-Administrator
     Set-CnInstallerEnvironment
 
     $installerPath = Join-Path $PSScriptRoot "install.ps1"

--- a/scripts/install_zh.sh
+++ b/scripts/install_zh.sh
@@ -18,6 +18,7 @@ Flocks 中国用户源码安装脚本。
 默认软件源：
   PyPI: https://mirrors.aliyun.com/pypi/simple
   npm : https://registry.npmmirror.com/
+  uv  : https://astral.org.cn/uv/install.sh
 
 一键安装入口：
   curl -fsSL $RAW_INSTALL_ZH_SH_URL | bash
@@ -31,10 +32,13 @@ EOF
 }
 
 configure_cn_environment() {
+  export FLOCKS_INSTALL_LANGUAGE="${FLOCKS_INSTALL_LANGUAGE:-zh-CN}"
   export FLOCKS_INSTALL_REPO_URL="${FLOCKS_INSTALL_REPO_URL:-https://gitee.com/flocks/flocks.git}"
   export FLOCKS_RAW_INSTALL_SH_URL="${FLOCKS_RAW_INSTALL_SH_URL:-$RAW_INSTALL_ZH_SH_URL}"
   export FLOCKS_RAW_INSTALL_PS1_URL="${FLOCKS_RAW_INSTALL_PS1_URL:-$RAW_INSTALL_ZH_PS1_URL}"
   export FLOCKS_UV_DEFAULT_INDEX="${FLOCKS_UV_DEFAULT_INDEX:-https://mirrors.aliyun.com/pypi/simple}"
+  export FLOCKS_UV_INSTALL_SH_URL="${FLOCKS_UV_INSTALL_SH_URL:-https://astral.org.cn/uv/install.sh}"
+  export FLOCKS_UV_INSTALL_PS1_URL="${FLOCKS_UV_INSTALL_PS1_URL:-https://astral.org.cn/uv/install.ps1}"
   export FLOCKS_NPM_REGISTRY="${FLOCKS_NPM_REGISTRY:-https://registry.npmmirror.com/}"
   export PUPPETEER_CHROME_DOWNLOAD_BASE_URL="${PUPPETEER_CHROME_DOWNLOAD_BASE_URL:-https://cdn.npmmirror.com/binaries/chrome-for-testing}"
   export FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL="${FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL:-https://nodejs.org/zh-cn/download}"

--- a/tests/scripts/test_browser_runtime_configuration.py
+++ b/tests/scripts/test_browser_runtime_configuration.py
@@ -12,12 +12,14 @@ def test_bash_installer_prefers_explicit_browser_configuration() -> None:
     assert "get_chrome_for_testing_dir()" in script
     assert "resolve_chrome_for_testing_path_from_dir()" in script
     assert 'npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir"' in script
-    assert 'Downloading Chrome for Testing (~200MB). The download progress will be shown below...' in script
+    assert 'Downloading Chrome for Testing.' in script
+    assert 'If browser installation fails, Flocks can still start and you can reinstall it later.' in script
     assert 'npm_config_registry="$NPM_REGISTRY" npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir" 1>&2' in script
     assert '"$browser_dir"/**/"Google Chrome for Testing"' in script
     assert '"$browser_dir"/**/chrome.exe' in script
     assert '"$browser_dir"/**/chrome' in script
     assert '"$HOME/.flocks/browser"' in script
+    assert 'Found existing Chrome for Testing. agent-browser will use: $browser_path' in script
     assert 'npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir" 2>&1 | tee' not in script
     assert "agent-browser install" not in script
     assert 'require("@puppeteer/browsers")' not in script
@@ -37,11 +39,13 @@ def test_powershell_installer_prefers_explicit_browser_configuration() -> None:
     assert '$candidateNames = @("chrome.exe", "Google Chrome for Testing", "chrome")' in script
     assert 'Get-ChildItem -Path $BrowserDir -Recurse -File' in script
     assert 'Join-Path $HOME ".flocks\\browser"' in script
-    assert 'Downloading Chrome for Testing (~200MB). The download progress will be shown below...' in script
+    assert 'Downloading Chrome for Testing.' in script
+    assert 'If browser installation fails, Flocks can still start and you can reinstall it later.' in script
     assert '$process = Start-Process' in script
     assert '-NoNewWindow' in script
     assert '-Wait' in script
     assert '-PassThru' in script
     assert '$env:npm_config_registry = $script:NpmRegistry' in script
+    assert 'Found existing Chrome for Testing. agent-browser will use: $browserPath' in script
     assert "agent-browser install" not in script
     assert 'require("@puppeteer/browsers")' not in script

--- a/tests/scripts/test_browser_runtime_configuration.py
+++ b/tests/scripts/test_browser_runtime_configuration.py
@@ -10,11 +10,15 @@ def test_bash_installer_prefers_explicit_browser_configuration() -> None:
     assert "detect_system_browser_path()" in script
     assert "AGENT_BROWSER_EXECUTABLE_PATH" in script
     assert "get_chrome_for_testing_dir()" in script
+    assert "resolve_chrome_for_testing_path_from_dir()" in script
     assert 'npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir"' in script
-    assert 'chrome@*\' \'*|chromium@*\' \'*' in script
-    assert 'candidate="${line#* }"' in script
+    assert 'Downloading Chrome for Testing (~200MB). The download progress will be shown below...' in script
+    assert 'npm_config_registry="$NPM_REGISTRY" npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir" 1>&2' in script
+    assert '"$browser_dir"/**/"Google Chrome for Testing"' in script
+    assert '"$browser_dir"/**/chrome.exe' in script
+    assert '"$browser_dir"/**/chrome' in script
     assert '"$HOME/.flocks/browser"' in script
-    assert 'npm_config_registry="$NPM_REGISTRY" npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir"' in script
+    assert 'npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir" 2>&1 | tee' not in script
     assert "agent-browser install" not in script
     assert 'require("@puppeteer/browsers")' not in script
     assert "npx --yes --package @puppeteer/browsers node -e" not in script
@@ -26,14 +30,18 @@ def test_powershell_installer_prefers_explicit_browser_configuration() -> None:
     assert "Find-SystemBrowserPath" in script
     assert "AGENT_BROWSER_EXECUTABLE_PATH" in script
     assert "Get-ChromeForTestingDir" in script
-    assert "Invoke-NativeCommandOrFail" in script
-    assert '-FilePath "npx.cmd"' in script
+    assert "Resolve-ChromeForTestingPath" in script
+    assert 'Get-CommandPath "npx.cmd"' in script
     assert '"@puppeteer/browsers"' in script
     assert '"chrome@stable"' in script
-    assert '$line -like "chrome@* *"' in script
-    assert '$candidate = $line.Substring($firstSpaceIndex + 1).Trim()' in script
+    assert '$candidateNames = @("chrome.exe", "Google Chrome for Testing", "chrome")' in script
+    assert 'Get-ChildItem -Path $BrowserDir -Recurse -File' in script
     assert 'Join-Path $HOME ".flocks\\browser"' in script
-    assert '-Description "Chrome for Testing installation"' in script
-    assert '-Environment @{ npm_config_registry = $script:NpmRegistry }' in script
+    assert 'Downloading Chrome for Testing (~200MB). The download progress will be shown below...' in script
+    assert '$process = Start-Process' in script
+    assert '-NoNewWindow' in script
+    assert '-Wait' in script
+    assert '-PassThru' in script
+    assert '$env:npm_config_registry = $script:NpmRegistry' in script
     assert "agent-browser install" not in script
     assert 'require("@puppeteer/browsers")' not in script

--- a/tests/scripts/test_install_script_help.py
+++ b/tests/scripts/test_install_script_help.py
@@ -37,6 +37,7 @@ def test_bootstrap_powershell_install_help_mentions_current_directory_default() 
     assert result.returncode == 0, output
     assert str(install_cwd / "flocks") in output
     assert "current directory" in output
+    assert "Administrator" in output
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh is required to inspect PowerShell scriptblock output")
@@ -100,6 +101,7 @@ def test_bootstrap_powershell_install_zh_help_mentions_gitee_raw_and_current_dir
     assert str(install_cwd / "flocks") in output
     assert "当前目录" in output
     assert "https://gitee.com/flocks/flocks/raw/main/install_zh.ps1" in output
+    assert "管理员" in output
 
 
 def test_bash_install_help_mentions_optional_tui() -> None:

--- a/tests/scripts/test_install_script_process_cleanup.py
+++ b/tests/scripts/test_install_script_process_cleanup.py
@@ -42,7 +42,7 @@ def test_powershell_installer_stops_processes_before_retrying_locked_operations(
     assert "-RedirectStandardOutput $stdoutPath" in script
     assert "-RedirectStandardError $stderrPath" in script
     assert "Invoke-InstallerCommandWithLockRetry" in script
-    assert "$result = Invoke-NativeCommandOrFail" in script
+    assert "$process = Start-Process" in script
     assert "$null = Invoke-NativeCommandOrFail" in script
     assert '-Description "Python backend dependency installation"' in script
     assert "flocks.cmd" in script

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -19,6 +19,12 @@ def test_install_zh_bash_bootstrap_uses_gitee_archive_and_delegates_to_zh_worksp
     assert 'scripts/install_zh.sh' in script
     assert 'https://gitee.com/flocks/flocks/raw/main/install_zh.sh' in script
     assert 'https://gitee.com/flocks/flocks/raw/main/install_zh.ps1' in script
+    assert 'FLOCKS_INSTALL_LANGUAGE' in script
+    assert 'zh-CN' in script
+    assert 'FLOCKS_UV_INSTALL_SH_URL' in script
+    assert 'https://astral.org.cn/uv/install.sh' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
+    assert 'https://astral.org.cn/uv/install.ps1' in script
     assert 'PUPPETEER_CHROME_DOWNLOAD_BASE_URL' in script
     assert 'https://cdn.npmmirror.com/binaries/chrome-for-testing' in script
 
@@ -31,6 +37,12 @@ def test_install_zh_powershell_bootstrap_uses_gitee_archive_and_delegates_to_zh_
     assert 'scripts\\install_zh.ps1' in script
     assert 'https://gitee.com/flocks/flocks/raw/main/install_zh.sh' in script
     assert 'https://gitee.com/flocks/flocks/raw/main/install_zh.ps1' in script
+    assert 'FLOCKS_INSTALL_LANGUAGE' in script
+    assert 'zh-CN' in script
+    assert 'FLOCKS_UV_INSTALL_SH_URL' in script
+    assert 'https://astral.org.cn/uv/install.sh' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
+    assert 'https://astral.org.cn/uv/install.ps1' in script
     assert 'PUPPETEER_CHROME_DOWNLOAD_BASE_URL' in script
     assert 'https://cdn.npmmirror.com/binaries/chrome-for-testing' in script
 
@@ -38,6 +50,8 @@ def test_install_zh_powershell_bootstrap_uses_gitee_archive_and_delegates_to_zh_
 def test_install_zh_bash_wrapper_sets_cn_sources_and_reuses_main_installer() -> None:
     script = (SCRIPT_DIR / "install_zh.sh").read_text(encoding="utf-8")
 
+    assert 'FLOCKS_INSTALL_LANGUAGE' in script
+    assert 'zh-CN' in script
     assert 'FLOCKS_INSTALL_REPO_URL' in script
     assert 'https://gitee.com/flocks/flocks.git' in script
     assert 'FLOCKS_RAW_INSTALL_SH_URL' in script
@@ -48,6 +62,10 @@ def test_install_zh_bash_wrapper_sets_cn_sources_and_reuses_main_installer() -> 
     assert 'https://cdn.npmmirror.com/binaries/chrome-for-testing' in script
     assert 'FLOCKS_UV_DEFAULT_INDEX' in script
     assert 'https://mirrors.aliyun.com/pypi/simple' in script
+    assert 'FLOCKS_UV_INSTALL_SH_URL' in script
+    assert 'https://astral.org.cn/uv/install.sh' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
+    assert 'https://astral.org.cn/uv/install.ps1' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'https://registry.npmmirror.com/' in script
     assert 'FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL' in script
@@ -58,6 +76,8 @@ def test_install_zh_bash_wrapper_sets_cn_sources_and_reuses_main_installer() -> 
 def test_install_zh_powershell_wrapper_sets_cn_sources_and_reuses_main_installer() -> None:
     script = (SCRIPT_DIR / "install_zh.ps1").read_text(encoding="utf-8-sig")
 
+    assert 'FLOCKS_INSTALL_LANGUAGE' in script
+    assert 'zh-CN' in script
     assert 'FLOCKS_INSTALL_REPO_URL' in script
     assert 'https://gitee.com/flocks/flocks.git' in script
     assert 'FLOCKS_RAW_INSTALL_SH_URL' in script
@@ -68,6 +88,10 @@ def test_install_zh_powershell_wrapper_sets_cn_sources_and_reuses_main_installer
     assert 'https://cdn.npmmirror.com/binaries/chrome-for-testing' in script
     assert 'FLOCKS_UV_DEFAULT_INDEX' in script
     assert 'https://mirrors.aliyun.com/pypi/simple' in script
+    assert 'FLOCKS_UV_INSTALL_SH_URL' in script
+    assert 'https://astral.org.cn/uv/install.sh' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
+    assert 'https://astral.org.cn/uv/install.ps1' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'https://registry.npmmirror.com/' in script
     assert 'FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL' in script
@@ -78,10 +102,14 @@ def test_install_zh_powershell_wrapper_sets_cn_sources_and_reuses_main_installer
 def test_main_bash_installer_uses_configured_default_sources_without_probing() -> None:
     script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
 
+    assert 'FLOCKS_INSTALL_LANGUAGE' in script
     assert 'FLOCKS_UV_DEFAULT_INDEX' in script
+    assert 'FLOCKS_UV_INSTALL_SH_URL' in script
+    assert 'https://astral.sh/uv/install.sh' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'Using PyPI index: $UV_DEFAULT_INDEX' in script
     assert 'Using npm registry: $NPM_REGISTRY' in script
+    assert 'Using uv install script: $UV_INSTALL_SH_URL' in script
     assert 'pick_fastest_url' not in script
     assert 'Probing PyPI and npm registries to choose the faster source' not in script
     assert 'npm_config_registry="$NPM_REGISTRY" npm install' in script
@@ -93,10 +121,38 @@ def test_main_bash_installer_uses_configured_default_sources_without_probing() -
     assert "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh" in script
     assert "load_nvm()" in script
     assert 'curl -o- "$NVM_INSTALL_SCRIPT_URL" | bash' in script
+    assert 'curl -LsSf "$UV_INSTALL_SH_URL" | sh' in script
     assert 'nvm install "$MIN_NODE_MAJOR"' in script
     assert 'nvm use "$MIN_NODE_MAJOR" >/dev/null' in script
     assert "Homebrew was not found. Trying to install nvm..." in script
     assert "Homebrew was not found. Using the existing nvm installation..." in script
+
+
+def test_main_powershell_installer_uses_configured_default_sources_and_admin_precheck() -> None:
+    script = (SCRIPT_DIR / "install.ps1").read_text(encoding="utf-8-sig")
+
+    assert 'FLOCKS_INSTALL_LANGUAGE' in script
+    assert 'FLOCKS_UV_DEFAULT_INDEX' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
+    assert 'https://astral.sh/uv/install.ps1' in script
+    assert 'Using PyPI index: $script:UvDefaultIndex' in script
+    assert 'Using npm registry: $script:NpmRegistry' in script
+    assert 'Using uv install script: $script:UvInstallPs1Url' in script
+    assert 'irm $script:UvInstallPs1Url | iex' in script
+    assert 'function Assert-Administrator' in script
+    assert 'Assert-Administrator' in script
+
+
+def test_windows_powershell_installers_require_admin_before_install() -> None:
+    for path in (
+        REPO_ROOT / "install.ps1",
+        REPO_ROOT / "install_zh.ps1",
+        SCRIPT_DIR / "install.ps1",
+        SCRIPT_DIR / "install_zh.ps1",
+    ):
+        script = path.read_text(encoding="utf-8-sig")
+        assert 'function Test-IsAdministrator' in script
+        assert 'function Assert-Administrator' in script
 
 
 def test_main_bash_installer_falls_back_to_nvm_when_brew_is_missing_on_macos() -> None:
@@ -187,6 +243,84 @@ def test_main_bash_installer_falls_back_to_nvm_when_brew_is_missing_on_macos() -
         }
         [[ "$install_log" == *"Trying to install nvm"* ]] || {
           printf 'nvm install message missing: %s\n' "$install_log" >&2
+          exit 1
+        }
+        """
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", test_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
+
+
+def test_main_bash_installer_checks_node_modules_dir_before_accepting_global_prefix() -> None:
+    script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
+    script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)
+    test_script = script_without_main + textwrap.dedent(
+        r"""
+
+        export HOME="$(mktemp -d)"
+        export TEST_PREFIX="$HOME/system-prefix"
+        export TEST_LOG="$HOME/npm-prefix.log"
+        mkdir -p "$TEST_PREFIX/lib/node_modules"
+
+        chmod 755 "$TEST_PREFIX"
+        chmod 755 "$TEST_PREFIX/lib"
+        chmod 555 "$TEST_PREFIX/lib/node_modules"
+
+        has_cmd() {
+          [[ "$1" == "npm" ]]
+        }
+
+        nodejs_manual_download_hint() {
+          printf ''
+        }
+
+        info() {
+          printf '%s\n' "$1" >> "$TEST_LOG"
+        }
+
+        fail() {
+          printf 'FAIL:%s\n' "$1" >&2
+          exit 1
+        }
+
+        refresh_path() {
+          :
+        }
+
+        npm() {
+          if [[ "$1" == "config" && "$2" == "get" && "$3" == "prefix" ]]; then
+            printf '%s\n' "$TEST_PREFIX"
+            return 0
+          fi
+
+          if [[ "$1" == "config" && "$2" == "set" && "$3" == "prefix" ]]; then
+            printf '%s\n' "$4" > "$HOME/npm-prefix-set.txt"
+            return 0
+          fi
+
+          printf 'unexpected npm invocation: %s\n' "$*" >&2
+          exit 1
+        }
+
+        ensure_npm_global_prefix_writable
+
+        configured_prefix="$(<"$HOME/npm-prefix-set.txt")"
+        install_log="$(<"$TEST_LOG")"
+
+        [[ "$configured_prefix" == "$HOME/.npm-global" ]] || {
+          printf 'unexpected configured prefix: %s\n' "$configured_prefix" >&2
+          exit 1
+        }
+        [[ "$install_log" == *"Switching to user prefix"* ]] || {
+          printf 'missing fallback log: %s\n' "$install_log" >&2
           exit 1
         }
         """

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -712,6 +712,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },


### PR DESCRIPTION
## Summary

- Require Windows Administrator in bootstrap (`install.ps1`, `install_zh.ps1`) and `scripts/install.ps1`.
- `install_zh` bootstrap: default CN-friendly env (`FLOCKS_INSTALL_LANGUAGE`, Aliyun PyPI, astral.org.cn uv installers, npmmirror npm, Node.js zh download page).
- `scripts/install.sh` / `install.ps1`: `FLOCKS_INSTALL_LANGUAGE` drives zh/cn vs English messages, clone hints, and uv install script URL (`FLOCKS_UV_INSTALL_SH_URL` / `FLOCKS_UV_INSTALL_PS1_URL`).
- Bash: additional npm global prefix writability helpers; `install_zh` scripts aligned with CN defaults.
- `README_zh.md`: quick install points to `install_zh` scripts.
- Tests: extended `test_install_script_sources.py`; `test_install_script_help.py` updated.