### PR TITLE
fix(task): recover blocked scheduled executions

### DIFF
--- a/flocks/server/routes/health.py
+++ b/flocks/server/routes/health.py
@@ -23,6 +23,11 @@ class HealthResponse(BaseModel):
     task_scheduler_running: bool
     task_scheduler_available: bool
     task_manager_error: str | None = None
+    task_queue_paused: bool = False
+    task_queue_running: int = 0
+    task_queue_queued: int = 0
+    task_stale_running: int = 0
+    task_oldest_running_seconds: int | None = None
 
 
 @router.get(
@@ -42,6 +47,7 @@ async def health_check() -> HealthResponse:
     config = Config.get_global()
     from flocks.task.manager import TaskManager
     task_status = TaskManager.runtime_status()
+    queue_status = await TaskManager.queue_status()
     
     from flocks.updater import get_current_version
     return HealthResponse(
@@ -51,6 +57,11 @@ async def health_check() -> HealthResponse:
         config_dir=str(config.config_dir),
         data_dir=str(config.data_dir),
         **task_status,
+        task_queue_paused=queue_status["paused"],
+        task_queue_running=queue_status["running"],
+        task_queue_queued=queue_status["queued"],
+        task_stale_running=queue_status["stale_running"],
+        task_oldest_running_seconds=queue_status["oldest_running_seconds"],
     )
 
 

--- a/flocks/task/background.py
+++ b/flocks/task/background.py
@@ -46,6 +46,7 @@ class BackgroundTask:
     started_at: Optional[int] = None
     completed_at: Optional[int] = None
     last_activity_at: Optional[int] = None  # 最近一次有交互的时间戳（ms），用于不活跃超时检测
+    allow_user_questions: bool = True
 
 
 @dataclass
@@ -129,6 +130,8 @@ class BackgroundManager:
         session_id: str,
         description: str,
         agent: str,
+        *,
+        allow_user_questions: bool = True,
     ) -> BackgroundTask:
         """Run the session loop on an already-created session.
 
@@ -144,6 +147,7 @@ class BackgroundManager:
             prompt="",
             agent=agent,
             session_id=session_id,
+            allow_user_questions=allow_user_questions,
         )
         self._tasks[task_id] = task
         handle = asyncio.create_task(self._run_existing_session(task, session_id))
@@ -157,7 +161,12 @@ class BackgroundManager:
             task.status = "running"
             try:
                 callbacks = self._build_activity_callbacks(task)
-                result = await self._run_session_with_watchdog(task, session_id, callbacks)
+                result = await self._run_session_with_watchdog(
+                    task,
+                    session_id,
+                    callbacks,
+                    allow_user_questions=task.allow_user_questions,
+                )
                 output = ""
                 if result.last_message:
                     output = await Message.get_text_content(result.last_message)
@@ -182,7 +191,7 @@ class BackgroundManager:
         try:
             await asyncio.wait_for(handle, timeout=timeout)
         except asyncio.TimeoutError:
-            pass
+            return None
         return self._tasks.get(task_id)
 
     def cancel(self, task_id: Optional[str] = None, all_tasks: bool = False) -> int:
@@ -254,9 +263,12 @@ class BackgroundManager:
         session_id: str,
         callbacks,
         timeout_seconds: int = _INACTIVITY_TIMEOUT_SECONDS,
+        *,
+        allow_user_questions: bool = True,
     ):
         """运行 SessionLoop，若超过 timeout_seconds 无任何活跃交互则取消并抛出异常。"""
         inactivity_triggered: list[bool] = [False]
+        question_blocked: list[bool] = [False]
 
         loop_task = asyncio.create_task(
             SessionLoop.run(session_id, callbacks=callbacks)
@@ -269,8 +281,17 @@ class BackgroundManager:
                     break
                 # Skip timeout check while waiting for user to answer a question
                 try:
-                    from flocks.server.routes.question import has_pending_questions
+                    from flocks.server.routes.question import (
+                        has_pending_questions,
+                        reject_session_questions,
+                    )
+
                     if has_pending_questions(session_id):
+                        if not allow_user_questions:
+                            question_blocked[0] = True
+                            await reject_session_questions(session_id)
+                            loop_task.cancel()
+                            break
                         task.last_activity_at = int(datetime.now().timestamp() * 1000)
                         continue
                 except Exception:
@@ -292,6 +313,12 @@ class BackgroundManager:
             result = await loop_task
             return result
         except asyncio.CancelledError:
+            if question_blocked[0]:
+                raise RuntimeError(
+                    "Scheduled/background tasks cannot wait for user input. "
+                    "Remove question prompts, approvals, or other interactive steps "
+                    "from this task."
+                )
             if inactivity_triggered[0]:
                 raise RuntimeError(
                     f"任务因 {timeout_seconds} 秒内无活跃交互而超时"

--- a/flocks/task/executor.py
+++ b/flocks/task/executor.py
@@ -1,9 +1,10 @@
 """Task Executor — dispatch a task execution instance."""
 
 import asyncio
+import threading
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from flocks.utils.log import Log
 
@@ -20,9 +21,23 @@ from .store import TaskStore
 log = Log.create(service="task.executor")
 
 _TASK_ABSOLUTE_TIMEOUT_S: int = 2 * 3600
+_workflow_cancel_lock = threading.Lock()
+_workflow_cancel_events: dict[str, threading.Event] = {}
+_workflow_done_events: dict[str, threading.Event] = {}
 
 
 class TaskExecutor:
+    @classmethod
+    def request_runtime_cancel(cls, execution: TaskExecution) -> bool:
+        if execution.execution_mode != ExecutionMode.WORKFLOW:
+            return False
+        with _workflow_cancel_lock:
+            cancel_event = _workflow_cancel_events.get(execution.id)
+        if cancel_event is None:
+            return False
+        cancel_event.set()
+        return True
+
     @classmethod
     async def dispatch(
         cls,
@@ -118,6 +133,7 @@ class TaskExecutor:
             session_id=session_id,
             description=execution.title,
             agent=execution.agent_name,
+            allow_user_questions=False,
         )
         completed = await manager.wait_for(
             bg_task.id,
@@ -132,6 +148,8 @@ class TaskExecutor:
                 f"Task exceeded absolute timeout of {_TASK_ABSOLUTE_TIMEOUT_S}s "
                 f"({_TASK_ABSOLUTE_TIMEOUT_S // 3600}h)"
             )
+        if completed.status == "cancelled":
+            raise RuntimeError(completed.error or "Agent execution was cancelled")
         if completed.status == "error":
             raise RuntimeError(completed.error or "Agent execution failed")
         return completed.output
@@ -141,7 +159,6 @@ class TaskExecutor:
         cls, execution: TaskExecution, scheduler: TaskScheduler
     ) -> Optional[str]:
         from flocks.workflow.fs_store import read_workflow_from_fs
-        from flocks.workflow.runner import run_workflow
 
         if not execution.workflow_id:
             raise ValueError("workflow execution_mode requires workflow_id")
@@ -151,13 +168,50 @@ class TaskExecutor:
         snapshot = execution.execution_input_snapshot or {}
         inputs = snapshot.get("context") or scheduler.context or {}
         result = await asyncio.to_thread(
-            run_workflow,
-            workflow=workflow_data["workflowJson"],
-            inputs=inputs,
+            cls._run_workflow_sync,
+            execution.id,
+            workflow_data["workflowJson"],
+            inputs,
         )
+        result_status = getattr(result, "status", None)
+        if result_status == "CANCELLED":
+            raise RuntimeError(result.error or "Workflow execution cancelled")
+        if result_status == "TIMED_OUT":
+            raise TimeoutError(result.error or "Workflow execution timed out")
         if result.error:
             raise RuntimeError(f"Workflow failed: {result.error}")
         return str(result.outputs) if result.outputs else None
+
+    @classmethod
+    def _run_workflow_sync(
+        cls,
+        execution_id: str,
+        workflow: dict[str, Any],
+        inputs: Dict[str, Any],
+    ):
+        from flocks.workflow.runner import run_workflow
+
+        cancel_event = threading.Event()
+        done_event = threading.Event()
+        with _workflow_cancel_lock:
+            _workflow_cancel_events[execution_id] = cancel_event
+            _workflow_done_events[execution_id] = done_event
+        try:
+            return run_workflow(
+                workflow=workflow,
+                inputs=inputs,
+                timeout_s=_TASK_ABSOLUTE_TIMEOUT_S,
+                cancel=cancel_event.is_set,
+            )
+        finally:
+            done_event.set()
+            with _workflow_cancel_lock:
+                current_cancel = _workflow_cancel_events.get(execution_id)
+                if current_cancel is cancel_event:
+                    _workflow_cancel_events.pop(execution_id, None)
+                current_done = _workflow_done_events.get(execution_id)
+                if current_done is done_event:
+                    _workflow_done_events.pop(execution_id, None)
 
     @classmethod
     async def _resolve_task_session_context(

--- a/flocks/task/manager.py
+++ b/flocks/task/manager.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel as _BaseModel
 from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 
-from .executor import TaskExecutor
+from .executor import _TASK_ABSOLUTE_TIMEOUT_S, TaskExecutor
 from .models import (
     DeliveryStatus,
     ExecutionMode,
@@ -36,6 +36,9 @@ log = Log.create(service="task.manager")
 _TASK_EXPIRY_HOURS: int = 24
 _CLEANUP_INTERVAL_S: int = 3600
 _RETRY_CHECK_INTERVAL_S: int = 30
+_STALE_RECOVERY_INTERVAL_S: int = 30
+_DISPATCH_GUARD_TIMEOUT_S: int = _TASK_ABSOLUTE_TIMEOUT_S + 30
+_RUNNING_RECOVERY_TIMEOUT_S: int = _DISPATCH_GUARD_TIMEOUT_S + 300
 
 
 class _TaskEventProps(_BaseModel):
@@ -51,7 +54,7 @@ class TaskManager:
     def __init__(
         self,
         *,
-        max_concurrent: int = 1,
+        max_concurrent: int = 4,
         poll_interval: int = 5,
         scheduler_interval: int = 30,
         default_retry: Optional[RetryConfig] = None,
@@ -64,6 +67,7 @@ class TaskManager:
         self._cleanup_task: Optional[asyncio.Task] = None
         self._running = False
         self._last_retry_check: float = 0.0
+        self._last_stale_recovery_check: float = 0.0
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -73,7 +77,7 @@ class TaskManager:
     async def start(
         cls,
         *,
-        max_concurrent: int = 1,
+        max_concurrent: int = 4,
         poll_interval: int = 5,
         scheduler_interval: int = 30,
     ) -> "TaskManager":
@@ -425,14 +429,7 @@ class TaskManager:
         execution = await TaskStore.get_execution(execution_id)
         if not execution or execution.is_terminal:
             return execution
-        session_id = execution.session_id
-        if session_id:
-            try:
-                from flocks.task.background import get_background_manager
-
-                get_background_manager().cancel_by_session_id(session_id)
-            except Exception:
-                pass
+        await cls._cancel_execution_runtime(execution)
         execution.status = TaskStatus.CANCELLED
         execution.completed_at = execution.completed_at or datetime.now(timezone.utc)
         if execution.started_at and execution.duration_ms is None:
@@ -559,8 +556,38 @@ class TaskManager:
     async def queue_status(cls) -> Dict[str, Any]:
         mgr = cls._instance
         if not mgr:
-            return {"paused": False, "max_concurrent": 1, "running": 0, "queued": 0}
-        return await mgr.queue.status()
+            return {
+                "paused": False,
+                "max_concurrent": 4,
+                "running": 0,
+                "queued": 0,
+                "stale_running": 0,
+                "oldest_running_seconds": None,
+            }
+        status = await mgr.queue.status()
+        running = await TaskStore.list_executions_by_status(TaskStatus.RUNNING)
+        stale_cutoff = datetime.now(timezone.utc) - timedelta(seconds=_RUNNING_RECOVERY_TIMEOUT_S)
+        oldest_running_seconds: Optional[int] = None
+        stale_running = 0
+        now = datetime.now(timezone.utc)
+        for execution in running:
+            started_at = (
+                execution.started_at
+                or execution.queued_at
+                or execution.created_at
+            )
+            if oldest_running_seconds is None or started_at < (
+                now - timedelta(seconds=oldest_running_seconds)
+            ):
+                oldest_running_seconds = max(
+                    int((now - started_at).total_seconds()),
+                    0,
+                )
+            if started_at < stale_cutoff:
+                stale_running += 1
+        status["stale_running"] = stale_running
+        status["oldest_running_seconds"] = oldest_running_seconds
+        return status
 
     @classmethod
     async def get_unviewed_results(cls) -> List[TaskExecution]:
@@ -620,6 +647,9 @@ class TaskManager:
                 if now - self._last_retry_check >= _RETRY_CHECK_INTERVAL_S:
                     self._last_retry_check = now
                     await self._process_retry_queue()
+                if now - self._last_stale_recovery_check >= _STALE_RECOVERY_INTERVAL_S:
+                    self._last_stale_recovery_check = now
+                    await self._recover_stale_active_executions()
                 execution = await self.queue.dequeue()
                 if execution:
                     task = asyncio.create_task(self._run_execution(execution))
@@ -645,13 +675,23 @@ class TaskManager:
             await TaskStore.update_execution(execution)
             return
         try:
-            execution = await TaskExecutor.dispatch(execution, scheduler)
+            execution = await asyncio.wait_for(
+                TaskExecutor.dispatch(execution, scheduler),
+                timeout=_DISPATCH_GUARD_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            await self._cancel_execution_runtime(execution)
+            log.error(
+                "manager.execution_timeout",
+                {"id": execution.id, "timeout_s": _DISPATCH_GUARD_TIMEOUT_S},
+            )
+            execution = await self._mark_execution_failed(
+                execution,
+                self._dispatch_timeout_message(),
+            )
         except Exception as exc:
             log.error("manager.execution_error", {"id": execution.id, "error": str(exc)})
-            execution.status = TaskStatus.FAILED
-            execution.error = str(exc)
-            execution.completed_at = datetime.now(timezone.utc)
-            await TaskStore.update_execution(execution)
+            execution = await self._mark_execution_failed(execution, str(exc))
         finally:
             self.queue.mark_finished(execution.id)
             await TaskStore.finish_queue_ref(execution.id)
@@ -719,6 +759,26 @@ class TaskManager:
             await TaskStore.update_execution(execution)
             await TaskStore.finish_queue_ref(execution.id)
         return len(stale)
+
+    async def _recover_stale_active_executions(self) -> int:
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=_RUNNING_RECOVERY_TIMEOUT_S)
+        stale = await TaskStore.list_stale_running_executions(before=cutoff)
+        recovered = 0
+        for execution in stale:
+            await self._cancel_execution_runtime(execution)
+            execution = await self._mark_execution_failed(
+                execution,
+                self._stale_execution_message(),
+            )
+            self.queue.mark_finished(execution.id)
+            await TaskStore.finish_queue_ref(execution.id)
+            recovered += 1
+        if recovered:
+            log.warn(
+                "manager.stale_active_recovered",
+                {"count": recovered, "timeout_s": _RUNNING_RECOVERY_TIMEOUT_S},
+            )
+        return recovered
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -798,6 +858,72 @@ class TaskManager:
         workspace_root = WorkspaceManager.get_instance().get_workspace_dir()
         today = date.today().isoformat()
         return str(workspace_root / "tasks" / today / f"exec-{datetime.now(timezone.utc).timestamp():.0f}")
+
+    @staticmethod
+    def _dispatch_timeout_message() -> str:
+        return (
+            "Task execution exceeded the hard timeout "
+            f"({_DISPATCH_GUARD_TIMEOUT_S}s) and was cancelled to unblock the queue."
+        )
+
+    @staticmethod
+    def _stale_execution_message() -> str:
+        return (
+            "Task execution was still marked running past the recovery threshold "
+            f"({_RUNNING_RECOVERY_TIMEOUT_S}s) and was failed automatically "
+            "to unblock scheduled tasks."
+        )
+
+    @classmethod
+    async def _cancel_execution_runtime(cls, execution: TaskExecution) -> None:
+        latest = await TaskStore.get_execution(execution.id)
+        if latest is not None:
+            execution.execution_mode = latest.execution_mode
+            execution.session_id = execution.session_id or latest.session_id
+            execution.started_at = execution.started_at or latest.started_at
+
+        try:
+            TaskExecutor.request_runtime_cancel(execution)
+        except Exception:
+            pass
+
+        session_id = execution.session_id
+        if not session_id:
+            return
+
+        try:
+            from flocks.task.background import get_background_manager
+
+            get_background_manager().cancel_by_session_id(session_id)
+        except Exception:
+            pass
+
+        try:
+            from flocks.server.routes.question import reject_session_questions
+
+            await reject_session_questions(session_id)
+        except Exception:
+            pass
+
+    @classmethod
+    async def _mark_execution_failed(
+        cls,
+        execution: TaskExecution,
+        error: str,
+    ) -> TaskExecution:
+        current = await TaskStore.get_execution(execution.id)
+        if current is not None:
+            execution = current
+
+        completed_at = datetime.now(timezone.utc)
+        execution.status = TaskStatus.FAILED
+        execution.error = error
+        execution.completed_at = completed_at
+        if execution.started_at:
+            execution.duration_ms = int(
+                (completed_at - execution.started_at).total_seconds() * 1000
+            )
+        return await TaskStore.update_execution(execution)
 
     @classmethod
     async def _publish_execution_update(cls, execution: TaskExecution) -> None:

--- a/flocks/task/manager.py
+++ b/flocks/task/manager.py
@@ -576,13 +576,9 @@ class TaskManager:
                 or execution.queued_at
                 or execution.created_at
             )
-            if oldest_running_seconds is None or started_at < (
-                now - timedelta(seconds=oldest_running_seconds)
-            ):
-                oldest_running_seconds = max(
-                    int((now - started_at).total_seconds()),
-                    0,
-                )
+            elapsed = max(int((now - started_at).total_seconds()), 0)
+            if oldest_running_seconds is None or elapsed > oldest_running_seconds:
+                oldest_running_seconds = elapsed
             if started_at < stale_cutoff:
                 stale_running += 1
         status["stale_running"] = stale_running

--- a/flocks/task/queue.py
+++ b/flocks/task/queue.py
@@ -12,7 +12,7 @@ log = Log.create(service="task.queue")
 
 
 class TaskQueue:
-    def __init__(self, max_concurrent: int = 1):
+    def __init__(self, max_concurrent: int = 4):
         self.max_concurrent = max_concurrent
         self._paused = False
         self._running_ids: set[str] = set()

--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -719,6 +719,23 @@ class TaskStore:
             rows = await cur.fetchall()
         return [cls._row_to_execution(row) for row in rows]
 
+    @classmethod
+    async def list_stale_running_executions(
+        cls, before: datetime
+    ) -> List[TaskExecution]:
+        db = await cls._db()
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            """
+            SELECT * FROM task_executions
+            WHERE status = 'running'
+              AND COALESCE(started_at, queued_at, created_at, updated_at) < ?
+            """,
+            (before.isoformat(),),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [cls._row_to_execution(row) for row in rows]
+
     # ------------------------------------------------------------------
     # Row helpers
     # ------------------------------------------------------------------

--- a/flocks/tool/system/background_output.py
+++ b/flocks/tool/system/background_output.py
@@ -72,7 +72,8 @@ async def background_output_tool(
     task = _find_task(manager, task_id)
 
     if task and block:
-        task = await manager.wait_for(task.id, timeout_ms)
+        waited = await manager.wait_for(task.id, timeout_ms)
+        task = waited or _find_task(manager, task.id)
 
     if task:
         output = (

--- a/tests/integration/test_task_queue_integration.py
+++ b/tests/integration/test_task_queue_integration.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+import flocks.task.manager as task_manager_module
+from flocks.task.models import ExecutionMode
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
 from flocks.task.executor import TaskExecutor
@@ -118,6 +120,112 @@ async def test_rerun_execution_creates_new_execution_with_same_scheduler(monkeyp
     assert rerun.id != first.id
     assert rerun.scheduler_id == first.scheduler_id
     assert rerun.trigger_type == ExecutionTriggerType.RERUN
+
+
+@pytest.mark.asyncio
+async def test_dispatch_timeout_releases_queue_for_following_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    calls = {"count": 0}
+
+    async def fake_dispatch(execution, scheduler):
+        calls["count"] += 1
+        execution.started_at = datetime.now(timezone.utc)
+        execution.status = TaskStatus.RUNNING
+        await TaskStore.update_execution(execution)
+
+        if calls["count"] == 1:
+            await asyncio.sleep(0.2)
+
+        execution.status = TaskStatus.COMPLETED
+        execution.completed_at = execution.started_at + timedelta(milliseconds=10)
+        execution.duration_ms = 10
+        execution.result_summary = f"{scheduler.title} done"
+        return await TaskStore.update_execution(execution)
+
+    monkeypatch.setattr(TaskExecutor, "dispatch", fake_dispatch)
+    monkeypatch.setattr(task_manager_module, "_DISPATCH_GUARD_TIMEOUT_S", 0.05)
+    await TaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
+
+    first_scheduler = await TaskManager.create_scheduler(
+        title="超时任务",
+        mode=SchedulerMode.ONCE,
+        trigger=TaskTrigger(run_immediately=True),
+        workspace_directory=str(tmp_path / "workspace-1"),
+    )
+    second_scheduler = await TaskManager.create_scheduler(
+        title="后续任务",
+        mode=SchedulerMode.ONCE,
+        trigger=TaskTrigger(run_immediately=True),
+        workspace_directory=str(tmp_path / "workspace-2"),
+    )
+
+    first = (await TaskManager.list_scheduler_executions(first_scheduler.id))[0][0]
+    second = (await TaskManager.list_scheduler_executions(second_scheduler.id))[0][0]
+
+    failed = await _wait_for_execution(first.id, status=TaskStatus.FAILED, timeout=1.0)
+    completed = await _wait_for_execution(second.id, status=TaskStatus.COMPLETED, timeout=1.0)
+
+    assert "hard timeout" in (failed.error or "")
+    assert completed.result_summary == "后续任务 done"
+
+
+@pytest.mark.asyncio
+async def test_workflow_timeout_signals_cancel_and_stops_before_next_node(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    from flocks.workflow import fs_store
+
+    side_effect_file = tmp_path / "step2.txt"
+    workflow_json = {
+        "name": "slow-cancellable-workflow",
+        "start": "step1",
+        "nodes": [
+            {
+                "id": "step1",
+                "type": "python",
+                "code": "import time\ntime.sleep(0.05)\noutputs['value'] = 1",
+            },
+            {
+                "id": "step2",
+                "type": "python",
+                "code": (
+                    f"from pathlib import Path\n"
+                    f"Path({str(side_effect_file)!r}).write_text('ran', encoding='utf-8')\n"
+                    "outputs['value'] = inputs['value'] + 1"
+                ),
+            },
+        ],
+        "edges": [
+            {"from": "step1", "to": "step2"},
+        ],
+    }
+
+    monkeypatch.setattr(
+        fs_store,
+        "read_workflow_from_fs",
+        lambda workflow_id: {"workflowJson": workflow_json} if workflow_id == "wf_slow_cancel" else None,
+    )
+    monkeypatch.setattr(task_manager_module, "_DISPATCH_GUARD_TIMEOUT_S", 0.01)
+    await TaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
+
+    scheduler = await TaskManager.create_scheduler(
+        title="可取消 workflow",
+        mode=SchedulerMode.ONCE,
+        trigger=TaskTrigger(run_immediately=True),
+        execution_mode=ExecutionMode.WORKFLOW,
+        workflow_id="wf_slow_cancel",
+        workspace_directory=str(tmp_path / "workspace"),
+    )
+
+    execution = (await TaskManager.list_scheduler_executions(scheduler.id))[0][0]
+    failed = await _wait_for_execution(execution.id, status=TaskStatus.FAILED, timeout=1.0)
+    await asyncio.sleep(0.15)
+
+    assert "hard timeout" in (failed.error or "")
+    assert not side_effect_file.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -47,6 +47,21 @@ async def test_health_check(client):
     assert "task_manager_started" in data
     assert "task_scheduler_running" in data
     assert "task_scheduler_available" in data
+    assert "task_queue_running" in data
+    assert "task_queue_queued" in data
+    assert "task_stale_running" in data
+
+
+@pytest.mark.asyncio
+async def test_task_queue_status_includes_diagnostics(client):
+    response = await client.get("/api/task-system/queue/status")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["max_concurrent"] == 4
+    assert "running" in data
+    assert "queued" in data
+    assert "stale_running" in data
+    assert "oldest_running_seconds" in data
 
 
 @pytest.mark.asyncio

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+import flocks.task.background as background_module
+import flocks.task.manager as task_manager_module
+from flocks.server.routes import question as question_routes
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
+from flocks.task.background import BackgroundManager, BackgroundTask
 from flocks.task.executor import TaskExecutor
 from flocks.task.manager import TaskManager
 from flocks.task.models import (
@@ -132,6 +137,124 @@ async def test_cron_scheduler_does_not_spawn_second_active_execution(tmp_path: P
     assert total == 1
     assert executions[0].status == TaskStatus.QUEUED
     assert executions[0].trigger_type == ExecutionTriggerType.SCHEDULED
+
+
+@pytest.mark.asyncio
+async def test_recover_stale_running_execution_unblocks_scheduler(tmp_path: Path):
+    manager = TaskManager(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    scheduler = await TaskManager.create_scheduler(
+        title="恢复阻塞循环任务",
+        mode=SchedulerMode.CRON,
+        trigger=TaskTrigger(cron="*/5 * * * *", timezone="Asia/Shanghai"),
+        workspace_directory=str(tmp_path / "workspace"),
+    )
+    scheduler.trigger.next_run = datetime.now(timezone.utc) - timedelta(seconds=1)
+    await TaskStore.update_scheduler(scheduler)
+
+    execution = await TaskManager.create_execution_from_scheduler(
+        scheduler,
+        trigger_type=ExecutionTriggerType.SCHEDULED,
+        enqueue=False,
+    )
+    started_at = datetime.now(timezone.utc) - timedelta(
+        seconds=task_manager_module._RUNNING_RECOVERY_TIMEOUT_S + 5
+    )
+    execution.status = TaskStatus.RUNNING
+    execution.started_at = started_at
+    execution.queued_at = started_at
+    execution.session_id = "ses_stale_task"
+    await TaskStore.update_execution(execution)
+    await TaskStore.enqueue_execution_ref(execution.id)
+
+    recovered = await manager._recover_stale_active_executions()
+
+    assert recovered == 1
+    failed = await TaskManager.get_execution(execution.id)
+    assert failed is not None
+    assert failed.status == TaskStatus.FAILED
+    assert "recovery threshold" in (failed.error or "")
+    assert await TaskStore.get_queue_ref(execution.id) is None
+
+    loop = SchedulerLoop()
+    await loop._tick()
+    executions, total = await TaskManager.list_scheduler_executions(scheduler.id, limit=10)
+
+    assert total == 2
+    assert any(item.id == execution.id and item.status == TaskStatus.FAILED for item in executions)
+    assert any(item.id != execution.id and item.status == TaskStatus.QUEUED for item in executions)
+
+
+@pytest.mark.asyncio
+async def test_queue_status_reports_stale_running_execution(tmp_path: Path):
+    await TaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    scheduler = await TaskManager.create_scheduler(
+        title="阻塞诊断",
+        mode=SchedulerMode.ONCE,
+        trigger=TaskTrigger(run_immediately=False),
+        workspace_directory=str(tmp_path / "workspace"),
+    )
+    execution = await TaskManager.create_execution_from_scheduler(
+        scheduler,
+        trigger_type=ExecutionTriggerType.RUN_ONCE,
+        enqueue=False,
+    )
+    started_at = datetime.now(timezone.utc) - timedelta(
+        seconds=task_manager_module._RUNNING_RECOVERY_TIMEOUT_S + 15
+    )
+    execution.status = TaskStatus.RUNNING
+    execution.started_at = started_at
+    execution.queued_at = started_at
+    await TaskStore.update_execution(execution)
+
+    status = await TaskManager.queue_status()
+
+    assert status["stale_running"] == 1
+    assert isinstance(status["oldest_running_seconds"], int)
+    assert status["oldest_running_seconds"] >= task_manager_module._RUNNING_RECOVERY_TIMEOUT_S
+
+
+@pytest.mark.asyncio
+async def test_background_task_fails_fast_when_user_input_is_required(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_session_loop(_session_id: str, callbacks=None):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise
+
+    rejected: list[str] = []
+
+    monkeypatch.setattr(background_module, "_WATCHDOG_CHECK_INTERVAL", 0.01)
+    monkeypatch.setattr(background_module.SessionLoop, "run", staticmethod(fake_session_loop))
+    monkeypatch.setattr(question_routes, "has_pending_questions", lambda _session_id: True)
+
+    async def fake_reject(session_id: str) -> int:
+        rejected.append(session_id)
+        return 1
+
+    monkeypatch.setattr(question_routes, "reject_session_questions", fake_reject)
+
+    manager = BackgroundManager()
+    task = BackgroundTask(
+        id="bg_test",
+        status="running",
+        description="scheduled",
+        prompt="",
+        agent="rex",
+        allow_user_questions=False,
+    )
+
+    with pytest.raises(RuntimeError, match="cannot wait for user input"):
+        await manager._run_session_with_watchdog(
+            task,
+            "ses_interactive_block",
+            callbacks=None,
+            timeout_seconds=1,
+            allow_user_questions=False,
+        )
+
+    assert rejected == ["ses_interactive_block"]
 
 
 @pytest.mark.asyncio

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -214,6 +214,45 @@ async def test_queue_status_reports_stale_running_execution(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_queue_status_uses_largest_elapsed_running_time(tmp_path: Path):
+    await TaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    scheduler = await TaskManager.create_scheduler(
+        title="阻塞诊断-多任务",
+        mode=SchedulerMode.ONCE,
+        trigger=TaskTrigger(run_immediately=False),
+        workspace_directory=str(tmp_path / "workspace"),
+    )
+    older_execution = await TaskManager.create_execution_from_scheduler(
+        scheduler,
+        trigger_type=ExecutionTriggerType.RUN_ONCE,
+        enqueue=False,
+    )
+    newer_execution = await TaskManager.create_execution_from_scheduler(
+        scheduler,
+        trigger_type=ExecutionTriggerType.RUN_ONCE,
+        enqueue=False,
+    )
+    older_started_at = datetime.now(timezone.utc) - timedelta(
+        seconds=task_manager_module._RUNNING_RECOVERY_TIMEOUT_S + 15
+    )
+    newer_started_at = datetime.now(timezone.utc) - timedelta(seconds=10)
+    older_execution.status = TaskStatus.RUNNING
+    older_execution.started_at = older_started_at
+    older_execution.queued_at = older_started_at
+    newer_execution.status = TaskStatus.RUNNING
+    newer_execution.started_at = newer_started_at
+    newer_execution.queued_at = newer_started_at
+    await TaskStore.update_execution(older_execution)
+    await TaskStore.update_execution(newer_execution)
+
+    status = await TaskManager.queue_status()
+
+    assert status["stale_running"] == 1
+    assert isinstance(status["oldest_running_seconds"], int)
+    assert status["oldest_running_seconds"] >= task_manager_module._RUNNING_RECOVERY_TIMEOUT_S + 15
+
+
+@pytest.mark.asyncio
 async def test_background_task_fails_fast_when_user_input_is_required(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
## Summary
- add hard timeouts, stale-running recovery, and diagnostics so blocked scheduled executions stop holding the task queue forever
- fail fast when scheduled/background tasks try to wait for user input and wire workflow task cancellation into the existing workflow CANCELLED semantics
- raise default task concurrency to 4 so different schedulers can run concurrently by default

## Test plan
- [x] `uv run pytest tests/server/test_server.py tests/task/test_task.py tests/integration/test_task_queue_integration.py`
- [x] `uv run pytest tests/integration/test_task_queue_integration.py tests/task/test_task.py tests/workflow/test_workflow_cancellation.py tests/server/test_server.py`
- [x] `uv run ruff check flocks/task/queue.py flocks/task/manager.py tests/server/test_server.py`
- [x] `uv run ruff check flocks/task/executor.py flocks/task/manager.py tests/integration/test_task_queue_integration.py`
