### PR TITLE
fix(session): normalize assistant message fields before serialization

### DIFF
--- a/flocks/session/message.py
+++ b/flocks/session/message.py
@@ -585,6 +585,39 @@ class Message:
         
         model_class = type_map.get(part_type, TextPart)
         return model_class.model_validate(part_data)
+
+    @staticmethod
+    def _normalize_assistant_message(message: MessageInfo) -> MessageInfo:
+        """Coerce assistant fields back to typed models before serialization."""
+        if not isinstance(message, AssistantMessageInfo):
+            return message
+
+        updates: Dict[str, Any] = {}
+        if isinstance(message.tokens, dict):
+            updates["tokens"] = TokenUsage.model_validate(message.tokens)
+        if isinstance(message.path, dict):
+            updates["path"] = MessagePath.model_validate(message.path)
+
+        if not updates:
+            return message
+        return message.model_copy(update=updates)
+
+    @classmethod
+    def _normalize_message_patch(
+        cls,
+        message: MessageInfo,
+        patch: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Coerce typed assistant fields when update callers pass plain dicts."""
+        if not isinstance(message, AssistantMessageInfo):
+            return patch
+
+        normalized = dict(patch)
+        if isinstance(normalized.get("tokens"), dict):
+            normalized["tokens"] = TokenUsage.model_validate(normalized["tokens"])
+        if isinstance(normalized.get("path"), dict):
+            normalized["path"] = MessagePath.model_validate(normalized["path"])
+        return normalized
     
     @classmethod
     async def _persist_messages(cls, session_id: str) -> None:
@@ -596,7 +629,13 @@ class Message:
         """
         storage_key = f"{cls._MESSAGE_PREFIX}:{session_id}"
         messages = cls._messages_cache.get(session_id, [])
-        await Storage.set(storage_key, [m.model_dump() for m in messages])
+        serialized_messages = []
+        for index, message in enumerate(messages):
+            normalized = cls._normalize_assistant_message(message)
+            if normalized is not message:
+                messages[index] = normalized
+            serialized_messages.append(normalized.model_dump())
+        await Storage.set(storage_key, serialized_messages)
     
     @classmethod
     async def _persist_parts(cls, session_id: str, *, message_id: Optional[str] = None) -> None:
@@ -1429,6 +1468,7 @@ class Message:
             
             # Build update dict (skip None values)
             patch = {k: v for k, v in updates.items() if v is not None}
+            patch = cls._normalize_message_patch(message, patch)
             
             # Update timestamp
             time_data = message.time if hasattr(message, 'time') else message.model_dump().get("time", {})

--- a/tests/session/test_session.py
+++ b/tests/session/test_session.py
@@ -3,11 +3,12 @@ Tests for session module
 """
 
 import asyncio
+import warnings
 from unittest.mock import AsyncMock
 
 import pytest
 from flocks.session.session import Session
-from flocks.session.message import Message, MessageRole, MessageInfo
+from flocks.session.message import Message, MessageInfo, MessageRole, TokenUsage
 from flocks.session.callable_state import add_session_callable_tools, get_session_callable_tools
 from flocks.agent.registry import Agent
 from flocks.storage.storage import Storage
@@ -257,6 +258,46 @@ async def test_message_get():
     text_result = Message.get_text_content(retrieved)
     text = await text_result if asyncio.iscoroutine(text_result) else text_result
     assert text == "Test message"
+
+
+@pytest.mark.asyncio
+async def test_message_update_coerces_dict_tokens_to_token_usage():
+    """Assistant token updates should stay aligned with the Pydantic schema."""
+    session_id = "test_session_tokens_update"
+
+    message = await Message.create(
+        session_id=session_id,
+        role=MessageRole.ASSISTANT,
+        content="Token update test",
+        parentID="msg_parent",
+        modelID="test-model",
+        providerID="test-provider",
+        mode="rex",
+        agent="rex",
+    )
+
+    updated = await Message.update(
+        session_id,
+        message.id,
+        tokens={
+            "input": 12,
+            "output": 8,
+            "reasoning": 3,
+            "cache": {"read": 5, "write": 2},
+        },
+    )
+
+    assert updated is not None
+    assert isinstance(updated.tokens, TokenUsage)
+    assert updated.tokens.input == 12
+    assert updated.tokens.cache.read == 5
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        dumped = updated.model_dump()
+
+    assert dumped["tokens"]["output"] == 8
+    assert not any("Pydantic serializer warnings" in str(w.message) for w in caught)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- normalize assistant message `tokens` and `path` updates back into typed Pydantic models before `model_copy(update=...)` can leave dict-shaped values in the message cache
- self-heal assistant messages during persistence so legacy or already-polluted cache entries no longer trigger serializer warnings on `model_dump()`
- add a regression test covering dict-based token updates to prevent the `TokenUsage` serialization warning from returning

## Test plan
- [x] `uv run pytest tests/session/test_session.py tests/session/test_message_parts.py`
