### PR TITLE
feat(workflow): business failure outcome, stats refresh, node panel UX

### DIFF
--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -436,6 +436,34 @@ def _normalize_execution_status(status: str) -> str:
     return (status or "error").strip().lower() or "error"
 
 
+def _extract_business_failure_message(outputs: Dict[str, Any]) -> Optional[str]:
+    """Return a user-facing failure reason from workflow outputs."""
+    for key in ("reason", "error_message", "errorMessage", "message"):
+        value = outputs.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _resolve_execution_outcome(result: RunWorkflowResult) -> tuple[str, Optional[str]]:
+    """Resolve API execution status from runner status and workflow outputs."""
+    status_value = _normalize_execution_status(result.status)
+    error_message = result.error
+
+    if status_value != "success" or not isinstance(result.outputs, dict):
+        return status_value, error_message
+
+    if result.outputs.get("workflow_success") is False:
+        return (
+            "error",
+            error_message
+            or _extract_business_failure_message(result.outputs)
+            or "Workflow reported business failure.",
+        )
+
+    return status_value, error_message
+
+
 async def _record_execution_result(workflow_id: str, exec_id: str, exec_data: Dict[str, Any]) -> None:
     """Persist the final execution record and audit trail."""
     await Storage.write(_workflow_execution_key(exec_id), exec_data)
