### PR TITLE
fix(sangfor-xdr): return payload via ToolResult.output and harden par…

### DIFF
--- a/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
+++ b/.flocks/plugins/tools/api/sangfor_xdr/sangfor_xdr.handler.py
@@ -398,7 +398,13 @@ async def _run_request(
         timeout_obj = aiohttp.ClientTimeout(total=cfg.timeout)
         async with aiohttp.ClientSession(connector=connector, timeout=timeout_obj) as session:
             result = await _request(cfg, session, method, path, data=data, params=params)
-        return ToolResult(success=True, data=result)
+        # CRITICAL: ``ToolResult`` declares ``output`` (not ``data``) as the
+        # payload field.  Earlier versions of this handler returned
+        # ``ToolResult(success=True, data=result)`` — pydantic silently
+        # dropped the unknown kwarg, so callers (LLM agents) received
+        # ``output=None`` and reported "返回内容都是空的" even though
+        # authentication and the API call had both succeeded.
+        return ToolResult(success=True, output=result)
     except Exception as exc:
         return ToolResult(success=False, error=str(exc))
 
@@ -406,14 +412,48 @@ async def _run_request(
 # ── Time helpers ─────────────────────────────────────────────────────────────
 
 def _to_ts(v: Any) -> int:
+    """Coerce ``v`` to a Unix-second timestamp.
+
+    Accepts ints/floats (already epoch seconds — milliseconds are *not*
+    auto-detected; callers should normalise first), all-digit strings,
+    and a wide variety of human-readable timestamp formats.  In
+    particular ISO-8601 strings produced by JS ``Date.toISOString()``
+    (``"2026-04-21T00:00:00Z"`` / ``"2026-04-21T00:00:00.000Z"``) used
+    to crash with ``Cannot parse time value`` because the trailing
+    ``Z`` was not declared in any of the strptime formats — and the
+    LLM agent has been observed handing exactly that shape over from
+    the user's natural-language window ("过去 24 小时").
+    """
     if v is None:
         return 0
     if isinstance(v, (int, float)):
         return int(v)
     s = str(v).strip()
+    if not s:
+        return 0
     if s.isdigit():
         return int(s)
-    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+    # ``datetime.fromisoformat`` (Py3.11+) handles trailing ``Z`` natively;
+    # for broader compatibility we strip ``Z`` and force UTC ourselves.
+    iso_candidate = s
+    if iso_candidate.endswith("Z"):
+        iso_candidate = iso_candidate[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(iso_candidate)
+    except ValueError:
+        dt = None
+    if dt is not None:
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
+    for fmt in (
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d",
+    ):
         try:
             dt = datetime.strptime(s, fmt)
             return int(dt.replace(tzinfo=timezone.utc).timestamp())
@@ -429,6 +469,52 @@ def _resolve_time_range(params: dict[str, Any], default_hours: int = 24) -> tupl
     return from_ts, to_ts
 
 
+# ── Action alias normalisation ───────────────────────────────────────────────
+
+# LLM agents observed to emit synonyms like ``query`` / ``search`` / ``get``
+# instead of the canonical ``list`` declared in the YAML schema's ``enum``
+# (the 各工具功能测试 session shows the agent's first attempt across all
+# six tools used ``action="query"`` / ``"query_baseline"``).  Returning a
+# hard ``Unknown action`` error wastes round-trips and makes the agent give
+# up before recovering.  We map the most common misnomers to their canonical
+# action so the request still goes through.
+_ACTION_ALIASES: dict[str, str] = {
+    "query": "list",
+    "search": "list",
+    "get": "list",
+    "fetch": "list",
+    "find": "list",
+    "query_list": "list",
+    "query_baseline": "baseline",
+    "fetch_baseline": "baseline",
+    "get_baseline": "baseline",
+    "query_vuln": "vuln_list",
+    "query_vulns": "vuln_list",
+    "list_vulns": "vuln_list",
+    "vuls_list": "vuln_list",
+    "fix_status": "update_status",
+    "update_fix_status": "update_status",
+    "isolate": "isolate_list",
+    "list_isolate": "isolate_list",
+    "host_isolate_list": "isolate_list",
+}
+
+
+def _normalise_action(value: Any, default: str) -> str:
+    """Return a canonical action name, mapping common LLM aliases.
+
+    ``None`` / empty / non-string values fall back to ``default`` so a
+    missing ``action`` key always picks the most useful default for the
+    tool (typically ``list``).
+    """
+    if value is None:
+        return default
+    s = str(value).strip().lower()
+    if not s:
+        return default
+    return _ACTION_ALIASES.get(s, s)
+
+
 # ═════════════════════════════════════════════════════════════════════════════
 # Tool entry points
 # ═════════════════════════════════════════════════════════════════════════════
@@ -437,7 +523,7 @@ def _resolve_time_range(params: dict[str, Any], default_hours: int = 24) -> tupl
 
 async def run_alerts(ctx: ToolContext) -> ToolResult:
     params = dict(ctx.params)
-    action = params.pop("action", "list")
+    action = _normalise_action(params.pop("action", None), default="list")
 
     if action == "list":
         from_ts, to_ts = _resolve_time_range(params)
@@ -497,7 +583,7 @@ async def run_alerts(ctx: ToolContext) -> ToolResult:
 
 async def run_incidents(ctx: ToolContext) -> ToolResult:
     params = dict(ctx.params)
-    action = params.pop("action", "list")
+    action = _normalise_action(params.pop("action", None), default="list")
 
     if action == "list":
         from_ts, to_ts = _resolve_time_range(params)
@@ -569,7 +655,7 @@ async def run_incidents(ctx: ToolContext) -> ToolResult:
 
 async def run_responses(ctx: ToolContext) -> ToolResult:
     params = dict(ctx.params)
-    action = params.pop("action", "isolate_list")
+    action = _normalise_action(params.pop("action", None), default="isolate_list")
 
     if action == "isolate_list":
         return await _run_request("POST", "/api/xdr/v1/responses/host/isolate/list", data={})
@@ -588,7 +674,7 @@ async def run_responses(ctx: ToolContext) -> ToolResult:
 
 async def run_whitelists(ctx: ToolContext) -> ToolResult:
     params = dict(ctx.params)
-    action = params.pop("action", "list")
+    action = _normalise_action(params.pop("action", None), default="list")
 
     if action == "list":
         # Spec (开放接口列表 → POST /api/xdr/v1/whitelists/list) defines the
@@ -644,14 +730,19 @@ async def run_whitelists(ctx: ToolContext) -> ToolResult:
 
 async def run_assets(ctx: ToolContext) -> ToolResult:
     params = dict(ctx.params)
-    action = params.pop("action", "list")
+    action = _normalise_action(params.pop("action", "list"), default="list")
 
     if action == "list":
-        body: dict[str, Any] = {}
-        if params.get("page_size"):
-            body["pageSize"] = int(params["page_size"])
-        if params.get("page_num"):
-            body["pageNum"] = int(params["page_num"])
+        # Like ``whitelists/list``, the assets list endpoint validates
+        # paging keys as ``page`` / ``pageSize`` (NOT ``pageNum`` /
+        # ``pageSize``).  Sending the legacy pair triggers
+        # ``参数: {'pageSize': 5, 'pageNum': 1} 不合法，请确认后重新添加``
+        # observed in the 各工具功能测试 session.  Provide defaults so
+        # callers that omit paging still satisfy the strict validator.
+        body: dict[str, Any] = {
+            "page": int(params.get("page_num") or params.get("page") or 1),
+            "pageSize": int(params.get("page_size") or params.get("pageSize") or 20),
+        }
         return await _run_request("POST", "/api/xdr/v1/assets/list", data=body)
 
     elif action == "ip_segment_tree":
@@ -691,7 +782,7 @@ async def run_assets(ctx: ToolContext) -> ToolResult:
 
 async def run_vulns(ctx: ToolContext) -> ToolResult:
     params = dict(ctx.params)
-    action = params.pop("action", "baseline")
+    action = _normalise_action(params.pop("action", None), default="baseline")
 
     if action == "baseline":
         # Spec uses ``page`` / ``pageSize``; we tolerate the legacy

--- a/tests/tool/test_sangfor_xdr_handler.py
+++ b/tests/tool/test_sangfor_xdr_handler.py
@@ -445,3 +445,141 @@ def test_request_get_does_not_transmit_body_but_signs_canonical_payload(handler)
         )
 
     assert "data" not in session.calls[0], "GET requests must omit body kwarg"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the 各工具功能测试 session
+# ---------------------------------------------------------------------------
+
+def test_run_request_returns_payload_via_output_field(handler):
+    """The handler historically called ``ToolResult(success=True, data=...)``.
+
+    ``ToolResult`` declares ``output`` (not ``data``) as its payload
+    field; pydantic silently dropped the unknown kwarg, so every call —
+    even successful ones — surfaced ``output=None`` to the LLM agent
+    which then reported "认证后请求恢复内容都是空的".  This test pins
+    the field name so the regression cannot recur.
+    """
+    import asyncio
+
+    captured = {"called": False}
+
+    async def _fake_request(cfg, session, method, path, data=None, params=None):
+        captured["called"] = True
+        return {"code": "Success", "data": {"item": [{"uuId": "abc"}], "total": 1}}
+
+    cfg = handler.RuntimeConfig(
+        base_url="https://10.0.0.1",
+        timeout=5,
+        auth_code="deadbeef",
+        verify_ssl=False,
+    )
+    with (
+        patch.object(handler, "_resolve_runtime_config", return_value=cfg),
+        patch.object(handler, "_request", side_effect=_fake_request),
+    ):
+        result = asyncio.run(handler._run_request("POST", "/api/xdr/v1/alerts/list"))
+
+    assert captured["called"]
+    assert result.success is True
+    assert result.error is None
+    # MUST be on .output (not .data) — see ToolResult class definition.
+    assert result.output == {
+        "code": "Success",
+        "data": {"item": [{"uuId": "abc"}], "total": 1},
+    }, (
+        "ToolResult payload must arrive on the `output` attribute. "
+        "If this assertion fails, the handler is constructing "
+        "ToolResult(data=...) again — pydantic silently drops the kwarg "
+        "and downstream consumers see output=None."
+    )
+
+
+@pytest.mark.parametrize(
+    # 2026-04-21 00:00:00 UTC == 1776729600 (verified via:
+    #   datetime(2026,4,21,tzinfo=timezone.utc).timestamp())
+    "raw, expected_seconds_utc",
+    [
+        ("2026-04-21T00:00:00Z", 1776729600),
+        ("2026-04-21T00:00:00.000Z", 1776729600),
+        ("2026-04-21T00:00:00", 1776729600),
+        ("2026-04-21 00:00:00", 1776729600),
+        ("2026-04-21", 1776729600),
+        # 2026-04-21 08:30:00 +08:00 == 2026-04-21 00:30:00 UTC
+        ("2026-04-21T08:30:00+08:00", 1776729600 + 1800),
+        ("1776729600", 1776729600),
+        (1776729600, 1776729600),
+    ],
+)
+def test_to_ts_handles_iso8601_with_z_suffix(handler, raw, expected_seconds_utc):
+    """The first 各工具功能测试 attempt failed with
+    ``Cannot parse time value: '2026-04-21T00:00:00Z'`` because the
+    trailing ``Z`` was unsupported.  Accept ISO-8601 in all the shapes
+    a JS ``Date.toISOString()`` (and reasonable LLM guesses) can emit.
+    """
+    assert handler._to_ts(raw) == expected_seconds_utc
+
+
+def test_assets_list_uses_page_not_pageNum(handler):
+    """Spec rejects ``{'pageSize': 5, 'pageNum': 1}`` with
+    ``参数: ... 不合法``; the assets list endpoint is a sibling of
+    whitelists/list and uses the same ``page`` / ``pageSize`` keys."""
+    captured = _run_action(handler, handler.run_assets, {"action": "list"})
+    assert captured["path"] == "/api/xdr/v1/assets/list"
+    body = captured["data"]
+    assert "page" in body and "pageSize" in body, body
+    assert "pageNum" not in body, f"pageNum must not appear, got {body!r}"
+    assert body["page"] == 1
+    assert body["pageSize"] == 20
+
+
+def test_assets_list_honours_explicit_paging(handler):
+    captured = _run_action(
+        handler,
+        handler.run_assets,
+        {"action": "list", "page_num": 2, "page_size": 30},
+    )
+    assert captured["data"] == {"page": 2, "pageSize": 30}
+
+
+@pytest.mark.parametrize(
+    "alias, canonical, run_fn_name, expected_path",
+    [
+        # alerts: query → list (1st 各工具功能测试 round had every tool
+        # default to action="query" and got "Unknown ... action")
+        ("query", "list", "run_alerts", "/api/xdr/v1/alerts/list"),
+        ("search", "list", "run_alerts", "/api/xdr/v1/alerts/list"),
+        ("get", "list", "run_incidents", "/api/xdr/v1/incidents/list"),
+        ("fetch", "list", "run_whitelists", "/api/xdr/v1/whitelists/list"),
+        # vulns: agent guessed "query_baseline" then "query_vuln"
+        ("query_baseline", "baseline", "run_vulns", "/api/xdr/v1/vuls/baseline/list"),
+        ("query_vuln", "vuln_list", "run_vulns", "/api/xdr/v1/vuls/risk/list"),
+        ("query", "list", "run_assets", "/api/xdr/v1/assets/list"),
+        # responses default
+        ("isolate", "isolate_list", "run_responses",
+         "/api/xdr/v1/responses/host/isolate/list"),
+    ],
+)
+def test_action_alias_normalisation(handler, alias, canonical, run_fn_name, expected_path):
+    """LLM agents observed to emit synonyms instead of canonical action
+    names.  The handler now maps the most common ones back so the
+    request still goes through (vs. surfacing ``Unknown ... action``)."""
+    run_fn = getattr(handler, run_fn_name)
+    captured = _run_action(handler, run_fn, {"action": alias})
+    assert captured["path"] == expected_path, (
+        f"alias {alias!r} should route to {canonical!r} "
+        f"({expected_path}) but went to {captured['path']!r}"
+    )
+
+
+def test_normalise_action_default_when_missing(handler):
+    """``None`` / empty / unknown all fall through gracefully."""
+    assert handler._normalise_action(None, "list") == "list"
+    assert handler._normalise_action("", "baseline") == "baseline"
+    assert handler._normalise_action("   ", "list") == "list"
+    # Unknown but non-empty values pass through unchanged so the per-action
+    # ``Unknown ... action`` error message can still guide the caller.
+    assert handler._normalise_action("unknown_op", "list") == "unknown_op"
+    # Case folding: agents sometimes capitalise.
+    assert handler._normalise_action("LIST", "list") == "list"
+    assert handler._normalise_action("Query", "list") == "list"


### PR DESCRIPTION

Root cause for :
the handler constructed ``ToolResult(success=True, data=result)`` but the ``ToolResult`` model declares ``output`` (not ``data``) as the payload field. Pydantic silently dropped the unknown kwarg, so every successful call surfaced ``output=None`` to the LLM agent — authentication and the API call both succeeded, yet the agent reported empty responses.

Additional fixes surfaced by the same session:

- ``_to_ts`` now accepts ISO-8601 with the trailing ``Z`` (and ``.fffZ``) produced by ``Date.toISOString()`` / common LLM guesses; previously the first connectivity probe failed with ``Cannot parse time value: '2026-04-21T00:00:00Z'``.
- ``assets/list`` switches from the legacy ``pageNum``/``pageSize`` pair to the spec-compliant ``page``/``pageSize`` (with defaults 1/20).  The appliance was rejecting the old shape with ``参数: {'pageSize': 5, 'pageNum': 1} 不合法``.
- New ``_normalise_action`` helper maps common LLM aliases (``query``, ``search``, ``get``, ``fetch``, ``query_baseline``, ``query_vuln``, ``isolate`` …) to canonical action names so the agent's first attempt no longer hard-fails with ``Unknown ... action``.

54 targeted tests pass; full ``tests/tool/`` suite shows no regressions (the 9 pre-existing errors are missing ``skyeye_cli`` / ``tdp_cli`` modules, unrelated to this change).