### PR TITLE
chore: bump version to v2026.4.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.4.13"
+version = "v2026.4.15"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.4.13"
+version = "2026.4.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Update project version from v2026.4.13 to v2026.4.15 in pyproject.toml, uv.lock and webui/package-lock.json.