### PR TITLE
fix(dingtalk): add ESM package.json to resolve runner.ts top-level aw…

### DIFF
--- a/.flocks/plugins/channels/dingtalk/package.json
+++ b/.flocks/plugins/channels/dingtalk/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }


### PR DESCRIPTION
runner.ts uses top-level await but tsx defaults to CJS output format when no package.json with "type": "module" exists in the file's parent directory. The connector's own package.json already declares ESM but it lives in a child directory and does not cover runner.ts.

Adding a minimal package.json next to runner.ts tells Node.js/tsx to treat it as an ES module, allowing esbuild to use the ESM output format which supports top-level await.