### PR TITLE
fix(install): CN uv fallback and safe install parent dirs on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -193,7 +193,7 @@ function Main {
         }
 
         $installParent = Split-Path -Parent $InstallDir
-        if (-not [string]::IsNullOrWhiteSpace($installParent)) {
+        if ((-not [string]::IsNullOrWhiteSpace($installParent)) -and -not (Test-Path -LiteralPath $installParent)) {
             New-Item -ItemType Directory -Path $installParent -Force | Out-Null
         }
         if (Test-Path $InstallDir) {

--- a/install_zh.ps1
+++ b/install_zh.ps1
@@ -178,6 +178,9 @@ function Set-CnInstallerEnvironment {
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) {
         $env:FLOCKS_UV_INSTALL_PS1_URL = "https://astral.org.cn/uv/install.ps1"
     }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL)) {
+        $env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL = "https://uv.agentsmirror.com/install-cn.ps1"
+    }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) {
         $env:FLOCKS_NPM_REGISTRY = "https://registry.npmmirror.com/"
     }
@@ -216,7 +219,7 @@ function Main {
         }
 
         $installParent = Split-Path -Parent $InstallDir
-        if (-not [string]::IsNullOrWhiteSpace($installParent)) {
+        if ((-not [string]::IsNullOrWhiteSpace($installParent)) -and -not (Test-Path -LiteralPath $installParent)) {
             New-Item -ItemType Directory -Path $installParent -Force | Out-Null
         }
         if (Test-Path $InstallDir) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -13,6 +13,7 @@ $MinNodeMajor = 22
 $script:InstallLanguage = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_LANGUAGE)) { "en" } else { $env:FLOCKS_INSTALL_LANGUAGE }
 $script:UvDefaultIndex = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_DEFAULT_INDEX)) { "https://pypi.org/simple" } else { $env:FLOCKS_UV_DEFAULT_INDEX }
 $script:UvInstallPs1Url = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) { "https://astral.sh/uv/install.ps1" } else { $env:FLOCKS_UV_INSTALL_PS1_URL }
+$script:UvInstallPs1FallbackUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL)) { "https://uv.agentsmirror.com/install-cn.ps1" } else { $env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL }
 $script:NpmRegistry = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) { "https://registry.npmjs.org/" } else { $env:FLOCKS_NPM_REGISTRY }
 $script:NodejsManualDownloadUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL)) { "https://nodejs.org/en/download" } else { $env:FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL }
 
