### PR TITLE
fix(task): resolve scheduled workflow IDs from filesystem

### DIFF
--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -29,15 +29,18 @@ from flocks.workflow.center import (
     list_registry_entries,
     list_workflow_releases,
     publish_workflow,
-    resolve_global_workflow_roots,
-    resolve_project_workflow_roots,
     scan_skill_workflows,
     stop_workflow_service,
 )
 from flocks.session.recorder import Recorder
 from flocks.workflow.workflow_lint import lint_workflow
 from flocks.workflow.compiler import compile_workflow
-from flocks.workflow.fs_store import read_workflow_from_fs as shared_read_workflow_from_fs
+from flocks.workflow.fs_store import (
+    find_workspace_root as _find_workspace_root,
+    read_workflow_dir as _read_workflow_dir,
+    read_workflow_from_fs as shared_read_workflow_from_fs,
+    workflow_scan_dirs as _all_scan_dirs,
+)
 from flocks.workflow.io import load_workflow, dump_workflow
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
@@ -162,26 +165,6 @@ class WorkflowStatsResponse(BaseModel):
 # Filesystem Helpers (Single Source of Truth)
 # =============================================================================
 
-_workspace_root: Optional[Path] = None
-
-
-def _find_workspace_root() -> Path:
-    """Walk up from cwd until a directory containing .flocks/ is found.
-
-    The result is cached for the lifetime of the process since the workspace
-    root does not change at runtime.
-    """
-    global _workspace_root
-    if _workspace_root is not None:
-        return _workspace_root
-    current = Path.cwd()
-    for candidate in [current, *current.parents]:
-        if (candidate / ".flocks").is_dir():
-            _workspace_root = candidate
-            return candidate
-    _workspace_root = current
-    return current
-
 
 def _workflow_dir(workflow_id: str) -> Path:
     """Return the project-level directory for a workflow."""
@@ -191,64 +174,6 @@ def _workflow_dir(workflow_id: str) -> Path:
 def _global_workflow_dir(workflow_id: str) -> Path:
     """Return the global-level directory for a workflow (~/.flocks/plugins/workflows/<id>/)."""
     return Path.home() / ".flocks" / "plugins" / "workflows" / workflow_id
-
-
-def _all_scan_dirs() -> List[tuple[Path, str]]:
-    """Return all workflow scan directories with their source labels.
-
-    Ordered from lowest to highest priority so that later entries
-    override earlier ones when the same workflow ID appears.
-    """
-    workspace = _find_workspace_root()
-    return [
-        (root, "global") for root in resolve_global_workflow_roots()
-    ] + [
-        (root, "project") for root in resolve_project_workflow_roots(workspace)
-    ]
-
-
-def _read_workflow_dir(wf_dir: Path, workflow_id: str, source: str) -> Optional[Dict[str, Any]]:
-    """Read a single workflow directory and return its data dict, or None."""
-    json_file = wf_dir / "workflow.json"
-    if not json_file.is_file():
-        return None
-
-    try:
-        with open(json_file, "r", encoding="utf-8") as f:
-            workflow_json = json.load(f)
-
-        meta_file = wf_dir / "meta.json"
-        if meta_file.is_file():
-            with open(meta_file, "r", encoding="utf-8") as f:
-                meta = json.load(f)
-        else:
-            mtime_ms = int(json_file.stat().st_mtime * 1000)
-            meta = {
-                "name": workflow_json.get("name", workflow_id),
-                "description": workflow_json.get("description"),
-                "category": workflow_json.get("category", "default"),
-                "status": "active",
-                "createdBy": None,
-                "createdAt": mtime_ms,
-                "updatedAt": mtime_ms,
-            }
-
-        md_file = wf_dir / "workflow.md"
-        markdown_content: Optional[str] = None
-        if md_file.is_file():
-            with open(md_file, "r", encoding="utf-8") as f:
-                markdown_content = f.read()
-
-        return {
-            **meta,
-            "id": workflow_id,
-            "source": source,
-            "workflowJson": workflow_json,
-            "markdownContent": markdown_content,
-        }
-    except Exception as exc:
-        log.warning("workflow.fs.read.failed", {"id": workflow_id, "source": source, "error": str(exc)})
-        return None
 
 
 def _read_workflow_from_fs(workflow_id: str) -> Optional[Dict[str, Any]]:

