### PR TITLE
fix/api service test prefer login probe

### DIFF
--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -2200,7 +2200,7 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
         else:
             # This is an API service (not a registered provider)
             # Try to test connectivity by calling a simple tool
-            from flocks.tool.registry import ToolRegistry, ToolCategory
+            from flocks.tool.registry import ToolRegistry, ToolCategory, ToolInfo
             from flocks.server.routes.tool import _get_tool_source
             
             ToolRegistry.init()
@@ -2246,11 +2246,35 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
             # Prefer simpler tools for connectivity testing.
             # Rank tools by required-parameter count (fewer = simpler);
             # prefer lightweight query/scan tools and avoid file/upload handlers.
-            def _tool_sort_key(t):
+            #
+            # NOTE: For services that expose a dedicated login/auth probe
+            # (e.g. qingteng_login, skyeye_login), we want it tried *first* —
+            # it is parameter-free and exercises the credential pipeline end
+            # to end without invoking business APIs that may need extra
+            # required fields beyond the JSON schema (e.g. assets.refresh
+            # which the handler validates needs `resource`/`os_type`).
+            def _is_login_probe(t: ToolInfo) -> bool:
+                if t.requires_confirmation:
+                    return False
+                if any(p.required for p in t.parameters):
+                    return False
+                name_lower = t.name.lower()
+                # Keep this list tight: each keyword must be substring-safe
+                # (no false positives on common business tool names) and
+                # describe a parameter-free probe by convention.
+                login_kw = ("login", "whoami", "ping", "health")
+                return any(kw in name_lower for kw in login_kw)
+
+            def _tool_sort_key(t: ToolInfo) -> tuple[int, int, str]:
                 required_count = sum(1 for p in t.parameters if p.required)
                 name_lower = t.name.lower()
+                # Highest priority: dedicated login/health probes. These are the
+                # safest connectivity test because they have no required params
+                # and only exercise the auth/sign-in flow.
+                if _is_login_probe(t):
+                    priority = -1
                 # Prefer query/scan style tools first, and push upload/file tools last.
-                if "ip" in name_lower:
+                elif "ip" in name_lower:
                     priority = 0
                 elif "url" in name_lower or "scan" in name_lower or "query" in name_lower:
                     priority = 1
@@ -2379,7 +2403,17 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
                     param_sets = next_sets or param_sets
                 return param_sets or [{}]
 
-            last_response = None
+            def _short_repr(value: object, limit: int = 80) -> str:
+                """Compact repr for params, capped to *limit* chars to keep
+                the failure summary message readable (and the cached status
+                payload small)."""
+                text = repr(value)
+                if len(text) <= limit:
+                    return text
+                return text[: limit - 3] + "..."
+
+            attempts: list[dict[str, object]] = []
+            last_response: Optional[dict[str, object]] = None
             for test_tool in service_tools[:5]:
                 for test_params in _build_param_sets(test_tool):
                     try:
@@ -2398,11 +2432,23 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
                                 "message": f"✅ API 连通性测试成功！使用工具 '{test_tool.name}' 进行测试。",
                                 "latency_ms": latency,
                                 "tool_tested": test_tool.name,
+                                "attempts": attempts,
                             }
                             await _save_api_service_status(provider_id, response)
                             return response
 
                         error_detail = result.error or "Unknown error"
+                        log.warning("testing.api.connectivity.failed", {
+                            "service": provider_id,
+                            "tool": test_tool.name,
+                            "params": test_params,
+                            "error": error_detail,
+                        })
+                        attempts.append({
+                            "tool": test_tool.name,
+                            "params": test_params,
+                            "error": error_detail,
+                        })
                         last_response = {
                             "success": False,
                             "message": f"❌ API 调用失败: {error_detail}",
@@ -2412,6 +2458,18 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
                         }
                     except Exception as tool_error:
                         latency = int((time.time() - start) * 1000)
+                        log.warning("testing.api.connectivity.failed", {
+                            "service": provider_id,
+                            "tool": test_tool.name,
+                            "params": test_params,
+                            "error": str(tool_error),
+                            "exception": True,
+                        })
+                        attempts.append({
+                            "tool": test_tool.name,
+                            "params": test_params,
+                            "error": str(tool_error),
+                        })
                         last_response = {
                             "success": False,
                             "message": f"❌ API 连通性测试失败: {str(tool_error)}",
@@ -2426,6 +2484,21 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
                 "error": "No executable connectivity test candidate",
                 "latency_ms": int((time.time() - start) * 1000),
             }
