### PR TITLE
fix(install): improve Node.js fallback installer sources

### DIFF
--- a/install_zh.sh
+++ b/install_zh.sh
@@ -42,6 +42,8 @@ Flocks 中国用户一键安装脚本。
 然后转交 scripts/install_zh.sh 继续安装。默认会在当前工作目录下创建 "flocks" 子目录。
 
 默认会为 install_zh 注入国内软件源与 uv 安装镜像。
+  npm 源: https://registry.npmmirror.com/
+  nvm 源: https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh
   uv 备用源: https://uv.agentsmirror.com/install-cn.sh
 
 远程使用：
@@ -130,6 +132,8 @@ resolve_project_dir() {
 
 configure_cn_environment() {
   export FLOCKS_INSTALL_LANGUAGE="${FLOCKS_INSTALL_LANGUAGE:-zh-CN}"
+  export FLOCKS_NPM_REGISTRY="${FLOCKS_NPM_REGISTRY:-https://registry.npmmirror.com/}"
+  export FLOCKS_NVM_INSTALL_SCRIPT_URL="${FLOCKS_NVM_INSTALL_SCRIPT_URL:-https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh}"
   export FLOCKS_UV_INSTALL_SH_URL="${FLOCKS_UV_INSTALL_SH_URL:-https://astral.org.cn/uv/install.sh}"
   export FLOCKS_UV_INSTALL_SH_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_FALLBACK_URL:-https://uv.agentsmirror.com/install-cn.sh}"
   export FLOCKS_UV_INSTALL_PS1_URL="${FLOCKS_UV_INSTALL_PS1_URL:-https://astral.org.cn/uv/install.ps1}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,7 @@ select_install_sources() {
     info "使用 PyPI 源: $UV_DEFAULT_INDEX"
     info "使用 npm 源: $NPM_REGISTRY"
     info "使用 uv 安装脚本: $UV_INSTALL_SH_URL"
+    info "使用 nvm 安装脚本: $NVM_INSTALL_SCRIPT_URL"
     if [[ -n "$UV_INSTALL_SH_FALLBACK_URL" ]]; then
       info "使用 uv 备用安装脚本: $UV_INSTALL_SH_FALLBACK_URL"
     fi
@@ -67,6 +68,7 @@ select_install_sources() {
     info "Using PyPI index: $UV_DEFAULT_INDEX"
     info "Using npm registry: $NPM_REGISTRY"
     info "Using uv install script: $UV_INSTALL_SH_URL"
+    info "Using nvm install script: $NVM_INSTALL_SCRIPT_URL"
   fi
 }
 
@@ -391,29 +393,57 @@ load_nvm() {
   command -v nvm >/dev/null 2>&1
 }
 
-install_nodejs_macos() {
-  if has_cmd brew; then
-    info "Trying to install or upgrade Node.js with Homebrew..."
-    brew install node
-    return
-  fi
-
-  has_cmd curl || fail "A compatible npm installation was not found. Homebrew is not installed, and curl is required to install nvm automatically on macOS. Install Homebrew first and retry: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"$(nodejs_manual_download_hint)"
+install_nodejs_with_nvm() {
+  has_cmd curl || {
+    warn "curl is required to install nvm automatically.$(nodejs_manual_download_hint)"
+    return 1
+  }
 
   if load_nvm; then
-    info "Homebrew was not found. Using the existing nvm installation..."
+    info "Using the existing nvm installation..."
   else
-    info "Homebrew was not found. Trying to install nvm..."
-    curl -o- "$NVM_INSTALL_SCRIPT_URL" | bash
-    load_nvm || fail "nvm was installed, but it could not be loaded from $NVM_DIR/nvm.sh. Open a new shell and retry.$(nodejs_manual_download_hint)"
+    info "Trying to install nvm..."
+    if ! curl -o- "$NVM_INSTALL_SCRIPT_URL" | bash; then
+      warn "Failed to install nvm from: $NVM_INSTALL_SCRIPT_URL$(nodejs_manual_download_hint)"
+      return 1
+    fi
+    if ! load_nvm; then
+      warn "nvm was installed, but it could not be loaded from $NVM_DIR/nvm.sh. Open a new shell and retry.$(nodejs_manual_download_hint)"
+      return 1
+    fi
   fi
 
   info "Trying to install Node.js ${MIN_NODE_MAJOR} with nvm..."
-  nvm install "$MIN_NODE_MAJOR"
-  nvm use "$MIN_NODE_MAJOR" >/dev/null
+  if ! nvm install "$MIN_NODE_MAJOR"; then
+    warn "Failed to install Node.js ${MIN_NODE_MAJOR} with nvm.$(nodejs_manual_download_hint)"
+    return 1
+  fi
+  if ! nvm use "$MIN_NODE_MAJOR" >/dev/null; then
+    warn "Node.js ${MIN_NODE_MAJOR} was installed with nvm, but activating it failed.$(nodejs_manual_download_hint)"
+    return 1
+  fi
 }
 
-install_nodejs_linux() {
+install_nodejs_macos() {
+  if has_cmd brew; then
+    info "Trying to install or upgrade Node.js with Homebrew..."
+    if brew install node; then
+      return
+    fi
+    warn "Homebrew failed to install Node.js. Falling back to nvm..."
+  fi
+
+  if install_nodejs_with_nvm; then
+    return
+  fi
+
+  if has_cmd brew; then
+    fail "Homebrew and nvm could not install a compatible Node.js runtime on macOS.$(nodejs_manual_download_hint)"
+  fi
+  fail "A compatible npm installation was not found. Homebrew is not installed, and nvm could not be installed automatically on macOS. Install Homebrew first and retry: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"$(nodejs_manual_download_hint)"
+}
+
+install_nodejs_linux_with_package_manager() {
   info "A compatible npm installation was not found. Trying to install or upgrade Node.js automatically..."
 
   if has_cmd apt-get; then
@@ -464,6 +494,16 @@ install_nodejs_linux() {
   fi
 
   fail "No supported Linux package manager was detected, so Node.js (including npm) cannot be installed automatically.$(nodejs_manual_download_hint)"
+}
+
+install_nodejs_linux() {
+  info "Trying to install Node.js ${MIN_NODE_MAJOR} with nvm first on Linux..."
+  if install_nodejs_with_nvm; then
+    return
+  fi
+
+  warn "nvm installation failed on Linux. Falling back to the system package manager..."
+  install_nodejs_linux_with_package_manager
 }
 
 ensure_npm_installed() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,6 +21,8 @@ UV_INSTALL_SH_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_FALLBACK_URL:-}"
 NPM_REGISTRY="${FLOCKS_NPM_REGISTRY:-https://registry.npmjs.org/}"
 NODEJS_MANUAL_DOWNLOAD_URL="${FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL:-https://nodejs.org/en/download}"
 NVM_INSTALL_SCRIPT_URL="${FLOCKS_NVM_INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh}"
+NVM_GITEE_REPO_URL="${FLOCKS_NVM_GITEE_REPO_URL:-https://gitee.com/mirrors/nvm.git}"
+NVM_GITEE_RAW_URL_PREFIX="${FLOCKS_NVM_GITEE_RAW_URL_PREFIX:-https://gitee.com/mirrors/nvm/raw}"
 
 info() {
   printf '[flocks] %s\n' "$1"
@@ -393,6 +395,54 @@ load_nvm() {
   command -v nvm >/dev/null 2>&1
 }
 
+should_patch_nvm_install_script_for_gitee() {
+  [[ "$NVM_INSTALL_SCRIPT_URL" == https://gitee.com/* ]]
+}
+
+patch_nvm_install_script_for_gitee() {
+  local install_script="$1" patched_script
+  [[ -f "$install_script" ]] || return 1
+
+  if ! should_patch_nvm_install_script_for_gitee; then
+    return 0
+  fi
+
+  patched_script="$(mktemp "${TMPDIR:-/tmp}/flocks-nvm-install-patched.XXXXXX")" || return 1
+  if ! sed \
+    -e "s#https://raw.githubusercontent.com/\\\${NVM_GITHUB_REPO}/\\\${NVM_VERSION}/nvm.sh#${NVM_GITEE_RAW_URL_PREFIX}/\\\${NVM_VERSION}/nvm.sh#g" \
+    -e "s#https://raw.githubusercontent.com/\\\${NVM_GITHUB_REPO}/\\\${NVM_VERSION}/nvm-exec#${NVM_GITEE_RAW_URL_PREFIX}/\\\${NVM_VERSION}/nvm-exec#g" \
+    -e "s#https://raw.githubusercontent.com/\\\${NVM_GITHUB_REPO}/\\\${NVM_VERSION}/bash_completion#${NVM_GITEE_RAW_URL_PREFIX}/\\\${NVM_VERSION}/bash_completion#g" \
+    -e "s#https://github.com/\\\${NVM_GITHUB_REPO}\\.git#${NVM_GITEE_REPO_URL}#g" \
+    "$install_script" > "$patched_script"; then
+    rm -f "$patched_script"
+    return 1
+  fi
+
+  mv "$patched_script" "$install_script"
+}
+
+run_nvm_install_script() {
+  local install_script=""
+  install_script="$(mktemp "${TMPDIR:-/tmp}/flocks-nvm-install.XXXXXX.sh")" || return 1
+
+  if ! curl -fsSL "$NVM_INSTALL_SCRIPT_URL" -o "$install_script"; then
+    rm -f "$install_script"
+    return 1
+  fi
+
+  if ! patch_nvm_install_script_for_gitee "$install_script"; then
+    rm -f "$install_script"
+    return 1
+  fi
+
+  if ! bash "$install_script"; then
+    rm -f "$install_script"
+    return 1
+  fi
+
+  rm -f "$install_script"
+}
+
 install_nodejs_with_nvm() {
   has_cmd curl || {
     warn "curl is required to install nvm automatically.$(nodejs_manual_download_hint)"
@@ -403,7 +453,7 @@ install_nodejs_with_nvm() {
     info "Using the existing nvm installation..."
   else
     info "Trying to install nvm..."
-    if ! curl -o- "$NVM_INSTALL_SCRIPT_URL" | bash; then
+    if ! run_nvm_install_script; then
       warn "Failed to install nvm from: $NVM_INSTALL_SCRIPT_URL$(nodejs_manual_download_hint)"
       return 1
     fi

--- a/scripts/install_zh.sh
+++ b/scripts/install_zh.sh
@@ -19,6 +19,7 @@ Flocks 中国用户源码安装脚本。
   PyPI: https://mirrors.aliyun.com/pypi/simple
   npm : https://registry.npmmirror.com/
   uv  : https://astral.org.cn/uv/install.sh
+  nvm : https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh
   uv 备用源: https://uv.agentsmirror.com/install-cn.sh
 
 一键安装入口：
@@ -42,6 +43,7 @@ configure_cn_environment() {
   export FLOCKS_UV_INSTALL_SH_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_FALLBACK_URL:-https://uv.agentsmirror.com/install-cn.sh}"
   export FLOCKS_UV_INSTALL_PS1_URL="${FLOCKS_UV_INSTALL_PS1_URL:-https://astral.org.cn/uv/install.ps1}"
   export FLOCKS_NPM_REGISTRY="${FLOCKS_NPM_REGISTRY:-https://registry.npmmirror.com/}"
+  export FLOCKS_NVM_INSTALL_SCRIPT_URL="${FLOCKS_NVM_INSTALL_SCRIPT_URL:-https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh}"
   export PUPPETEER_CHROME_DOWNLOAD_BASE_URL="${PUPPETEER_CHROME_DOWNLOAD_BASE_URL:-https://cdn.npmmirror.com/binaries/chrome-for-testing}"
   export FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL="${FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL:-https://nodejs.org/zh-cn/download}"
 }

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -697,6 +697,7 @@ def test_main_bash_installer_prefers_nvm_on_linux_before_package_manager() -> No
         r"""
 
         export HOME="$(mktemp -d)"
+        unset NVM_DIR
         export TEST_LOG="$HOME/install-node.log"
 
         info() {
@@ -819,6 +820,7 @@ def test_main_bash_installer_falls_back_to_package_manager_when_nvm_fails_on_lin
         r"""
 
         export HOME="$(mktemp -d)"
+        unset NVM_DIR
         export TEST_LOG="$HOME/install-node.log"
         export TEST_URL="https://example.invalid/nvm-install.sh"
         NVM_INSTALL_SCRIPT_URL="$TEST_URL"

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -27,6 +27,10 @@ def test_install_zh_bash_bootstrap_uses_gitee_archive_and_delegates_to_zh_worksp
     assert 'https://uv.agentsmirror.com/install-cn.sh' in script
     assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
     assert 'https://astral.org.cn/uv/install.ps1' in script
+    assert 'FLOCKS_NPM_REGISTRY' in script
+    assert 'https://registry.npmmirror.com/' in script
+    assert 'FLOCKS_NVM_INSTALL_SCRIPT_URL' in script
+    assert 'https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh' in script
     assert 'PUPPETEER_CHROME_DOWNLOAD_BASE_URL' in script
     assert 'https://cdn.npmmirror.com/binaries/chrome-for-testing' in script
 
@@ -72,6 +76,8 @@ def test_install_zh_bash_wrapper_sets_cn_sources_and_reuses_main_installer() -> 
     assert 'https://astral.org.cn/uv/install.ps1' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'https://registry.npmmirror.com/' in script
+    assert 'FLOCKS_NVM_INSTALL_SCRIPT_URL' in script
+    assert 'https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh' in script
     assert 'FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL' in script
     assert "https://nodejs.org/zh-cn/download" in script
     assert 'exec bash "$SCRIPT_DIR/install.sh" "$@"' in script
@@ -117,25 +123,31 @@ def test_main_bash_installer_uses_configured_default_sources_without_probing() -
     assert 'Using PyPI index: $UV_DEFAULT_INDEX' in script
     assert 'Using npm registry: $NPM_REGISTRY' in script
     assert 'Using uv install script: $UV_INSTALL_SH_URL' in script
+    assert 'Using nvm install script: $NVM_INSTALL_SCRIPT_URL' in script
     assert 'Using uv fallback script' not in script
     assert '使用 uv 备用安装脚本: $UV_INSTALL_SH_FALLBACK_URL' in script
     assert 'pick_fastest_url' not in script
     assert 'Probing PyPI and npm registries to choose the faster source' not in script
     assert 'npm_config_registry="$NPM_REGISTRY" npm install' in script
+    assert 'npm_config_registry="$NPM_REGISTRY" npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir"' in script
     assert 'npm_config_registry="$NPM_REGISTRY" npm install --global agent-browser' in script
+    assert 'local connector_dir="$ROOT_DIR/.flocks/plugins/channels/dingtalk/dingtalk-openclaw-connector"' in script
     assert "FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL" in script
     assert "https://nodejs.org/en/download" in script
     assert "nodejs_manual_download_hint" in script
     assert "FLOCKS_NVM_INSTALL_SCRIPT_URL" in script
     assert "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh" in script
     assert "load_nvm()" in script
+    assert "install_nodejs_with_nvm()" in script
+    assert "install_nodejs_linux_with_package_manager()" in script
     assert 'curl -o- "$NVM_INSTALL_SCRIPT_URL" | bash' in script
     assert 'curl -LsSf "$UV_INSTALL_SH_URL" | sh' in script
     assert 'curl -LsSf "$UV_INSTALL_SH_FALLBACK_URL" | sh' in script
     assert 'nvm install "$MIN_NODE_MAJOR"' in script
     assert 'nvm use "$MIN_NODE_MAJOR" >/dev/null' in script
-    assert "Homebrew was not found. Trying to install nvm..." in script
-    assert "Homebrew was not found. Using the existing nvm installation..." in script
+    assert "Homebrew failed to install Node.js. Falling back to nvm..." in script
+    assert 'info "Trying to install Node.js ${MIN_NODE_MAJOR} with nvm first on Linux..."' in script
+    assert 'warn "nvm installation failed on Linux. Falling back to the system package manager..."' in script
 
 
 def test_main_powershell_installer_uses_configured_default_sources_and_admin_precheck() -> None:
@@ -266,6 +278,121 @@ def test_main_bash_installer_falls_back_to_nvm_when_brew_is_missing_on_macos() -
         }
         [[ "$install_log" == *"Trying to install nvm"* ]] || {
           printf 'nvm install message missing: %s\n' "$install_log" >&2
+          exit 1
+        }
+        """
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", test_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
+
+
+def test_main_bash_installer_falls_back_to_nvm_when_brew_install_fails_on_macos() -> None:
+    script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
+    script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)
+    test_script = script_without_main + textwrap.dedent(
+        r"""
+
+        export HOME="$(mktemp -d)"
+        unset NVM_DIR
+        export TEST_LOG="$HOME/install-node.log"
+
+        info() {
+          printf '%s\n' "$1" >> "$TEST_LOG"
+        }
+
+        warn() {
+          printf 'WARN:%s\n' "$1" >> "$TEST_LOG"
+        }
+
+        fail() {
+          printf 'FAIL:%s\n' "$1" >&2
+          exit 1
+        }
+
+        has_cmd() {
+          case "$1" in
+            brew|curl)
+              return 0
+              ;;
+            *)
+              command -v "$1" >/dev/null 2>&1
+              ;;
+          esac
+        }
+
+        brew() {
+          printf '%s\n' "$*" >> "$HOME/brew-commands.log"
+          return 1
+        }
+
+        curl() {
+          cat <<'EOF'
+        mkdir -p "$HOME/.nvm"
+        cat > "$HOME/.nvm/nvm.sh" <<'EOS'
+        nvm() {
+          printf '%s\n' "$*" >> "$HOME/nvm-commands.log"
+          if [[ "$1" == "install" ]]; then
+            mkdir -p "$HOME/.nvm/versions/node/v22.22.2/bin"
+            cat > "$HOME/.nvm/versions/node/v22.22.2/bin/node" <<'EON'
+        #!/usr/bin/env bash
+        printf 'v22.22.2\n'
+        EON
+            cat > "$HOME/.nvm/versions/node/v22.22.2/bin/npm" <<'EON'
+        #!/usr/bin/env bash
+        printf '10.9.7\n'
+        EON
+            chmod +x "$HOME/.nvm/versions/node/v22.22.2/bin/node" "$HOME/.nvm/versions/node/v22.22.2/bin/npm"
+            export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+            return 0
+          fi
+          if [[ "$1" == "use" ]]; then
+            export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+            return 0
+          fi
+          return 0
+        }
+        EOS
+        EOF
+        }
+
+        install_nodejs_macos
+
+        node_version="$(node -v)"
+        npm_version="$(npm -v)"
+        brew_commands="$(<"$HOME/brew-commands.log")"
+        nvm_commands="$(<"$HOME/nvm-commands.log")"
+        install_log="$(<"$TEST_LOG")"
+
+        [[ "$node_version" == "v22.22.2" ]] || {
+          printf 'unexpected node version: %s\n' "$node_version" >&2
+          exit 1
+        }
+        [[ "$npm_version" == "10.9.7" ]] || {
+          printf 'unexpected npm version: %s\n' "$npm_version" >&2
+          exit 1
+        }
+        [[ "$brew_commands" == *"install node"* ]] || {
+          printf 'brew install node was not attempted: %s\n' "$brew_commands" >&2
+          exit 1
+        }
+        [[ "$nvm_commands" == *"install 22"* ]] || {
+          printf 'nvm install was not called: %s\n' "$nvm_commands" >&2
+          exit 1
+        }
+        [[ "$nvm_commands" == *"use 22"* ]] || {
+          printf 'nvm use was not called: %s\n' "$nvm_commands" >&2
+          exit 1
+        }
+        [[ "$install_log" == *"WARN:Homebrew failed to install Node.js. Falling back to nvm..."* ]] || {
+          printf 'brew fallback warning missing: %s\n' "$install_log" >&2
           exit 1
         }
         """
@@ -437,6 +564,200 @@ def test_main_bash_installer_uses_cn_uv_fallback_when_primary_script_fails() -> 
         }
         [[ "$install_log" == *"默认 uv 安装脚本失败，正在尝试中国大陆备用源"* ]] || {
           printf 'fallback log missing: %s\n' "$install_log" >&2
+          exit 1
+        }
+        """
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", test_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
+
+
+def test_main_bash_installer_prefers_nvm_on_linux_before_package_manager() -> None:
+    script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
+    script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)
+    test_script = script_without_main + textwrap.dedent(
+        r"""
+
+        export HOME="$(mktemp -d)"
+        export TEST_LOG="$HOME/install-node.log"
+
+        info() {
+          printf 'INFO:%s\n' "$1" >> "$TEST_LOG"
+        }
+
+        fail() {
+          printf 'FAIL:%s\n' "$1" >&2
+          exit 1
+        }
+
+        has_cmd() {
+          case "$1" in
+            curl|pacman)
+              return 0
+              ;;
+            *)
+              command -v "$1" >/dev/null 2>&1
+              ;;
+          esac
+        }
+
+        curl() {
+          cat <<'EOF'
+        mkdir -p "$HOME/.nvm"
+        cat > "$HOME/.nvm/nvm.sh" <<'EOS'
+        nvm() {
+          printf '%s\n' "$*" >> "$HOME/nvm-commands.log"
+          if [[ "$1" == "install" ]]; then
+            mkdir -p "$HOME/.nvm/versions/node/v22.22.2/bin"
+            cat > "$HOME/.nvm/versions/node/v22.22.2/bin/node" <<'EON'
+        #!/usr/bin/env bash
+        printf 'v22.22.2\n'
+        EON
+            cat > "$HOME/.nvm/versions/node/v22.22.2/bin/npm" <<'EON'
+        #!/usr/bin/env bash
+        printf '10.9.7\n'
+        EON
+            chmod +x "$HOME/.nvm/versions/node/v22.22.2/bin/node" "$HOME/.nvm/versions/node/v22.22.2/bin/npm"
+            export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+            return 0
+          fi
+          if [[ "$1" == "use" ]]; then
+            export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+            return 0
+          fi
+          return 0
+        }
+        EOS
+        EOF
+        }
+
+        run_with_privilege() {
+          printf '%s\n' "$*" >> "$HOME/pkg-commands.log"
+          return 0
+        }
+
+        install_nodejs_linux
+
+        node_version="$(node -v)"
+        npm_version="$(npm -v)"
+        nvm_commands="$(<"$HOME/nvm-commands.log")"
+        install_log="$(<"$TEST_LOG")"
+
+        [[ "$node_version" == "v22.22.2" ]] || {
+          printf 'unexpected node version: %s\n' "$node_version" >&2
+          exit 1
+        }
+        [[ "$npm_version" == "10.9.7" ]] || {
+          printf 'unexpected npm version: %s\n' "$npm_version" >&2
+          exit 1
+        }
+        [[ "$nvm_commands" == *"install 22"* ]] || {
+          printf 'nvm install was not called: %s\n' "$nvm_commands" >&2
+          exit 1
+        }
+        [[ "$nvm_commands" == *"use 22"* ]] || {
+          printf 'nvm use was not called: %s\n' "$nvm_commands" >&2
+          exit 1
+        }
+        [[ "$install_log" == *"INFO:Trying to install Node.js 22 with nvm first on Linux..."* ]] || {
+          printf 'linux nvm-first log missing: %s\n' "$install_log" >&2
+          exit 1
+        }
+        [[ ! -f "$HOME/pkg-commands.log" ]] || {
+          printf 'package manager fallback should not run when nvm succeeds: %s\n' "$(<"$HOME/pkg-commands.log")" >&2
+          exit 1
+        }
+        """
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", test_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
+
+
+def test_main_bash_installer_falls_back_to_package_manager_when_nvm_fails_on_linux() -> None:
+    script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
+    script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)
+    test_script = script_without_main + textwrap.dedent(
+        r"""
+
+        export HOME="$(mktemp -d)"
+        export TEST_LOG="$HOME/install-node.log"
+        export TEST_URL="https://example.invalid/nvm-install.sh"
+        NVM_INSTALL_SCRIPT_URL="$TEST_URL"
+
+        info() {
+          printf 'INFO:%s\n' "$1" >> "$TEST_LOG"
+        }
+
+        warn() {
+          printf 'WARN:%s\n' "$1" >> "$TEST_LOG"
+        }
+
+        fail() {
+          printf 'FAIL:%s\n' "$1" >&2
+          exit 1
+        }
+
+        nodejs_manual_download_hint() {
+          printf ''
+        }
+
+        has_cmd() {
+          case "$1" in
+            curl|pacman)
+              return 0
+              ;;
+            *)
+              return 1
+              ;;
+          esac
+        }
+
+        curl() {
+          printf '%s\n' "$*" >> "$HOME/curl-commands.log"
+          return 22
+        }
+
+        run_with_privilege() {
+          printf '%s\n' "$*" >> "$HOME/pkg-commands.log"
+          return 0
+        }
+
+        install_nodejs_linux
+
+        curl_commands="$(<"$HOME/curl-commands.log")"
+        pkg_commands="$(<"$HOME/pkg-commands.log")"
+        install_log="$(<"$TEST_LOG")"
+
+        [[ "$curl_commands" == *"$TEST_URL"* ]] || {
+          printf 'nvm install url was not attempted: %s\n' "$curl_commands" >&2
+          exit 1
+        }
+        [[ "$pkg_commands" == *"pacman -Sy --noconfirm nodejs npm"* ]] || {
+          printf 'package manager fallback was not used: %s\n' "$pkg_commands" >&2
+          exit 1
+        }
+        [[ "$install_log" == *"WARN:Failed to install nvm from: $TEST_URL"* ]] || {
+          printf 'nvm failure warning missing: %s\n' "$install_log" >&2
+          exit 1
+        }
+        [[ "$install_log" == *"WARN:nvm installation failed on Linux. Falling back to the system package manager..."* ]] || {
+          printf 'linux fallback warning missing: %s\n' "$install_log" >&2
           exit 1
         }
         """

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -137,10 +137,17 @@ def test_main_bash_installer_uses_configured_default_sources_without_probing() -
     assert "nodejs_manual_download_hint" in script
     assert "FLOCKS_NVM_INSTALL_SCRIPT_URL" in script
     assert "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh" in script
+    assert "FLOCKS_NVM_GITEE_REPO_URL" in script
+    assert "https://gitee.com/mirrors/nvm.git" in script
+    assert "FLOCKS_NVM_GITEE_RAW_URL_PREFIX" in script
+    assert "https://gitee.com/mirrors/nvm/raw" in script
     assert "load_nvm()" in script
+    assert "should_patch_nvm_install_script_for_gitee()" in script
+    assert "patch_nvm_install_script_for_gitee()" in script
+    assert "run_nvm_install_script()" in script
     assert "install_nodejs_with_nvm()" in script
     assert "install_nodejs_linux_with_package_manager()" in script
-    assert 'curl -o- "$NVM_INSTALL_SCRIPT_URL" | bash' in script
+    assert 'curl -fsSL "$NVM_INSTALL_SCRIPT_URL" -o "$install_script"' in script
     assert 'curl -LsSf "$UV_INSTALL_SH_URL" | sh' in script
     assert 'curl -LsSf "$UV_INSTALL_SH_FALLBACK_URL" | sh' in script
     assert 'nvm install "$MIN_NODE_MAJOR"' in script
@@ -148,6 +155,8 @@ def test_main_bash_installer_uses_configured_default_sources_without_probing() -
     assert "Homebrew failed to install Node.js. Falling back to nvm..." in script
     assert 'info "Trying to install Node.js ${MIN_NODE_MAJOR} with nvm first on Linux..."' in script
     assert 'warn "nvm installation failed on Linux. Falling back to the system package manager..."' in script
+    assert "https://github.com/" in script
+    assert "https://raw.githubusercontent.com/" in script
 
 
 def test_main_powershell_installer_uses_configured_default_sources_and_admin_precheck() -> None:
@@ -224,7 +233,20 @@ def test_main_bash_installer_falls_back_to_nvm_when_brew_is_missing_on_macos() -
         }
 
         curl() {
-          cat <<'EOF'
+          local output_file=""
+          while [[ $# -gt 0 ]]; do
+            case "$1" in
+              -o)
+                output_file="$2"
+                shift 2
+                ;;
+              *)
+                shift
+                ;;
+            esac
+          done
+
+          cat > "$output_file" <<'EOF'
         mkdir -p "$HOME/.nvm"
         cat > "$HOME/.nvm/nvm.sh" <<'EOS'
         nvm() {
@@ -334,7 +356,20 @@ def test_main_bash_installer_falls_back_to_nvm_when_brew_install_fails_on_macos(
         }
 
         curl() {
-          cat <<'EOF'
+          local output_file=""
+          while [[ $# -gt 0 ]]; do
+            case "$1" in
+              -o)
+                output_file="$2"
+                shift 2
+                ;;
+              *)
+                shift
+                ;;
+            esac
+          done
+
+          cat > "$output_file" <<'EOF'
         mkdir -p "$HOME/.nvm"
         cat > "$HOME/.nvm/nvm.sh" <<'EOS'
         nvm() {
@@ -580,6 +615,81 @@ def test_main_bash_installer_uses_cn_uv_fallback_when_primary_script_fails() -> 
     assert result.returncode == 0, output
 
 
+def test_main_bash_installer_patches_gitee_nvm_script_before_execution() -> None:
+    script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
+    script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)
+    test_script = script_without_main + textwrap.dedent(
+        r"""
+
+        export HOME="$(mktemp -d)"
+        export NVM_INSTALL_SCRIPT_URL="https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh"
+        export NVM_GITEE_REPO_URL="https://gitee.com/mirrors/nvm.git"
+        export NVM_GITEE_RAW_URL_PREFIX="https://gitee.com/mirrors/nvm/raw"
+
+        curl() {
+          local output_file=""
+          while [[ $# -gt 0 ]]; do
+            case "$1" in
+              -o)
+                output_file="$2"
+                shift 2
+                ;;
+              *)
+                shift
+                ;;
+            esac
+          done
+
+          cat > "$output_file" <<'EOF'
+        #!/usr/bin/env bash
+        printf '%s\n' 'https://github.com/${NVM_GITHUB_REPO}.git' > "$HOME/patched-nvm-urls.txt"
+        printf '%s\n' 'https://raw.githubusercontent.com/${NVM_GITHUB_REPO}/${NVM_VERSION}/nvm.sh' >> "$HOME/patched-nvm-urls.txt"
+        printf '%s\n' 'https://raw.githubusercontent.com/${NVM_GITHUB_REPO}/${NVM_VERSION}/nvm-exec' >> "$HOME/patched-nvm-urls.txt"
+        printf '%s\n' 'https://raw.githubusercontent.com/${NVM_GITHUB_REPO}/${NVM_VERSION}/bash_completion' >> "$HOME/patched-nvm-urls.txt"
+        EOF
+        }
+
+        run_nvm_install_script
+
+        patched_urls="$(<"$HOME/patched-nvm-urls.txt")"
+        [[ "$patched_urls" == *"https://gitee.com/mirrors/nvm.git"* ]] || {
+          printf 'git url was not patched: %s\n' "$patched_urls" >&2
+          exit 1
+        }
+        [[ "$patched_urls" == *"https://gitee.com/mirrors/nvm/raw/\${NVM_VERSION}/nvm.sh"* ]] || {
+          printf 'nvm.sh url was not patched: %s\n' "$patched_urls" >&2
+          exit 1
+        }
+        [[ "$patched_urls" == *"https://gitee.com/mirrors/nvm/raw/\${NVM_VERSION}/nvm-exec"* ]] || {
+          printf 'nvm-exec url was not patched: %s\n' "$patched_urls" >&2
+          exit 1
+        }
+        [[ "$patched_urls" == *"https://gitee.com/mirrors/nvm/raw/\${NVM_VERSION}/bash_completion"* ]] || {
+          printf 'bash_completion url was not patched: %s\n' "$patched_urls" >&2
+          exit 1
+        }
+        [[ "$patched_urls" != *"github.com"* ]] || {
+          printf 'github url remained after patch: %s\n' "$patched_urls" >&2
+          exit 1
+        }
+        [[ "$patched_urls" != *"raw.githubusercontent.com"* ]] || {
+          printf 'raw github url remained after patch: %s\n' "$patched_urls" >&2
+          exit 1
+        }
+        """
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", test_script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, output
+
+
 def test_main_bash_installer_prefers_nvm_on_linux_before_package_manager() -> None:
     script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
     script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)
@@ -610,7 +720,20 @@ def test_main_bash_installer_prefers_nvm_on_linux_before_package_manager() -> No
         }
 
         curl() {
-          cat <<'EOF'
+          local output_file=""
+          while [[ $# -gt 0 ]]; do
+            case "$1" in
+              -o)
+                output_file="$2"
+                shift 2
+                ;;
+              *)
+                shift
+                ;;
+            esac
+          done
+
+          cat > "$output_file" <<'EOF'
         mkdir -p "$HOME/.nvm"
         cat > "$HOME/.nvm/nvm.sh" <<'EOS'
         nvm() {


### PR DESCRIPTION
## Summary
- improve the bash installer's Node.js fallback flow and Chinese-source handling, including Gitee-backed nvm patching and fallback selection
- ensure the zh bootstrap installers pass the configured npm and uv mirrors through to the underlying installers, including DingTalk dependency installation
- expand installer source coverage with regression tests for bootstrap behavior, source selection, and Linux/macOS fallback paths