@@ -89,6 +90,9 @@ function Initialize-InstallSources {
     Write-Info (Get-LocalizedText -English "Using PyPI index: $script:UvDefaultIndex" -Chinese "使用 PyPI 源: $script:UvDefaultIndex")
     Write-Info (Get-LocalizedText -English "Using npm registry: $script:NpmRegistry" -Chinese "使用 npm 源: $script:NpmRegistry")
     Write-Info (Get-LocalizedText -English "Using uv install script: $script:UvInstallPs1Url" -Chinese "使用 uv 安装脚本: $script:UvInstallPs1Url")
+    if (Test-IsZhInstall) {
+        Write-Info (Get-LocalizedText -English "Using uv fallback script: $script:UvInstallPs1FallbackUrl" -Chinese "使用 uv 备用安装脚本: $script:UvInstallPs1FallbackUrl")
+    }
 }
 
 function Get-NodeMajorVersion {
@@ -371,8 +375,45 @@ function Install-Uv {
     }
 
     Write-Info (Get-LocalizedText -English "uv was not found. Installing it automatically..." -Chinese "未检测到 uv，正在自动安装...")
-    powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm $script:UvInstallPs1Url | iex"
+    $primaryInstallError = $null
+    try {
+        powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm '$script:UvInstallPs1Url' | iex"
+    }
+    catch {
+        $primaryInstallError = $_.Exception.Message
+    }
     Refresh-Path
+
+    if (Test-Command "uv") {
+        return
+    }
+
+    if (Test-IsZhInstall) {
+        if ($null -ne $primaryInstallError) {
+            Write-Info (Get-LocalizedText -English "Primary uv install script failed. Trying the mainland China fallback script..." -Chinese "默认 uv 安装脚本失败，正在尝试中国大陆备用源...")
+            Write-Warning $primaryInstallError
+        }
+        else {
+            Write-Info (Get-LocalizedText -English "uv is still unavailable after the primary install script. Trying the mainland China fallback script..." -Chinese "默认 uv 安装脚本执行后仍未检测到 uv，正在尝试中国大陆备用源...")
+        }
+
+        $fallbackInstallError = $null
+        try {
+            powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm '$script:UvInstallPs1FallbackUrl' | iex"
+        }
+        catch {
+            $fallbackInstallError = $_.Exception.Message
+        }
+        Refresh-Path
+
+        if (Test-Command "uv") {
+            return
+        }
+
+        if ($null -ne $fallbackInstallError) {
+            Fail (Get-LocalizedText -English "uv installation failed with both the primary script and the mainland China fallback script. Check network access or PATH and retry." -Chinese "默认 uv 安装脚本和中国大陆备用源都执行失败。请检查网络连通性或 PATH 后重试。")
+        }
+    }
 
     if (-not (Test-Command "uv")) {
         Fail (Get-LocalizedText -English "uv finished installing, but it is still not available. Check PATH and retry." -Chinese "uv 安装已完成，但当前仍无法找到 uv。请检查 PATH 后重试。")

--- a/scripts/install_zh.ps1
+++ b/scripts/install_zh.ps1
@@ -44,6 +44,7 @@ function Show-Usage {
     Write-Host "  PyPI: https://mirrors.aliyun.com/pypi/simple"
     Write-Host "  npm : https://registry.npmmirror.com/"
     Write-Host "  uv  : https://astral.org.cn/uv/install.ps1"
+    Write-Host "  uv 备用源: https://uv.agentsmirror.com/install-cn.ps1"
     Write-Host ""
     Write-Host "一键安装入口："
     Write-Host "  curl -fsSL $RawInstallZhShUrl | bash"
@@ -75,6 +76,9 @@ function Set-CnInstallerEnvironment {
     }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) {
         $env:FLOCKS_UV_INSTALL_PS1_URL = "https://astral.org.cn/uv/install.ps1"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL)) {
+        $env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL = "https://uv.agentsmirror.com/install-cn.ps1"
     }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) {
         $env:FLOCKS_NPM_REGISTRY = "https://registry.npmmirror.com/"

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -43,6 +43,8 @@ def test_install_zh_powershell_bootstrap_uses_gitee_archive_and_delegates_to_zh_
     assert 'https://astral.org.cn/uv/install.sh' in script
     assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
     assert 'https://astral.org.cn/uv/install.ps1' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_FALLBACK_URL' in script
+    assert 'https://uv.agentsmirror.com/install-cn.ps1' in script
     assert 'PUPPETEER_CHROME_DOWNLOAD_BASE_URL' in script
     assert 'https://cdn.npmmirror.com/binaries/chrome-for-testing' in script
 
@@ -92,6 +94,8 @@ def test_install_zh_powershell_wrapper_sets_cn_sources_and_reuses_main_installer
     assert 'https://astral.org.cn/uv/install.sh' in script
     assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
     assert 'https://astral.org.cn/uv/install.ps1' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_FALLBACK_URL' in script
+    assert 'https://uv.agentsmirror.com/install-cn.ps1' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'https://registry.npmmirror.com/' in script
     assert 'FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL' in script
@@ -134,11 +138,14 @@ def test_main_powershell_installer_uses_configured_default_sources_and_admin_pre
     assert 'FLOCKS_INSTALL_LANGUAGE' in script
     assert 'FLOCKS_UV_DEFAULT_INDEX' in script
     assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_FALLBACK_URL' in script
     assert 'https://astral.sh/uv/install.ps1' in script
+    assert 'https://uv.agentsmirror.com/install-cn.ps1' in script
     assert 'Using PyPI index: $script:UvDefaultIndex' in script
     assert 'Using npm registry: $script:NpmRegistry' in script
     assert 'Using uv install script: $script:UvInstallPs1Url' in script
-    assert 'irm $script:UvInstallPs1Url | iex' in script
+    assert "irm '$script:UvInstallPs1Url' | iex" in script
+    assert "irm '$script:UvInstallPs1FallbackUrl' | iex" in script
     assert 'function Assert-Administrator' in script
     assert 'Assert-Administrator' in script
 
@@ -153,6 +160,16 @@ def test_windows_powershell_installers_require_admin_before_install() -> None:
         script = path.read_text(encoding="utf-8-sig")
         assert 'function Test-IsAdministrator' in script
         assert 'function Assert-Administrator' in script
+
+
+def test_windows_bootstrap_installers_only_create_missing_parent_directories() -> None:
+    for path in (
+        REPO_ROOT / "install.ps1",
+        REPO_ROOT / "install_zh.ps1",
+    ):
+        script = path.read_text(encoding="utf-8-sig")
+        assert "Split-Path -Parent $InstallDir" in script
+        assert "Test-Path -LiteralPath $installParent" in script
 
 
 def test_main_bash_installer_falls_back_to_nvm_when_brew_is_missing_on_macos() -> None:


### PR DESCRIPTION
## Summary
- Add mainland China fallback URL (`FLOCKS_UV_INSTALL_PS1_FALLBACK_URL`) when primary uv install fails or uv is still missing in zh install flows.
- Quote `irm` URLs in `scripts/install.ps1`; log fallback usage for zh installs.
- Root bootstrap `install*.ps1`: only create install parent directory when it does not exist (`Test-Path -LiteralPath`).
- Update `install_zh.ps1` help and `test_install_script_sources` assertions.