### PR TITLE
fix/sangfor xdr test credentials

### DIFF
--- a/.flocks/plugins/tools/api/sangfor_xdr/_provider.yaml
+++ b/.flocks/plugins/tools/api/sangfor_xdr/_provider.yaml
@@ -35,13 +35,11 @@ credential_fields:
     input_type: text
     required: false
     default: "443"
-  - key: verify_ssl
-    label: Verify SSL
-    storage: config
-    config_key: verify_ssl
-    input_type: text
-    required: false
-    default: "false"
+  # NOTE: ``verify_ssl`` was previously declared here as a free-text
+  # credential field, which duplicated the generic "SSL 验证" toggle that
+  # ServiceDetailPanel renders for every API service (both write to the
+  # same ``raw_config["verify_ssl"]`` key).  The duplicate text input has
+  # been removed — use the toggle below the credential form instead.
 defaults:
   timeout: 60
   category: custom
@@ -52,4 +50,5 @@ notes: |
   3. 将联动码填入 Auth Code 字段
   4. 联动码内部包含 AK/SK，Handler 会自动解密并使用 HMAC-SHA256 签名
   5. 签名完成后不可修改请求的任何内容
-  6. 内网部署环境可将 Verify SSL 设为 false
+  6. 内网部署环境请通过下方『SSL 验证』开关关闭证书校验
+     （与原 Verify SSL 输入框等价，已统一收敛到通用开关）

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
@@ -450,16 +450,20 @@ async def run_alerts(ctx: ToolContext) -> ToolResult:
         uuid = params.get("uuid", "")
         if not uuid:
             return ToolResult(success=False, error="uuid is required for get_proof")
-        return await _run_request("POST", f"/api/xdr/v1/alerts/{uuid}/proof", data={})
-
-    elif action == "get_detail":
-        uuid = params.get("uuid", "")
-        if not uuid:
-            return ToolResult(success=False, error="uuid is required for get_detail")
-        return await _run_request("POST", f"/api/xdr/v1/alerts/{uuid}/detail", data={})
+        # Spec: GET /api/xdr/v1/alerts/:uuid/proof  (开放接口列表 v1，
+        # apiRequestType=1 即 GET).  Earlier versions sent POST and were
+        # silently ignored / 404'd by the appliance.
+        return await _run_request("GET", f"/api/xdr/v1/alerts/{uuid}/proof")
 
     else:
-        return ToolResult(success=False, error=f"Unknown alert action: {action}. Use: list, update_status, status_list, get_proof, get_detail")
+        return ToolResult(
+            success=False,
+            error=(
+                f"Unknown alert action: {action}. Use: list, update_status, "
+                "status_list, get_proof. (注：标准开放列表中没有 alerts/:uuid/detail "
+                "接口，如需查看告警详情请使用 list 并按 uuId 过滤。)"
+            ),
+        )
 
 
 # ── Incidents ────────────────────────────────────────────────────────────────
@@ -496,7 +500,8 @@ async def run_incidents(ctx: ToolContext) -> ToolResult:
         uuid = params.get("uuid", "")
         if not uuid:
             return ToolResult(success=False, error="uuid is required for get_proof")
-        return await _run_request("POST", f"/api/xdr/v1/incidents/{uuid}/proof", data={})
+        # Spec: GET /api/xdr/v1/incidents/:uuid/proof
+        return await _run_request("GET", f"/api/xdr/v1/incidents/{uuid}/proof")
 
     elif action == "get_entities":
         uuid = params.get("uuid", "")
@@ -506,16 +511,22 @@ async def run_incidents(ctx: ToolContext) -> ToolResult:
         valid_types = ("host", "dns", "innerip", "ip", "file", "process")
         if entity_type not in valid_types:
             return ToolResult(success=False, error=f"entity_type must be one of {valid_types}")
-        return await _run_request("POST", f"/api/xdr/v1/incidents/{uuid}/entities/{entity_type}", data={})
-
-    elif action == "get_detail":
-        uuid = params.get("uuid", "")
-        if not uuid:
-            return ToolResult(success=False, error="uuid is required for get_detail")
-        return await _run_request("POST", f"/api/xdr/v1/incidents/{uuid}/detail", data={})
+        # Spec: GET /api/xdr/v1/incidents/:uuid/entities/{dns,file,host,
+        # innerip,ip,process}.  All six entity sub-paths are GET in the
+        # 开放接口列表; POST returns 405 / signature mismatch.
+        return await _run_request(
+            "GET", f"/api/xdr/v1/incidents/{uuid}/entities/{entity_type}"
+        )
 
     else:
-        return ToolResult(success=False, error=f"Unknown incident action: {action}. Use: list, update_status, status_list, get_proof, get_entities, get_detail")
+        return ToolResult(
+            success=False,
+            error=(
+                f"Unknown incident action: {action}. Use: list, update_status, "
+                "status_list, get_proof, get_entities. (注：标准开放列表中没有 "
+                "incidents/:uuid/detail 接口，事件详情请通过 list 按 uuId 过滤获取。)"
+            ),
+        )
 
 
 # ── Responses (Isolate / Unisolate) ─────────────────────────────────────────
@@ -664,7 +675,10 @@ async def run_vulns(ctx: ToolContext) -> ToolResult:
             body["pageSize"] = int(params["page_size"])
         if params.get("page_num"):
             body["pageNum"] = int(params["page_num"])
