### PR TITLE
chore: bump version to v2026.4.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.4.21"
+version = "v2026.4.22"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.4.21"
+version = "2026.4.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Bump project version from `v2026.4.21` to `v2026.4.22` in `pyproject.toml` and sync `uv.lock`.

## Changes
- `pyproject.toml`: `version = "v2026.4.22"`
- `uv.lock`: flocks package version `2026.4.22`

Made with [Cursor](https://cursor.com)