--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -37,6 +37,7 @@ from flocks.workflow.center import (
 from flocks.session.recorder import Recorder
 from flocks.workflow.workflow_lint import lint_workflow
 from flocks.workflow.compiler import compile_workflow
+from flocks.workflow.fs_store import read_workflow_from_fs as shared_read_workflow_from_fs
 from flocks.workflow.io import load_workflow, dump_workflow
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
@@ -257,16 +258,7 @@ def _read_workflow_from_fs(workflow_id: str) -> Optional[Dict[str, Any]]:
     resolve_global_workflow_roots / resolve_project_workflow_roots; per-id dir
     is ``<root>/<id>/`` with ``workflow.json`` inside.
     """
-    candidates = [
-        (root / workflow_id, source)
-        for root, source in _all_scan_dirs()
-    ]
-    result = None
-    for wf_dir, source in candidates:
-        data = _read_workflow_dir(wf_dir, workflow_id, source)
-        if data is not None:
-            result = data
-    return result
+    return shared_read_workflow_from_fs(workflow_id)
 
 
 def _write_workflow_to_fs(

--- a/flocks/task/executor.py
+++ b/flocks/task/executor.py
@@ -140,15 +140,19 @@ class TaskExecutor:
     async def _trigger_workflow(
         cls, execution: TaskExecution, scheduler: TaskScheduler
     ) -> Optional[str]:
+        from flocks.workflow.fs_store import read_workflow_from_fs
         from flocks.workflow.runner import run_workflow
 
         if not execution.workflow_id:
             raise ValueError("workflow execution_mode requires workflow_id")
+        workflow_data = read_workflow_from_fs(execution.workflow_id)
+        if workflow_data is None:
+            raise FileNotFoundError(f"Workflow not found: {execution.workflow_id}")
         snapshot = execution.execution_input_snapshot or {}
         inputs = snapshot.get("context") or scheduler.context or {}
         result = await asyncio.to_thread(
             run_workflow,
-            workflow=execution.workflow_id,
+            workflow=workflow_data["workflowJson"],
             inputs=inputs,
         )
         if result.error:

--- a/flocks/workflow/fs_store.py
+++ b/flocks/workflow/fs_store.py
@@ -15,12 +15,22 @@ log = Log.create(service="workflow.fs-store")
 _workspace_root: Optional[Path] = None
 
 
+def _is_cached_workspace_root_valid(current: Path, cached_root: Path) -> bool:
+    """Return True when the cached root still applies to the current cwd."""
+    if not (cached_root / ".flocks").is_dir():
+        return False
+    return current == cached_root or cached_root in current.parents
+
+
 def find_workspace_root() -> Path:
     """Walk up from cwd until a directory containing `.flocks/` is found."""
     global _workspace_root
-    if _workspace_root is not None:
+    current = Path.cwd().resolve()
+    if (
+        _workspace_root is not None
+        and _is_cached_workspace_root_valid(current, _workspace_root)
+    ):
         return _workspace_root
-    current = Path.cwd()
     for candidate in [current, *current.parents]:
         if (candidate / ".flocks").is_dir():
             _workspace_root = candidate

--- a/flocks/workflow/fs_store.py
+++ b/flocks/workflow/fs_store.py
@@ -1,0 +1,97 @@
+"""Shared filesystem-backed workflow lookup helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from flocks.utils.log import Log
+
+from .center import resolve_global_workflow_roots, resolve_project_workflow_roots
+
+log = Log.create(service="workflow.fs-store")
+
+_workspace_root: Optional[Path] = None
+
+
+def find_workspace_root() -> Path:
+    """Walk up from cwd until a directory containing `.flocks/` is found."""
+    global _workspace_root
+    if _workspace_root is not None:
+        return _workspace_root
+    current = Path.cwd()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".flocks").is_dir():
+            _workspace_root = candidate
+            return candidate
+    _workspace_root = current
+    return current
+
+
+def workflow_scan_dirs() -> list[tuple[Path, str]]:
+    """Return all workflow roots ordered from lowest to highest priority."""
+    workspace = find_workspace_root()
+    return [
+        (root, "global") for root in resolve_global_workflow_roots()
+    ] + [
+        (root, "project") for root in resolve_project_workflow_roots(workspace)
+    ]
+
+
+def read_workflow_dir(
+    wf_dir: Path,
+    workflow_id: str,
+    source: str,
+) -> Optional[Dict[str, Any]]:
+    """Read a single workflow directory and return metadata plus JSON."""
+    json_file = wf_dir / "workflow.json"
+    if not json_file.is_file():
+        return None
+
+    try:
+        workflow_json = json.loads(json_file.read_text(encoding="utf-8"))
+
+        meta_file = wf_dir / "meta.json"
+        if meta_file.is_file():
+            meta = json.loads(meta_file.read_text(encoding="utf-8"))
+        else:
+            mtime_ms = int(json_file.stat().st_mtime * 1000)
+            meta = {
+                "name": workflow_json.get("name", workflow_id),
+                "description": workflow_json.get("description"),
+                "category": workflow_json.get("category", "default"),
+                "status": "active",
+                "createdBy": None,
+                "createdAt": mtime_ms,
+                "updatedAt": mtime_ms,
+            }
+
+        md_file = wf_dir / "workflow.md"
+        markdown_content: Optional[str] = None
+        if md_file.is_file():
+            markdown_content = md_file.read_text(encoding="utf-8")
+
+        return {
+            **meta,
+            "id": workflow_id,
+            "source": source,
+            "workflowJson": workflow_json,
+            "markdownContent": markdown_content,
+        }
+    except Exception as exc:
+        log.warning(
+            "workflow.fs.read.failed",
+            {"id": workflow_id, "source": source, "error": str(exc)},
+        )
+        return None
+
+
+def read_workflow_from_fs(workflow_id: str) -> Optional[Dict[str, Any]]:
+    """Resolve a workflow by ID from workflow directories on disk."""
+    result = None
+    for root, source in workflow_scan_dirs():
+        data = read_workflow_dir(root / workflow_id, workflow_id, source)
+        if data is not None:
+            result = data
+    return result

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -2,18 +2,23 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
+from flocks.task.executor import TaskExecutor
 from flocks.task.manager import TaskManager
 from flocks.task.models import (
     DeliveryStatus,
+    ExecutionMode,
     ExecutionTriggerType,
     SchedulerMode,
     SchedulerStatus,
+    TaskExecution,
     TaskPriority,
+    TaskScheduler,
     TaskStatus,
     TaskTrigger,
 )