+            # Attach all attempts so the WebUI/log can show why every probe
+            # failed, instead of only the message of the very last attempt.
+            response["attempts"] = attempts
+            if attempts:
+                # Keep message single-line so any UI (toast/popover) renders
+                # consistently regardless of whitespace handling. Per-attempt
+                # params are truncated to avoid blowing up the cached message.
+                detail = "; ".join(
+                    f"{a['tool']}({_short_repr(a.get('params') or {})})→{a['error']}"
+                    for a in attempts
+                )
+                response["message"] = (
+                    f"❌ API 连通性测试失败（共尝试 {len(attempts)} 次）。"
+                    f"最后一次错误: {response.get('error', 'unknown')}｜尝试明细: {detail}"
+                )
             await _save_api_service_status(provider_id, response)
             return response
     except Exception as e:

--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -2253,17 +2253,24 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
             # to end without invoking business APIs that may need extra
             # required fields beyond the JSON schema (e.g. assets.refresh
             # which the handler validates needs `resource`/`os_type`).
+            # Match either the bare keyword (e.g. "login") or the conventional
+            # `<provider>_<keyword>` suffix (e.g. "qingteng_login"). A loose
+            # substring match would over-trigger on business tools whose names
+            # merely contain the word — for example tdp_login_api_list and
+            # tdp_login_weakpwd_list are query endpoints, not probes.
+            login_probe_keywords = ("login", "whoami", "ping", "health")
+
             def _is_login_probe(t: ToolInfo) -> bool:
                 if t.requires_confirmation:
                     return False
                 if any(p.required for p in t.parameters):
                     return False
                 name_lower = t.name.lower()
-                # Keep this list tight: each keyword must be substring-safe
-                # (no false positives on common business tool names) and
-                # describe a parameter-free probe by convention.
-                login_kw = ("login", "whoami", "ping", "health")
-                return any(kw in name_lower for kw in login_kw)
+                if name_lower in login_probe_keywords:
+                    return True
+                return any(
+                    name_lower.endswith(f"_{kw}") for kw in login_probe_keywords
+                )
 
             def _tool_sort_key(t: ToolInfo) -> tuple[int, int, str]:
                 required_count = sum(1 for p in t.parameters if p.required)

--- a/tests/provider/test_test_credentials.py
+++ b/tests/provider/test_test_credentials.py
@@ -284,6 +284,130 @@ class TestTestCredentialsToolExecution:
             )
 
     @pytest.mark.asyncio
