### PR TITLE
feat(tool): persist user enable/disable in flocks.json tool_settings

### DIFF
--- a/flocks/config/config_writer.py
+++ b/flocks/config/config_writer.py
@@ -526,6 +526,88 @@ class ConfigWriter:
         return True
 
     # ------------------------------------------------------------------
+    # Tool settings  (tool_settings section)
+    # ------------------------------------------------------------------
+    #
+    # User-level overlay for per-tool settings (currently: ``enabled``).
+    # The section mirrors ``model_settings`` for naming consistency —
+    # both are flat maps keyed by the entity's unique id.
+    #
+    # Why this exists:  YAML plugin tool files under
+    # ``<project>/.flocks/plugins/tools/`` are tracked by git and may be
+    # overwritten on upgrade.  Writing a user toggle (e.g. enable/disable)
+    # back into the YAML pollutes git diffs and breaks upgrades.  We keep
+    # the YAML as "factory defaults" and store the user's choice in
+    # ``flocks.json`` instead.
+    #
+    # The same overlay applies uniformly to user-level YAML files under
+    # ``~/.flocks/plugins/tools/`` so that UI behaviour is consistent
+    # regardless of where the YAML lives.
+
+    @classmethod
+    def list_tool_settings(cls) -> Dict[str, Dict[str, Any]]:
+        """Return all raw tool_settings entries from flocks.json."""
+        data = cls._read_raw()
+        settings = data.get("tool_settings", {})
+        return settings if isinstance(settings, dict) else {}
+
+    @classmethod
+    def get_tool_setting(cls, tool_name: str) -> Optional[Dict[str, Any]]:
+        """Read a single tool_settings entry, or None if not set."""
+        settings = cls.list_tool_settings()
+        entry = settings.get(tool_name)
+        return entry if isinstance(entry, dict) else None
+
+    @classmethod
+    def set_tool_setting(cls, tool_name: str, setting: Dict[str, Any]) -> None:
+        """Merge ``setting`` into the tool_settings[tool_name] entry.
+
+        Existing keys not present in ``setting`` are preserved so callers
+        can update a single field (e.g. ``{"enabled": False}``) without
+        wiping other overlay fields that may be added later.
+        """
+        if not tool_name:
+            raise ValueError("tool_name must be a non-empty string")
+        data = cls._read_raw()
+        settings = data.get("tool_settings")
+        if not isinstance(settings, dict):
+            settings = {}
+        existing = settings.get(tool_name)
+        if not isinstance(existing, dict):
+            existing = {}
+        merged = {**existing, **(setting or {})}
+        settings[tool_name] = merged
+        data["tool_settings"] = settings
+        cls._write_raw(data)
+        log.info("config_writer.tool_setting_set", {
+            "tool": tool_name,
+            "fields": sorted(merged.keys()),
+        })
+
+    @classmethod
+    def delete_tool_setting(cls, tool_name: str) -> bool:
+        """Remove the tool_settings[tool_name] entry.
+
+        Pops the whole ``tool_settings`` key when the last entry is
+        removed so flocks.json doesn't accumulate empty container objects
+        as users toggle their last customised tool back to default.
+
+        Returns True if an entry existed and was removed.
+        """
+        data = cls._read_raw()
+        settings = data.get("tool_settings")
+        if not isinstance(settings, dict) or tool_name not in settings:
+            return False
+        del settings[tool_name]
+        if settings:
+            data["tool_settings"] = settings
+        else:
+            data.pop("tool_settings", None)
+        cls._write_raw(data)
+        log.info("config_writer.tool_setting_removed", {"tool": tool_name})
+        return True
+
+    # ------------------------------------------------------------------
     # Default model cleanup helpers
     # ------------------------------------------------------------------
 

--- a/flocks/server/routes/tool.py
+++ b/flocks/server/routes/tool.py
@@ -32,7 +32,9 @@ class ToolInfoResponse(BaseModel):
     source: str = Field("builtin", description="Tool source: builtin, mcp, api, custom")
     source_name: Optional[str] = Field(None, description="Source detail, e.g. MCP server name or API module name")
     parameters: List[Dict[str, Any]] = Field(default_factory=list, description="Tool parameters")
-    enabled: bool = Field(True, description="Is tool enabled")
+    enabled: bool = Field(True, description="Effective enabled state (overlay applied, ANDed with API service flag)")
+    enabled_default: bool = Field(True, description="Factory default from the YAML/registration source (no overlay)")
+    enabled_customized: bool = Field(False, description="True if a user setting is recorded in flocks.json tool_settings")
     requires_confirmation: bool = Field(False, description="Requires confirmation")
 
 
@@ -126,8 +128,11 @@ def _get_tool_source(tool_info: ToolInfo) -> tuple:
 
 
 def _build_tool_response(t: ToolInfo) -> ToolInfoResponse:
-    """Build ToolInfoResponse with source info."""
+    """Build ToolInfoResponse with source info and overlay metadata."""
     source, source_name = _get_tool_source(t)
+    setting = ConfigWriter.get_tool_setting(t.name) or {}
+    customized = "enabled" in setting
+    enabled_default = _get_default_enabled(t)
     return ToolInfoResponse(
         name=t.name,
         description=t.description,
@@ -137,8 +142,45 @@ def _build_tool_response(t: ToolInfo) -> ToolInfoResponse:
         source_name=source_name,
         parameters=[p.model_dump() for p in t.parameters],
         enabled=_get_effective_tool_enabled(t),
+        enabled_default=enabled_default,
+        enabled_customized=customized,
         requires_confirmation=t.requires_confirmation,
     )
+
+
+def _get_default_enabled(t: ToolInfo) -> bool:
+    """Return the registration-time default for ``enabled``.
+
+    Prefers :meth:`ToolRegistry.get_default_enabled` (a snapshot taken
+    before sync/overlay mutate ``info.enabled`` in place).  Falls back to
+    the YAML file when the snapshot is missing (e.g. a tool registered
+    after init), then to the live value as the very last resort.
+    """
+    snapshot = ToolRegistry.get_default_enabled(t.name)
+    if snapshot is not None:
+        return snapshot
+    try:
+        from flocks.tool.tool_loader import read_yaml_tool
+        raw = read_yaml_tool(t.name)
+    except Exception:
+        raw = None
+    if isinstance(raw, dict) and "enabled" in raw:
+        return bool(raw["enabled"])
+    return t.enabled
+
+
+def _service_allows_enable(t: ToolInfo) -> bool:
+    """Return True when the API service backing ``t`` (if any) is enabled.
+
+    Mirrors the gate in :meth:`ToolRegistry._apply_tool_settings` so that
+    HTTP mutations stay consistent with what the registry would compute
+    on its next reload: an overlay can never *open* a tool whose service
+    is currently disabled.
+    """
+    if not t.provider:
+        return True
+    svc = ConfigWriter.get_api_service_raw(t.provider) or {}
+    return bool(svc.get("enabled", False))
 
 
 def _get_effective_tool_enabled(tool_info: ToolInfo) -> bool:
@@ -230,17 +272,26 @@ async def get_tool(tool_name: str):
 )
 async def update_tool(tool_name: str, request: ToolUpdateRequest):
     """
-    Update tool settings (e.g., enable or disable)
+    Update tool settings (e.g., enable or disable).
 
-    Args:
-        tool_name: Tool name
-        request: Update payload
+    The ``enabled`` flag is persisted to the user-level overlay in
+    ``flocks.json`` (``tool_settings.<tool_name>.enabled``) instead of
+    mutating the YAML plugin file.  This keeps project-level YAML files
+    (which may be tracked by git and overwritten on upgrade) clean and
+    treats the YAML's ``enabled:`` field as the factory default that the
+    overlay can selectively customise.
 
-    Returns:
-        Updated tool information
+    Two behaviours of note:
+
+    * If ``request.enabled`` matches the registration-time default we
+      *delete* the overlay entry instead of writing one — the tool is
+      back to "no customisation", and the UI's "已自定义" badge clears.
+    * Asking to enable a tool whose API service is currently disabled
+      still persists the overlay (so the intent survives the service
+      being re-enabled later) but does not flip the in-memory
+      ``info.enabled`` flag, mirroring the gate in
+      :meth:`ToolRegistry._apply_tool_settings`.
     """
-    from flocks.tool.tool_loader import find_yaml_tool, update_yaml_tool
-
     ToolRegistry.init()
 
     tool = ToolRegistry.get(tool_name)
@@ -250,11 +301,70 @@ async def update_tool(tool_name: str, request: ToolUpdateRequest):
             detail=f"Tool not found: {tool_name}",
         )
 
-    if find_yaml_tool(tool_name):
-        update_yaml_tool(tool_name, {"enabled": request.enabled})
+    desired = bool(request.enabled)
+    default = _get_default_enabled(tool.info)
+    # Service gate: only matters when the user is trying to enable.
+    # Disabling is always honoured.
+    service_ok = _service_allows_enable(tool.info)
+    new_enabled = desired and service_ok
 
