### PR TITLE
feat(provider): align reasoning defaults and add kimi-k2.6 to catalog

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -139,6 +139,26 @@
           "output": 10.0,
           "currency": "CNY"
         }
+      },
+      "kimi-k2.6": {
+        "name": "kimi-k2.6",
+        "family": "kimi-k2.6",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 256000,
+          "max_input_tokens": 224000,
+          "max_output_tokens": 16000
+        },
+        "pricing": {
+          "input": 6.5,
+          "output": 27.0,
+          "cache_read": 1.3,
+          "currency": "CNY"
+        }
       }
     }
   },

--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -1021,6 +1021,26 @@
           "currency": "CNY"
         }
       },
+      "kimi-k2.6": {
+        "name": "Kimi K2.6",
+        "family": "kimi-k2.6",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 256000,
+          "max_input_tokens": 224000,
+          "max_output_tokens": 16000
+        },
+        "pricing": {
+          "input": 6.5,
+          "output": 27.0,
+          "cache_read": 1.3,
+          "currency": "CNY"
+        }
+      },
       "kimi-k2-thinking": {
         "name": "Kimi K2 Thinking",
         "family": "kimi-k2",

--- a/flocks/provider/model_catalog.py
+++ b/flocks/provider/model_catalog.py
@@ -145,6 +145,7 @@ def _parse_model_definitions(
 
         limits = ModelLimits(
             context_window=limits_raw.get("context_window", 128000),
+            max_input_tokens=limits_raw.get("max_input_tokens"),
             max_output_tokens=limits_raw.get("max_output_tokens", 4096),
         )
 

--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -22,10 +22,48 @@ DEFAULT_THINKING_BUDGET = 16000
 DEFAULT_OUTPUT_BUFFER = 8192
 
 
+def _coerce_optional_bool(value: Any) -> Optional[bool]:
+    """Coerce config values to bool while preserving None."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _resolve_reasoning_enabled(provider_id: str, model_id: str) -> Optional[bool]:
+    """Read model-level default reasoning settings from flocks.json."""
+    try:
+        from flocks.provider.model_manager import get_model_manager
+
+        setting = get_model_manager().get_setting(provider_id, model_id)
+        if not setting:
+            return None
+
+        default_parameters = setting.default_parameters or {}
+        return _coerce_optional_bool(default_parameters.get("enable_thinking"))
+    except Exception as exc:
+        log.debug("options.reasoning_setting_lookup_failed", {
+            "provider_id": provider_id,
+            "model_id": model_id,
+            "error": str(exc),
+        })
+        return None
+
+
 def build_provider_options(
     provider_id: str,
     model_id: str,
     *,
+    reasoning_enabled: Optional[bool] = None,
     thinking_budget: int = DEFAULT_THINKING_BUDGET,
     resolve_max_tokens: bool = True,
 ) -> Dict[str, Any]:
@@ -49,6 +87,11 @@ def build_provider_options(
     """
     options: Dict[str, Any] = {}
     model_lower = model_id.lower()
+    reasoning_enabled = (
+        _coerce_optional_bool(reasoning_enabled)
+        if reasoning_enabled is not None
+        else _resolve_reasoning_enabled(provider_id, model_id)
+    )
 
     # -- Claude extended thinking (any provider, including proxies) ----------
     if "claude" in model_lower:
@@ -57,22 +100,23 @@ def build_provider_options(
         # the catalog entry (catalog takes priority over flocks.json overrides
         # per anthropic.py get_model_definitions), so api_limit reflects the
         # real Anthropic limit (e.g. 64 000 for claude-sonnet-4-20250514).
-        api_limit = _get_catalog_model_max_tokens(model_id)
-        effective_budget = min(thinking_budget, api_limit // 2) if api_limit else thinking_budget
-        options["thinking"] = {
-            "type": "enabled",
-            "budget_tokens": effective_budget,
-        }
-        options["max_tokens"] = api_limit if api_limit else (thinking_budget + DEFAULT_OUTPUT_BUFFER)
+        if reasoning_enabled is not False:
+            api_limit = _get_catalog_model_max_tokens(model_id)
+            effective_budget = min(thinking_budget, api_limit // 2) if api_limit else thinking_budget
+            options["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": effective_budget,
+            }
+            options["max_tokens"] = api_limit if api_limit else (thinking_budget + DEFAULT_OUTPUT_BUFFER)
 
     # -- OpenAI reasoning (o1 / o3 / gpt-5) --------------------------------
     elif provider_id == "openai":
-        if any(tag in model_lower for tag in ("o1", "o3", "gpt-5")):
+        if reasoning_enabled is not False and any(tag in model_lower for tag in ("o1", "o3", "gpt-5")):
             options["reasoningEffort"] = "medium"
 
     # -- Google Gemini thinking ---------------------------------------------
     elif provider_id == "google":
-        if "gemini" in model_lower:
+        if reasoning_enabled is not False and "gemini" in model_lower:
             if "2.5" in model_lower:
                 options["thinkingConfig"] = {
                     "includeThoughts": True,
@@ -86,21 +130,31 @@ def build_provider_options(
 
     # -- Groq thinking ------------------------------------------------------
     elif provider_id == "groq":
-        options["thinkingLevel"] = "high"
+        if reasoning_enabled is not False:
+            options["thinkingLevel"] = "high"
 
     # -- Qwen reasoning (ThreatBook-hosted or Alibaba DashScope) -------------
-    elif provider_id in ("threatbook-cn-llm", "threatbook-io-llm", "alibaba"):
+    elif provider_id in ("threatbook-cn-llm", "threatbook-io-llm", "alibaba", "moonshot"):
         if "qwen3-max" in model_lower or "qwen3.6-plus" in model_lower:
-            options["extra_body"] = {"enable_thinking": True}
+            options["extra_body"] = {
+                "enable_thinking": True if reasoning_enabled is None else reasoning_enabled
+            }
+        elif "kimi-k2.5" in model_lower or "kimi-k2.6" in model_lower:
+            # ThreatBook CN defaults hybrid-thinking models to reasoning-on.
+            # Other compatible providers keep direct reply as the default.
+            default_enabled = provider_id == "threatbook-cn-llm"
+            options["extra_body"] = {
+                "enable_thinking": default_enabled if reasoning_enabled is None else reasoning_enabled
+            }
 
     # -- Amazon Bedrock reasoning -------------------------------------------
     elif provider_id == "amazon-bedrock":
-        if "anthropic" in model_lower:
+        if reasoning_enabled is not False and "anthropic" in model_lower:
             options["reasoningConfig"] = {
                 "type": "enabled",
                 "budget_tokens": thinking_budget,
             }
-        elif "nova" in model_lower:
+        elif reasoning_enabled is not False and "nova" in model_lower:
             options["reasoningConfig"] = {
                 "type": "enabled",
                 "maxReasoningEffort": "high",

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -30,6 +30,7 @@ class TestCuratedCatalogProviders:
             "zhipu",
             "minimax",
             "stepfun",
+            "cherry",
         }
 
     def test_removed_provider_ids_are_absent(self):
@@ -97,9 +98,9 @@ class TestCuratedCatalogModels:
 
         models = get_provider_model_definitions("anthropic")
         ids = {m.id for m in models}
-        assert ids == {"claude-sonnet-4.6", "claude-opus-4.6"}
+        assert ids == {"claude-sonnet-4-6", "claude-opus-4-6"}
 
-        opus = next(m for m in models if m.id == "claude-opus-4.6")
+        opus = next(m for m in models if m.id == "claude-opus-4-6")
         assert opus.capabilities.supports_vision is True
         assert opus.pricing.output == 25.0
 
@@ -208,13 +209,20 @@ class TestCuratedCatalogModels:
             "minimax-m2.7",
             "minimax-m2.5",
             "GLM-5",
+            "qwen3.6-plus",
+            "qwen3-max",
+            "kimi-k2.6",
         }
 
-        glm5 = next(m for m in models if m.id == "GLM-5")
-        assert glm5.pricing.currency == "CNY"
-        assert glm5.pricing.output == 18.0
-        assert glm5.limits.context_window == 200000
-        assert glm5.limits.max_output_tokens == 128000
+        kimi = next(m for m in models if m.id == "kimi-k2.6")
+        assert kimi.capabilities.supports_reasoning is True
+        assert kimi.pricing.currency == "CNY"
+        assert kimi.pricing.cache_read == 1.3
+        assert kimi.pricing.input == 6.5
+        assert kimi.pricing.output == 27.0
+        assert kimi.limits.context_window == 256000
+        assert kimi.limits.max_input_tokens == 224000
+        assert kimi.limits.max_output_tokens == 16000
 
     def test_threatbook_io_llm_catalog(self):
         meta = get_provider_meta("threatbook-io-llm")
@@ -226,6 +234,8 @@ class TestCuratedCatalogModels:
             "minimax-m2.7",
             "minimax-m2.5",
             "GLM-5",
+            "qwen3.6-plus",
+            "qwen3-max",
         }
 
         m27 = next(m for m in models if m.id == "minimax-m2.7")

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -165,9 +165,16 @@ class TestCuratedCatalogModels:
         models = get_provider_model_definitions("moonshot")
         assert {m.id for m in models} == {
             "kimi-k2.5",
+            "kimi-k2.6",
             "kimi-k2-thinking",
             "kimi-k2",
         }
+
+        k26 = next(m for m in models if m.id == "kimi-k2.6")
+        assert k26.capabilities.supports_reasoning is True
+        assert k26.pricing.currency == "CNY"
+        assert k26.pricing.cache_read == 1.3
+        assert k26.limits.context_window == 256000
 
         thinking = next(m for m in models if m.id == "kimi-k2-thinking")
         assert thinking.capabilities.supports_reasoning is True

--- a/tests/provider/test_provider_options.py
+++ b/tests/provider/test_provider_options.py
@@ -1,0 +1,81 @@
+from flocks.provider import options as provider_options
+
+
+class TestBuildProviderOptions:
+    def test_claude_reasoning_can_be_disabled(self):
+        options = provider_options.build_provider_options(
+            "anthropic",
+            "claude-sonnet-4-6",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+
+        assert "thinking" not in options
+
+    def test_threatbook_qwen_enables_thinking_by_default(self):
+        options = provider_options.build_provider_options(
+            "threatbook-cn-llm",
+            "qwen3.6-plus",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"]["enable_thinking"] is True
+
+    def test_threatbook_qwen_respects_reasoning_toggle(self):
+        options = provider_options.build_provider_options(
+            "threatbook-cn-llm",
+            "qwen3.6-plus",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"]["enable_thinking"] is False
+
+    def test_threatbook_kimi_hybrid_models_enable_thinking_by_default(self):
+        options = provider_options.build_provider_options(
+            "threatbook-cn-llm",
+            "kimi-k2.6",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"]["enable_thinking"] is True
+
+    def test_moonshot_kimi_hybrid_models_disable_thinking_by_default(self):
+        options = provider_options.build_provider_options(
+            "moonshot",
+            "kimi-k2.6",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"]["enable_thinking"] is False
+
+    def test_kimi_hybrid_models_respect_explicit_reasoning_toggle(self):
+        options = provider_options.build_provider_options(
+            "threatbook-cn-llm",
+            "kimi-k2.5",
+            reasoning_enabled=True,
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"]["enable_thinking"] is True
+
+    def test_model_setting_enable_thinking_is_applied(self, monkeypatch):
+        monkeypatch.setattr(provider_options, "_resolve_reasoning_enabled", lambda *_args: True)
+
+        options = provider_options.build_provider_options(
+            "moonshot",
+            "kimi-k2.6",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"]["enable_thinking"] is True
+
+    def test_openai_reasoning_can_be_disabled(self):
+        options = provider_options.build_provider_options(
+            "openai",
+            "gpt-5.4",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+
+        assert "reasoningEffort" not in options

--- a/tests/server/routes/test_provider_model_bootstrap.py
+++ b/tests/server/routes/test_provider_model_bootstrap.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from flocks.config.config_writer import ConfigWriter
+from flocks.provider.model_catalog import (
+    get_provider_model_definitions,
+    sync_catalog_models_to_config,
+)
+from flocks.server.routes import provider as provider_routes
+
+
+class TestThreatBookProviderModelBootstrap:
+    @pytest.mark.asyncio
+    async def test_set_provider_credentials_bootstraps_kimi_k26_from_catalog(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        fake_secrets = MagicMock()
+        runtime_provider = MagicMock()
+
+        monkeypatch.setattr("flocks.security.get_secret_manager", lambda: fake_secrets)
+        monkeypatch.setattr(provider_routes.Provider, "_ensure_initialized", MagicMock())
+        monkeypatch.setattr(provider_routes.Provider, "get", lambda _provider_id: runtime_provider)
+
+        result = await provider_routes.set_provider_credentials(
+            "threatbook-cn-llm",
+            provider_routes.ProviderCredentialRequest(api_key="tb-key"),
+        )
+
+        assert result["success"] is True
+
+        raw = ConfigWriter.get_provider_raw("threatbook-cn-llm")
+        assert raw is not None
+        assert "kimi-k2.6" in raw["models"]
+        assert raw["models"]["kimi-k2.6"]["name"] == "kimi-k2.6"
+        fake_secrets.set.assert_called_once_with("threatbook-cn-llm_llm_key", "tb-key")
+        runtime_provider.configure.assert_called_once()
+
+    def test_sync_catalog_models_to_config_backfills_missing_kimi_k26(self):
+        existing_models = {
+            model.id: {"name": model.name}
+            for model in get_provider_model_definitions("threatbook-cn-llm")
+            if model.id != "kimi-k2.6"
+        }
+        assert "kimi-k2.6" not in existing_models
+
+        ConfigWriter.add_provider(
+            "threatbook-cn-llm",
+            ConfigWriter.build_provider_config(
+                "threatbook-cn-llm",
+                npm="@ai-sdk/openai-compatible",
+                base_url="https://llm.threatbook.cn/v1",
+                models=existing_models,
+            ),
+        )
+
+        added = sync_catalog_models_to_config()
+        raw = ConfigWriter.get_provider_raw("threatbook-cn-llm")
+
+        assert added == 1
+        assert raw is not None
+        assert "kimi-k2.6" in raw["models"]
+        assert raw["models"]["kimi-k2.6"]["name"] == "kimi-k2.6"

--- a/webui/src/pages/Model/index.tsx
+++ b/webui/src/pages/Model/index.tsx
@@ -2004,6 +2004,25 @@ function ToggleField({ label, checked, onChange }: {
   );
 }
 
+function getDefaultReasoningToggleValue(providerId: string, modelId: string): boolean {
+  const lowered = modelId.toLowerCase();
+
+  if (providerId === 'threatbook-cn-llm') return true;
+
+  if (lowered.includes('claude')) return true;
+  if (providerId === 'openai' && ['o1', 'o3', 'gpt-5'].some(tag => lowered.includes(tag))) return true;
+  if (providerId === 'google' && lowered.includes('gemini') && (lowered.includes('2.5') || lowered.includes('gemini-3'))) return true;
+  if (providerId === 'groq') return true;
+  if (providerId === 'amazon-bedrock' && (lowered.includes('anthropic') || lowered.includes('nova'))) return true;
+
+  if (['threatbook-cn-llm', 'threatbook-io-llm', 'alibaba', 'moonshot'].includes(providerId)) {
+    if (lowered.includes('qwen3-max') || lowered.includes('qwen3.6-plus')) return true;
+    if (lowered.includes('kimi-k2.5') || lowered.includes('kimi-k2.6')) return false;
+  }
+
+  return false;
+}
+
 // ==================== Configure Dialog ====================
 
 function ConfigureProviderDialog({ provider, existingCredentials, models, onClose, onConfigured, onTestResult, onDelete }: {
@@ -2394,25 +2413,42 @@ function ModelDetailSheet({
   const toast = useToast();
   const { t } = useTranslation('model');
   const features = model.capabilities?.features || [];
+  const modelSupportsReasoning = features.includes('reasoning') || !!model.capabilities?.supports_reasoning;
   const [name, setName] = useState(model.name);
   const [contextWindow, setContextWindow] = useState(model.limits?.context_window != null ? String(model.limits.context_window) : '128000');
   const [maxOutput, setMaxOutput] = useState(model.limits?.max_output_tokens != null ? String(model.limits.max_output_tokens) : '4096');
   const [supportsTools, setSupportsTools] = useState(features.includes('tool_call') || !!model.capabilities?.supports_tools);
   const [supportsVision, setSupportsVision] = useState(features.includes('vision') || !!model.capabilities?.supports_vision);
   const [supportsStreaming, setSupportsStreaming] = useState(!!model.capabilities?.supports_streaming);
-  const [supportsReasoning, setSupportsReasoning] = useState(features.includes('reasoning') || !!model.capabilities?.supports_reasoning);
+  const [supportsReasoning, setSupportsReasoning] = useState(modelSupportsReasoning);
   const [inputPrice, setInputPrice] = useState(model.pricing ? String(model.pricing.input) : '0');
   const [outputPrice, setOutputPrice] = useState(model.pricing ? String(model.pricing.output) : '0');
   const [currency, setCurrency] = useState(model.pricing?.currency ?? 'USD');
   const [enabled, setEnabled] = useState(true);
+  const [defaultParameters, setDefaultParameters] = useState<Record<string, any>>({});
   const [loading, setLoading] = useState(false);
   const [loadingSettings, setLoadingSettings] = useState(true);
 
   useEffect(() => {
     modelSettingsAPI.get(provider.id, model.id).then(r => {
       setEnabled(r.data.enabled !== false);
-    }).catch(() => setEnabled(true)).finally(() => setLoadingSettings(false));
-  }, [provider.id, model.id]);
+      setDefaultParameters(r.data.default_parameters || {});
+      if (modelSupportsReasoning) {
+        const configured = r.data.default_parameters?.enable_thinking;
+        setSupportsReasoning(
+          typeof configured === 'boolean'
+            ? configured
+            : getDefaultReasoningToggleValue(provider.id, model.id)
+        );
+      }
+    }).catch(() => {
+      setEnabled(true);
+      setDefaultParameters({});
+      if (modelSupportsReasoning) {
+        setSupportsReasoning(getDefaultReasoningToggleValue(provider.id, model.id));
+      }
+    }).finally(() => setLoadingSettings(false));
+  }, [model.id, modelSupportsReasoning, provider.id]);
 
   const handleSave = async () => {
     setLoading(true);
@@ -2426,12 +2462,20 @@ function ModelDetailSheet({
           supports_vision: supportsVision,
           supports_tools: supportsTools,
           supports_streaming: supportsStreaming,
-          supports_reasoning: supportsReasoning,
+          supports_reasoning: modelSupportsReasoning ? modelSupportsReasoning : supportsReasoning,
           input_price: parseFloat(inputPrice) || 0,
           output_price: parseFloat(outputPrice) || 0,
           currency,
         }),
-        modelSettingsAPI.update(provider.id, model.id, { enabled }),
+        modelSettingsAPI.update(provider.id, model.id, {
+          enabled,
+          default_parameters: modelSupportsReasoning
+            ? {
+              ...defaultParameters,
+              enable_thinking: supportsReasoning,
+            }
+            : undefined,
+        }),
       ]);
       toast.success(t('credentialsSaved'));
       onSaved();


### PR DESCRIPTION
## Summary
- Respect `enable_thinking` from model settings when building provider options (Claude/OpenAI/Gemini/Groq/Bedrock/Qwen/Kimi paths).
- Parse optional `max_input_tokens` from the curated catalog; add **kimi-k2.6** entry for `threatbook-cn-llm`.
- WebUI Model sheet: align the reasoning toggle with server defaults and persist `enable_thinking` in `default_parameters` on save.
- Tests: refresh curated catalog expectations (e.g. Anthropic model ids, cherry provider) and add `test_provider_options.py`.