### PR TITLE
fix(config): JSON-escape {secret:} / {env:} substitutions in flocks.json

### DIFF
--- a/flocks/config/config.py
+++ b/flocks/config/config.py
@@ -844,6 +844,18 @@ class Config:
         # Convert back to ConfigInfo
         return ConfigInfo.model_validate(merged)
     
+    @staticmethod
+    def _json_string_escape(value: str) -> str:
+        """JSON-escape a value so it is safe to splice into a JSON string literal.
+
+        Strips the surrounding quotes that ``json.dumps`` adds, leaving just the
+        escaped body. This guarantees backslashes, quotes and control characters
+        in the substituted value cannot break the surrounding JSON document
+        (e.g. a Windows-style path or a token containing ``\\u`` would otherwise
+        produce an "Invalid \\escape" error when the file is parsed).
+        """
+        return json.dumps(value, ensure_ascii=False)[1:-1]
+
     @classmethod
     def replace_env_vars(cls, text: str) -> str:
         """
@@ -859,7 +871,8 @@ class Config:
         """
         def replacer(match):
             var_name = match.group(1)
-            return os.getenv(var_name, "")
+            value = os.getenv(var_name, "")
+            return cls._json_string_escape(value)
         
         return re.sub(r'\{env:([^}]+)\}', replacer, text)
     
@@ -876,13 +889,22 @@ class Config:
         Returns:
             Text with secrets substituted
         """
-        # Only import when needed to avoid circular dependencies
         if '{secret:' not in text:
             return text
         
         try:
-            from flocks.security import resolve_secret_refs
-            return resolve_secret_refs(text)
+            from flocks.security import resolve_secret_value, get_secret_manager
+
+            secrets = get_secret_manager()
+
+            def replacer(match: "re.Match") -> str:
+                secret_id = match.group(1)
+                value = resolve_secret_value(secret_id, secrets)
+                if value is None:
+                    return ""
+                return cls._json_string_escape(value)
+
+            return re.sub(r'\{secret:([^}]+)\}', replacer, text)
         except Exception as e:
             from flocks.utils.log import Log
             log = Log.create(service="config")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -226,3 +226,56 @@ def test_sandbox_mode_config_parsing():
     config = ConfigInfo.model_validate({"sandbox": {"mode": "on"}})
     assert config.sandbox is not None
     assert config.sandbox.get("mode") == "on"
+
+
+@pytest.mark.asyncio
+async def test_load_text_handles_secret_with_backslash(tmp_path, monkeypatch):
+    """Secret values containing ``\\`` must be JSON-escaped on substitution.
+
+    Regression test for the "Invalid \\escape" failure observed on Anolis OS
+    after configuring an API service whose key contained a backslash.
+    The substituted value used to land verbatim inside the JSON string,
+    producing an unparsable file (``json.JSONDecodeError: Invalid \\escape``).
+    """
+    secret_value = r"abc\def\u1234\"qq"  # backslashes + quote + \u sequence
+
+    monkeypatch.setattr(
+        "flocks.security.resolve_secret_value",
+        lambda secret_id, secrets=None: secret_value if secret_id == "broken_key" else None,
+    )
+    monkeypatch.setattr(
+        "flocks.security.get_secret_manager",
+        lambda: object(),
+    )
+
+    config_file = tmp_path / "flocks.json"
+    config_file.write_text(
+        json.dumps({"provider": {"x": {"options": {"apiKey": "{secret:broken_key}"}}}}, indent=2),
+        encoding="utf-8",
+    )
+
+    loaded = await Config.load_file(config_file)
+
+    provider = (loaded.provider or {}).get("x")
+    assert provider is not None
+    assert provider.options is not None
+    assert provider.options.api_key == secret_value
+
+
+@pytest.mark.asyncio
+async def test_load_text_handles_env_with_backslash(tmp_path, monkeypatch):
+    """Environment values containing ``\\`` must also be JSON-escaped."""
+    monkeypatch.setenv("FLOCKS_TEST_BACKSLASH", r"C:\Users\me\token\nVAL")
+
+    config_file = tmp_path / "flocks.json"
+    config_file.write_text(
+        json.dumps({"provider": {"x": {"options": {"apiKey": "{env:FLOCKS_TEST_BACKSLASH}"}}}}, indent=2),
+        encoding="utf-8",
+    )
+
+    loaded = await Config.load_file(config_file)
+
+    provider = (loaded.provider or {}).get("x")
+    assert provider is not None
+    assert provider.options is not None
+    assert provider.options.api_key == r"C:\Users\me\token\nVAL"


### PR DESCRIPTION
Config.load_text used to splice secret and environment values straight into the raw flocks.json text before json.loads. Any value containing a backslash, double quote, control char or "\u" sequence (e.g. a Windows-style path or a token with a stray backslash) silently corrupted the file and surfaced as "Invalid JSON in flocks.json: Invalid \escape".

Reported on Anolis OS after saving an API service credential from the web UI: the key was stored correctly in .secret.json (json.dump escapes properly), but every subsequent load failed because the substituted value was re-injected into a JSON string literal without escaping.

Mirror what replace_file_refs already does and route both replacers through a small _json_string_escape helper
(json.dumps(value, ensure_ascii=False)[1:-1]). Add regression tests covering backslash, quote and "\u" sequences for both secret and env substitutions.

Made-with: Cursor