-    tool.info.enabled = request.enabled
-    log.info("tool.updated", {"name": tool_name, "enabled": request.enabled})
+    if desired == default:
+        removed = ConfigWriter.delete_tool_setting(tool_name)
+        log.info("tool.updated.reset_to_default", {
+            "name": tool_name,
+            "enabled": new_enabled,
+            "default": default,
+            "removed_overlay": removed,
+        })
+    else:
+        ConfigWriter.set_tool_setting(tool_name, {"enabled": desired})
+        log.info("tool.updated", {
+            "name": tool_name,
+            "enabled": new_enabled,
+            "requested": desired,
+            "blocked_by_service": desired and not service_ok,
+            "native": tool.info.native,
+            "store": "overlay",
+        })
+
+    tool.info.enabled = new_enabled
+    return _build_tool_response(tool.info)
+
+
+@router.post(
+    "/{tool_name}/reset",
+    response_model=ToolInfoResponse,
+    summary="Reset a tool to its YAML/registration default",
+)
+async def reset_tool_setting(tool_name: str):
+    """Remove the user setting for ``tool_name`` and restore the default.
+
+    Restores the registration-time ``enabled`` value from the registry's
+    snapshot (or the YAML file as a fallback) and re-applies the same
+    service gate as :meth:`ToolRegistry._apply_tool_settings`, so the
+    HTTP layer never leaves the in-memory state in a position the
+    registry would refuse on its next reload.
+    """
+    ToolRegistry.init()
+
+    tool = ToolRegistry.get(tool_name)
+    if not tool:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Tool not found: {tool_name}",
+        )
+
+    removed = ConfigWriter.delete_tool_setting(tool_name)
+    default = _get_default_enabled(tool.info)
+    new_enabled = default and _service_allows_enable(tool.info)
+    tool.info.enabled = new_enabled
+
+    log.info("tool.setting.reset", {
+        "name": tool_name,
+        "removed": removed,
+        "default": default,
+        "restored_enabled": new_enabled,
+    })
     return _build_tool_response(tool.info)
 
 

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -407,6 +407,15 @@ class ToolRegistry:
     _failure_state: Dict[str, Dict[str, Any]] = {}
     _failure_disable_threshold: int = 3
 
+    # Snapshot of every tool's registration-time ``enabled`` flag — taken
+    # after :meth:`_load_plugin_tools` finishes loading but BEFORE
+    # ``_sync_api_service_states`` / ``_apply_tool_settings`` mutate
+    # ``tool.info.enabled`` in place.  This is the source of truth for the
+    # "factory default" surfaced in the HTTP API and used by
+    # :func:`reset_tool_setting` to recover the original value for tools
+    # that don't have a YAML file (built-in / plugin_py).
+    _enabled_defaults: Dict[str, bool] = {}
+
     @classmethod
     def register(cls, tool: Tool) -> None:
         """Register a tool"""
@@ -689,7 +698,11 @@ class ToolRegistry:
                 tool.info.source = "plugin_py"
         cls._plugin_tool_names = new_plugin_tools
         cls._bootstrap_user_api_services()
+        # Snapshot defaults BEFORE any in-place mutation so the "factory
+        # default" is preserved even after sync/overlay run.
+        cls._snapshot_enabled_defaults()
         cls._sync_api_service_states()
+        cls._apply_tool_settings()
 
     @classmethod
     def _bootstrap_user_api_services(cls) -> None:
@@ -771,6 +784,94 @@ class ToolRegistry:
             log.info("tool_registry.api_service_sync", {
                 "disabled_tools": disabled_count,
                 "disabled_providers": disabled_providers,
+            })
+
+    @classmethod
+    def _snapshot_enabled_defaults(cls) -> None:
+        """Capture the registration-time ``enabled`` flag of every tool.
+
+        Called once per :meth:`_load_plugin_tools` cycle, before
+        :meth:`_sync_api_service_states` and :meth:`_apply_tool_settings`
+        run so the snapshot reflects the YAML/registration defaults
+        rather than the post-sync state.
+
+        Uses ``setdefault`` so that a ``refresh_plugin_tools`` cycle does
+        NOT overwrite snapshot entries for tools that were not reloaded
+        (e.g. built-in tools).  Without this, the stale in-memory
+        ``info.enabled`` (which may already reflect an overlay) would be
+        captured as the new "default", making ``reset_tool_setting``
+        return the wrong value.
+        """
+        for name, t in cls._tools.items():
+            cls._enabled_defaults.setdefault(name, bool(t.info.enabled))
+
+    @classmethod
+    def get_default_enabled(cls, name: str) -> Optional[bool]:
+        """Return the YAML/registration default ``enabled`` for ``name``.
+
+        Returns ``None`` if the tool was never seen during plugin loading
+        (e.g. dynamic tools registered after init).  Callers should fall
+        back to the live ``ToolInfo.enabled`` in that case.
+        """
+        return cls._enabled_defaults.get(name)
+
+    @classmethod
+    def _apply_tool_settings(cls) -> None:
+        """Apply user-level ``tool_settings`` from flocks.json on top of YAML defaults.
+
+        The YAML file is treated as the factory default; the overlay in
+        ``flocks.json`` (``tool_settings[<tool_name>]``) is the user's
+        current choice and is applied last.
+
+        Service gate: an overlay can NEVER enable a tool whose API service
+        is currently ``enabled: false`` in ``api_services``.  Without this
+        gate ``ToolRegistry.execute`` (which only checks
+        ``tool.info.enabled``) would happily run a tool whose service has
+        no credentials configured, producing repeated auth failures and
+        eventually triggering the auto-disable threshold in
+        :meth:`_record_failure`.
+
+        An overlay can always *disable* a tool, regardless of service
+        state.
+        """
+        try:
+            from flocks.config.config_writer import ConfigWriter
+            settings = ConfigWriter.list_tool_settings()
+            api_services = ConfigWriter.list_api_services_raw()
+        except Exception:
+            return
+
+        applied = 0
+        unknown: List[str] = []
+        blocked: List[str] = []
+        for name, entry in settings.items():
+            if not isinstance(entry, dict):
+                continue
+            tool = cls._tools.get(name)
+            if tool is None:
+                unknown.append(name)
+                continue
+            if "enabled" not in entry:
+                continue
+
+            desired = bool(entry["enabled"])
+            if desired and tool.info.provider:
+                svc = api_services.get(tool.info.provider, {})
+                if not svc.get("enabled", False):
+                    # Service disabled — refuse to "open" the tool via overlay.
+                    # The overlay entry stays in flocks.json so that re-enabling
+                    # the service later restores the user's intent automatically.
+                    blocked.append(name)
+                    continue
+
+            tool.info.enabled = desired
+            applied += 1
+
+        if applied or unknown or blocked:
+            log.info("tool_registry.tool_settings_applied", {
+                "applied": applied,
+                "stale": unknown,
+                "blocked_by_service": blocked,
             })
 
     @classmethod

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -816,25 +816,33 @@ class ToolRegistry:
         """Idempotent safety-net for the ``_enabled_defaults`` snapshot.
 
         The *primary* write path is :meth:`register` (see comment on
-        ``_enabled_defaults``).  This method exists only as a defensive
-        backstop for:
+        ``_enabled_defaults``); refresh paths keep the snapshot fresh via
+        :meth:`_unregister_plugin_tools` / :meth:`_unregister_dynamic_tools`
+        popping the entry and the subsequent ``register`` call overwriting
+        it.  This method exists only as a defensive backstop for:
 
         - Tests that bypass :meth:`register` by poking at ``_tools``
           directly (``tests/tool/test_apply_tool_settings.py`` uses this
           to stage stub tools without invoking catalog-defaults logic).
         - Any future registration path that inserts into ``_tools``
-          outside :meth:`register` — we'd rather notice a stale snapshot
-          here than hand out a bogus ``enabled_default`` via the API.
+          outside :meth:`register` — we'd rather have a best-effort
+          factory value in the snapshot than hand out ``None`` via the
+          HTTP API.
 
-        It runs at the end of :meth:`_load_plugin_tools` where no
-        mutation of ``tool.info.enabled`` has occurred yet
-        (``_sync_api_service_states`` and ``_apply_tool_settings`` run
-        *after* this), so the read is still a factory value.  Direct
-        assignment is used so that a YAML upgrade that changed
-        ``enabled:`` is picked up even on the snapshot-only path.
+        ``setdefault`` is deliberate: this method is called at the end of
+        :meth:`_load_plugin_tools`, which in turn runs on every
+        :meth:`refresh_plugin_tools` cycle.  On the *second* and later
+        cycles any built-in / previously-registered tool's
+        ``info.enabled`` has already been mutated by the prior run's
+        :meth:`_sync_api_service_states` / :meth:`_apply_tool_settings`,
+        so a direct assignment here would overwrite the true factory
+        default with the post-sync state.  Since :meth:`register` is the
+        authoritative writer for anything that actually goes through it,
+        a ``setdefault`` here only fills in genuinely missing entries and
+        leaves correct snapshots untouched.
         """
         for name, t in cls._tools.items():