@@ -493,14 +521,14 @@ async def _run_workflow_execution_task(
 
         duration = time.time() - start_time
         current_data = await Storage.read(exec_key)
-        status_value = _normalize_execution_status(result.status)
+        status_value, error_message = _resolve_execution_outcome(result)
         current_data.update({
             "outputResults": result.outputs,
             "status": status_value,
             "finishedAt": int(time.time() * 1000),
             "duration": duration,
             "executionLog": result.history or list(step_history),
-            "errorMessage": result.error,
+            "errorMessage": error_message,
         })
 
         if status_value == "success":

--- a/tests/server/routes/test_remaining_routes.py
+++ b/tests/server/routes/test_remaining_routes.py
@@ -58,6 +58,7 @@ async def _wait_for_execution_terminal_state(
 def isolated_workflow_filesystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Redirect workflow route filesystem writes into a per-test temp dir."""
     from flocks.server.routes import workflow as workflow_routes
+    from flocks.workflow import fs_store
 
     workspace_root = tmp_path / "workspace"
     project_root = workspace_root / ".flocks" / "plugins" / "workflows"
@@ -80,15 +81,19 @@ def isolated_workflow_filesystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(workflow_routes, "_workspace_root", workspace_root, raising=False)
     monkeypatch.setattr(workflow_routes, "_find_workspace_root", lambda: workspace_root)
+    monkeypatch.setattr(fs_store, "_workspace_root", workspace_root, raising=False)
+    monkeypatch.setattr(fs_store, "find_workspace_root", lambda: workspace_root)
     monkeypatch.setattr(
-        workflow_routes,
+        fs_store,
         "resolve_project_workflow_roots",
-        lambda workspace: [legacy_project_main, legacy_project_plugin, project_root],
+        lambda workspace=None: [legacy_project_main, legacy_project_plugin, project_root],
+        raising=False,
     )
     monkeypatch.setattr(
-        workflow_routes,
+        fs_store,
         "resolve_global_workflow_roots",
         lambda: [legacy_global_main, legacy_global_plugin, global_root],
+        raising=False,
     )
 
     yield
@@ -193,6 +198,67 @@ class TestWorkflowRoutes:
         assert data["status"] == "running"
         assert data["id"]
         assert data["inputParams"] == {"topic": "demo"}
+
+    @pytest.mark.asyncio
+    async def test_run_workflow_marks_business_failure_as_error(self, client: AsyncClient):
+        """A workflow that reports workflow_success=false should count as a failed run."""
+        payload = {
+            "name": "business-failure-workflow",
+            "description": "workflow that reports business failure",
+            "workflowJson": {
+                "start": "node_1",
+                "nodes": [
+                    {
+                        "id": "node_1",
+                        "type": "python",
+                        "code": (
+                            "outputs['workflow_success'] = False\n"
+                            "outputs['reason'] = 'Script file not found'"
+                        ),
+                    }
+                ],
+                "edges": [],
+            },
+        }
+        create_resp = await client.post("/api/workflow", json=payload)
+        wf_id = create_resp.json()["id"]
+
+        run_resp = await client.post(f"/api/workflow/{wf_id}/run", json={"inputs": {}})
+        assert run_resp.status_code == status.HTTP_200_OK, run_resp.text
+        exec_id = run_resp.json()["id"]
+
+        final = await _wait_for_execution_terminal_state(client, wf_id, exec_id)
+        assert final["status"] == "error"
+        assert final["errorMessage"] == "Script file not found"
+        assert final["outputResults"]["workflow_success"] is False
+
+        workflow_resp = await client.get(f"/api/workflow/{wf_id}")
+        assert workflow_resp.status_code == status.HTTP_200_OK, workflow_resp.text
+        stats = workflow_resp.json()["stats"]
+        assert stats["callCount"] == 1
+        assert stats["successCount"] == 0
+        assert stats["errorCount"] == 1
+
+    @pytest.mark.asyncio
+    async def test_run_workflow_success_updates_success_stats(self, client: AsyncClient):
+        """A normal successful workflow should remain successful in execution and stats."""
+        create_resp = await client.post("/api/workflow", json=_WORKFLOW_PAYLOAD)
+        wf_id = create_resp.json()["id"]
+
+        run_resp = await client.post(f"/api/workflow/{wf_id}/run", json={"inputs": {}})
+        assert run_resp.status_code == status.HTTP_200_OK, run_resp.text
+        exec_id = run_resp.json()["id"]
+
+        final = await _wait_for_execution_terminal_state(client, wf_id, exec_id)
+        assert final["status"] == "success"
+        assert final.get("errorMessage") in (None, "")
+
+        workflow_resp = await client.get(f"/api/workflow/{wf_id}")
+        assert workflow_resp.status_code == status.HTTP_200_OK, workflow_resp.text
+        stats = workflow_resp.json()["stats"]
+        assert stats["callCount"] == 1
+        assert stats["successCount"] == 1
+        assert stats["errorCount"] == 0
 
     @pytest.mark.asyncio
     async def test_cancel_running_workflow_execution(self, client: AsyncClient):

--- a/webui/src/pages/WorkflowDetail/NodeInfoPanel.test.tsx
+++ b/webui/src/pages/WorkflowDetail/NodeInfoPanel.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import NodeInfoPanel from './NodeInfoPanel';
 
@@ -260,17 +260,22 @@ describe('NodeInfoPanel', () => {
 
     const expandedEditor = screen.getByRole('dialog', { name: '大编辑器' }).querySelector('textarea');
     expect(expandedEditor).not.toBeNull();
-    await user.clear(expandedEditor!);
-    await user.type(expandedEditor!, 'print("expanded")');
+    const lineNumbers = within(screen.getByTestId('expanded-code-line-numbers'));
+    expect(lineNumbers.getByText('1')).toBeInTheDocument();
 
-    expect(screen.getAllByDisplayValue('print("expanded")').length).toBeGreaterThanOrEqual(1);
+    await user.clear(expandedEditor!);
+    await user.type(expandedEditor!, 'print("expanded"){enter}print("next")');
+
+    expect(lineNumbers.getByText('2')).toBeInTheDocument();
+    expect((expandedEditor as HTMLTextAreaElement).value).toBe('print("expanded")\nprint("next")');
 
     await user.click(screen.getByRole('button', { name: '收起编辑' }));
     expect(screen.queryByRole('dialog', { name: '大编辑器' })).not.toBeInTheDocument();
-    expect(screen.getByDisplayValue('print("expanded")')).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/print\("expanded"\)/)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/print\("next"\)/)).toBeInTheDocument();
   });
 
-  it('places run node section after the code editor for code nodes', () => {
+  it('places runtime section between the code editor and run node section for code nodes', () => {
     render(
       <NodeInfoPanel
         node={workflow.workflowJson.nodes[0]}
@@ -282,10 +287,14 @@ describe('NodeInfoPanel', () => {
     );
 
     const codeLabel = screen.getByText('代码');
+    const runtimeLabel = screen.getByText('最近一次运行');
     const runNodeLabel = screen.getByText('单节点执行');
 
     expect(
-      codeLabel.compareDocumentPosition(runNodeLabel) & Node.DOCUMENT_POSITION_FOLLOWING,
+      codeLabel.compareDocumentPosition(runtimeLabel) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      runtimeLabel.compareDocumentPosition(runNodeLabel) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 

--- a/webui/src/pages/WorkflowDetail/NodeInfoPanel.tsx
+++ b/webui/src/pages/WorkflowDetail/NodeInfoPanel.tsx
@@ -2,7 +2,7 @@
  * NodeInfoPanel — 并列在对话左侧的节点信息/编辑面板
  * 当用户点击画布节点时展开，可关闭。
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, AlertCircle, Save, Loader2, ChevronDown, ChevronRight, Play, RotateCcw, Maximize2 } from 'lucide-react';
 import { workflowAPI, Workflow, WorkflowEdge, WorkflowExecution, WorkflowNode, WorkflowNodeExecution } from '@/api/workflow';
@@ -140,6 +140,64 @@ function JsonField({ label, value, onChange, placeholder }: {
         spellCheck={false}
       />
       {err && <p className="mt-1 text-[11px] text-red-500 flex items-center gap-1"><AlertCircle className="w-3 h-3" />{err}</p>}
+    </div>
+  );
+}
+
+function ExpandedCodeEditor({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const lineNumberTrackRef = useRef<HTMLDivElement | null>(null);
+  const lineNumbers = useMemo(() => {
+    const totalLines = Math.max(1, value.split('\n').length);
+    return Array.from({ length: totalLines }, (_, index) => index + 1);
+  }, [value]);
+
+  const syncLineNumberOffset = () => {
+    if (!lineNumberTrackRef.current) {
+      return;
+    }
+    const scrollTop = textareaRef.current?.scrollTop ?? 0;
+    lineNumberTrackRef.current.style.transform = `translateY(-${scrollTop}px)`;
+  };
+
+  useEffect(() => {
+    syncLineNumberOffset();
+  }, [lineNumbers.length]);
+
+  return (
+    <div className="flex h-full min-h-0 min-w-0 overflow-hidden rounded-xl border border-[#30363d] bg-[#0d1117]">
+      <div
+        aria-hidden="true"
+        data-testid="expanded-code-line-numbers"
+        className="flex-shrink-0 overflow-hidden select-none border-r border-[#30363d] bg-[#0b0f14] px-3 py-3 text-right font-mono text-[12px] leading-relaxed text-[#6e7681]"
+      >
+        <div ref={lineNumberTrackRef}>
+          {lineNumbers.map((lineNumber) => (
+            <div key={lineNumber} data-line-number={lineNumber}>
+              {lineNumber}
+            </div>
+          ))}
+        </div>
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onScroll={syncLineNumberOffset}
+        rows={24}
+        wrap="off"
+        className="h-full min-h-0 min-w-0 w-full resize-none overflow-auto bg-[#0d1117] px-4 py-3 font-mono text-[12px] leading-relaxed text-[#e6edf3] focus:outline-none focus:ring-2 focus:ring-red-400"
+        placeholder={placeholder}
+        spellCheck={false}
+      />
     </div>
   );
 }
@@ -564,7 +622,9 @@ export default function NodeInfoPanel({ node, workflow, latestExecution, width =
       {/* Body */}
       <div className="flex-1 overflow-y-auto px-3 pt-4 pb-3 space-y-4">
         <DataFlow node={node} edges={workflow.workflowJson.edges} />
-        <RuntimeSection nodeId={node.id} latestExecution={latestExecution} />
+        {!isCodeNode && (
+          <RuntimeSection nodeId={node.id} latestExecution={latestExecution} />
+        )}
 
         <div className="space-y-4">
           <div>
@@ -601,6 +661,10 @@ export default function NodeInfoPanel({ node, workflow, latestExecution, width =
                 spellCheck={false}
               />
             </div>
+          )}
+
+          {isCodeNode && (
+            <RuntimeSection nodeId={node.id} latestExecution={latestExecution} />
           )}
 
           {isCodeNode && (
@@ -720,7 +784,7 @@ export default function NodeInfoPanel({ node, workflow, latestExecution, width =
             role="dialog"
             aria-modal="true"
             aria-label={t('detail.nodeInfo.expandedCodeEditorTitle')}
-            className="flex h-[85vh] w-[min(96vw,960px)] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl"
+            className="flex h-[85vh] w-[min(96vw,960px)] min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl"
           >
             <div className="flex items-center justify-between gap-3 border-b border-gray-100 px-4 py-3">
               <div>
@@ -736,14 +800,11 @@ export default function NodeInfoPanel({ node, workflow, latestExecution, width =
                 {t('detail.nodeInfo.closeExpandedEditor')}
               </button>
             </div>
-            <div className="flex-1 bg-[#0d1117] p-4">
-              <textarea
+            <div className="flex-1 min-h-0 min-w-0 bg-[#0d1117] p-4">
+              <ExpandedCodeEditor
                 value={form.code ?? ''}
-                onChange={(e) => set('code', e.target.value)}
-                rows={24}
-                className="h-full w-full resize-none rounded-xl border border-[#30363d] bg-[#0d1117] px-4 py-3 font-mono text-[12px] leading-relaxed text-[#e6edf3] focus:outline-none focus:ring-2 focus:ring-red-400"
+                onChange={(value) => set('code', value)}
                 placeholder={t('detail.nodeInfo.codePlaceholder')}
-                spellCheck={false}
               />
             </div>
           </div>

--- a/webui/src/pages/WorkflowDetail/RightPanel.tsx
+++ b/webui/src/pages/WorkflowDetail/RightPanel.tsx
@@ -67,6 +67,7 @@ interface RightPanelProps {
   open: boolean;
   width?: number;
   onLatestExecutionChange?: (execution: WorkflowExecution | null) => void;
+  onExecutionSettled?: () => void;
   onWorkflowUpdated?: (updated: Workflow) => void;
   onFirstMessageSent?: () => void;
   /** Currently selected node — passed to ChatTab to show reference chip in input */
@@ -78,6 +79,7 @@ interface RightPanelProps {
 export default function RightPanel({
   workflow, latestExecution, open, width = 320,
   onLatestExecutionChange,
+  onExecutionSettled,
   onWorkflowUpdated,
   onFirstMessageSent,
   selectedNode, onDeselectNode,
@@ -151,6 +153,7 @@ export default function RightPanel({
               workflow={workflow}
               latestExecution={latestExecution ?? null}
               onLatestExecutionChange={onLatestExecutionChange}
+              onExecutionSettled={onExecutionSettled}
             />
           </TabErrorBoundary>
         )}

--- a/webui/src/pages/WorkflowDetail/index.tsx
+++ b/webui/src/pages/WorkflowDetail/index.tsx
@@ -85,24 +85,43 @@ export default function WorkflowDetail() {
     window.addEventListener('mouseup', onUp);
   }, [panelWidth]);
 
+  const loadWorkflow = useCallback(async (
+    options?: { preserveExecution?: boolean; silent?: boolean }
+  ) => {
+    if (!id) return;
+    const isSilent = options?.silent === true;
+    try {
+      if (!isSilent) {
+        setLoading(true);
+        setError(null);
+      }
+      const res = await workflowAPI.get(id);
+      setWorkflow(res.data);
+      if (!options?.preserveExecution) {
+        setLatestExecution(null);
+      }
+      if (!isSilent) {
+        setError(null);
+      }
+    } catch (err: unknown) {
+      if (!isSilent) {
+        setError(extractErrorMessage(err, t('detail.loadFailed')));
+      }
+    } finally {
+      if (!isSilent) {
+        setLoading(false);
+      }
+    }
+  }, [id, t]);
+
   useEffect(() => {
     if (!id) return;
-    loadWorkflow();
-  }, [id]);
+    void loadWorkflow();
+  }, [id, loadWorkflow]);
 
-  const loadWorkflow = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const res = await workflowAPI.get(id!);
-      setWorkflow(res.data);
-      setLatestExecution(null);
-    } catch (err: unknown) {
-      setError(extractErrorMessage(err, t('detail.loadFailed')));
-    } finally {
-      setLoading(false);
-    }
-  };
+  const refreshWorkflowStats = useCallback(() => {
+    void loadWorkflow({ preserveExecution: true, silent: true });
+  }, [loadWorkflow]);
 
   const showToast = useCallback((type: 'success' | 'error', text: string) => {
     setRunToast({ type, text });
@@ -195,7 +214,7 @@ export default function WorkflowDetail() {
         <p className="text-red-600 text-sm">{error || t('detail.notFound')}</p>
         <div className="flex gap-3">
           <button
-            onClick={loadWorkflow}
+            onClick={() => void loadWorkflow()}
             className="px-4 py-2 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700"
           >
             {t('common:button.retry')}
@@ -374,6 +393,7 @@ export default function WorkflowDetail() {
           open={panelOpen}
           width={panelWidth}
           onLatestExecutionChange={setLatestExecution}
+          onExecutionSettled={refreshWorkflowStats}
           onWorkflowUpdated={handleWorkflowUpdated}
           onFirstMessageSent={handleFirstMessageSent}
           selectedNode={drawerNode}

--- a/webui/src/pages/WorkflowDetail/tabs/RunTab.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/RunTab.tsx
@@ -19,6 +19,7 @@ interface RunTabProps {
   workflow: Workflow;
   latestExecution: WorkflowExecution | null;
   onLatestExecutionChange?: (execution: WorkflowExecution | null) => void;
+  onExecutionSettled?: () => void;
 }
 
 function SectionHeader({
@@ -172,10 +173,12 @@ function TestSection({
   workflow,
   execution,
   onExecutionChange,
+  onExecutionSettled,
 }: {
   workflow: Workflow;
   execution: WorkflowExecution | null;
   onExecutionChange?: (execution: WorkflowExecution | null) => void;
+  onExecutionSettled?: () => void;
 }) {
   const { t } = useTranslation('workflow');
   const [expanded, setExpanded] = useState(true);
@@ -249,6 +252,8 @@ function TestSection({
         onExecutionChange?.(response.data);
         if (response.data.status === 'running') {
           timerId = window.setTimeout(pollExecution, 1000);
+        } else {
+          onExecutionSettled?.();
         }
       } catch (error) {
         if (cancelled) return;
@@ -269,7 +274,7 @@ function TestSection({
         window.clearTimeout(timerId);
       }
     };
-  }, [execution, onExecutionChange, t, workflow.id]);
+  }, [execution, onExecutionChange, onExecutionSettled, t, workflow.id]);
 
   const scheduleSampleSave = useCallback((raw: string, parsed: Record<string, any>) => {
     if (saveTimerRef.current) {
@@ -1015,6 +1020,7 @@ export default function RunTab({
   workflow,
   latestExecution,
   onLatestExecutionChange,
+  onExecutionSettled,
 }: RunTabProps) {
   return (
     <div className="flex-1 min-h-0 overflow-y-auto divide-y divide-gray-100">
@@ -1022,6 +1028,7 @@ export default function RunTab({
         workflow={workflow}
         execution={latestExecution}
         onExecutionChange={onLatestExecutionChange}
+        onExecutionSettled={onExecutionSettled}
       />
       <PublishSection workflowId={workflow.id} />
       <KafkaSection workflowId={workflow.id} />


### PR DESCRIPTION
## Summary
- **API**: When the runner reports success but outputs include `workflow_success: false`, persist the run as **error** and surface a user-facing message from outputs (`reason`, `error_message`, etc.).
- **Tests**: Route tests for business failure vs success stats; isolate `fs_store` workflow root resolution in tests.
- **Web UI**: Expanded code editor with line numbers and scroll sync; runtime section order for code nodes; after a workflow run finishes, silently reload workflow to refresh **stats** without clearing the current execution view.

## Testing
- Python: `uv run pytest tests/server/routes/test_remaining_routes.py -q` (recommended)
- Web: existing Vitest for NodeInfoPanel

Made with [Cursor](https://cursor.com)