+    async def test_service_prefers_login_probe_over_action_dispatch_tool(self):
+        """When a parameter-free login tool exists (e.g. qingteng_login), it
+        should be tried before action-dispatch tools whose handler-side validation
+        requires extra fields beyond the JSON schema (e.g. qingteng_assets which
+        needs `resource` + `os_type` for `assets.refresh`).
+        """
+        from flocks.server.routes.provider import test_provider_credentials
+
+        login_tool = ToolInfo(
+            name="qingteng_login",
+            description="Qingteng login probe",
+            category=ToolCategory.CUSTOM,
+            parameters=[],
+            requires_confirmation=False,
+        )
+        assets_tool = ToolInfo(
+            name="qingteng_assets",
+            description="Qingteng assets dispatch",
+            category=ToolCategory.CUSTOM,
+            parameters=[
+                ToolParameter(
+                    name="action",
+                    type=ParameterType.STRING,
+                    description="Asset action",
+                    required=True,
+                    enum=["list", "refresh", "refresh_status", "delete_host"],
+                )
+            ],
+            requires_confirmation=True,
+        )
+
+        mock_secrets = MagicMock()
+        mock_secrets.get.return_value = "valid-creds"
+
+        with (
+            patch(_PATCH_SECRET_MGR, return_value=mock_secrets),
+            patch(_PATCH_PROVIDER) as mock_provider_cls,
+            patch(_PATCH_TOOL_REGISTRY) as mock_tr,
+            patch(_PATCH_TOOL_SOURCE, return_value=("api", "qingteng")),
+        ):
+            mock_provider_cls._ensure_initialized = MagicMock()
+            mock_provider_cls.apply_config = AsyncMock()
+            mock_provider_cls.get.return_value = None
+
+            mock_tr.init = MagicMock()
+            mock_tr.list_tools.return_value = [assets_tool, login_tool]
+            mock_tr._dynamic_tools_by_module = {
+                "flocks.tool.generated.qingteng": ["qingteng_assets", "qingteng_login"],
+            }
+            mock_tr.execute = AsyncMock(return_value=ToolResult(
+                success=True,
+                output={"jwt": "fake", "signKey": "fake", "comId": "1"},
+            ))
+
+            result = await test_provider_credentials("qingteng")
+
+            assert result["success"] is True, result
+            assert result["tool_tested"] == "qingteng_login"
+            mock_tr.execute.assert_awaited_once_with(tool_name="qingteng_login")
+
+    @pytest.mark.asyncio
+    async def test_failed_attempts_are_aggregated_in_message(self):
+        """When every tool/param combination fails, the response should expose
+        the per-attempt error log so the WebUI can show why each probe failed
+        instead of only the message of the last attempt.
+        """
+        from flocks.server.routes.provider import test_provider_credentials
+
+        assets_tool = ToolInfo(
+            name="qingteng_assets",
+            description="Qingteng assets dispatch",
+            category=ToolCategory.CUSTOM,
+            parameters=[
+                ToolParameter(
+                    name="action",
+                    type=ParameterType.STRING,
+                    description="Asset action",
+                    required=True,
+                    enum=["list", "refresh"],
+                )
+            ],
+            requires_confirmation=True,
+        )
+
+        mock_secrets = MagicMock()
+        mock_secrets.get.return_value = "valid-creds"
+
+        with (
+            patch(_PATCH_SECRET_MGR, return_value=mock_secrets),
+            patch(_PATCH_PROVIDER) as mock_provider_cls,
+            patch(_PATCH_TOOL_REGISTRY) as mock_tr,
+            patch(_PATCH_TOOL_SOURCE, return_value=("api", "qingteng")),
+        ):
+            mock_provider_cls._ensure_initialized = MagicMock()
+            mock_provider_cls.apply_config = AsyncMock()
+            mock_provider_cls.get.return_value = None
+
+            mock_tr.init = MagicMock()
+            mock_tr.list_tools.return_value = [assets_tool]
+            mock_tr._dynamic_tools_by_module = {
+                "flocks.tool.generated.qingteng": ["qingteng_assets"],
+            }
+
+            errors_by_action = {
+                "list": "Missing required parameters for assets.list: resource, os_type",
+                "refresh": "Missing required parameters for assets.refresh: resource, os_type",
+            }
+
+            async def _execute(tool_name, **params):
+                action = params.get("action")
+                return ToolResult(success=False, error=errors_by_action[action])
+
+            mock_tr.execute = AsyncMock(side_effect=_execute)
+
+            result = await test_provider_credentials("qingteng")
+
+            assert result["success"] is False, result
+            assert "attempts" in result, result
+            attempted_actions = {a["params"].get("action") for a in result["attempts"]}
+            assert {"list", "refresh"}.issubset(attempted_actions), result["attempts"]
+            assert "assets.list" in result["message"]
+            assert "assets.refresh" in result["message"]
+
+    @pytest.mark.asyncio
     async def test_service_metadata_secret_is_used_for_hyphenated_service(self):
         """API services should prefer metadata-defined secret ids over provider_id defaults."""
         from flocks.server.routes.provider import test_provider_credentials

--- a/tests/provider/test_test_credentials.py
+++ b/tests/provider/test_test_credentials.py
@@ -345,6 +345,87 @@ class TestTestCredentialsToolExecution:
             mock_tr.execute.assert_awaited_once_with(tool_name="qingteng_login")
 
     @pytest.mark.asyncio