-            cls._enabled_defaults[name] = bool(t.info.enabled)
+            cls._enabled_defaults.setdefault(name, bool(t.info.enabled))
 
     @classmethod
     def get_default_enabled(cls, name: str) -> Optional[bool]:
@@ -1254,6 +1262,14 @@ class ToolRegistry:
             return
         for tool_name in old_tools:
             cls._tools.pop(tool_name, None)
+            # Mirror ``_unregister_plugin_tools``: the factory-default
+            # snapshot lives in lock-step with ``_tools``.  Reload of the
+            # same module re-registers via ``register()`` which overwrites
+            # the entry, but when a dynamic module is deleted entirely
+            # (the ``module_name not in modules`` branch of
+            # ``_register_dynamic_tools``) nothing re-adds it, so without
+            # this pop a stale factory default would linger forever.
+            cls._enabled_defaults.pop(tool_name, None)
         log.info("tool.dynamic.unregistered", {
             "module": module_name,
             "tools": old_tools,

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -407,13 +407,22 @@ class ToolRegistry:
     _failure_state: Dict[str, Dict[str, Any]] = {}
     _failure_disable_threshold: int = 3
 
-    # Snapshot of every tool's registration-time ``enabled`` flag — taken
-    # after :meth:`_load_plugin_tools` finishes loading but BEFORE
-    # ``_sync_api_service_states`` / ``_apply_tool_settings`` mutate
-    # ``tool.info.enabled`` in place.  This is the source of truth for the
+    # Snapshot of every tool's factory-default ``enabled`` flag — captured
+    # in :meth:`register` at the moment the tool object is handed to the
+    # registry (i.e. right after construction from YAML / decorator /
+    # ``TOOLS`` attribute + :func:`apply_tool_catalog_defaults`, but
+    # BEFORE any of the overlay / service-sync machinery gets to mutate
+    # ``tool.info.enabled``).  This is the source of truth for the
     # "factory default" surfaced in the HTTP API and used by
     # :func:`reset_tool_setting` to recover the original value for tools
     # that don't have a YAML file (built-in / plugin_py).
+    #
+    # Lifecycle is kept in lock-step with ``_tools``:
+    #   • :meth:`register`                 → write (always overwrites,
+    #     so a YAML upgrade that flips the default is picked up on the
+    #     next reload/`POST /reload`).
+    #   • :meth:`_unregister_plugin_tools` → pop  (avoids stale defaults
+    #     leaking across ``refresh_plugin_tools`` cycles).
     _enabled_defaults: Dict[str, bool] = {}
 
     @classmethod
@@ -428,6 +437,19 @@ class ToolRegistry:
                 "name": tool.info.name,
                 "error": str(e),
             })