-        return await _run_request("POST", "/api/xdr/v1/vuls/list", data=body)
+        # Spec: POST /api/xdr/v1/vuls/risk/list (获取漏洞、弱密码数据).
+        # The legacy ``/api/xdr/v1/vuls/list`` path does not exist in the
+        # 开放接口列表 and was returning 404 / signature failures.
+        return await _run_request("POST", "/api/xdr/v1/vuls/risk/list", data=body)
 
     else:
         return ToolResult(success=False, error=f"Unknown vuln action: {action}. Use: baseline, update_status, source_device, vuln_list")

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
@@ -312,12 +312,22 @@ async def _request(
     session: aiohttp.ClientSession,
     method: str,
     path: str,
-    data: Optional[dict[str, Any]] = None,
+    data: Optional[Any] = None,
     params: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     ak, sk = _decode_auth_code(cfg.auth_code)
     url = f"{cfg.base_url}{path}"
-    payload = json.dumps(data) if data else ""
+    # IMPORTANT: ``data`` may legitimately be an empty container (``{}`` or
+    # ``[]``) — many XDR ``/list`` endpoints accept an empty filter object
+    # but still require a *parsable* JSON body, otherwise return
+    # "参数解析异常" / "参数不合法".  Using ``if data`` would treat an empty
+    # dict as falsy and send an empty string body, which both breaks JSON
+    # parsing and changes the signed payload hash from
+    # ``SHA256("{}")`` to ``SHA256("")``.
+    if data is None:
+        payload = ""
+    else:
+        payload = json.dumps(data, ensure_ascii=False)
     headers = {CONTENT_TYPE_KEY: DEFAULT_CONTENT_TYPE}
     headers = _sign_request(ak, sk, method, url, headers, params=params, payload=payload)
     # Ask the server not to compress the response — some XDR appliances ignore
@@ -378,7 +388,7 @@ def _parse_response_body(raw: bytes, status: int) -> dict[str, Any]:
 async def _run_request(
     method: str,
     path: str,
-    data: Optional[dict[str, Any]] = None,
+    data: Optional[Any] = None,
     params: Optional[dict[str, Any]] = None,
 ) -> ToolResult:
     try:
@@ -451,7 +461,17 @@ async def run_alerts(ctx: ToolContext) -> ToolResult:
         return await _run_request("POST", "/api/xdr/v1/alerts/dealstatus", data=body)
 
     elif action == "status_list":
-        return await _run_request("POST", "/api/xdr/v1/alerts/dealstatus/list", data={})
+        # Spec: POST /api/xdr/v1/alerts/dealstatus/list with a JSON *array*
+        # body (apiRequestParamType=1, demo body: ``["alert-uuid"]``).  The
+        # endpoint returns the current dealStatus for the supplied alert
+        # UUIDs; previously we sent ``{}`` which made the appliance reply
+        # with "参数解析异常" because a list was expected.
+        uuids = params.get("uuids") or []
+        if isinstance(uuids, str):
+            uuids = [u.strip() for u in uuids.split(",") if u.strip()]
+        return await _run_request(
+            "POST", "/api/xdr/v1/alerts/dealstatus/list", data=list(uuids)
+        )
 
     elif action == "get_proof":
         uuid = params.get("uuid", "")
@@ -501,7 +521,16 @@ async def run_incidents(ctx: ToolContext) -> ToolResult:
         return await _run_request("POST", "/api/xdr/v1/incidents/dealstatus", data=body)
 
     elif action == "status_list":
-        return await _run_request("POST", "/api/xdr/v1/incidents/dealstatus/list", data={})
+        # Spec: POST /api/xdr/v1/incidents/dealstatus/list — like the alerts
+        # counterpart this expects a JSON *array* of incident UUIDs and
+        # returns ``[{"uuId": ..., "dealStatus": ...}]``.  Sending ``{}``
+        # produced "参数解析异常".
+        uuids = params.get("uuids") or []
+        if isinstance(uuids, str):
+            uuids = [u.strip() for u in uuids.split(",") if u.strip()]
+        return await _run_request(
+            "POST", "/api/xdr/v1/incidents/dealstatus/list", data=list(uuids)
+        )
 
     elif action == "get_proof":
         uuid = params.get("uuid", "")

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
@@ -66,22 +66,24 @@ def _calculate_aes_secret(builders: list[str]) -> bytes:
 
 
 def _aes_cbc_decrypt(cipher_text: str, key: bytes) -> str:
+    """Decrypt one AK/SK ciphertext slot from the auth_code.
+
+    Mirrors the official Sangfor demo (``aksk_py3.Signature.__aes_cbc_decrypt``)
+    which uses AES-CBC **decryption** with a zero IV.  An earlier version of
+    this file accidentally used ``cipher.encryptor()`` which silently produced
+    garbage AK/SK and made every signed request fail with
+    ``access key not exist`` / ``Full ak/sk authentication is required``.
+    """
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
     from cryptography.hazmat.backends import default_backend
+
     backend = default_backend()
     cipher = Cipher(algorithms.AES(key), modes.CBC(bytearray(16)), backend=backend)
-    encryptor = cipher.encryptor()
-    ct = encryptor.update(bytes.fromhex(cipher_text)) + encryptor.finalize()
-    # Strip both NUL padding and any other trailing non-printable bytes that
-    # the Sangfor SDK historically appends.  ``decode("utf-8")`` would raise
-    # on stray 0x80-0xFF bytes that occasionally leak through after the
-    # ciphertext alignment, so fall back to ``errors="ignore"`` to keep the
-    # AK/SK printable hex characters.
-    plain = ct.rstrip(b"\x00")
-    try:
-        return plain.decode("utf-8")
-    except UnicodeDecodeError:
-        return plain.decode("utf-8", errors="ignore")
+    decryptor = cipher.decryptor()
+    pt = decryptor.update(bytes.fromhex(cipher_text)) + decryptor.finalize()
+    # Sangfor SDK pads ciphertext with NUL bytes; the AK/SK plaintext is
+    # always ASCII hex once decrypted correctly.
+    return pt.rstrip(b"\x00").decode("utf-8")
 
 
 def _decode_auth_code(auth_code: str) -> tuple[str, str]:
@@ -182,12 +184,20 @@ def _sign_request(
     header_str = "".join(f"{k}:{v}\n" for k, v in header_keys)
     sign_header_keys = ";".join(k for k, _ in header_keys)
 
+    # Match the official demo's ``__query_str_transform``: keys are sorted
+    # before urlencoding so the canonical request is deterministic regardless
+    # of the dict iteration order on the client side.
+    canonical_query = ""
+    if params:
+        sorted_items = sorted(params.items(), key=lambda kv: kv[0])
+        canonical_query = urlencode(sorted_items)
+
     canonical_parts = [
         method.upper(),
         "\n",
         _url_transform(url),
         "\n",
-        urlencode(params) if params else "",
+        canonical_query,
         "\n",
         header_str,
         sign_header_keys,

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
@@ -244,20 +244,23 @@ def _resolve_runtime_config() -> RuntimeConfig:
     raw = ConfigWriter.get_api_service_raw(SERVICE_ID)
     raw = raw if isinstance(raw, dict) else {}
 
-    host = (_resolve_ref(raw.get("host")) or os.getenv("SANGFOR_XDR_HOST") or "").strip()
-    # Tolerate users pasting the full URL (with scheme and/or trailing slash)
-    # in the WebUI ``host`` field — without this normalisation we would build
-    # ``https://https://10.0.0.1`` which silently routes to nowhere.
-    if "://" in host:
-        host = host.split("://", 1)[1]
-    host = host.strip("/").strip()
-    # The host field may also contain an inline port (``10.0.0.1:8443``).
-    inline_port: Optional[int] = None
-    if ":" in host and not host.startswith("["):
-        host_part, _, port_part = host.partition(":")
-        if port_part.isdigit():
-            host = host_part
-            inline_port = int(port_part)
+    raw_host = (_resolve_ref(raw.get("host")) or os.getenv("SANGFOR_XDR_HOST") or "").strip()
+    # Tolerate users pasting any URL form into the WebUI ``host`` field —
+    # ``10.0.0.1``, ``https://10.0.0.1``, ``https://10.0.0.1:8443/api/?x=1``
+    # all collapse to a clean scheme://host[:port] base.  Without this we
+    # produced things like ``https://https://10.0.0.1`` (double scheme) or
+    # ``https://10.0.0.1/api/api/xdr/v1/...`` (leaked path component) and
+    # every signed request silently routed to nowhere.
+    candidate = raw_host if "://" in raw_host else f"https://{raw_host}"
+    parsed_host = urlparse(candidate)
+    hostname = (parsed_host.hostname or "").strip()
+    inline_port: Optional[int] = parsed_host.port
+
+    # Preserve IPv6 literal brackets when re-assembling the URL.
+    if hostname and ":" in hostname and not hostname.startswith("["):
+        hostname_for_url = f"[{hostname}]"
+    else:
+        hostname_for_url = hostname
 
     port_raw = raw.get("port") or inline_port or DEFAULT_PORT
     try:
@@ -265,7 +268,11 @@ def _resolve_runtime_config() -> RuntimeConfig:
     except (TypeError, ValueError):
         port = DEFAULT_PORT
 
-    base_url = f"https://{host}:{port}" if port != 443 else f"https://{host}"
+    base_url = (
+        f"https://{hostname_for_url}:{port}"
+        if port != 443
+        else f"https://{hostname_for_url}"
+    )
 
     timeout_raw = raw.get("timeout", DEFAULT_TIMEOUT)
     try:
@@ -288,7 +295,7 @@ def _resolve_runtime_config() -> RuntimeConfig:
     else:
         verify_ssl = str(verify_ssl_raw).strip().lower() in {"1", "true", "yes", "on"}
 
-    if not host:
+    if not hostname:
         raise ValueError("Sangfor XDR host not configured. Set api_services.sangfor_xdr.host or SANGFOR_XDR_HOST.")
     if not auth_code:
         raise ValueError(

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
@@ -72,17 +72,47 @@ def _aes_cbc_decrypt(cipher_text: str, key: bytes) -> str:
     cipher = Cipher(algorithms.AES(key), modes.CBC(bytearray(16)), backend=backend)
     encryptor = cipher.encryptor()
     ct = encryptor.update(bytes.fromhex(cipher_text)) + encryptor.finalize()
-    return ct.rstrip(b"\x00").decode("utf-8")
+    # Strip both NUL padding and any other trailing non-printable bytes that
+    # the Sangfor SDK historically appends.  ``decode("utf-8")`` would raise
+    # on stray 0x80-0xFF bytes that occasionally leak through after the
+    # ciphertext alignment, so fall back to ``errors="ignore"`` to keep the
+    # AK/SK printable hex characters.
+    plain = ct.rstrip(b"\x00")
+    try:
+        return plain.decode("utf-8")
+    except UnicodeDecodeError:
+        return plain.decode("utf-8", errors="ignore")
 
 
 def _decode_auth_code(auth_code: str) -> tuple[str, str]:
     cached = _AK_SK_CACHE.get(auth_code)
     if cached:
         return cached
-    builder_str = _reverse_hex(auth_code)
-    builders = builder_str.decode("utf-8").split("|")
+    if not auth_code:
+        raise ValueError("auth_code is empty")
+    cleaned = auth_code.strip()
+    # Reject obviously non-hex inputs early with a clear message instead of
+    # the cryptic ``binascii.Error: Non-hexadecimal digit found``.
+    try:
+        builder_bytes = _reverse_hex(cleaned)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError(
+            "auth_code is not a valid hex string. Please copy the 联动码 "
+            "from XDR (配置管理 → 系统设置 → 开放性 → 联动码管理)."
+        ) from exc
+    try:
+        builder_str = builder_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            "auth_code decoded bytes are not valid UTF-8 — likely a wrong or "
+            "truncated 联动码."
+        ) from exc
+    builders = builder_str.split("|")
     if len(builders) != AUTH_CODE_PARAMS_NUM:
-        raise ValueError(f"auth_code decode error: expected {AUTH_CODE_PARAMS_NUM} parts, got {len(builders)}")
+        raise ValueError(
+            f"auth_code decode error: expected {AUTH_CODE_PARAMS_NUM} parts, "
+            f"got {len(builders)}"
+        )
     aes_secret = _calculate_aes_secret(builders)
     ak = _aes_cbc_decrypt(builders[9], aes_secret)
     sk = _aes_cbc_decrypt(builders[10], aes_secret)
@@ -205,7 +235,21 @@ def _resolve_runtime_config() -> RuntimeConfig:
     raw = raw if isinstance(raw, dict) else {}
 
     host = (_resolve_ref(raw.get("host")) or os.getenv("SANGFOR_XDR_HOST") or "").strip()
-    port_raw = raw.get("port") or DEFAULT_PORT
+    # Tolerate users pasting the full URL (with scheme and/or trailing slash)
+    # in the WebUI ``host`` field — without this normalisation we would build
+    # ``https://https://10.0.0.1`` which silently routes to nowhere.
+    if "://" in host:
+        host = host.split("://", 1)[1]
+    host = host.strip("/").strip()
+    # The host field may also contain an inline port (``10.0.0.1:8443``).
+    inline_port: Optional[int] = None
+    if ":" in host and not host.startswith("["):
+        host_part, _, port_part = host.partition(":")
+        if port_part.isdigit():
+            host = host_part
+            inline_port = int(port_part)
+
+    port_raw = raw.get("port") or inline_port or DEFAULT_PORT
     try:
         port = int(str(port_raw).strip())
     except (TypeError, ValueError):
@@ -259,6 +303,11 @@ async def _request(
     payload = json.dumps(data) if data else ""
     headers = {CONTENT_TYPE_KEY: DEFAULT_CONTENT_TYPE}
     headers = _sign_request(ak, sk, method, url, headers, params=params, payload=payload)
+    # Ask the server not to compress the response — some XDR appliances ignore
+    # ``Accept-Encoding`` negotiation and ship gzip bytes that aiohttp cannot
+    # transparently decode on every code path, surfacing as
+    # ``'utf-8' codec can't decode byte 0x8d in position 0``.
+    headers.setdefault("Accept-Encoding", "identity")
 
     kwargs: dict[str, Any] = {"headers": headers}
     if method.upper() in ("POST", "PUT", "PATCH", "DELETE"):
@@ -267,16 +316,46 @@ async def _request(
         kwargs["params"] = params
 
     async with session.request(method, url, **kwargs) as resp:
-        try:
-            result = await resp.json(content_type=None)
-        except Exception:
-            text = await resp.text()
-            raise RuntimeError(f"XDR response parse error (HTTP {resp.status}): {text[:500]}")
+        raw_bytes = await resp.read()
+        result = _parse_response_body(raw_bytes, resp.status)
 
     code = result.get("code")
     if code == "Success" or code == 0:
         return result
     raise RuntimeError(f"XDR API error: code={code}, message={result.get('message', '')}")
+
+
+def _parse_response_body(raw: bytes, status: int) -> dict[str, Any]:
+    """Decode an XDR response body with broad encoding tolerance.
+
+    The Sangfor XDR appliance has been observed returning JSON encoded as
+    UTF-8, GBK or even raw bytes that fail strict UTF-8 validation
+    (``0x8d`` in position 0).  ``aiohttp`` defaults to UTF-8, which made
+    every connectivity probe surface a misleading
+    ``'utf-8' codec can't decode byte 0x8d`` error.
+    """
+    if not raw:
+        raise RuntimeError(f"XDR returned empty body (HTTP {status})")
+    last_error: Optional[Exception] = None
+    for encoding in ("utf-8", "utf-8-sig", "gbk", "gb18030", "latin-1"):
+        try:
+            text = raw.decode(encoding)
+        except UnicodeDecodeError as exc:
+            last_error = exc
+            continue
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            last_error = exc
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+        return {"code": "Success", "data": parsed}
+    snippet = raw[:120].hex()
+    raise RuntimeError(
+        f"XDR response parse error (HTTP {status}): could not decode body "
+        f"(first bytes hex={snippet}, last={last_error})"
+    )
 
 
 async def _run_request(

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
@@ -591,11 +591,17 @@ async def run_whitelists(ctx: ToolContext) -> ToolResult:
     action = params.pop("action", "list")
 
     if action == "list":
-        body: dict[str, Any] = {}
-        if params.get("page_size"):
-            body["pageSize"] = int(params["page_size"])
-        if params.get("page_num"):
-            body["pageNum"] = int(params["page_num"])
+        # Spec (开放接口列表 → POST /api/xdr/v1/whitelists/list) defines the
+        # paging keys as ``page`` and ``pageSize`` (NOT ``pageNum``).  This
+        # XDR build hard-rejects ``pageNum`` with
+        # ``param page cannot be null`` because it never finds the expected
+        # key.  Always default page=1 / pageSize=20 so the WebUI
+        # connectivity probe (which sends no params) still satisfies the
+        # appliance's strict validator.
+        body: dict[str, Any] = {
+            "page": int(params.get("page_num") or params.get("page") or 1),
+            "pageSize": int(params.get("page_size") or 20),
+        }
         return await _run_request("POST", "/api/xdr/v1/whitelists/list", data=body)
 
     elif action == "create":
@@ -688,11 +694,12 @@ async def run_vulns(ctx: ToolContext) -> ToolResult:
     action = params.pop("action", "baseline")
 
     if action == "baseline":
-        body: dict[str, Any] = {}
-        if params.get("page_size"):
-            body["pageSize"] = int(params["page_size"])
-        if params.get("page_num"):
-            body["pageNum"] = int(params["page_num"])
+        # Spec uses ``page`` / ``pageSize``; we tolerate the legacy
+        # ``page_num`` alias for backwards compatibility.
+        body: dict[str, Any] = {
+            "page": int(params.get("page_num") or params.get("page") or 1),
+            "pageSize": int(params.get("page_size") or 20),
+        }
         return await _run_request("POST", "/api/xdr/v1/vuls/baseline/list", data=body)
 
     elif action == "update_status":
@@ -706,14 +713,18 @@ async def run_vulns(ctx: ToolContext) -> ToolResult:
         return await _run_request("GET", "/api/xdr/v1/vuls/sourcedevice")
 
     elif action == "vuln_list":
-        body = {}
-        if params.get("page_size"):
-            body["pageSize"] = int(params["page_size"])
-        if params.get("page_num"):
-            body["pageNum"] = int(params["page_num"])
         # Spec: POST /api/xdr/v1/vuls/risk/list (获取漏洞、弱密码数据).
-        # The legacy ``/api/xdr/v1/vuls/list`` path does not exist in the
-        # 开放接口列表 and was returning 404 / signature failures.
+        # The 开放接口列表 marks ``dataType`` as the *only* paramNotNull=0
+        # (i.e. required) request field; the appliance returns
+        # "请求参数校验失败" if it is missing.  Default to ``loophole``
+        # (vulnerabilities) and let callers override with ``weakpwd`` when
+        # they want weak-password records instead.
+        data_type = params.get("data_type") or "loophole"
+        body: dict[str, Any] = {
+            "dataType": data_type,
+            "page": int(params.get("page_num") or params.get("page") or 1),
+            "pageSize": int(params.get("page_size") or 20),
+        }
         return await _run_request("POST", "/api/xdr/v1/vuls/risk/list", data=body)
 
     else:

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_alerts.yaml
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_alerts.yaml
@@ -1,12 +1,13 @@
 name: sangfor_xdr_alerts
 description: >
   Manage Sangfor XDR security alerts. Query alerts by time range,
-  update alert disposition status, retrieve alert proof/evidence,
-  and view alert details. Essential for security incident triage.
+  update alert disposition status, and retrieve alert proof/evidence.
+  Essential for security incident triage.
 description_cn: >
   管理深信服 XDR 安全告警。支持按时间范围查询告警列表、
-  批量修改告警处置状态、获取告警举证信息和告警详情。
-  适用于安全事件分诊和告警运营。
+  批量修改告警处置状态、获取告警举证信息。适用于安全事件分诊和告警运营。
+  （注：标准开放接口列表中没有 alerts/:uuid/detail，告警详情请使用 list
+  并按 uuId 过滤获取。）
 category: custom
 enabled: true
 requires_confirmation: false
@@ -22,9 +23,8 @@ inputSchema:
         - `list`          ：查询安全告警列表（按时间范围分页查询）
         - `update_status`  ：批量修改告警处置状态
         - `status_list`    ：查询告警处置状态枚举列表
-        - `get_proof`      ：根据告警 UUID 获取举证信息
-        - `get_detail`     ：根据告警 UUID 获取告警详情
-      enum: [list, update_status, status_list, get_proof, get_detail]
+        - `get_proof`      ：根据告警 UUID 获取举证信息（GET /alerts/:uuid/proof）
+      enum: [list, update_status, status_list, get_proof]
       default: list
     start_time:
       type: integer
@@ -44,7 +44,7 @@ inputSchema:
       default: 1
     uuid:
       type: string
-      description: 告警唯一ID（get_proof / get_detail 时必填）。
+      description: 告警唯一ID（get_proof 时必填）。
     uuids:
       type: array
       description: 告警 UUID 数组（update_status 时必填）。

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_alerts.yaml
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_alerts.yaml
@@ -22,7 +22,8 @@ inputSchema:
         告警操作类型：
         - `list`          ：查询安全告警列表（按时间范围分页查询）
         - `update_status`  ：批量修改告警处置状态
-        - `status_list`    ：查询告警处置状态枚举列表
+        - `status_list`    ：根据告警 UUID 数组批量查询告警当前处置状态
+                           （POST /alerts/dealstatus/list，body 为 `["alert-uuid1", ...]`）
         - `get_proof`      ：根据告警 UUID 获取举证信息（GET /alerts/:uuid/proof）
       enum: [list, update_status, status_list, get_proof]
       default: list
@@ -47,7 +48,9 @@ inputSchema:
       description: 告警唯一ID（get_proof 时必填）。
     uuids:
       type: array
-      description: 告警 UUID 数组（update_status 时必填）。
+      description: >
+        告警 UUID 数组（update_status 必填；status_list 时为查询主体，
+        留空则发送 `[]`，部分 XDR 版本会返回"参数不合法"，建议显式提供至少一个 UUID）。
       items:
         type: string
     deal_status:

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_incidents.yaml
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_incidents.yaml
@@ -7,6 +7,8 @@ description_cn: >
   管理深信服 XDR 安全事件。支持按时间范围查询事件列表、
   批量修改事件处置状态、获取事件举证信息，以及查询事件关联实体
   （主机、内外网IP、文件、进程、DNS），是安全事件响应的核心工具。
+  （注：标准开放接口列表中没有 incidents/:uuid/detail，事件详情请使用 list
+  并按 uuId 过滤获取。）
 category: custom
 enabled: true
 requires_confirmation: false
@@ -22,10 +24,9 @@ inputSchema:
         - `list`           ：查询安全事件列表
         - `update_status`   ：批量修改事件处置状态
         - `status_list`     ：查询事件处置状态枚举列表
-        - `get_proof`       ：根据事件 UUID 获取举证信息
-        - `get_entities`    ：根据事件 UUID 获取处置实体（需指定 entity_type）
-        - `get_detail`      ：根据事件 UUID 获取事件详情
-      enum: [list, update_status, status_list, get_proof, get_entities, get_detail]
+        - `get_proof`       ：根据事件 UUID 获取举证信息（GET /incidents/:uuid/proof）
+        - `get_entities`    ：根据事件 UUID 获取处置实体（GET /incidents/:uuid/entities/{type}，需指定 entity_type）
+      enum: [list, update_status, status_list, get_proof, get_entities]
       default: list
     start_time:
       type: integer
@@ -43,7 +44,7 @@ inputSchema:
       default: 1
     uuid:
       type: string
-      description: 事件唯一ID（get_proof / get_entities / get_detail 时必填）。
+      description: 事件唯一ID（get_proof / get_entities 时必填）。
     uuids:
       type: array
       description: 事件 UUID 数组（update_status 时必填）。

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_incidents.yaml
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_incidents.yaml
@@ -23,7 +23,8 @@ inputSchema:
         事件操作类型：
         - `list`           ：查询安全事件列表
         - `update_status`   ：批量修改事件处置状态
-        - `status_list`     ：查询事件处置状态枚举列表
+        - `status_list`     ：根据事件 UUID 数组批量查询事件当前处置状态
+                            （POST /incidents/dealstatus/list，body 为 `["incident-uuid1", ...]`）
         - `get_proof`       ：根据事件 UUID 获取举证信息（GET /incidents/:uuid/proof）
         - `get_entities`    ：根据事件 UUID 获取处置实体（GET /incidents/:uuid/entities/{type}，需指定 entity_type）
       enum: [list, update_status, status_list, get_proof, get_entities]
@@ -47,7 +48,9 @@ inputSchema:
       description: 事件唯一ID（get_proof / get_entities 时必填）。
     uuids:
       type: array
-      description: 事件 UUID 数组（update_status 时必填）。
+      description: >
+        事件 UUID 数组（update_status 必填；status_list 时为查询主体，
+        留空则发送 `[]`，部分 XDR 版本会返回"参数不合法"，建议显式提供至少一个 UUID）。
       items:
         type: string
     deal_status:

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_vulns.yaml
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_vulns.yaml
@@ -19,7 +19,7 @@ inputSchema:
       description: >
         脆弱性操作类型：
         - `baseline`      ：获取基线合规数据
-        - `vuln_list`     ：获取漏洞列表
+        - `vuln_list`     ：获取漏洞、弱密码数据（POST /vuls/risk/list）
         - `update_status` ：修改漏洞修复状态
         - `source_device` ：获取数据源设备列表
       enum: [baseline, vuln_list, update_status, source_device]

--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_vulns.yaml
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr_vulns.yaml
@@ -32,6 +32,15 @@ inputSchema:
       type: integer
       description: 页码，从 1 开始。
       default: 1
+    data_type:
+      type: string
+      description: >
+        脆弱性类型（vuln_list 时使用，spec 中此字段为唯一必填项；
+        缺失会触发"请求参数校验失败"）：
+        - `loophole` ：漏洞数据（默认）
+        - `weakpwd`  ：弱密码数据
+      enum: [loophole, weakpwd]
+      default: loophole
     ids:
       type: array
       description: 漏洞 ID 列表（update_status 时使用）。

--- a/flocks/tool/tool_loader.py
+++ b/flocks/tool/tool_loader.py
@@ -410,9 +410,18 @@ def _build_script_handler(cfg: dict, yaml_path: Path) -> ToolHandler:
     fn_has_var_kw = any(
         p.kind == inspect.Parameter.VAR_KEYWORD for p in fn_params.values()
     )
+    # Skip the first positional argument (always the ``ctx`` we supply
+    # ourselves) so a user-provided kwarg named ``ctx`` cannot trigger
+    # ``TypeError: got multiple values for argument 'ctx'``.
+    _param_items = list(fn_params.items())
+    if _param_items and _param_items[0][1].kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.POSITIONAL_ONLY,
+    ):
+        _param_items = _param_items[1:]
     fn_param_names = {
         name
-        for name, p in fn_params.items()
+        for name, p in _param_items
         if p.kind
         in (
             inspect.Parameter.POSITIONAL_OR_KEYWORD,

--- a/flocks/tool/tool_loader.py
+++ b/flocks/tool/tool_loader.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import inspect
 import re
 import urllib.parse
 from pathlib import Path
@@ -395,8 +396,45 @@ def _build_script_handler(cfg: dict, yaml_path: Path) -> ToolHandler:
     if not callable(fn):
         raise TypeError(f"'{function_name}' in {script_path} is not callable")
 
+    # Inspect the target function signature once so the wrapper can adapt the
+    # invocation to legacy handlers that either:
+    #   * read parameters from ``ctx.params`` (signature: ``(ctx) -> ...``); or
+    #   * take parameters as explicit keyword arguments / ``**kwargs``.
+    #
+    # Without this adaptation, callers like the test-credentials flow that
+    # invoke ``ToolRegistry.execute(tool_name, **params)`` would either raise
+    # ``TypeError: got an unexpected keyword argument`` or
+    # ``AttributeError: 'ToolContext' object has no attribute 'params'``.
+    fn_sig = inspect.signature(fn)
+    fn_params = fn_sig.parameters
+    fn_has_var_kw = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in fn_params.values()
+    )
+    fn_param_names = {
+        name
+        for name, p in fn_params.items()
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    }
+
     async def handler(ctx: ToolContext, **kwargs: Any) -> ToolResult:
-        result = await fn(ctx, **kwargs)
+        # Always expose the raw kwargs on the context so handlers that read
+        # from ``ctx.params`` (e.g. ``params = dict(ctx.params)``) keep working
+        # regardless of whether the caller created a fresh ``ToolContext``.
+        try:
+            ctx.params = kwargs  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+
+        if fn_has_var_kw:
+            call_kwargs = kwargs
+        else:
+            call_kwargs = {k: v for k, v in kwargs.items() if k in fn_param_names}
+
+        result = await fn(ctx, **call_kwargs)
         if isinstance(result, ToolResult):
             return result
         return ToolResult(success=True, output=result)

--- a/tests/tool/test_sangfor_xdr_handler.py
+++ b/tests/tool/test_sangfor_xdr_handler.py
@@ -247,3 +247,121 @@ def test_parse_response_body_undecodable_raises(handler):
     with pytest.raises(RuntimeError) as exc:
         handler._parse_response_body(raw, 200)
     assert "could not decode" in str(exc.value).lower() or "parse" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# _request body serialisation
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def read(self):
+        return self._body
+
+
+class _FakeSession:
+    """Minimal stand-in for ``aiohttp.ClientSession`` that captures the
+    keyword arguments passed to ``session.request`` so tests can assert on
+    the wire-level body the handler actually transmits."""
+
+    def __init__(self, response_body: bytes = b'{"code":"Success","data":null}'):
+        self.calls: list[dict[str, Any]] = []
+        self._response_body = response_body
+
+    def request(self, method: str, url: str, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return _FakeResponse(self._response_body)
+
+
+@pytest.mark.parametrize(
+    "data, expected_body",
+    [
+        # The historical bug: ``if data`` treats {} as falsy and therefore
+        # transmits an empty string body — the XDR appliance then rejects
+        # it with "参数解析异常".  After the fix, an empty dict serialises
+        # to the canonical JSON literal ``{}``.
+        ({}, "{}"),
+        ({"foo": "bar"}, '{"foo": "bar"}'),
+        # ``alerts/dealstatus/list`` and ``incidents/dealstatus/list``
+        # require a JSON *array* body; an empty list must NOT degrade to
+        # an empty string either.
+        ([], "[]"),
+        (["alert-uuid-1"], '["alert-uuid-1"]'),
+        # ``data=None`` is the only case allowed to send a truly empty
+        # body (e.g. for plain GET endpoints with no payload).
+        (None, ""),
+    ],
+)
+def test_request_serialises_body_for_empty_containers(handler, data, expected_body):
+    """Regression for the wire-level body sent to the XDR appliance.
+
+    Empty ``{}`` / ``[]`` containers must serialise to the canonical
+    JSON literals so that:
+
+      1.  The signed payload hash matches what the server computes
+          (otherwise we get signature mismatches even when the body is
+          accepted), and
+      2.  The server's strict JSON parser does not reject the request
+          with "参数解析异常 / 请求参数校验失败 / 参数不合法".
+    """
+    import asyncio
+
+    cfg = handler.RuntimeConfig(
+        base_url="https://10.0.0.1",
+        timeout=5,
+        auth_code="deadbeef",
+        verify_ssl=False,
+    )
+
+    session = _FakeSession()
+
+    with (
+        patch.object(handler, "_decode_auth_code", return_value=("AK", "SK")),
+        # Don't actually compute HMAC headers — we only care about body.
+        patch.object(handler, "_sign_request", side_effect=lambda *a, **kw: kw.get("headers") or a[4]),
+    ):
+        result = asyncio.run(
+            handler._request(cfg, session, "POST", "/api/xdr/v1/whitelists/list", data=data)
+        )
+
+    assert result == {"code": "Success", "data": None}
+    assert len(session.calls) == 1
+    sent_body = session.calls[0].get("data")
+    assert sent_body == expected_body, (
+        f"_request transmitted {sent_body!r} for data={data!r}; "
+        f"expected {expected_body!r}.  Empty containers must round-trip "
+        "as JSON literals so the XDR signature & body parser both succeed."
+    )
+
+
+def test_request_get_does_not_transmit_body_but_signs_canonical_payload(handler):
+    """GET requests must not put a body on the wire, but the signed payload
+    hash should still reflect ``""`` (not ``{}``) for null ``data``."""
+    import asyncio
+
+    cfg = handler.RuntimeConfig(
+        base_url="https://10.0.0.1",
+        timeout=5,
+        auth_code="deadbeef",
+        verify_ssl=False,
+    )
+    session = _FakeSession()
+
+    with (
+        patch.object(handler, "_decode_auth_code", return_value=("AK", "SK")),
+        patch.object(handler, "_sign_request", side_effect=lambda *a, **kw: kw.get("headers") or a[4]),
+    ):
+        asyncio.run(
+            handler._request(cfg, session, "GET", "/api/xdr/v1/alerts/uuid/proof")
+        )
+
+    assert "data" not in session.calls[0], "GET requests must omit body kwarg"

--- a/tests/tool/test_sangfor_xdr_handler.py
+++ b/tests/tool/test_sangfor_xdr_handler.py
@@ -150,6 +150,79 @@ def test_parse_response_body_does_not_leak_unicode_decode_error(handler):
     assert not isinstance(exc.value, UnicodeDecodeError)
 
 
+# ---------------------------------------------------------------------------
+# AES-CBC decryption (regression: must use decryptor, not encryptor)
+# ---------------------------------------------------------------------------
+
+def test_aes_cbc_decrypt_round_trips_against_reference_encryption(handler):
+    """Guard against the historical regression where ``_aes_cbc_decrypt`` was
+    implemented with ``cipher.encryptor()`` instead of ``cipher.decryptor()``.
+
+    The bug silently returned a re-encrypted blob in place of the AK/SK,
+    which the XDR server then rejected with ``access key not exist`` /
+    ``Full ak/sk authentication is required``.  We assert that the helper
+    matches the canonical AES-CBC behaviour from the official Sangfor demo
+    (``aksk_py3.Signature.__aes_cbc_decrypt``): zero IV, NUL padding, and a
+    real *decrypt* operation.
+    """
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    key = b"0123456789abcdef"  # 16-byte AES key
+    plaintext = b"AKSK_TEST_VALUE\x00"  # 16 bytes, NUL-padded like the SDK
+    cipher = Cipher(algorithms.AES(key), modes.CBC(bytearray(16)), backend=default_backend())
+    encryptor = cipher.encryptor()
+    cipher_bytes = encryptor.update(plaintext) + encryptor.finalize()
+    cipher_hex = cipher_bytes.hex()
+
+    decoded = handler._aes_cbc_decrypt(cipher_hex, key)
+
+    assert decoded == "AKSK_TEST_VALUE", (
+        "AES decrypt regressed: handler is no longer reversing the SDK's "
+        "AES-CBC encryption (likely encryptor() was reintroduced)."
+    )
+
+
+def test_sign_request_sorts_query_params(handler, monkeypatch):
+    """Demo (``aksk_py3.__query_str_transform``) sorts query params by key
+    before signing.  Two requests with the same params in different dict
+    orders must therefore produce identical signatures."""
+    headers_a = {handler.CONTENT_TYPE_KEY: handler.DEFAULT_CONTENT_TYPE}
+    headers_b = {handler.CONTENT_TYPE_KEY: handler.DEFAULT_CONTENT_TYPE}
+
+    fixed = "20260101T000000Z"
+
+    class _FixedDT:
+        @staticmethod
+        def now(tz=None):  # noqa: ARG004 - signature compatibility
+            class _D:
+                @staticmethod
+                def strftime(_fmt):
+                    return fixed
+
+            return _D()
+
+    monkeypatch.setattr(handler, "datetime", _FixedDT)
+
+    signed_a = handler._sign_request(
+        ak="ak",
+        sk="sk",
+        method="GET",
+        url="https://10.0.0.1/api/v1/alerts",
+        headers=headers_a,
+        params={"b": "2", "a": "1", "c": "3"},
+    )
+    signed_b = handler._sign_request(
+        ak="ak",
+        sk="sk",
+        method="GET",
+        url="https://10.0.0.1/api/v1/alerts",
+        headers=headers_b,
+        params={"c": "3", "a": "1", "b": "2"},
+    )
+    assert signed_a[handler.AUTH_HEADER_KEY] == signed_b[handler.AUTH_HEADER_KEY]
+
+
 def test_parse_response_body_empty_raises(handler):
     with pytest.raises(RuntimeError) as exc:
         handler._parse_response_body(b"", 502)

--- a/tests/tool/test_sangfor_xdr_handler.py
+++ b/tests/tool/test_sangfor_xdr_handler.py
@@ -1,0 +1,164 @@
+"""Targeted tests for the Sangfor XDR plugin handler.
+
+The handler lives under ``.flocks/plugins/tools/api/sangfor_xdr/`` and is
+loaded dynamically at runtime, so we import it via a path-based loader to
+exercise the helpers we just hardened:
+
+* ``_resolve_runtime_config`` strips protocol prefixes / inline ports from
+  the user-supplied ``host`` so the WebUI ``host=https://10.0.0.1`` value
+  stops producing ``https://https://10.0.0.1``.
+* ``_decode_auth_code`` raises a friendly error instead of a cryptic
+  ``binascii.Error`` when the user pastes a non-hex secret.
+* ``_parse_response_body`` falls back through UTF-8 / GBK so the test-
+  credentials probe no longer fails with
+  ``'utf-8' codec can't decode byte 0x8d in position 0``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+_HANDLER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".flocks"
+    / "plugins"
+    / "tools"
+    / "api"
+    / "sangfor_xdr"
+    / "sangfor_xdr.handler.py"
+)
+
+
+def _load_handler_module():
+    if not _HANDLER_PATH.exists():
+        pytest.skip(f"Sangfor XDR handler not present at {_HANDLER_PATH}")
+    spec = importlib.util.spec_from_file_location(
+        "_sangfor_xdr_handler_under_test",
+        str(_HANDLER_PATH),
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def handler():
+    return _load_handler_module()
+
+
+# ---------------------------------------------------------------------------
+# Host normalisation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw_host, expected_base_url",
+    [
+        ("10.0.0.1", "https://10.0.0.1"),
+        ("https://10.0.0.1", "https://10.0.0.1"),
+        ("https://10.0.0.1/", "https://10.0.0.1"),
+        ("http://10.0.0.1", "https://10.0.0.1"),
+        ("HTTPS://example.test", "https://example.test"),
+        ("10.0.0.1:8443", "https://10.0.0.1:8443"),
+        ("https://10.0.0.1:8443/", "https://10.0.0.1:8443"),
+    ],
+)
+def test_resolve_runtime_config_normalises_host(handler, raw_host, expected_base_url):
+    fake_secret_manager = type(
+        "_SM",
+        (),
+        {"get": staticmethod(lambda key: "deadbeef" if "auth_code" in key else None)},
+    )()
+
+    raw_cfg: dict[str, Any] = {
+        "host": raw_host,
+        "auth_code": "deadbeef",
+        "verify_ssl": False,
+    }
+
+    with (
+        patch.object(handler.ConfigWriter, "get_api_service_raw", return_value=raw_cfg),
+        patch.object(handler, "_get_secret_manager", return_value=fake_secret_manager),
+    ):
+        cfg = handler._resolve_runtime_config()
+
+    assert cfg.base_url == expected_base_url
+    assert cfg.verify_ssl is False
+    assert cfg.auth_code == "deadbeef"
+
+
+# ---------------------------------------------------------------------------
+# auth_code decoding
+# ---------------------------------------------------------------------------
+
+def test_decode_auth_code_rejects_non_hex(handler):
+    handler._AK_SK_CACHE.clear()
+    with pytest.raises(ValueError) as exc:
+        handler._decode_auth_code("lxy/FS$)K10R822_v1WRt)$n")
+    assert "联动码" in str(exc.value) or "hex" in str(exc.value).lower()
+
+
+def test_decode_auth_code_rejects_empty(handler):
+    handler._AK_SK_CACHE.clear()
+    with pytest.raises(ValueError):
+        handler._decode_auth_code("")
+
+
+# ---------------------------------------------------------------------------
+# Response body parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_response_body_utf8(handler):
+    body = json.dumps({"code": "Success", "data": {"hello": "世界"}}).encode("utf-8")
+    parsed = handler._parse_response_body(body, 200)
+    assert parsed["code"] == "Success"
+    assert parsed["data"]["hello"] == "世界"
+
+
+def test_parse_response_body_gbk_fallback(handler):
+    body = json.dumps({"code": "Success", "msg": "成功"}, ensure_ascii=False).encode("gbk")
+    # The first byte of "成" in GBK is 0xB3 — not the canonical 0x8d that
+    # broke the user's setup, but the same code path handles every leading
+    # byte that fails strict UTF-8 validation.
+    parsed = handler._parse_response_body(body, 200)
+    assert parsed["msg"] == "成功"
+
+
+def test_parse_response_body_does_not_leak_unicode_decode_error(handler):
+    """Reproduces the user's symptom: a body that fails strict UTF-8 must
+    surface as a deterministic ``RuntimeError`` rather than the raw
+    ``'utf-8' codec can't decode byte 0x8d in position 0`` ``UnicodeError``
+    bubbling out of ``aiohttp``."""
+
+    body = bytes([0x8D, 0xFF, 0xFE, 0xC0])  # not a valid prefix in any encoding+JSON
+    with pytest.raises(UnicodeDecodeError):
+        body.decode("utf-8")
+
+    with pytest.raises(RuntimeError) as exc:
+        handler._parse_response_body(body, 200)
+
+    # Crucially: it is *not* a UnicodeDecodeError — operators see a clear
+    # XDR-specific message instead of an opaque codec failure.
+    assert not isinstance(exc.value, UnicodeDecodeError)
+
+
+def test_parse_response_body_empty_raises(handler):
+    with pytest.raises(RuntimeError) as exc:
+        handler._parse_response_body(b"", 502)
+    assert "empty body" in str(exc.value)
+    assert "502" in str(exc.value)
+
+
+def test_parse_response_body_undecodable_raises(handler):
+    raw = bytes([0x8D, 0xFF, 0xFE, 0xC0])
+    with pytest.raises(RuntimeError) as exc:
+        handler._parse_response_body(raw, 200)
+    assert "could not decode" in str(exc.value).lower() or "parse" in str(exc.value).lower()

--- a/tests/tool/test_sangfor_xdr_handler.py
+++ b/tests/tool/test_sangfor_xdr_handler.py
@@ -343,6 +343,86 @@ def test_request_serialises_body_for_empty_containers(handler, data, expected_bo
     )
 
 
+# ---------------------------------------------------------------------------
+# Action-specific body shape (regression for "param page cannot be null"
+# and "请求参数校验失败" surfaced by the second WebUI test report)
+# ---------------------------------------------------------------------------
+
+def _run_action(handler, run_fn, params: dict[str, Any]) -> dict[str, Any]:
+    """Invoke a tool handler with patched IO and return the body that
+    ``_run_request`` would have transmitted, plus the method/path."""
+    import asyncio
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_run_request(method, path, data=None, params=None):
+        captured["method"] = method
+        captured["path"] = path
+        captured["data"] = data
+        captured["params"] = params
+
+        class _R:
+            success = True
+            error = None
+            data = {"code": "Success"}
+
+        return _R()
+
+    ctx = type("_Ctx", (), {"params": params})()
+
+    with patch.object(handler, "_run_request", side_effect=_fake_run_request):
+        asyncio.run(run_fn(ctx))
+
+    return captured
+
+
+def test_whitelists_list_uses_page_not_pageNum(handler):
+    """Spec defines the paging key as ``page``; the appliance rejects
+    ``pageNum`` with ``param page cannot be null``."""
+    captured = _run_action(handler, handler.run_whitelists, {"action": "list"})
+    assert captured["path"] == "/api/xdr/v1/whitelists/list"
+    body = captured["data"]
+    assert "page" in body, f"expected 'page' key, got {body!r}"
+    assert "pageNum" not in body, f"'pageNum' must not appear, got {body!r}"
+    assert body["page"] == 1
+    assert body["pageSize"] == 20
+
+
+def test_whitelists_list_honours_explicit_paging(handler):
+    captured = _run_action(
+        handler,
+        handler.run_whitelists,
+        {"action": "list", "page_num": 3, "page_size": 50},
+    )
+    assert captured["data"] == {"page": 3, "pageSize": 50}
+
+
+def test_vuln_list_includes_required_dataType(handler):
+    """Spec marks ``dataType`` as the only paramNotNull=0 field on
+    /vuls/risk/list; missing it produces ``请求参数校验失败``."""
+    captured = _run_action(handler, handler.run_vulns, {"action": "vuln_list"})
+    assert captured["path"] == "/api/xdr/v1/vuls/risk/list"
+    body = captured["data"]
+    assert body["dataType"] == "loophole"
+    assert body["page"] == 1
+    assert body["pageSize"] == 20
+
+
+def test_vuln_list_allows_weakpwd_dataType(handler):
+    captured = _run_action(
+        handler,
+        handler.run_vulns,
+        {"action": "vuln_list", "data_type": "weakpwd"},
+    )
+    assert captured["data"]["dataType"] == "weakpwd"
+
+
+def test_baseline_list_uses_page_not_pageNum(handler):
+    captured = _run_action(handler, handler.run_vulns, {"action": "baseline"})
+    body = captured["data"]
+    assert "page" in body and "pageNum" not in body, body
+
+
 def test_request_get_does_not_transmit_body_but_signs_canonical_payload(handler):
     """GET requests must not put a body on the wire, but the signed payload
     hash should still reflect ``""`` (not ``{}``) for null ``data``."""

--- a/tests/tool/test_sangfor_xdr_handler.py
+++ b/tests/tool/test_sangfor_xdr_handler.py
@@ -69,6 +69,18 @@ def handler():
         ("HTTPS://example.test", "https://example.test"),
         ("10.0.0.1:8443", "https://10.0.0.1:8443"),
         ("https://10.0.0.1:8443/", "https://10.0.0.1:8443"),
+        # Path / query / fragment must not leak into base_url; otherwise the
+        # final URL becomes ``https://10.0.0.1/api/api/xdr/v1/...`` which
+        # silently fails signing.
+        ("https://10.0.0.1/api", "https://10.0.0.1"),
+        ("https://10.0.0.1/api/", "https://10.0.0.1"),
+        ("https://10.0.0.1:8443/some/sub/path", "https://10.0.0.1:8443"),
+        ("https://10.0.0.1?x=1", "https://10.0.0.1"),
+        ("https://10.0.0.1#frag", "https://10.0.0.1"),
+        # IPv6 literal must keep its bracketed form so urls remain parseable.
+        ("https://[::1]:8443", "https://[::1]:8443"),
+        # Surrounding whitespace.
+        (" https://10.0.0.1 ", "https://10.0.0.1"),
     ],
 )
 def test_resolve_runtime_config_normalises_host(handler, raw_host, expected_base_url):

--- a/tests/tool/test_script_handler_wrapper.py
+++ b/tests/tool/test_script_handler_wrapper.py
@@ -1,0 +1,135 @@
+"""Tests for ``_build_script_handler`` keyword adaptation.
+
+The wrapper has to support two legacy handler conventions:
+
+* Modern handlers declare explicit kwargs (``async def handle(ctx, *, foo)``).
+* Legacy handlers (e.g. the Sangfor XDR plugin) accept only ``ctx`` and read
+  parameters from ``ctx.params``.
+
+Without adaptation, the test-credentials flow (which calls
+``ToolRegistry.execute(tool_name, **params)`` with a default ``ToolContext``)
+either crashes with ``TypeError: got an unexpected keyword argument`` or with
+``AttributeError: 'ToolContext' object has no attribute 'params'``.
+
+See ``flocks.tool.tool_loader._build_script_handler`` for the implementation.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from flocks.tool.registry import ToolContext, ToolResult
+from flocks.tool.tool_loader import _build_script_handler
+
+
+def _make_context() -> ToolContext:
+    return ToolContext(session_id="t", message_id="t")
+
+
+def _write_script(tmp_path: Path, source: str) -> Path:
+    plugins_root = tmp_path / ".flocks" / "plugins" / "tools" / "api" / "demo"
+    plugins_root.mkdir(parents=True)
+    script = plugins_root / "demo.handler.py"
+    script.write_text(textwrap.dedent(source))
+    yaml_stub = plugins_root / "demo.yaml"
+    yaml_stub.touch()
+    return yaml_stub
+
+
+@pytest.mark.asyncio
+async def test_script_handler_filters_unexpected_kwargs(tmp_path, monkeypatch):
+    """Legacy ``run(ctx)`` handler must not receive extra kwargs."""
+
+    monkeypatch.chdir(tmp_path)
+    yaml_stub = _write_script(
+        tmp_path,
+        """
+        async def run(ctx):
+            return {"action": ctx.params.get("action"), "extra": ctx.params.get("extra")}
+        """,
+    )
+    handler = _build_script_handler(
+        {"script_file": "demo.handler.py", "function": "run"},
+        yaml_stub,
+    )
+
+    result = await handler(_make_context(), action="list", extra=42)
+
+    assert isinstance(result, ToolResult) and result.success
+    assert result.output == {"action": "list", "extra": 42}
+
+
+@pytest.mark.asyncio
+async def test_script_handler_passes_declared_kwargs(tmp_path, monkeypatch):
+    """Modern handlers that declare explicit kwargs still receive them."""
+
+    monkeypatch.chdir(tmp_path)
+    yaml_stub = _write_script(
+        tmp_path,
+        """
+        async def run(ctx, foo: str = "", bar: int = 0):
+            return {"foo": foo, "bar": bar}
+        """,
+    )
+    handler = _build_script_handler(
+        {"script_file": "demo.handler.py", "function": "run"},
+        yaml_stub,
+    )
+
+    result = await handler(_make_context(), foo="hello", bar=7, extra="ignored")
+
+    assert isinstance(result, ToolResult) and result.success
+    assert result.output == {"foo": "hello", "bar": 7}
+
+
+@pytest.mark.asyncio
+async def test_script_handler_var_kwargs(tmp_path, monkeypatch):
+    """Handlers declaring ``**kwargs`` still receive every argument."""
+
+    monkeypatch.chdir(tmp_path)
+    yaml_stub = _write_script(
+        tmp_path,
+        """
+        async def run(ctx, **kwargs):
+            return dict(kwargs)
+        """,
+    )
+    handler = _build_script_handler(
+        {"script_file": "demo.handler.py", "function": "run"},
+        yaml_stub,
+    )
+
+    result = await handler(_make_context(), a=1, b="x")
+
+    assert isinstance(result, ToolResult) and result.success
+    assert result.output == {"a": 1, "b": "x"}
+
+
+@pytest.mark.asyncio
+async def test_script_handler_injects_ctx_params(tmp_path, monkeypatch):
+    """``ctx.params`` is populated even when the context lacks the attribute."""
+
+    monkeypatch.chdir(tmp_path)
+    yaml_stub = _write_script(
+        tmp_path,
+        """
+        async def run(ctx):
+            return {"params": dict(ctx.params)}
+        """,
+    )
+    handler = _build_script_handler(
+        {"script_file": "demo.handler.py", "function": "run"},
+        yaml_stub,
+    )
+
+    ctx = _make_context()
+    assert not hasattr(ctx, "params")
+
+    result = await handler(ctx, action="list", uuid="abc")
+
+    assert isinstance(result, ToolResult) and result.success
+    assert result.output == {"params": {"action": "list", "uuid": "abc"}}
+    assert ctx.params == {"action": "list", "uuid": "abc"}


### PR DESCRIPTION
Fix(sangfor-xdr): drop duplicate Verify SSL field from credential form

The provider's ``_provider.yaml`` declared ``verify_ssl`` as a free-text
credential field, but ServiceDetailPanel already renders a generic
"SSL 验证" toggle for every API service.  Both controls write to the
same ``raw_config["verify_ssl"]`` key, so the WebUI showed two SSL
inputs side-by-side (a "Verify SSL" text box that accepted "true"/"false"
strings, and the toggle directly below it).

Removing the credential-field declaration leaves the canonical toggle as
the single source of truth.  Handler behaviour is unchanged because
``_resolve_runtime_config`` already reads ``raw["verify_ssl"]`` regardless
of where it was set.

Notes section also updated to direct users to the SSL toggle.