+    async def test_login_probe_does_not_overmatch_business_tools(self):
+        """`_is_login_probe` must only match dedicated probes — not arbitrary
+        business tools whose names happen to contain ``login`` (e.g. TDP's
+        ``tdp_login_api_list`` / ``tdp_login_weakpwd_list``). Otherwise we
+        would prioritise an expensive query endpoint over the cheaper
+        connectivity-style tool that the sort key normally prefers.
+        """
+        from flocks.server.routes.provider import test_provider_credentials
+
+        login_business_tool = ToolInfo(
+            name="tdp_login_api_list",
+            description="TDP login entry list (business query, NOT a probe)",
+            category=ToolCategory.CUSTOM,
+            parameters=[
+                ToolParameter(
+                    name="action",
+                    type=ParameterType.STRING,
+                    description="sub-action",
+                    required=False,
+                    enum=["summary", "category", "list"],
+                )
+            ],
+            requires_confirmation=False,
+        )
+        ip_query_tool = ToolInfo(
+            name="tdp_ip_query",
+            description="TDP IP query (preferred lightweight check)",
+            category=ToolCategory.CUSTOM,
+            parameters=[
+                ToolParameter(
+                    name="ip",
+                    type=ParameterType.STRING,
+                    description="IP address",
+                    required=False,
+                )
+            ],
+            requires_confirmation=False,
+        )
+
+        mock_secrets = MagicMock()
+        mock_secrets.get.return_value = "valid-creds"
+
+        with (
+            patch(_PATCH_SECRET_MGR, return_value=mock_secrets),
+            patch(_PATCH_PROVIDER) as mock_provider_cls,
+            patch(_PATCH_TOOL_REGISTRY) as mock_tr,
+            patch(_PATCH_TOOL_SOURCE, return_value=("api", "tdp_api")),
+        ):
+            mock_provider_cls._ensure_initialized = MagicMock()
+            mock_provider_cls.apply_config = AsyncMock()
+            mock_provider_cls.get.return_value = None
+
+            mock_tr.init = MagicMock()
+            mock_tr.list_tools.return_value = [login_business_tool, ip_query_tool]
+            mock_tr._dynamic_tools_by_module = {
+                "flocks.tool.generated.tdp_api": [
+                    "tdp_login_api_list",
+                    "tdp_ip_query",
+                ],
+            }
+            mock_tr.execute = AsyncMock(return_value=ToolResult(
+                success=True,
+                output={"items": []},
+            ))
+
+            result = await test_provider_credentials("tdp_api")
+
+            assert result["success"] is True, result
+            assert result["tool_tested"] == "tdp_ip_query", (
+                "Expected the lightweight ip_query tool to be picked, but "
+                "got %r. This usually means _is_login_probe is doing a loose "
+                "substring match and mis-classifying tdp_login_api_list as a "
+                "probe." % result.get("tool_tested")
+            )
+            executed_tool = mock_tr.execute.await_args.kwargs["tool_name"]
+            assert executed_tool == "tdp_ip_query", (
+                "Only the lightweight ip_query tool should have been awaited; "
+                "got %r." % executed_tool
+            )
+
+    @pytest.mark.asyncio
     async def test_failed_attempts_are_aggregated_in_message(self):
         """When every tool/param combination fails, the response should expose
         the per-attempt error log so the WebUI can show why each probe failed


### PR DESCRIPTION
ix(server/routes/provider): prefer login probe when testing API service

The API-service connectivity test (`test_provider_credentials`) used to
sort tools only by name keywords (`ip`/`url`/`scan`/`query`/`domain`)
and fall back to the required-parameter count. For services like
Qingteng whose tools are all named `qingteng_*`, the sort collapsed to
parameter count alone, so action-dispatch tools (e.g. `qingteng_assets`,
`qingteng_asset_discovery`) were tried first. Their JSON schema only
marks `action` as required, but the handler then validates each action
needs additional fields (`assets.refresh` requires `resource`/`os_type`,
`assetdiscovery.job_execute` requires `specId`, etc.), so every probe
failed with `Missing required parameters for assets.refresh: ...`.

Prefer parameter-free login probes (`*_login`, `*_whoami`, `*_ping`,
`*_health`) by giving them the highest sort priority, gated by
`requires_confirmation == False` and zero required params to avoid
misclassifying write tools that happen to contain `login` in the name.
This makes the existing `qingteng_login` (and similar Skyeye/OneSEC
auth probes) the first thing tried, which exercises the full
credential pipeline without invoking business APIs.

Also aggregate every failed attempt into the response under a new
`attempts` field and a single-line summary in `message`, so the WebUI
and logs can show why each probe failed instead of only the very last
attempt's error. Add a structured warning log per failed attempt for
operational visibility.