### PR TITLE
ci: split Windows packaging and Gitee release sync

### DIFF
--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -1,7 +1,8 @@
 name: Sync GitHub Release to Gitee
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   sync:

--- a/.github/workflows/windows-packaging-publish.yml
+++ b/.github/workflows/windows-packaging-publish.yml
@@ -100,19 +100,3 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  sync-gitee:
-    name: Sync GitHub Release to Gitee
-    runs-on: ubuntu-latest
-    needs: release-asset
-    steps:
-      - name: Sync GitHub Release to Gitee
-        uses: trustedinster/sync-release-gitee@v1.3
-        with:
-          gitee_owner: flocks
-          gitee_repo: flocks
-          gitee_token: ${{ secrets.GITEE_TOKEN }}
-          github_owner: AgentFlocks
-          github_repo: flocks
-          gitee_upload_retry_times: 3
-          debug: false


### PR DESCRIPTION
## Summary

- Rename/split the former `packaging-sync-gitee.yml` into `windows-packaging-publish.yml`, keeping only the Windows installer build and GitHub Release asset upload.
- Update `sync-gitee.yml` to run on `release: types: [published]` instead of `workflow_dispatch`.

## Notes

- Both workflows now start on the same `release.published` event. If Gitee sync must run **after** the installer upload finishes, consider chaining them (e.g. `workflow_run` on the packaging workflow, or a single workflow with `needs`) so uploads are ordered.


Made with [Cursor](https://cursor.com)