### PR TITLE
feat(tools): gate HTTP tool execution with session context

### DIFF
--- a/flocks/server/routes/tool.py
+++ b/flocks/server/routes/tool.py
@@ -2,18 +2,21 @@
 Tool routes - API endpoints for tool management and execution
 """
 
+import asyncio
 from typing import List, Optional, Dict, Any
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
 
 from flocks.utils.log import Log
 from flocks.config.config_writer import ConfigWriter
+from flocks.permission.next import DeniedError, PermissionNext
 from flocks.tool.registry import (
     ToolRegistry,
     ToolInfo,
     ToolSchema,
     ToolResult,
     ToolCategory,
+    ToolContext,
 )
 
 
@@ -49,7 +52,22 @@ class ToolUpdateRequest(BaseModel):
 
 class ToolExecuteRequest(BaseModel):
     """Tool execution request"""
+    model_config = {"populate_by_name": True}
     params: Dict[str, Any] = Field(default_factory=dict, description="Tool parameters")
+    session_id: Optional[str] = Field(
+        None,
+        alias="sessionID",
+        description="Optional session ID used for permission-gated execution",
+    )
+    message_id: Optional[str] = Field(
+        None,
+        alias="messageID",
+        description="Optional message ID used for permission-gated execution",
+    )
+    agent: Optional[str] = Field(
+        "rex",
+        description="Agent name recorded for the execution context",
+    )
 
 
 class ToolExecuteResponse(BaseModel):
@@ -68,8 +86,23 @@ class BatchToolCall(BaseModel):
 
 class BatchExecuteRequest(BaseModel):
     """Batch tool execution request"""
+    model_config = {"populate_by_name": True}
     calls: List[BatchToolCall] = Field(..., description="Tool calls to execute")
     parallel: bool = Field(True, description="Execute in parallel")
+    session_id: Optional[str] = Field(
+        None,
+        alias="sessionID",
+        description="Optional session ID used for permission-gated execution",
+    )
+    message_id: Optional[str] = Field(
+        None,
+        alias="messageID",
+        description="Optional message ID used for permission-gated execution",
+    )
+    agent: Optional[str] = Field(
+        "rex",
+        description="Agent name recorded for the execution context",
+    )
 
 
 class BatchExecuteResponse(BaseModel):
@@ -83,6 +116,15 @@ _BUILTIN_CATEGORIES = {
     ToolCategory.FILE, ToolCategory.TERMINAL, ToolCategory.BROWSER,
     ToolCategory.CODE, ToolCategory.SEARCH, ToolCategory.SYSTEM,
 }
+
+_DIRECT_HTTP_BLOCKED_MESSAGE = (
+    "Direct HTTP tool execution is disabled for local or permission-gated tools. "
+    "Use a session-backed request (provide sessionID/messageID) or run the tool via the normal agent/session flow."
+)
+_VERIFIED_CONTEXT_REQUIRED_MESSAGE = (
+    "Direct HTTP execution for local or permission-gated tools requires a verified "
+    "session-backed request with both sessionID and messageID."
+)
 
 
 def _get_tool_source(tool_info: ToolInfo) -> tuple:
@@ -139,6 +181,188 @@ def _build_tool_response(t: ToolInfo) -> ToolInfoResponse:
         enabled=_get_effective_tool_enabled(t),
         requires_confirmation=t.requires_confirmation,
     )
+
+
+def _requires_session_backed_context(tool_info: ToolInfo) -> bool:
+    """Return True when a tool must be anchored to a real session/message context."""
+    source, _ = _get_tool_source(tool_info)
+    return source == "builtin"
+
+
+async def _validate_verified_session_message_context(
+    *,
+    requires_verified_context: bool,
+    session_id: Optional[str],
+    message_id: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Validate that session/message context exists and the message belongs to the session."""
+    effective_session_id = str(session_id or "").strip() or None
+    effective_message_id = str(message_id or "").strip() or None
+    needs_verified_context = requires_verified_context or bool(effective_session_id or effective_message_id)
+
+    if not needs_verified_context:
+        return None, None
+
+    if not effective_session_id or not effective_message_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_VERIFIED_CONTEXT_REQUIRED_MESSAGE,
+        )
+
+    from flocks.session.message import Message
+    from flocks.session.session import Session
+
+    session = await Session.get_by_id(effective_session_id)
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session not found: {effective_session_id}",
+        )
+
+    message = await Message.get(effective_session_id, effective_message_id)
+    if not message:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Message {effective_message_id} not found in session {effective_session_id}",
+        )
+
+    return effective_session_id, effective_message_id
+
+
+async def _validate_session_message_context(
+    *,
+    tool_info: ToolInfo,
+    session_id: Optional[str],
+    message_id: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Validate context for a single tool execution request."""
+    return await _validate_verified_session_message_context(
+        requires_verified_context=_requires_session_backed_context(tool_info),
+        session_id=session_id,
+        message_id=message_id,
+    )
+
+
+def _build_http_tool_context(
+    *,
+    tool_name: str,
+    tool_info: ToolInfo,
+    session_id: Optional[str],
+    message_id: Optional[str],
+    agent: Optional[str],
+) -> ToolContext:
+    """Create a safe ToolContext for HTTP-triggered execution."""
+    agent_name = agent or "rex"
+    effective_message_id = message_id or f"http-tool:{tool_name}"
+
+    if session_id:
+        async def permission_callback(request) -> None:
+            metadata = dict(request.metadata or {})
+            metadata.setdefault("messageID", effective_message_id)
+            metadata.setdefault("route", "tool.execute")
+            await PermissionNext.ask(
+                session_id=session_id,
+                permission=request.permission,
+                patterns=list(request.patterns or []),
+                ruleset=[],
+                metadata=metadata,
+                always=list(request.always or []),
+                tool={"name": tool_name},
+            )
+
+        return ToolContext(
+            session_id=session_id,
+            message_id=effective_message_id,
+            agent=agent_name,
+            permission_callback=permission_callback,
+        )
+
+    if _requires_session_backed_context(tool_info):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_DIRECT_HTTP_BLOCKED_MESSAGE,
+        )
+
+    async def deny_permission_callback(request) -> None:
+        raise PermissionError(
+            "This HTTP execution context cannot auto-approve tool permissions."
+        )
+
+    return ToolContext(
+        session_id="http-tool",
+        message_id=effective_message_id,
+        agent=agent_name,
+        permission_callback=deny_permission_callback,
+    )
+
+
+def _permission_denied_http_error(exc: Exception) -> HTTPException:
+    """Normalize permission failures into a consistent 403 response."""
+    detail = str(exc).strip() or _DIRECT_HTTP_BLOCKED_MESSAGE
+    return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+async def _execute_with_http_context(
+    *,
+    tool_name: str,
+    tool_info: ToolInfo,
+    params: Dict[str, Any],
+    session_id: Optional[str],
+    message_id: Optional[str],
+    agent: Optional[str],
+) -> ToolResult:
+    """Execute a tool using an HTTP-safe ToolContext."""
+    validated_session_id, validated_message_id = await _validate_session_message_context(
+        tool_info=tool_info,
+        session_id=session_id,
+        message_id=message_id,
+    )
+    ctx = _build_http_tool_context(
+        tool_name=tool_name,
+        tool_info=tool_info,
+        session_id=validated_session_id,
+        message_id=validated_message_id,
+        agent=agent,
+    )
+    try:
+        return await ToolRegistry.execute(tool_name=tool_name, ctx=ctx, **params)
+    except (DeniedError, PermissionError) as exc:
+        raise _permission_denied_http_error(exc) from exc
+
+
+async def _execute_batch_with_http_context(
+    *,
+    calls: List[BatchToolCall],
+    session_id: Optional[str],
+    message_id: Optional[str],
+    agent: Optional[str],
+    parallel: bool,
+) -> List[ToolResult]:
+    """Execute batch calls with a per-tool HTTP context."""
+
+    async def run_call(call: BatchToolCall) -> ToolResult:
+        tool = ToolRegistry.get(call.name)
+        if tool is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Tool not found: {call.name}",
+            )
+        return await _execute_with_http_context(
+            tool_name=call.name,
+            tool_info=tool.info,
+            params=call.params,
+            session_id=session_id,
+            message_id=message_id,
+            agent=agent,
+        )
+
+    if parallel:
+        return await asyncio.gather(*(run_call(call) for call in calls))
+
+    results: List[ToolResult] = []
+    for call in calls:
+        results.append(await run_call(call))
+    return results
 
 
 def _get_effective_tool_enabled(tool_info: ToolInfo) -> bool:
@@ -322,9 +546,17 @@ async def execute_tool(tool_name: str, request: ToolExecuteRequest):
     log.info("tool.execute.request", {
         "tool": tool_name,
         "params": list(request.params.keys()),
+        "session": request.session_id,
     })
-    
-    result = await ToolRegistry.execute(tool_name=tool_name, **request.params)
+
+    result = await _execute_with_http_context(
+        tool_name=tool_name,
+        tool_info=tool.info,
+        params=request.params,
+        session_id=request.session_id,
+        message_id=request.message_id,
+        agent=request.agent,
+    )
     
     return ToolExecuteResponse(
         success=result.success,
@@ -363,11 +595,32 @@ async def execute_batch(request: BatchExecuteRequest):
     log.info("tool.batch.request", {
         "count": len(request.calls),
         "parallel": request.parallel,
+        "session": request.session_id,
     })
-    
-    # Execute batch
-    calls = [{"name": c.name, "params": c.params} for c in request.calls]
-    results = await ToolRegistry.execute_batch(calls, parallel=request.parallel)
+
+    requires_verified_context = False
+    for call in request.calls:
+        tool = ToolRegistry.get(call.name)
+        if tool and _requires_session_backed_context(tool.info):
+            requires_verified_context = True
+            break
+
+    validated_session_id, validated_message_id = await _validate_verified_session_message_context(
+        requires_verified_context=requires_verified_context,
+        session_id=request.session_id,
+        message_id=request.message_id,
+    )
+
+    try:
+        results = await _execute_batch_with_http_context(
+            calls=request.calls,
+            session_id=validated_session_id,
+            message_id=validated_message_id,
+            agent=request.agent,
+            parallel=request.parallel,
+        )
+    except (DeniedError, PermissionError) as exc:
+        raise _permission_denied_http_error(exc) from exc
     
     return BatchExecuteResponse(
         results=[
@@ -442,7 +695,22 @@ async def refresh_tools():
 
 class ToolTestRequest(BaseModel):
     """Request to test a tool"""
+    model_config = {"populate_by_name": True}
     params: Dict[str, Any] = Field(default_factory=dict, description="Test parameters")
+    session_id: Optional[str] = Field(
+        None,
+        alias="sessionID",
+        description="Optional session ID used for permission-gated execution",
+    )
+    message_id: Optional[str] = Field(
+        None,
+        alias="messageID",
+        description="Optional message ID used for permission-gated execution",
+    )
+    agent: Optional[str] = Field(
+        "rex",
+        description="Agent name recorded for the execution context",
+    )
 
 
 @router.post(
@@ -466,16 +734,32 @@ async def test_tool(name: str, request: ToolTestRequest):
         )
     
     log.info("tool.test", {"name": name, "params": request.params})
-    
+
+    tool_request = ToolExecuteRequest(
+        params=request.params,
+        sessionID=request.session_id,
+        messageID=request.message_id,
+        agent=request.agent,
+    )
+
     # Execute tool
     try:
-        result = await ToolRegistry.execute(tool_name=name, **request.params)
+        result = await _execute_with_http_context(
+            tool_name=name,
+            tool_info=tool.info,
+            params=tool_request.params,
+            session_id=tool_request.session_id,
+            message_id=tool_request.message_id,
+            agent=tool_request.agent,
+        )
         return ToolExecuteResponse(
             success=result.success,
             output=result.output,
             error=result.error,
             metadata=result.metadata,
         )
+    except HTTPException:
+        raise
     except Exception as e:
         log.error("tool.test.error", {"name": name, "error": str(e)})
         return ToolExecuteResponse(

--- a/tests/server/routes/test_tool_routes.py
+++ b/tests/server/routes/test_tool_routes.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+
+from flocks.session.message import Message, MessageRole
+from flocks.session.session import Session
+from flocks.tool.registry import Tool, ToolCategory, ToolInfo, ToolRegistry, ToolResult
+
+
+@contextmanager
+def _temporary_tool(tool: Tool) -> Iterator[None]:
+    ToolRegistry.init()
+    existing = ToolRegistry._tools.get(tool.info.name)
+    ToolRegistry.register(tool)
+    try:
+        yield
+    finally:
+        ToolRegistry._failure_state.pop(tool.info.name, None)
+        if existing is not None:
+            ToolRegistry._tools[tool.info.name] = existing
+        else:
+            ToolRegistry._tools.pop(tool.info.name, None)
+
+
+async def _create_session_and_message(title: str) -> tuple[str, str]:
+    session = await Session.create(
+        project_id="default",
+        directory=str(Path.cwd()),
+        title=title,
+        agent="rex",
+    )
+    message = await Message.create(
+        session_id=session.id,
+        role=MessageRole.USER,
+        content=f"{title} message",
+        agent="rex",
+    )
+    return session.id, message.id
+
+
+class TestToolRouteSecurity:
+    @pytest.mark.asyncio
+    async def test_execute_blocks_direct_bash_access(self, client: AsyncClient):
+        response = await client.post(
+            "/api/tools/bash/execute",
+            json={"params": {"command": "pwd"}},
+        )
+
+        assert response.status_code == 403
+        assert "session-backed request" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_test_endpoint_blocks_direct_bash_access(self, client: AsyncClient):
+        response = await client.post(
+            "/api/tools/bash/test",
+            json={"params": {"command": "pwd"}},
+        )
+
+        assert response.status_code == 403
+        assert "session-backed request" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_batch_blocks_direct_bash_access(self, client: AsyncClient):
+        response = await client.post(
+            "/api/tools/batch",
+            json={
+                "calls": [
+                    {
+                        "name": "bash",
+                        "params": {"command": "pwd"},
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 403
+        assert "session-backed request" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_execute_rejects_missing_message_id_for_local_tools(self, client: AsyncClient):
+        session_id, _ = await _create_session_and_message("missing-message-id")
+
+        response = await client.post(
+            "/api/tools/bash/execute",
+            json={
+                "params": {"command": "pwd"},
+                "sessionID": session_id,
+            },
+        )
+
+        assert response.status_code == 403
+        assert "verified" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_execute_rejects_unknown_session_for_local_tools(self, client: AsyncClient):
+        response = await client.post(
+            "/api/tools/bash/execute",
+            json={
+                "params": {"command": "pwd"},
+                "sessionID": "sess-missing",
+                "messageID": "msg-missing",
+            },
+        )
+
+        assert response.status_code == 404
+        assert "Session not found" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_execute_allows_direct_api_tools(self, client: AsyncClient):
+        async def handler(ctx, text: str) -> ToolResult:
+            return ToolResult(
+                success=True,
+                output=f"{text}:{ctx.session_id}",
+            )
+
+        tool = Tool(
+            info=ToolInfo(
+                name="http_safe_api_tool",
+                description="safe http api tool",
+                category=ToolCategory.CUSTOM,
+                source="api",
+            ),
+            handler=handler,
+        )
+
+        with _temporary_tool(tool):
+            response = await client.post(
+                "/api/tools/http_safe_api_tool/execute",
+                json={"params": {"text": "pong"}},
+            )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["output"] == "pong:http-tool"
+
+    @pytest.mark.asyncio
+    async def test_execute_allows_direct_custom_tools(self, client: AsyncClient):
+        async def handler(ctx, text: str) -> ToolResult:
+            return ToolResult(
+                success=True,
+                output=f"{text}:{ctx.session_id}",
+            )
+
+        tool = Tool(
+            info=ToolInfo(
+                name="http_safe_custom_tool",
+                description="safe http custom tool",
+                category=ToolCategory.CUSTOM,
+                source="custom",
+            ),
+            handler=handler,
+        )
+
+        with _temporary_tool(tool):
+            response = await client.post(
+                "/api/tools/http_safe_custom_tool/execute",
+                json={"params": {"text": "hello"}},
+            )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["output"] == "hello:http-tool"
+
+    @pytest.mark.asyncio
+    async def test_execute_rejects_message_outside_session(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from flocks.server.routes import tool as tool_routes
+
+        permission_ask = AsyncMock(return_value=None)
+        monkeypatch.setattr(tool_routes.PermissionNext, "ask", permission_ask)
+
+        session_id, _ = await _create_session_and_message("owner-session")
+        _, foreign_message_id = await _create_session_and_message("foreign-session")
+
+        async def handler(ctx) -> ToolResult:
+            await ctx.ask(
+                permission="bash",
+                patterns=["pwd"],
+                always=["*"],
+                metadata={"source": "test"},
+            )
+            return ToolResult(success=True, output="ok")
+
+        tool = Tool(
+            info=ToolInfo(
+                name="http_session_message_mismatch_tool",
+                description="session-message mismatch tool",
+                category=ToolCategory.SYSTEM,
+            ),
+            handler=handler,
+        )
+
+        with _temporary_tool(tool):
+            response = await client.post(
+                "/api/tools/http_session_message_mismatch_tool/execute",
+                json={
+                    "params": {},
+                    "sessionID": session_id,
+                    "messageID": foreign_message_id,
+                    "agent": "rex",
+                },
+            )
+
+        assert response.status_code == 404
+        assert "not found in session" in response.json()["message"]
+        permission_ask.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_execute_uses_permission_flow_when_session_context_is_present(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from flocks.server.routes import tool as tool_routes
+
+        permission_ask = AsyncMock(return_value=None)
+        monkeypatch.setattr(tool_routes.PermissionNext, "ask", permission_ask)
+        session_id, message_id = await _create_session_and_message("valid-session-context")
+
+        async def handler(ctx) -> ToolResult:
+            await ctx.ask(
+                permission="bash",
+                patterns=["pwd"],
+                always=["*"],
+                metadata={"source": "test"},
+            )
+            return ToolResult(success=True, output="ok")
+
+        tool = Tool(
+            info=ToolInfo(
+                name="http_session_bound_tool",
+                description="session-bound test tool",
+                category=ToolCategory.SYSTEM,
+            ),
+            handler=handler,
+        )
+
+        with _temporary_tool(tool):
+            response = await client.post(
+                "/api/tools/http_session_bound_tool/execute",
+                json={
+                    "params": {},
+                    "sessionID": session_id,
+                    "messageID": message_id,
+                    "agent": "rex",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["success"] is True
+        permission_ask.assert_awaited_once()
+        kwargs = permission_ask.await_args.kwargs
+        assert kwargs["session_id"] == session_id
+        assert kwargs["permission"] == "bash"
+        assert kwargs["metadata"]["messageID"] == message_id
+        assert kwargs["tool"] == {"name": "http_session_bound_tool"}
+
+    @pytest.mark.asyncio
+    async def test_batch_uses_actual_child_tool_name_for_permission_flow(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from flocks.server.routes import tool as tool_routes
+
+        permission_ask = AsyncMock(return_value=None)
+        monkeypatch.setattr(tool_routes.PermissionNext, "ask", permission_ask)
+        session_id, message_id = await _create_session_and_message("valid-batch-session-context")
+
+        async def handler(ctx) -> ToolResult:
+            await ctx.ask(
+                permission="bash",
+                patterns=["pwd"],
+                always=["*"],
+                metadata={"source": "batch-test"},
+            )
+            return ToolResult(success=True, output="ok")
+
+        tool = Tool(
+            info=ToolInfo(
+                name="http_batch_named_tool",
+                description="batch named test tool",
+                category=ToolCategory.SYSTEM,
+            ),
+            handler=handler,
+        )
+
+        with _temporary_tool(tool):
+            response = await client.post(
+                "/api/tools/batch",
+                json={
+                    "calls": [{"name": "http_batch_named_tool", "params": {}}],
+                    "parallel": True,
+                    "sessionID": session_id,
+                    "messageID": message_id,
+                    "agent": "rex",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["results"][0]["success"] is True
+        permission_ask.assert_awaited_once()
+        kwargs = permission_ask.await_args.kwargs
+        assert kwargs["session_id"] == session_id
+        assert kwargs["metadata"]["messageID"] == message_id
+        assert kwargs["tool"] == {"name": "http_batch_named_tool"}

--- a/webui/src/api/tool.ts
+++ b/webui/src/api/tool.ts
@@ -36,3 +36,6 @@ export const toolAPI = {
   delete: (name: string) =>
     client.delete<{ status: string; message: string }>(`/api/tools/${name}`),
 };
+
+export const canDirectlyTestTool = (tool: Pick<Tool, 'source'>) =>
+  tool.source !== 'builtin';

--- a/webui/src/locales/en-US/tool.json
+++ b/webui/src/locales/en-US/tool.json
@@ -310,6 +310,7 @@
     "executing": "Executing...",
     "runTest": "Run Test",
     "disabledNote": "This tool is disabled, cannot run test",
+    "sessionTestOnly": "Built-in tools cannot be tested directly from the Tool page. Please invoke them from a session instead.",
     "testResult": "Test Result",
     "execSuccess": "Execution Successful",
     "execFailed": "Execution Failed",

--- a/webui/src/locales/zh-CN/tool.json
+++ b/webui/src/locales/zh-CN/tool.json
@@ -310,6 +310,7 @@
     "executing": "执行中...",
     "runTest": "执行测试",
     "disabledNote": "该工具已禁用，无法执行测试",
+    "sessionTestOnly": "内置工具暂不支持在 Tool 页面直接测试，请在 session 中调用测试。",
     "testResult": "测试结果",
     "execSuccess": "执行成功",
     "execFailed": "执行失败",

--- a/webui/src/pages/Tool/components/ToolDetailModal.tsx
+++ b/webui/src/pages/Tool/components/ToolDetailModal.tsx
@@ -5,7 +5,7 @@ import {
   CheckCircle, XCircle, AlertTriangle,
 } from 'lucide-react';
 import type { Tool } from '@/api/tool';
-import { toolAPI } from '@/api/tool';
+import { canDirectlyTestTool, toolAPI } from '@/api/tool';
 import { SOURCE_BADGE, CATEGORY_LABEL_KEY } from '../constants';
 import { EnabledBadge } from './badges';
 
@@ -35,6 +35,7 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
   const [testParams, setTestParams] = useState(defaultParams);
   const [testResult, setTestResult] = useState<any>(null);
   const [testing, setTesting] = useState(false);
+  const canDirectTest = canDirectlyTestTool(tool);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') onClose();
@@ -49,6 +50,7 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
   const sourceLabel = sb.labelKey ? t(sb.labelKey) : (sb.label ?? tool.source);
 
   const handleTest = async () => {
+    if (!canDirectTest) return;
     try {
       setTesting(true);
       setTestResult(null);
@@ -185,7 +187,7 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
               </div>
               <button
                 onClick={handleTest}
-                disabled={testing || !tool.enabled}
+                disabled={testing || !tool.enabled || !canDirectTest}
                 className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-sm"
               >
                 {testing ? (
@@ -196,6 +198,9 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
               </button>
               {!tool.enabled && (
                 <p className="text-xs text-amber-600 text-center">{t('toolDetail.disabledNote')}</p>
+              )}
+              {canDirectTest ? null : (
+                <p className="text-xs text-amber-600 text-center">{t('toolDetail.sessionTestOnly')}</p>
               )}
               {testResult && (
                 <div>
@@ -230,7 +235,9 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
           {section === 'info' && (
             <button
               onClick={() => setSection('test')}
-              className="px-4 py-2 bg-red-600 rounded-lg text-sm font-medium text-white hover:bg-red-700 flex items-center"
+              className="px-4 py-2 bg-red-600 rounded-lg text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+              disabled={!canDirectTest}
+              title={canDirectTest ? undefined : t('toolDetail.sessionTestOnly')}
             >
               <TestTube className="w-4 h-4 mr-1.5" />{t('toolDetail.testTool')}
             </button>

--- a/webui/src/pages/Tool/index.tsx
+++ b/webui/src/pages/Tool/index.tsx
@@ -44,7 +44,7 @@ import {
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import EmptyState from '@/components/common/EmptyState';
 import { useTools } from '@/hooks/useTools';
-import { toolAPI, Tool, ToolSource } from '@/api/tool';
+import { canDirectlyTestTool, toolAPI, Tool, ToolSource } from '@/api/tool';
 import { mcpAPI, MCPServer } from '@/api/mcp';
 import { providerAPI } from '@/api/provider';
 import client from '@/api/client';
@@ -365,6 +365,7 @@ export default function ToolPage() {
 
   const handleTest = async () => {
     if (!selectedTool) return;
+    if (!canDirectlyTestTool(selectedTool)) return;
     try {
       setTesting(true);
       setTestResult(null);
@@ -3345,6 +3346,7 @@ function ToolDetailDrawer({
   const [toggling, setToggling] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const sb = SOURCE_BADGE[tool.source] || SOURCE_BADGE.custom;
+  const canDirectTest = canDirectlyTestTool(tool);
 
   useEffect(() => { setEnabled(tool.enabled); }, [tool.enabled]);
 
@@ -3531,7 +3533,7 @@ function ToolDetailDrawer({
               </div>
               <button
                 onClick={onTest}
-                disabled={testing || !tool.enabled}
+                disabled={testing || !tool.enabled || !canDirectTest}
                 className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-slate-700 text-white rounded-lg hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-sm transition-colors"
               >
                 {testing
@@ -3540,6 +3542,9 @@ function ToolDetailDrawer({
               </button>
               {!tool.enabled && (
                 <p className="text-xs text-amber-600 text-center">{t('toolDetail.disabledNote')}</p>
+              )}
+              {canDirectTest ? null : (
+                <p className="text-xs text-amber-600 text-center">{t('toolDetail.sessionTestOnly')}</p>
               )}
               {testResult && (
                 <div>


### PR DESCRIPTION
## Summary
HTTP-triggered tool execution (execute, batch, test) now validates session/message context for permission-sensitive paths, and builtin tools require a verified session-backed request.

## Changes
- **Server**: Add `sessionID` / `messageID` / `agent` to execute, batch, and test payloads; validate session/message; build `ToolContext` with `PermissionNext` when appropriate; map permission denials to HTTP 403.
- **WebUI**: Disable direct "Run test" for builtin tools; add EN/ZH copy explaining session-based testing.
- **Tests**: Add `tests/server/routes/test_tool_routes.py` for the new behavior.