@@ -127,6 +132,55 @@ async def test_cron_scheduler_does_not_spawn_second_active_execution(tmp_path: P
     assert total == 1
     assert executions[0].status == TaskStatus.QUEUED
     assert executions[0].trigger_type == ExecutionTriggerType.SCHEDULED
+
+
+@pytest.mark.asyncio
+async def test_trigger_workflow_resolves_workflow_id_from_filesystem(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from flocks.workflow import fs_store
+    from flocks.workflow import runner
+
+    workflow_json = {
+        "name": "Local Script Runner",
+        "start": "start",
+        "nodes": [],
+        "edges": [],
+    }
+    captured: dict[str, object] = {}
+
+    def fake_read_workflow_from_fs(workflow_id: str):
+        captured["workflow_id"] = workflow_id
+        return {"workflowJson": workflow_json}
+
+    def fake_run_workflow(*, workflow, inputs, **_kwargs):
+        captured["workflow"] = workflow
+        captured["inputs"] = inputs
+        return SimpleNamespace(error=None, outputs={"ok": True})
+
+    monkeypatch.setattr(fs_store, "read_workflow_from_fs", fake_read_workflow_from_fs)
+    monkeypatch.setattr(runner, "run_workflow", fake_run_workflow)
+
+    scheduler = TaskScheduler(
+        title="定时 workflow",
+        executionMode=ExecutionMode.WORKFLOW,
+        workflowID="local-script-runner",
+        context={"fallback": "scheduler"},
+    )
+    execution = TaskExecution(
+        schedulerID=scheduler.id,
+        title=scheduler.title,
+        executionMode=ExecutionMode.WORKFLOW,
+        workflowID="local-script-runner",
+        executionInputSnapshot={"context": {"source": "snapshot"}},
+    )
+
+    result = await TaskExecutor._trigger_workflow(execution, scheduler)
+
+    assert captured["workflow_id"] == "local-script-runner"
+    assert captured["workflow"] == workflow_json
+    assert captured["inputs"] == {"source": "snapshot"}
+    assert result == "{'ok': True}"
 
 
 @pytest.mark.asyncio

--- a/tests/workflow/test_fs_store.py
+++ b/tests/workflow/test_fs_store.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from flocks.workflow import fs_store
+
+
+@pytest.fixture(autouse=True)
+def reset_workspace_root_cache(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(fs_store, "_workspace_root", None)
+
+
+def _write_workflow(base_dir: Path, workflow_id: str, name: str) -> None:
+    workflow_dir = base_dir / ".flocks" / "plugins" / "workflows" / workflow_id
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "workflow.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "start": "n1",
+                "nodes": [{"id": "n1", "type": "python", "code": "outputs['ok'] = True"}],
+                "edges": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_read_workflow_from_fs_refreshes_cached_workspace_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    first_workspace = tmp_path / "workspace-a"
+    second_workspace = tmp_path / "workspace-b"
+    workflow_id = "cache-switch-demo"
+    _write_workflow(first_workspace, workflow_id, "workspace-a")
+    _write_workflow(second_workspace, workflow_id, "workspace-b")
+
+    monkeypatch.chdir(first_workspace)
+    first = fs_store.read_workflow_from_fs(workflow_id)
+
+    monkeypatch.chdir(second_workspace)
+    second = fs_store.read_workflow_from_fs(workflow_id)
+
+    assert first is not None
+    assert second is not None
+    assert first["workflowJson"]["name"] == "workspace-a"
+    assert second["workflowJson"]["name"] == "workspace-b"
+    assert fs_store.find_workspace_root() == second_workspace


### PR DESCRIPTION
## Summary
- extract a shared filesystem workflow lookup helper so workflow ID resolution is defined in one place
- make scheduled workflow executions resolve `workflowID` to workflow JSON before calling `run_workflow`, matching the manual run path
- add a regression test covering scheduled workflow execution with an ID-based workflow reference

## Test plan
- [x] `uv run pytest tests/task/test_task.py -q`
- [x] `uv run ruff check flocks/workflow/fs_store.py flocks/task/executor.py flocks/server/routes/workflow.py tests/task/test_task.py`

Made with [Cursor](https://cursor.com)