+        # Capture the factory default BEFORE anything else can touch
+        # ``info.enabled``.  ``apply_tool_catalog_defaults`` above only
+        # fills metadata like ``always_load`` and never flips
+        # ``enabled``, so whatever we read here is the value written in
+        # the YAML / decorator at source-tree time.
+        #
+        # Direct assignment (not setdefault) is deliberate: every
+        # ``register`` — including re-registering the same name after a
+        # YAML edit via ``POST /api/tools/{name}/reload`` or a
+        # ``refresh_plugin_tools`` cycle — must refresh the snapshot so
+        # ``enabled_default`` / ``reset`` reflect the current source of
+        # truth instead of the first value ever observed.
+        cls._enabled_defaults[tool.info.name] = bool(tool.info.enabled)
         cls._tools[tool.info.name] = tool
         log.debug("tool.registered", {
             "name": tool.info.name,
@@ -698,8 +720,11 @@ class ToolRegistry:
                 tool.info.source = "plugin_py"
         cls._plugin_tool_names = new_plugin_tools
         cls._bootstrap_user_api_services()
-        # Snapshot defaults BEFORE any in-place mutation so the "factory
-        # default" is preserved even after sync/overlay run.
+        # Defence-in-depth: ``register()`` is the canonical writer for
+        # ``_enabled_defaults`` but this catches any tool that landed in
+        # ``_tools`` via an unorthodox path.  Must run BEFORE
+        # ``_sync_api_service_states`` / ``_apply_tool_settings`` so the
+        # snapshot still reflects factory values, not overlay results.
         cls._snapshot_enabled_defaults()
         cls._sync_api_service_states()
         cls._apply_tool_settings()
@@ -788,22 +813,28 @@ class ToolRegistry:
 
     @classmethod
     def _snapshot_enabled_defaults(cls) -> None:
-        """Capture the registration-time ``enabled`` flag of every tool.
+        """Idempotent safety-net for the ``_enabled_defaults`` snapshot.
 
-        Called once per :meth:`_load_plugin_tools` cycle, before
-        :meth:`_sync_api_service_states` and :meth:`_apply_tool_settings`
-        run so the snapshot reflects the YAML/registration defaults
-        rather than the post-sync state.
+        The *primary* write path is :meth:`register` (see comment on
+        ``_enabled_defaults``).  This method exists only as a defensive
+        backstop for:
 
-        Uses ``setdefault`` so that a ``refresh_plugin_tools`` cycle does
-        NOT overwrite snapshot entries for tools that were not reloaded
-        (e.g. built-in tools).  Without this, the stale in-memory
-        ``info.enabled`` (which may already reflect an overlay) would be
-        captured as the new "default", making ``reset_tool_setting``
-        return the wrong value.
+        - Tests that bypass :meth:`register` by poking at ``_tools``
+          directly (``tests/tool/test_apply_tool_settings.py`` uses this
+          to stage stub tools without invoking catalog-defaults logic).
+        - Any future registration path that inserts into ``_tools``
+          outside :meth:`register` — we'd rather notice a stale snapshot
+          here than hand out a bogus ``enabled_default`` via the API.
+
+        It runs at the end of :meth:`_load_plugin_tools` where no
+        mutation of ``tool.info.enabled`` has occurred yet
+        (``_sync_api_service_states`` and ``_apply_tool_settings`` run
+        *after* this), so the read is still a factory value.  Direct
+        assignment is used so that a YAML upgrade that changed
+        ``enabled:`` is picked up even on the snapshot-only path.
         """
         for name, t in cls._tools.items():
-            cls._enabled_defaults.setdefault(name, bool(t.info.enabled))
+            cls._enabled_defaults[name] = bool(t.info.enabled)
 
     @classmethod
     def get_default_enabled(cls, name: str) -> Optional[bool]:
@@ -1064,11 +1095,19 @@ class ToolRegistry:
         so that tools registered via any mechanism (YAML, ``TOOLS``
         attribute, or ``@register_function`` decorator) are correctly
         cleaned up.
+
+        Also drops the matching entries from ``_enabled_defaults`` so a
+        subsequent ``_load_plugin_tools`` call picks up the current YAML
+        factory default rather than the one observed on a previous
+        cycle.  Without this, editing a YAML file to flip ``enabled:``
+        and hitting ``refresh_plugin_tools`` would leave the snapshot —
+        and therefore ``reset_tool_setting`` — stuck on the old value.
         """
         removed: List[str] = []
         for name in cls._plugin_tool_names:
             if cls._tools.pop(name, None) is not None:
                 removed.append(name)
+            cls._enabled_defaults.pop(name, None)
         if removed:
             log.info("tool.plugin.unregistered", {"tools": removed})
         cls._plugin_tool_names = []

--- a/tests/config/test_config_writer.py
+++ b/tests/config/test_config_writer.py
@@ -319,6 +319,81 @@ class TestConfigWriterModelSettings:
         assert "mcp" in data
 
 
+class TestConfigWriterToolSettings:
+    """Test tool_settings section CRUD (user-level overlay for plugin tools)."""
+
+    def test_list_empty(self, temp_project):
+        from flocks.config.config_writer import ConfigWriter
+        assert ConfigWriter.list_tool_settings() == {}
+
+    def test_get_missing_returns_none(self, temp_project):
+        from flocks.config.config_writer import ConfigWriter
+        assert ConfigWriter.get_tool_setting("onesec_threat") is None
+
+    def test_set_and_get(self, temp_project):
+        from flocks.config.config_writer import ConfigWriter
+        ConfigWriter.set_tool_setting("onesec_threat", {"enabled": False})
+        entry = ConfigWriter.get_tool_setting("onesec_threat")
+        assert entry == {"enabled": False}
+        assert ConfigWriter.list_tool_settings() == {"onesec_threat": {"enabled": False}}
+
+    def test_set_merges_existing_keys(self, temp_project):
+        from flocks.config.config_writer import ConfigWriter
+        ConfigWriter.set_tool_setting("onesec_threat", {"enabled": False, "note": "x"})
+        ConfigWriter.set_tool_setting("onesec_threat", {"enabled": True})
+        entry = ConfigWriter.get_tool_setting("onesec_threat")
+        assert entry == {"enabled": True, "note": "x"}
+
+    def test_delete_existing(self, temp_project):
+        from flocks.config.config_writer import ConfigWriter
+        ConfigWriter.set_tool_setting("onesec_threat", {"enabled": False})
+        assert ConfigWriter.delete_tool_setting("onesec_threat") is True
+        assert ConfigWriter.get_tool_setting("onesec_threat") is None
+        assert ConfigWriter.list_tool_settings() == {}
+
+    def test_delete_last_entry_pops_section(self, temp_project):
+        """Removing the last entry should drop ``tool_settings`` entirely."""
+        from flocks.config.config_writer import ConfigWriter
+        ConfigWriter.set_tool_setting("a", {"enabled": False})
+        ConfigWriter.set_tool_setting("b", {"enabled": True})
+
+        ConfigWriter.delete_tool_setting("a")
+        assert "tool_settings" in ConfigWriter._read_raw()
+
+        ConfigWriter.delete_tool_setting("b")
+        assert "tool_settings" not in ConfigWriter._read_raw()
+
+    def test_delete_missing_returns_false(self, temp_project):
+        from flocks.config.config_writer import ConfigWriter
+        assert ConfigWriter.delete_tool_setting("not_set") is False
+
+    def test_set_empty_name_raises(self, temp_project):
+        from flocks.config.config_writer import ConfigWriter
+        with pytest.raises(ValueError):
+            ConfigWriter.set_tool_setting("", {"enabled": True})
+
+    def test_preserves_other_sections(self, temp_project):
+        from flocks.config.config_writer import ConfigWriter
+        ConfigWriter.set_tool_setting("onesec_threat", {"enabled": False})
+        data = ConfigWriter._read_raw()
+        assert "provider" in data
+        assert "anthropic" in data["provider"]
+        assert data["tool_settings"]["onesec_threat"]["enabled"] is False
+
+    def test_corrupt_settings_section_treated_as_empty(self, temp_project):
+        """If tool_settings is somehow not a dict, the API should not crash."""
+        import json as _json
+        from flocks.config.config import Config
+        cfg_path = Config.get_config_file()
+        data = _json.loads(cfg_path.read_text())
+        data["tool_settings"] = "garbage"
+        cfg_path.write_text(_json.dumps(data))
+
+        from flocks.config.config_writer import ConfigWriter
+        assert ConfigWriter.list_tool_settings() == {}
+        assert ConfigWriter.get_tool_setting("anything") is None
+
+
 class TestConfigWriterDefaultModels:
     """Test default_models section CRUD."""
 

--- a/tests/server/test_tool_setting_routes.py
+++ b/tests/server/test_tool_setting_routes.py
@@ -1,0 +1,221 @@
+"""End-to-end tests for the tool overlay HTTP routes.
+
+Covers:
+- ``PATCH /api/tools/{name}`` writes/clears the user overlay correctly,
+  including the "request matches default → drop overlay" shortcut.
+- ``POST /api/tools/{name}/reset`` clears the overlay and restores the
+  registration default.
+- The service-gate semantics: overlay enabled=true must NOT open a tool
+  whose API service is currently disabled, both in-memory and on disk.
+- ToolInfoResponse exposes ``enabled_default`` / ``enabled_customized``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from flocks.tool.registry import (
+    Tool,
+    ToolCategory,
+    ToolContext,
+    ToolInfo,
+    ToolRegistry,
+    ToolResult,
+)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+def _stub_api_tool(name: str, *, enabled: bool, provider: str = "onesec_api") -> Tool:
+    async def handler(ctx: ToolContext, value: str = "ok") -> ToolResult:
+        return ToolResult(success=True, output=value)
+
+    return Tool(
+        info=ToolInfo(
+            name=name,
+            description=f"stub api tool {name}",
+            category=ToolCategory.CUSTOM,
+            enabled=enabled,
+            provider=provider,
+        ),
+        handler=handler,
+    )
+
+
+@pytest.fixture()
+def tool_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Build a TestClient with the tool router and an isolated config dir.
+
+    Seeds the registry with two stub API tools so tests can exercise the
+    overlay/service-gate combinations without touching real plugin YAML.
+    """
+    config_dir = tmp_path / ".flocks" / "config"
+    config_dir.mkdir(parents=True)
+    monkeypatch.setenv("FLOCKS_CONFIG_DIR", str(config_dir))
+
+    from flocks.config.config import Config
+    Config._global_config = None
+    Config._cached_config = None
+    (config_dir / "flocks.json").write_text(json.dumps({}))
+
+    saved_tools = dict(ToolRegistry._tools)
+    saved_defaults = dict(ToolRegistry._enabled_defaults)
+    saved_initialized = ToolRegistry._initialized
+
+    enabled_tool = _stub_api_tool("onesec_dns_test", enabled=True)
+    disabled_tool = _stub_api_tool("onesec_threat_test", enabled=False)
+    ToolRegistry._tools = {
+        enabled_tool.info.name: enabled_tool,
+        disabled_tool.info.name: disabled_tool,
+    }
+    ToolRegistry._enabled_defaults = {
+        enabled_tool.info.name: True,
+        disabled_tool.info.name: False,
+    }
+    # Skip plugin discovery — our stub registry is enough.
+    ToolRegistry._initialized = True
+
+    from flocks.server.routes.tool import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/tools")
+    client = TestClient(app, raise_server_exceptions=True)
+
+    yield client, enabled_tool, disabled_tool
+
+    ToolRegistry._tools = saved_tools
+    ToolRegistry._enabled_defaults = saved_defaults
+    ToolRegistry._initialized = saved_initialized
+
+
+def _set_service(*, enabled: bool, sid: str = "onesec_api") -> None:
+    from flocks.config.config_writer import ConfigWriter
+    ConfigWriter.set_api_service(sid, {
+        "apiKey": "{secret:test_key}",
+        "enabled": enabled,
+    })
+
+
+def _read_settings() -> dict:
+    from flocks.config.config_writer import ConfigWriter
+    return ConfigWriter.list_tool_settings()
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+class TestToolInfoResponse:
+    def test_lists_factory_default_and_no_setting_initially(self, tool_client):
+        client, _, disabled_tool = tool_client
+        _set_service(enabled=True)
+
+        res = client.get(f"/api/tools/{disabled_tool.info.name}")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["enabled"] is False  # YAML default
+        assert body["enabled_default"] is False
+        assert body["enabled_customized"] is False
+
+
+class TestUpdateTool:
+    def test_overlay_persisted_when_differs_from_default(self, tool_client):
+        client, _, disabled_tool = tool_client
+        _set_service(enabled=True)
+
+        res = client.patch(
+            f"/api/tools/{disabled_tool.info.name}",
+            json={"enabled": True},
+        )
+        body = res.json()
+        assert body["enabled"] is True
+        assert body["enabled_default"] is False
+        assert body["enabled_customized"] is True
+        assert _read_settings() == {disabled_tool.info.name: {"enabled": True}}
+        assert disabled_tool.info.enabled is True
+
+    def test_request_equal_to_default_drops_overlay(self, tool_client):
+        client, enabled_tool, _ = tool_client
+        _set_service(enabled=True)
+
+        # First disable to plant an overlay…
+        client.patch(f"/api/tools/{enabled_tool.info.name}", json={"enabled": False})
+        assert enabled_tool.info.name in _read_settings()
+
+        # …then re-enable, which equals the default and must REMOVE the overlay.
+        res = client.patch(f"/api/tools/{enabled_tool.info.name}", json={"enabled": True})
+        body = res.json()
+        assert body["enabled"] is True
+        assert body["enabled_customized"] is False
+        assert _read_settings() == {}
+
+    def test_overlay_enable_blocked_by_disabled_service(self, tool_client):
+        """The intent is persisted but the in-memory state stays disabled."""
+        client, _, disabled_tool = tool_client
+        _set_service(enabled=False)
+
+        res = client.patch(
+            f"/api/tools/{disabled_tool.info.name}",
+            json={"enabled": True},
+        )
+        body = res.json()
+        # In-memory result honours the gate.
+        assert disabled_tool.info.enabled is False
+        # Effective enabled (HTTP view) is also False because service is off.
+        assert body["enabled"] is False
+        # But the overlay IS persisted so re-enabling the service later restores intent.
+        assert _read_settings() == {disabled_tool.info.name: {"enabled": True}}
+        assert body["enabled_customized"] is True
+
+    def test_overlay_disable_works_regardless_of_service(self, tool_client):
+        client, enabled_tool, _ = tool_client
+        _set_service(enabled=True)
+
+        res = client.patch(
+            f"/api/tools/{enabled_tool.info.name}",
+            json={"enabled": False},
+        )
+        body = res.json()
+        assert body["enabled"] is False
+        assert enabled_tool.info.enabled is False
+        assert _read_settings() == {enabled_tool.info.name: {"enabled": False}}
+
+
+class TestResetToolSetting:
+    def test_reset_restores_default_and_removes_overlay(self, tool_client):
+        client, _, disabled_tool = tool_client
+        _set_service(enabled=True)
+
+        client.patch(f"/api/tools/{disabled_tool.info.name}", json={"enabled": True})
+        assert disabled_tool.info.enabled is True
+        assert _read_settings()  # has entry
+
+        res = client.post(f"/api/tools/{disabled_tool.info.name}/reset")
+        body = res.json()
+        assert body["enabled"] is False
+        assert body["enabled_default"] is False
+        assert body["enabled_customized"] is False
+        assert disabled_tool.info.enabled is False
+        assert _read_settings() == {}
+
+    def test_reset_for_default_enabled_with_disabled_service_yields_false(self, tool_client):
+        client, enabled_tool, _ = tool_client
+        _set_service(enabled=False)
+
+        # Plant a contrarian overlay first.
+        client.patch(f"/api/tools/{enabled_tool.info.name}", json={"enabled": False})
+
+        res = client.post(f"/api/tools/{enabled_tool.info.name}/reset")
+        body = res.json()
+        # Default is True, but service is off → in-memory enabled must be False.
+        assert body["enabled_default"] is True
+        assert body["enabled"] is False
+        assert enabled_tool.info.enabled is False
+
+    def test_reset_unknown_tool_returns_404(self, tool_client):
+        client, _, _ = tool_client
+        res = client.post("/api/tools/no_such_tool/reset")
+        assert res.status_code == 404

--- a/tests/server/test_tool_setting_routes.py
+++ b/tests/server/test_tool_setting_routes.py
@@ -120,6 +120,33 @@ class TestToolInfoResponse:
         assert body["enabled_default"] is False
         assert body["enabled_customized"] is False
 
+    def test_reload_path_refreshes_enabled_default(self, tool_client):
+        """Regression for review P2: when the YAML on disk changes its
+        ``enabled:`` default and the tool gets re-registered (as
+        ``POST /api/tools/{name}/reload`` and ``PUT /api/tools/{name}``
+        both do internally), the ``enabled_default`` exposed over HTTP
+        must pick up the new value instead of echoing the one observed
+        on first load.
+        """
+        client, enabled_tool, _ = tool_client
+        _set_service(enabled=True)
+
+        # Sanity: initial default is True (seeded by the fixture).
+        body = client.get(f"/api/tools/{enabled_tool.info.name}").json()
+        assert body["enabled_default"] is True
+
+        # Simulate the YAML being edited to ship with enabled: false
+        # and the same reload path the PUT/reload routes take.
+        v2 = _stub_api_tool(enabled_tool.info.name, enabled=False)
+        ToolRegistry.register(v2)
+
+        body = client.get(f"/api/tools/{enabled_tool.info.name}").json()
+        assert body["enabled_default"] is False, (
+            "register() must refresh _enabled_defaults; otherwise PUT/reload "
+            "leave the HTTP API exposing the old factory default and "
+            "`reset` restores the wrong value"
+        )
+
 
 class TestUpdateTool:
     def test_overlay_persisted_when_differs_from_default(self, tool_client):

--- a/tests/tool/test_apply_tool_settings.py
+++ b/tests/tool/test_apply_tool_settings.py
@@ -1,0 +1,249 @@
+"""Tests for ToolRegistry._apply_tool_settings — user-level enable/disable overlay."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from flocks.tool.registry import (
+    Tool,
+    ToolCategory,
+    ToolContext,
+    ToolInfo,
+    ToolRegistry,
+    ToolResult,
+)
+
+
+def _stub_tool(name: str, *, enabled: bool, native: bool = True) -> Tool:
+    async def handler(ctx: ToolContext, value: str = "ok") -> ToolResult:
+        return ToolResult(success=True, output=value)
+
+    return Tool(
+        info=ToolInfo(
+            name=name,
+            description=f"stub tool {name}",
+            category=ToolCategory.CUSTOM,
+            enabled=enabled,
+            native=native,
+        ),
+        handler=handler,
+    )
+
+
+@pytest.fixture
+def temp_config(tmp_path, monkeypatch):
+    """Isolated FLOCKS_CONFIG_DIR with an empty flocks.json."""
+    from flocks.config.config import Config
+
+    config_dir = tmp_path / ".flocks" / "config"
+    config_dir.mkdir(parents=True)
+    monkeypatch.setenv("FLOCKS_CONFIG_DIR", str(config_dir))
+    Config._global_config = None
+    Config._cached_config = None
+    (config_dir / "flocks.json").write_text(json.dumps({}))
+    return config_dir
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    """Replace the registry's tool dict + defaults snapshot with a known set."""
+    saved_tools = dict(ToolRegistry._tools)
+    saved_defaults = dict(ToolRegistry._enabled_defaults)
+    monkeypatch.setattr(ToolRegistry, "_tools", {})
+    monkeypatch.setattr(ToolRegistry, "_enabled_defaults", {})
+    yield
+    ToolRegistry._tools = saved_tools
+    ToolRegistry._enabled_defaults = saved_defaults
+
+
+def _set_api_service(name: str, *, enabled: bool) -> None:
+    """Helper to write a minimal api_services entry."""
+    from flocks.config.config_writer import ConfigWriter
+    ConfigWriter.set_api_service(name, {
+        "apiKey": "{secret:test_key}",
+        "enabled": enabled,
+    })
+
+
+def test_apply_tool_settings_enables_disabled_tool(temp_config, isolated_registry):
+    from flocks.config.config_writer import ConfigWriter
+
+    tool = _stub_tool("plugin_thing", enabled=False)
+    ToolRegistry._tools[tool.info.name] = tool
+
+    ConfigWriter.set_tool_setting("plugin_thing", {"enabled": True})
+    ToolRegistry._apply_tool_settings()
+
+    assert tool.info.enabled is True
+
+
+def test_apply_tool_settings_disables_enabled_tool(temp_config, isolated_registry):
+    from flocks.config.config_writer import ConfigWriter
+
+    tool = _stub_tool("plugin_thing", enabled=True)
+    ToolRegistry._tools[tool.info.name] = tool
+
+    ConfigWriter.set_tool_setting("plugin_thing", {"enabled": False})
+    ToolRegistry._apply_tool_settings()
+
+    assert tool.info.enabled is False
+
+
+def test_apply_tool_settings_skips_unknown_tool(temp_config, isolated_registry, caplog):
+    """Stale entries for tools that no longer exist must not crash."""
+    from flocks.config.config_writer import ConfigWriter
+
+    ConfigWriter.set_tool_setting("ghost_tool", {"enabled": False})
+    ToolRegistry._apply_tool_settings()
+
+    assert "ghost_tool" not in ToolRegistry._tools
+
+
+def test_apply_tool_settings_no_op_when_no_settings(temp_config, isolated_registry):
+    tool = _stub_tool("plugin_thing", enabled=True)
+    ToolRegistry._tools[tool.info.name] = tool
+
+    ToolRegistry._apply_tool_settings()
+
+    assert tool.info.enabled is True
+
+
+def test_apply_tool_settings_works_for_user_level_tools(temp_config, isolated_registry):
+    """Overlay should apply uniformly — including to non-native (user-level) plugin tools."""
+    from flocks.config.config_writer import ConfigWriter
+
+    tool = _stub_tool("user_thing", enabled=True, native=False)
+    ToolRegistry._tools[tool.info.name] = tool
+
+    ConfigWriter.set_tool_setting("user_thing", {"enabled": False})
+    ToolRegistry._apply_tool_settings()
+
+    assert tool.info.enabled is False
+
+
+def test_apply_tool_settings_ignores_non_enabled_keys(temp_config, isolated_registry):
+    """Overlay entries without an `enabled` key must not change tool state."""
+    from flocks.config.config_writer import ConfigWriter
+
+    tool = _stub_tool("plugin_thing", enabled=True)
+    ToolRegistry._tools[tool.info.name] = tool
+
+    ConfigWriter.set_tool_setting("plugin_thing", {"note": "future field"})
+    ToolRegistry._apply_tool_settings()
+
+    assert tool.info.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Service-gate interaction: overlay can never re-open a service-disabled tool
+# ---------------------------------------------------------------------------
+
+def _stub_api_tool(name: str, *, enabled: bool, provider: str) -> Tool:
+    async def handler(ctx: ToolContext, value: str = "ok") -> ToolResult:
+        return ToolResult(success=True, output=value)
+
+    return Tool(
+        info=ToolInfo(
+            name=name,
+            description=f"stub api tool {name}",
+            category=ToolCategory.CUSTOM,
+            enabled=enabled,
+            provider=provider,
+        ),
+        handler=handler,
+    )
+
+
+def test_overlay_cannot_enable_when_service_disabled(temp_config, isolated_registry):
+    """The most dangerous regression: overlay enabled=True must NOT leak past _sync."""
+    from flocks.config.config_writer import ConfigWriter
+
+    _set_api_service("onesec_api", enabled=False)
+    tool = _stub_api_tool("onesec_dns", enabled=True, provider="onesec_api")
+    ToolRegistry._tools[tool.info.name] = tool
+    ToolRegistry._snapshot_enabled_defaults()
+
+    ToolRegistry._sync_api_service_states()
+    assert tool.info.enabled is False
+
+    ConfigWriter.set_tool_setting("onesec_dns", {"enabled": True})
+    ToolRegistry._apply_tool_settings()
+    assert tool.info.enabled is False, (
+        "overlay must not be able to open a tool whose API service is disabled"
+    )
+
+
+def test_overlay_can_disable_even_when_service_enabled(temp_config, isolated_registry):
+    """The disable side of the gate has no constraint."""
+    from flocks.config.config_writer import ConfigWriter
+
+    _set_api_service("onesec_api", enabled=True)
+    tool = _stub_api_tool("onesec_dns", enabled=True, provider="onesec_api")
+    ToolRegistry._tools[tool.info.name] = tool
+    ToolRegistry._snapshot_enabled_defaults()
+
+    ConfigWriter.set_tool_setting("onesec_dns", {"enabled": False})
+    ToolRegistry._apply_tool_settings()
+    assert tool.info.enabled is False
+
+
+def test_overlay_re_enable_when_service_enabled(temp_config, isolated_registry):
+    """Overlay enabled=True is honoured once the API service is enabled."""
+    from flocks.config.config_writer import ConfigWriter
+
+    _set_api_service("onesec_api", enabled=True)
+    tool = _stub_api_tool("onesec_threat", enabled=False, provider="onesec_api")
+    ToolRegistry._tools[tool.info.name] = tool
+    ToolRegistry._snapshot_enabled_defaults()
+
+    ConfigWriter.set_tool_setting("onesec_threat", {"enabled": True})
+    ToolRegistry._apply_tool_settings()
+    assert tool.info.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Snapshot semantics
+# ---------------------------------------------------------------------------
+
+def test_snapshot_captures_yaml_default_before_sync(temp_config, isolated_registry):
+    """_enabled_defaults reflects the registration default, not post-sync state."""
+    _set_api_service("onesec_api", enabled=False)
+    tool = _stub_api_tool("onesec_threat", enabled=True, provider="onesec_api")
+    ToolRegistry._tools[tool.info.name] = tool
+    ToolRegistry._snapshot_enabled_defaults()
+
+    ToolRegistry._sync_api_service_states()
+    assert tool.info.enabled is False
+    # The snapshot must still report the YAML default, not the synced value.
+    assert ToolRegistry.get_default_enabled("onesec_threat") is True
+
+
+def test_get_default_enabled_returns_none_for_unknown(temp_config, isolated_registry):
+    assert ToolRegistry.get_default_enabled("never_seen") is None
+
+
+def test_snapshot_preserves_builtin_default_on_refresh(temp_config, isolated_registry):
+    """Regression: refresh_plugin_tools must NOT overwrite the snapshot of
+    builtin tools whose info.enabled was already mutated by a previous
+    overlay application.
+    """
+    from flocks.config.config_writer import ConfigWriter
+
+    builtin = _stub_tool("builtin_thing", enabled=True)
+    ToolRegistry._tools[builtin.info.name] = builtin
+    ToolRegistry._snapshot_enabled_defaults()
+    assert ToolRegistry.get_default_enabled("builtin_thing") is True
+
+    ConfigWriter.set_tool_setting("builtin_thing", {"enabled": False})
+    ToolRegistry._apply_tool_settings()
+    assert builtin.info.enabled is False
+
+    # Simulate what refresh_plugin_tools does: snapshot again.
+    # The snapshot must NOT pick up the overlay-mutated value.
+    ToolRegistry._snapshot_enabled_defaults()
+    assert ToolRegistry.get_default_enabled("builtin_thing") is True, (
+        "snapshot must use setdefault so a refresh cycle does not overwrite "
+        "the original default with the overlay-mutated value"
+    )

--- a/tests/tool/test_apply_tool_settings.py
+++ b/tests/tool/test_apply_tool_settings.py
@@ -51,11 +51,14 @@ def isolated_registry(monkeypatch):
     """Replace the registry's tool dict + defaults snapshot with a known set."""
     saved_tools = dict(ToolRegistry._tools)
     saved_defaults = dict(ToolRegistry._enabled_defaults)
+    saved_plugin_names = list(ToolRegistry._plugin_tool_names)
     monkeypatch.setattr(ToolRegistry, "_tools", {})
     monkeypatch.setattr(ToolRegistry, "_enabled_defaults", {})
+    monkeypatch.setattr(ToolRegistry, "_plugin_tool_names", [])
     yield
     ToolRegistry._tools = saved_tools
     ToolRegistry._enabled_defaults = saved_defaults
+    ToolRegistry._plugin_tool_names = saved_plugin_names
 
 
 def _set_api_service(name: str, *, enabled: bool) -> None:
@@ -224,26 +227,116 @@ def test_get_default_enabled_returns_none_for_unknown(temp_config, isolated_regi
     assert ToolRegistry.get_default_enabled("never_seen") is None
 
 
-def test_snapshot_preserves_builtin_default_on_refresh(temp_config, isolated_registry):
-    """Regression: refresh_plugin_tools must NOT overwrite the snapshot of
-    builtin tools whose info.enabled was already mutated by a previous
-    overlay application.
+# ---------------------------------------------------------------------------
+# Snapshot lifecycle — ``_enabled_defaults`` must stay in lock-step with
+# the current YAML/registration source of truth, NOT with the first value
+# the registry ever observed.  These cover the two real production paths
+# that used to leak a stale default:
+#
+#   1. A YAML edit + ``POST /api/tools/{name}/reload`` — calls
+#      :meth:`ToolRegistry.register` directly on the same name.
+#   2. A file-watcher / manual ``refresh_plugin_tools`` cycle — goes
+#      through :meth:`_unregister_plugin_tools` + :meth:`_load_plugin_tools`
+#      again.
+# ---------------------------------------------------------------------------
+
+def test_register_refreshes_enabled_default(temp_config, isolated_registry):
+    """Re-registering the same name (e.g. reload after YAML edit) must
+    overwrite the factory-default snapshot.  Previously the snapshot was
+    only written once under :meth:`_snapshot_enabled_defaults` which used
+    ``setdefault``, so a flipped ``enabled:`` in the YAML would never be
+    picked up until the process restarted.
+    """
+    tool_v1 = _stub_tool("plugin_thing", enabled=True)
+    ToolRegistry.register(tool_v1)
+    assert ToolRegistry.get_default_enabled("plugin_thing") is True
+
+    tool_v2 = _stub_tool("plugin_thing", enabled=False)
+    ToolRegistry.register(tool_v2)
+    assert ToolRegistry.get_default_enabled("plugin_thing") is False, (
+        "register() must treat the newly-constructed tool as the current "
+        "factory default, not fall back to the first value ever seen"
+    )
+
+
+def test_register_snapshot_is_immune_to_overlay_mutation(temp_config, isolated_registry):
+    """Applying a user setting that flips ``info.enabled`` must NOT change
+    the snapshot — it was captured at register time before any overlay
+    could run.
     """
     from flocks.config.config_writer import ConfigWriter
 
-    builtin = _stub_tool("builtin_thing", enabled=True)
-    ToolRegistry._tools[builtin.info.name] = builtin
-    ToolRegistry._snapshot_enabled_defaults()
-    assert ToolRegistry.get_default_enabled("builtin_thing") is True
+    tool = _stub_tool("plugin_thing", enabled=True)
+    ToolRegistry.register(tool)
+    assert ToolRegistry.get_default_enabled("plugin_thing") is True
 
-    ConfigWriter.set_tool_setting("builtin_thing", {"enabled": False})
+    ConfigWriter.set_tool_setting("plugin_thing", {"enabled": False})
     ToolRegistry._apply_tool_settings()
-    assert builtin.info.enabled is False
-
-    # Simulate what refresh_plugin_tools does: snapshot again.
-    # The snapshot must NOT pick up the overlay-mutated value.
-    ToolRegistry._snapshot_enabled_defaults()
-    assert ToolRegistry.get_default_enabled("builtin_thing") is True, (
-        "snapshot must use setdefault so a refresh cycle does not overwrite "
-        "the original default with the overlay-mutated value"
+    assert tool.info.enabled is False
+    assert ToolRegistry.get_default_enabled("plugin_thing") is True, (
+        "overlay must never leak into the factory-default snapshot"
     )
+
+
+def test_unregister_plugin_tools_drops_enabled_default(temp_config, isolated_registry):
+    """Regression for review P1: the refresh cycle calls
+    ``_unregister_plugin_tools`` before reloading.  If that step doesn't
+    pop ``_enabled_defaults`` the next ``register()`` still overwrites
+    the entry correctly, but any intermediate read (e.g. between
+    unregister and the new register, or for a tool that was deleted and
+    never re-registered) would hand back a stale factory value.
+    """
+    tool = _stub_tool("plugin_thing", enabled=True)
+    ToolRegistry.register(tool)
+    ToolRegistry._plugin_tool_names = ["plugin_thing"]
+    assert ToolRegistry.get_default_enabled("plugin_thing") is True
+
+    ToolRegistry._unregister_plugin_tools()
+    assert "plugin_thing" not in ToolRegistry._tools
+    assert ToolRegistry.get_default_enabled("plugin_thing") is None, (
+        "_unregister_plugin_tools must pop the snapshot entry so a stale "
+        "default cannot survive into the next refresh cycle"
+    )
+
+
+def test_refresh_cycle_picks_up_new_yaml_default(temp_config, isolated_registry):
+    """End-to-end check of the full refresh path: unregister + reload
+    (simulated by a fresh ``register`` of the same name with a different
+    factory default) must update the snapshot.  This is the exact
+    scenario the review flagged as High.
+    """
+    from flocks.config.config_writer import ConfigWriter
+
+    # v1 — shipped with enabled: true; user disables via overlay.
+    v1 = _stub_tool("plugin_thing", enabled=True)
+    ToolRegistry.register(v1)
+    ToolRegistry._plugin_tool_names = ["plugin_thing"]
+    ConfigWriter.set_tool_setting("plugin_thing", {"enabled": False})
+    ToolRegistry._apply_tool_settings()
+    assert v1.info.enabled is False
+
+    # Upgrade: YAML now ships with enabled: false by default.
+    ToolRegistry._unregister_plugin_tools()
+    v2 = _stub_tool("plugin_thing", enabled=False)
+    ToolRegistry.register(v2)
+    ToolRegistry._plugin_tool_names = ["plugin_thing"]
+
+    assert ToolRegistry.get_default_enabled("plugin_thing") is False, (
+        "after refresh the snapshot must reflect the new YAML factory "
+        "default, not the one observed before the upgrade"
+    )
+
+
+def test_snapshot_defaults_safety_net_uses_assignment(temp_config, isolated_registry):
+    """``_snapshot_enabled_defaults`` is a backstop for code paths that
+    insert into ``_tools`` without going through :meth:`register`.  It
+    must use direct assignment (not ``setdefault``) so a stale entry
+    from a previous cycle is corrected rather than kept.
+    """
+    tool = _stub_tool("plugin_thing", enabled=True)
+    ToolRegistry._tools[tool.info.name] = tool
+    ToolRegistry._enabled_defaults["plugin_thing"] = False  # stale entry
+
+    ToolRegistry._snapshot_enabled_defaults()
+
+    assert ToolRegistry.get_default_enabled("plugin_thing") is True

--- a/tests/tool/test_apply_tool_settings.py
+++ b/tests/tool/test_apply_tool_settings.py
@@ -48,17 +48,25 @@ def temp_config(tmp_path, monkeypatch):
 
 @pytest.fixture
 def isolated_registry(monkeypatch):
-    """Replace the registry's tool dict + defaults snapshot with a known set."""
+    """Replace the registry's tool dict + defaults snapshot with a known set.
+
+    Also shadows ``_plugin_tool_names`` and ``_dynamic_tools_by_module``
+    so tests exercising the unregister paths can't leak names into the
+    real registry when the test process later runs unrelated tests.
+    """
     saved_tools = dict(ToolRegistry._tools)
     saved_defaults = dict(ToolRegistry._enabled_defaults)
     saved_plugin_names = list(ToolRegistry._plugin_tool_names)
+    saved_dynamic = dict(ToolRegistry._dynamic_tools_by_module)
     monkeypatch.setattr(ToolRegistry, "_tools", {})
     monkeypatch.setattr(ToolRegistry, "_enabled_defaults", {})
     monkeypatch.setattr(ToolRegistry, "_plugin_tool_names", [])
+    monkeypatch.setattr(ToolRegistry, "_dynamic_tools_by_module", {})
     yield
     ToolRegistry._tools = saved_tools
     ToolRegistry._enabled_defaults = saved_defaults
     ToolRegistry._plugin_tool_names = saved_plugin_names
+    ToolRegistry._dynamic_tools_by_module = saved_dynamic
 
 
 def _set_api_service(name: str, *, enabled: bool) -> None:
@@ -327,16 +335,77 @@ def test_refresh_cycle_picks_up_new_yaml_default(temp_config, isolated_registry)
     )
 
 
-def test_snapshot_defaults_safety_net_uses_assignment(temp_config, isolated_registry):
-    """``_snapshot_enabled_defaults`` is a backstop for code paths that
-    insert into ``_tools`` without going through :meth:`register`.  It
-    must use direct assignment (not ``setdefault``) so a stale entry
-    from a previous cycle is corrected rather than kept.
+def test_snapshot_safety_net_does_not_clobber_post_sync_state(temp_config, isolated_registry):
+    """``_snapshot_enabled_defaults`` runs at the tail of every
+    ``_load_plugin_tools`` cycle — including the ones triggered by
+    :meth:`refresh_plugin_tools`.  By the time the *second* cycle
+    reaches it, the previous cycle's :meth:`_sync_api_service_states`
+    has already flipped ``info.enabled`` on any built-in / previously
+    registered tool whose API service is disabled.
+
+    If the safety net overwrote with direct assignment it would capture
+    that post-sync ``False`` as the "factory default", breaking
+    :meth:`reset_tool_setting` and ``enabled_default`` reporting for
+    every built-in API tool whose provider happens to be disabled.  The
+    contract is therefore: :meth:`register` is the authoritative writer,
+    the safety net must only fill genuine gaps (``setdefault``), and
+    must never clobber a correct snapshot.
+    """
+    tool = _stub_api_tool("onesec_threat", enabled=True, provider="onesec_api")
+    ToolRegistry.register(tool)
+    assert ToolRegistry.get_default_enabled("onesec_threat") is True
+
+    # Simulate the first init-style sequence: service sync flips live state.
+    _set_api_service("onesec_api", enabled=False)
+    ToolRegistry._sync_api_service_states()
+    assert tool.info.enabled is False
+
+    # And now the refresh-style tail call runs again.  It must not turn
+    # the snapshot into a mirror of the post-sync (False) state.
+    ToolRegistry._snapshot_enabled_defaults()
+
+    assert ToolRegistry.get_default_enabled("onesec_threat") is True, (
+        "safety net must never overwrite a correct factory-default "
+        "snapshot with the post-sync live state"
+    )
+
+
+def test_snapshot_safety_net_fills_missing_entry(temp_config, isolated_registry):
+    """For tools that landed in ``_tools`` without going through
+    :meth:`register` (exclusively a test / unorthodox code path) the
+    safety net is still expected to insert a best-effort factory
+    default so ``enabled_default`` doesn't come back as ``None``.
     """
     tool = _stub_tool("plugin_thing", enabled=True)
     ToolRegistry._tools[tool.info.name] = tool
-    ToolRegistry._enabled_defaults["plugin_thing"] = False  # stale entry
+    assert ToolRegistry.get_default_enabled("plugin_thing") is None
 
     ToolRegistry._snapshot_enabled_defaults()
 
     assert ToolRegistry.get_default_enabled("plugin_thing") is True
+
+
+def test_unregister_dynamic_tools_drops_enabled_default(temp_config, isolated_registry):
+    """Dynamic tools go through a different unregister path
+    (:meth:`_unregister_dynamic_tools`) than plugin tools.  When a
+    dynamic module is deleted — the ``module_name not in modules``
+    branch of :meth:`_register_dynamic_tools` — the tool vanishes
+    from ``_tools`` for good, so the matching factory-default snapshot
+    must be popped too.  Otherwise ``enabled_default`` would keep
+    reporting a stale value for a tool that no longer exists.
+    """
+    tool = _stub_tool("dyn_thing", enabled=True)
+    ToolRegistry.register(tool)
+    ToolRegistry._dynamic_tools_by_module["dyn_module"] = ["dyn_thing"]
+    assert ToolRegistry.get_default_enabled("dyn_thing") is True
+
+    try:
+        ToolRegistry._unregister_dynamic_tools("dyn_module")
+    finally:
+        ToolRegistry._dynamic_tools_by_module.pop("dyn_module", None)
+
+    assert "dyn_thing" not in ToolRegistry._tools
+    assert ToolRegistry.get_default_enabled("dyn_thing") is None, (
+        "_unregister_dynamic_tools must pop the snapshot entry to keep "
+        "the factory-default lifecycle symmetric with plugin tools"
+    )

--- a/webui/src/api/tool.ts
+++ b/webui/src/api/tool.ts
@@ -33,6 +33,13 @@ export const toolAPI = {
   setEnabled: (name: string, enabled: boolean) =>
     client.patch<Tool>(`/api/tools/${name}`, { enabled }),
 
+  /**
+   * Remove the user-level setting and restore the YAML/registration default
+   * for this tool (currently only the `enabled` flag is overlaid).
+   */
+  resetSetting: (name: string) =>
+    client.post<Tool>(`/api/tools/${name}/reset`),
+
   delete: (name: string) =>
     client.delete<{ status: string; message: string }>(`/api/tools/${name}`),
 };

--- a/webui/src/locales/en-US/tool.json
+++ b/webui/src/locales/en-US/tool.json
@@ -314,7 +314,11 @@
     "execSuccess": "Execution Successful",
     "execFailed": "Execution Failed",
     "close": "Close",
-    "testTool": "Test Tool"
+    "testTool": "Test Tool",
+    "customized": "Customized",
+    "customizedTooltip": "Current state comes from a user customization; YAML default is {{def}}",
+    "resetSetting": "Reset to default",
+    "resetting": "Resetting…"
   },
 
   "statusBadge": {

--- a/webui/src/locales/zh-CN/tool.json
+++ b/webui/src/locales/zh-CN/tool.json
@@ -314,7 +314,11 @@
     "execSuccess": "执行成功",
     "execFailed": "执行失败",
     "close": "关闭",
-    "testTool": "测试工具"
+    "testTool": "测试工具",
+    "customized": "已自定义",
+    "customizedTooltip": "当前状态来自用户自定义，YAML 默认值为 {{def}}",
+    "resetSetting": "恢复默认",
+    "resetting": "重置中…"
   },
 
   "statusBadge": {

--- a/webui/src/pages/Tool/components/LocalTabContent.tsx
+++ b/webui/src/pages/Tool/components/LocalTabContent.tsx
@@ -115,6 +115,19 @@ export default function LocalTabContent({
                     <span className={`px-1.5 py-0.5 text-xs font-medium rounded-full shrink-0 ${statusBadgeClass}`}>
                       {statusLabel}
                     </span>
+                    {tool.enabled_customized && (
+                      <span
+                        title={t('toolDetail.customizedTooltip', {
+                          defaultValue: '当前状态来自用户自定义，YAML 默认值为 {{def}}',
+                          def: (tool.enabled_default ?? tool.enabled)
+                            ? t('enabledBadge.enabled')
+                            : t('enabledBadge.disabled'),
+                        })}
+                        className="px-1.5 py-0.5 bg-amber-100 text-amber-800 text-xs font-medium rounded-full shrink-0"
+                      >
+                        {t('toolDetail.customized', { defaultValue: '已自定义' })}
+                      </span>
+                    )}
                     <span className="px-1.5 py-0.5 bg-blue-100 text-blue-700 text-xs font-medium rounded-full shrink-0">
                       {t('source.local')}
                     </span>

--- a/webui/src/pages/Tool/index.tsx
+++ b/webui/src/pages/Tool/index.tsx
@@ -3342,24 +3342,51 @@ function ToolDetailDrawer({
   const { t, i18n } = useTranslation('tool');
   const [section, setSection] = useState<'info' | 'test'>('info');
   const [enabled, setEnabled] = useState(tool.enabled);
+  const [customized, setCustomized] = useState<boolean>(!!tool.enabled_customized);
+  const [enabledDefault, setEnabledDefault] = useState<boolean>(
+    tool.enabled_default ?? tool.enabled
+  );
   const [toggling, setToggling] = useState(false);
+  const [resetting, setResetting] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const sb = SOURCE_BADGE[tool.source] || SOURCE_BADGE.custom;
 
-  useEffect(() => { setEnabled(tool.enabled); }, [tool.enabled]);
+  useEffect(() => {
+    setEnabled(tool.enabled);
+    setCustomized(!!tool.enabled_customized);
+    setEnabledDefault(tool.enabled_default ?? tool.enabled);
+  }, [tool.enabled, tool.enabled_customized, tool.enabled_default]);
 
   const handleToggleEnabled = async () => {
     if (toggling) return;
     const next = !enabled;
     setToggling(true);
     try {
-      await toolAPI.setEnabled(tool.name, next);
-      setEnabled(next);
-      onEnabledChange?.(tool.name, next);
+      const { data: updated } = await toolAPI.setEnabled(tool.name, next);
+      setEnabled(updated.enabled);
+      setCustomized(!!updated.enabled_customized);
+      setEnabledDefault(updated.enabled_default ?? updated.enabled);
+      onEnabledChange?.(tool.name, updated.enabled);
     } catch (err: any) {
       alert(err.response?.data?.message || err.response?.data?.detail || err.message);
     } finally {
       setToggling(false);
+    }
+  };
+
+  const handleResetSetting = async () => {
+    if (resetting) return;
+    setResetting(true);
+    try {
+      const { data: updated } = await toolAPI.resetSetting(tool.name);
+      setEnabled(updated.enabled);
+      setCustomized(!!updated.enabled_customized);
+      setEnabledDefault(updated.enabled_default ?? updated.enabled);
+      onEnabledChange?.(tool.name, updated.enabled);
+    } catch (err: any) {
+      alert(err.response?.data?.message || err.response?.data?.detail || err.message);
+    } finally {
+      setResetting(false);
     }
   };
 
@@ -3438,7 +3465,7 @@ function ToolDetailDrawer({
               <div className="flex flex-wrap gap-4 items-start">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1.5">{t('toolDetail.status')}</label>
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <button
                       onClick={handleToggleEnabled}
                       disabled={toggling}
@@ -3451,6 +3478,28 @@ function ToolDetailDrawer({
                     <span className={`text-sm font-medium ${enabled ? 'text-slate-700' : 'text-gray-400'}`}>
                       {toggling ? t('toolDetail.updating') : enabled ? t('toolDetail.enabled') : t('toolDetail.disabled')}
                     </span>
+                    {customized && (
+                      <>
+                        <span
+                          title={t('toolDetail.customizedTooltip', {
+                            defaultValue: '当前状态来自用户自定义，YAML 默认值为 {{def}}',
+                            def: enabledDefault ? t('toolDetail.enabled') : t('toolDetail.disabled'),
+                          })}
+                          className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800"
+                        >
+                          {t('toolDetail.customized', { defaultValue: '已自定义' })}
+                        </span>
+                        <button
+                          onClick={handleResetSetting}
+                          disabled={resetting || toggling}
+                          className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-slate-600 hover:text-slate-900 hover:bg-gray-100 disabled:opacity-50"
+                        >
+                          {resetting
+                            ? t('toolDetail.resetting', { defaultValue: '重置中…' })
+                            : t('toolDetail.resetSetting', { defaultValue: '恢复默认' })}
+                        </button>
+                      </>
+                    )}
                   </div>
                 </div>
                 {tool.requires_confirmation && (

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -192,6 +192,10 @@ export interface Tool {
   source_name?: string;
   parameters: ToolParameter[];
   enabled: boolean;
+  /** Factory default from the YAML/registration source (no overlay applied). */
+  enabled_default?: boolean;
+  /** True when a user setting is recorded in flocks.json `tool_settings`. */
+  enabled_customized?: boolean;
   requires_confirmation: boolean;
 }
 


### PR DESCRIPTION
The Tool UI toggle used to write directly back into the YAML plugin file (<project>/.flocks/plugins/tools/**/*.yaml). Those YAMLs are tracked by git and overwritten on upgrade, so every user click produced a dirty working tree, a potential merge conflict on `git pull`, and a lost customisation after each release. The same path also mutated user-level YAML under ~/.flocks/plugins/tools, leaving users without a single place to inspect their customisations.

Treat the YAML as the factory default and layer user choices into a new flocks.json section that mirrors the existing `model_settings`:

    "tool_settings": {
      "onesec_dns": { "enabled": false }
    }

Implementation:
- ConfigWriter gains list/get/set/delete_tool_setting CRUD; the whole `tool_settings` key is popped when its last entry is removed so flocks.json doesn't accumulate empty containers.
- ToolRegistry snapshots every tool's registration-time `enabled` flag into `_enabled_defaults` (using setdefault so a plugin-refresh cycle does not capture the overlay-mutated value as the new default) and runs `_apply_tool_settings` after `_sync_api_service_states` on every load.
- Service gate: an overlay can never *open* a tool whose backing API service is disabled. The intent is still persisted so re-enabling the service later restores it automatically; disabling is always honoured.
- PATCH /api/tools/{name} writes the overlay and auto-deletes it when the request equals the factory default. The response now carries `enabled_default` and `enabled_customized` so the UI can render the appropriate affordances.
- POST /api/tools/{name}/reset drops the overlay and restores the factory default (still gated by service state).
- Web UI: tool detail drawer and local-tools list show a "Customized" badge and a "Reset to default" action backed by the new endpoint.

The overlay applies uniformly to project-level YAML tools, user-level YAML tools under ~/.flocks/plugins/tools, and non-YAML built-in / plugin_py tools.