### PR TITLE
feat(session): explicit model pinning for sessions and HTTP resolution

### DIFF
--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -715,8 +715,7 @@ class InboundDispatcher:
         await Session.update(
             session.project_id,
             session.id,
-            provider=provider_id,
-            model=model_id,
+            **Session.explicit_model_updates(provider_id, model_id),
         )
         await self._trigger_command_hook(
             "model",
@@ -750,8 +749,7 @@ class InboundDispatcher:
             directory=session.directory,
             parent_id=parent_id,
             agent=session.agent,
-            provider=session.provider,
-            model=session.model,
+            **Session.inherited_model_kwargs(session),
         )
         new_binding = await self.binding_service.rebind(
             msg,

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -2050,6 +2050,19 @@ async def _process_session_message(
         "model_id": model_id,
         "source": model_source,
     })
+
+    if request.model:
+        pinned_session = await Session.update(
+            session.project_id,
+            sessionID,
+            **Session.explicit_model_updates(provider_id, model_id),
+        )
+        if pinned_session is not None:
+            session = pinned_session
+        else:
+            session.provider = provider_id
+            session.model = model_id
+            session.model_pinned = True
     
     # Ensure providers are initialized and configured
     Provider._ensure_initialized()
@@ -2314,13 +2327,17 @@ async def _process_session_message(
 
 async def _resolve_model(request, agent, sessionID: str):
     """
-    Resolve model with 5-level priority:
+    Resolve model using the same explicit-pinning semantics as SessionLoop.
+
+    Priority:
     1. request.model (explicit in request)
-    2. agent model override (storage) or agent.model (AgentInfo field)
-    3. config model (flocks.json)
-    4. lastModel(sessionID) (last used model)
-    5. environment variables (final fallback)
-    
+    2. session pinned model
+    3. agent model override (storage) or agent.model (AgentInfo field)
+    4. parent session pinned model
+    5. config model (flocks.json)
+    6. lastModel(sessionID) (last used model)
+    7. environment variables (final fallback)
+
     Returns (provider_id, model_id, source).
     """
     import os
@@ -2334,8 +2351,17 @@ async def _resolve_model(request, agent, sessionID: str):
         provider_id = request.model.providerID
         model_id = request.model.modelID
         source = "request"
-    
-    # Priority 2: Agent model (override from storage, then AgentInfo.model)
+
+    # Priority 2: Session explicit pin
+    session = None
+    if not provider_id or not model_id:
+        session = await Session.get_by_id(sessionID)
+        if Session.has_pinned_model(session):
+            provider_id = session.provider
+            model_id = session.model
+            source = "session"
+
+    # Priority 3: Agent model (override from storage, then AgentInfo.model)
     if not provider_id or not model_id:
         # 2a: Check model overrides from storage (set via UI for native agents)
         from flocks.storage.storage import Storage
@@ -2366,8 +2392,20 @@ async def _resolve_model(request, agent, sessionID: str):
                     model_id = getattr(agent.model, 'model_id', None) or getattr(agent.model, 'modelID', None)
                 if provider_id and model_id:
                     source = "agent"
-    
-    # Priority 3: System default from config (default_models.llm -> config.model fallback)
+
+    # Priority 4: Parent session explicit model
+    if not provider_id or not model_id:
+        if session is None:
+            session = await Session.get_by_id(sessionID)
+        parent_id = getattr(session, "parent_id", None) if session else None
+        if parent_id:
+            parent = await Session.get_by_id(parent_id)
+            if Session.has_pinned_model(parent):
+                provider_id = parent.provider
+                model_id = parent.model
+                source = "parent_session"
+
+    # Priority 5: System default from config (default_models.llm -> config.model fallback)
     if not provider_id or not model_id:
         try:
             from flocks.config.config import Config
@@ -2378,8 +2416,8 @@ async def _resolve_model(request, agent, sessionID: str):
                 source = "config"
         except Exception:
             pass
-    
-    # Priority 4: Last model used in session
+
+    # Priority 6: Last model used in session
     if not provider_id or not model_id:
         last_model = await _get_last_model(sessionID)
         if last_model:
@@ -2389,8 +2427,8 @@ async def _resolve_model(request, agent, sessionID: str):
                 provider_id = last_provider
                 model_id = last_model_id
                 source = "lastModel"
-    
-    # Priority 5: Fallback to environment variables
+
+    # Priority 7: Fallback to environment variables
     if not provider_id or not model_id:
         provider_id = os.environ.get("LLM_PROVIDER", "openai")
         model_id = os.environ.get("LLM_MODEL", "gpt-4-turbo-preview")

--- a/flocks/session/session.py
+++ b/flocks/session/session.py
@@ -88,6 +88,13 @@ class SessionInfo(BaseModel):
     agent: Optional[str] = Field("hephaestus", description="Agent type: hephaestus, build, plan, rex, …")
     model: Optional[str] = Field(None, description="Model ID")
     provider: Optional[str] = Field(None, description="Provider ID")
+    model_pinned: bool = Field(
+        False,
+        description=(
+            "Whether provider/model were explicitly locked for this session. "
+            "Unpinned sessions follow the normal default-model resolution chain."
+        ),
+    )
     
     # Session hierarchy
     parent_id: Optional[str] = Field(None, alias="parentID", description="Parent session for branching")
@@ -153,6 +160,36 @@ class Session:
         """Clear in-memory indexes when the underlying storage changes."""
         cls._id_index.clear()
         cls._all_sessions_cache = None
+
+    @staticmethod
+    def has_pinned_model(session: Optional[SessionInfo]) -> bool:
+        """Return whether a session has an explicit model lock."""
+        return bool(
+            session
+            and getattr(session, "model_pinned", False)
+            and getattr(session, "provider", None)
+            and getattr(session, "model", None)
+        )
+
+    @staticmethod
+    def explicit_model_updates(provider_id: str, model_id: str) -> Dict[str, Any]:
+        """Build update kwargs for explicitly pinning a session model."""
+        return {
+            "provider": provider_id,
+            "model": model_id,
+            "model_pinned": True,
+        }
+
+    @classmethod
+    def inherited_model_kwargs(cls, session: Optional[SessionInfo]) -> Dict[str, Any]:
+        """Return pinned model kwargs that should propagate to a child session."""
+        if not cls.has_pinned_model(session):
+            return {}
+        return {
+            "provider": session.provider,
+            "model": session.model,
+            "model_pinned": True,
+        }
     
     @classmethod
     def is_default_title(cls, title: str) -> bool:

--- a/flocks/session/session_loop.py
+++ b/flocks/session/session_loop.py
@@ -295,26 +295,15 @@ class SessionLoop:
             provider_id = provider_id or resolved_provider
             model_id = model_id or resolved_model
         
-        # Persist resolved model to session so child sessions can inherit it
-        session_model_changed = False
-        if provider_id and getattr(session, 'provider', None) != provider_id:
+        # Keep the in-memory session aligned with the runtime model so
+        # downstream helpers (title generation, compaction checks, etc.) see
+        # the model actually selected for this loop iteration. Unpinned
+        # sessions must not persist these values; otherwise switching the
+        # global default model would keep older sessions stuck on stale data.
+        if provider_id:
             session.provider = provider_id
-            session_model_changed = True
-        if model_id and getattr(session, 'model', None) != model_id:
+        if model_id:
             session.model = model_id
-            session_model_changed = True
-        if session_model_changed:
-            try:
-                project_id = getattr(session, 'project_id', None)
-                if project_id:
-                    await Session.update(project_id, session_id, model=model_id, provider=provider_id)
-                    log.info("loop.model_persisted", {
-                        "session_id": session_id,
-                        "provider": provider_id,
-                        "model": model_id,
-                    })
-            except Exception as exc:
-                log.debug("loop.model_persist_failed", {"error": str(exc)})
         
         # Create SessionContext interface for decoupled access
         from flocks.session.core.context import DefaultSessionContext
@@ -453,6 +442,8 @@ class SessionLoop:
         session: Any,
         provider_id: Optional[str],
         model_id: Optional[str],
+        *,
+        include_source: bool = False,
     ) -> tuple:
         """
         Resolve provider_id and model_id for session execution.
@@ -474,12 +465,14 @@ class SessionLoop:
         
         resolved_provider = provider_id
         resolved_model = model_id
+        source = "explicit" if provider_id and model_id else "unknown"
         
         # Priority 2: Session's stored model/provider
-        if not resolved_provider and hasattr(session, 'provider') and session.provider:
-            resolved_provider = session.provider
-        if not resolved_model and hasattr(session, 'model') and session.model:
-            resolved_model = session.model
+        if (not resolved_provider or not resolved_model) and Session.has_pinned_model(session):
+            resolved_provider = resolved_provider or session.provider
+            resolved_model = resolved_model or session.model
+            if resolved_provider and resolved_model:
+                source = "session"
         
         # Priority 3: Agent model override from Storage (set via WebUI)
         if not resolved_provider or not resolved_model:
@@ -495,6 +488,7 @@ class SessionLoop:
                         if override_provider and override_model:
                             resolved_provider = override_provider
                             resolved_model = override_model
+                            source = "agent_override"
                 except Exception as _e:
                     log.debug("loop.resolve_model.storage_override_failed", {"error": str(_e)})
         
@@ -508,6 +502,8 @@ class SessionLoop:
                     if agent_info and agent_info.model:
                         resolved_provider = resolved_provider or agent_info.model.provider_id
                         resolved_model = resolved_model or agent_info.model.model_id
+                        if resolved_provider and resolved_model:
+                            source = "agent"
                 except Exception as _e:
                     log.debug("loop.resolve_model.agent_model_failed", {"error": str(_e)})
         
@@ -517,9 +513,11 @@ class SessionLoop:
             if parent_id:
                 try:
                     parent = await Session.get_by_id(parent_id)
-                    if parent:
+                    if Session.has_pinned_model(parent):
                         resolved_provider = resolved_provider or getattr(parent, 'provider', None)
                         resolved_model = resolved_model or getattr(parent, 'model', None)
+                        if resolved_provider and resolved_model:
+                            source = "parent_session"
                 except Exception as _e:
                     log.debug("loop.resolve_model.parent_failed", {"error": str(_e)})
         
@@ -531,6 +529,8 @@ class SessionLoop:
                 if default_llm:
                     resolved_provider = resolved_provider or default_llm["provider_id"]
                     resolved_model = resolved_model or default_llm["model_id"]
+                    if resolved_provider and resolved_model:
+                        source = "config"
             except Exception as _e:
                 log.debug("loop.resolve_model.config_default_failed", {"error": str(_e)})
         
@@ -539,12 +539,18 @@ class SessionLoop:
             resolved_provider = os.environ.get("LLM_PROVIDER")
         if not resolved_model:
             resolved_model = os.environ.get("LLM_MODEL")
+        if resolved_provider and resolved_model and source == "unknown":
+            source = "env_default"
         
         # Priority 8: Hardcoded fallback
         from flocks.session.core.defaults import fallback_provider_id, fallback_model_id
         resolved_provider = resolved_provider or fallback_provider_id()
         resolved_model = resolved_model or fallback_model_id()
-        
+        if source == "unknown":
+            source = "fallback"
+
+        if include_source:
+            return resolved_provider, resolved_model, source
         return resolved_provider, resolved_model
 
     @classmethod

--- a/flocks/task/background.py
+++ b/flocks/task/background.py
@@ -364,6 +364,7 @@ class BackgroundManager:
                     agent=input_data.agent,
                     model=(input_data.model or {}).get("modelID"),
                     provider=(input_data.model or {}).get("providerID"),
+                    model_pinned=bool((input_data.model or {}).get("providerID") and (input_data.model or {}).get("modelID")),
                     category=input_data.category or "task",
                 )
                 task.session_id = child_session.id

--- a/flocks/task/background.py
+++ b/flocks/task/background.py
@@ -59,6 +59,7 @@ class LaunchInput:
     parent_agent: Optional[str]
     parent_model: Optional[dict] = None
     model: Optional[dict] = None
+    model_pinned: bool = False
     category: Optional[str] = None
     directory: Optional[str] = None
     project_id: Optional[str] = None
@@ -265,13 +266,20 @@ class BackgroundManager:
         timeout_seconds: int = _INACTIVITY_TIMEOUT_SECONDS,
         *,
         allow_user_questions: bool = True,
+        provider_id: Optional[str] = None,
+        model_id: Optional[str] = None,
     ):
         """运行 SessionLoop，若超过 timeout_seconds 无任何活跃交互则取消并抛出异常。"""
         inactivity_triggered: list[bool] = [False]
         question_blocked: list[bool] = [False]
 
         loop_task = asyncio.create_task(
-            SessionLoop.run(session_id, callbacks=callbacks)
+            SessionLoop.run(
+                session_id,
+                provider_id=provider_id,
+                model_id=model_id,
+                callbacks=callbacks,
+            )
         )
 
         async def _watchdog() -> None:
@@ -356,16 +364,30 @@ class BackgroundManager:
                 if not project_id or not directory:
                     raise RuntimeError("Failed to resolve project context for background task")
 
-                child_session = await Session.create(
+                launch_model = input_data.model or {}
+                launch_provider = launch_model.get("providerID")
+                launch_model_id = launch_model.get("modelID")
+                persist_model = bool(
+                    input_data.model_pinned and launch_provider and launch_model_id
+                )
+
+                create_kwargs = dict(
                     project_id=project_id,
                     directory=directory,
                     title=f"{input_data.description} (@{input_data.agent} subagent)",
                     parent_id=input_data.parent_session_id,
                     agent=input_data.agent,
-                    model=(input_data.model or {}).get("modelID"),
-                    provider=(input_data.model or {}).get("providerID"),
-                    model_pinned=bool((input_data.model or {}).get("providerID") and (input_data.model or {}).get("modelID")),
                     category=input_data.category or "task",
+                )
+                if persist_model:
+                    create_kwargs.update(
+                        model=launch_model_id,
+                        provider=launch_provider,
+                        model_pinned=True,
+                    )
+
+                child_session = await Session.create(
+                    **create_kwargs,
                 )
                 task.session_id = child_session.id
 
@@ -377,8 +399,14 @@ class BackgroundManager:
                 )
 
                 callbacks = self._build_activity_callbacks(task)
+                runtime_provider = launch_provider if launch_provider and not persist_model else None
+                runtime_model = launch_model_id if launch_model_id and not persist_model else None
                 result = await self._run_session_with_watchdog(
-                    task, child_session.id, callbacks
+                    task,
+                    child_session.id,
+                    callbacks,
+                    provider_id=runtime_provider,
+                    model_id=runtime_model,
                 )
                 output = ""
                 if result.last_message:

--- a/flocks/tool/agent/delegate_task.py
+++ b/flocks/tool/agent/delegate_task.py
@@ -411,6 +411,7 @@ async def delegate_task_tool(
                 parent_message_id=ctx.message_id,
                 parent_agent=ctx.agent,
                 model=category_model,
+                model_pinned=False,
                 category=category,
             )
         )
@@ -436,9 +437,6 @@ async def delegate_task_tool(
         title=f"{description} (@{agent_to_use} subagent)",
         parent_id=parent_session.id,
         agent=agent_to_use,
-        model=(category_model or {}).get("modelID"),
-        provider=(category_model or {}).get("providerID"),
-        model_pinned=bool((category_model or {}).get("providerID") and (category_model or {}).get("modelID")),
         permission=[{"permission": "question", "action": "deny", "pattern": "*"}],
         category="task",
     )
@@ -458,6 +456,8 @@ async def delegate_task_tool(
     ctx.metadata({"title": description, "metadata": {"sessionId": created.id, "status": "running"}})
     result = await SessionLoop.run(
         created.id,
+        provider_id=(category_model or {}).get("providerID"),
+        model_id=(category_model or {}).get("modelID"),
         callbacks=forwarder.build_callbacks(
             event_publish_callback=ctx.event_publish_callback,
         ),

--- a/flocks/tool/agent/delegate_task.py
+++ b/flocks/tool/agent/delegate_task.py
@@ -438,6 +438,7 @@ async def delegate_task_tool(
         agent=agent_to_use,
         model=(category_model or {}).get("modelID"),
         provider=(category_model or {}).get("providerID"),
+        model_pinned=bool((category_model or {}).get("providerID") and (category_model or {}).get("modelID")),
         permission=[{"permission": "question", "action": "deny", "pattern": "*"}],
         category="task",
     )

--- a/flocks/tool/task/task.py
+++ b/flocks/tool/task/task.py
@@ -7,7 +7,7 @@ Supports both synchronous (blocking) and background (async) execution.
 Model resolution priority for child sessions:
   1. Explicit ``model`` param (WebUI override, format: "provider/model" or "model")
   2. Agent-specific model from AgentInfo.model (set in flocks.json agent config)
-  3. Parent session's model/provider (inherits from Rex — TUI/CLI default)
+  3. Parent session's pinned model/provider
   4. Global default LLM (``default_models.llm`` in config)
   5. Environment / hardcoded fallback
 """
@@ -36,18 +36,19 @@ async def _resolve_child_model(
     agent_name: str,
     parent_session,
     model_override: Optional[str] = None,
-) -> Tuple[Optional[str], Optional[str]]:
-    """Resolve (provider_id, model_id) for a child subagent session.
+) -> Tuple[Optional[str], Optional[str], str]:
+    """Resolve ``(provider_id, model_id, source)`` for a child subagent session.
 
     Priority:
       1. ``model_override`` — explicit param from WebUI (format "provider/model" or "model")
       2. Agent model override from Storage (set via WebUI)
       3. Agent-specific model from ``AgentInfo.model``
-      4. Parent session's stored model/provider
+      4. Parent session's pinned model/provider
       5. Global default LLM from config
     """
     provider: Optional[str] = None
     model: Optional[str] = None
+    source = "unknown"
 
     # 1. Explicit override (WebUI)
     if model_override:
@@ -55,6 +56,7 @@ async def _resolve_child_model(
             provider, model = model_override.split("/", 1)
         else:
             model = model_override
+        source = "explicit"
 
     # 2. Agent model override from Storage (set via WebUI)
     if not model:
@@ -68,6 +70,7 @@ async def _resolve_child_model(
                 if override_provider and override_model:
                     provider = override_provider
                     model = override_model
+                    source = "agent_override"
         except Exception:
             pass
 
@@ -79,14 +82,16 @@ async def _resolve_child_model(
             if agent_info and agent_info.model:
                 provider = provider or agent_info.model.provider_id
                 model = agent_info.model.model_id
+                source = "agent"
         except Exception:
             pass
 
-    # 4. Inherit from parent session
-    if not model and parent_session:
-        model = getattr(parent_session, "model", None)
-    if not provider and parent_session:
-        provider = getattr(parent_session, "provider", None)
+    # 4. Inherit only explicit parent pins
+    if (not model or not provider) and parent_session and Session.has_pinned_model(parent_session):
+        provider = provider or getattr(parent_session, "provider", None)
+        model = model or getattr(parent_session, "model", None)
+        if provider and model:
+            source = "parent_session"
 
     # 5. Global default LLM
     if not model or not provider:
@@ -96,10 +101,12 @@ async def _resolve_child_model(
             if default_llm:
                 provider = provider or default_llm.get("provider_id")
                 model = model or default_llm.get("model_id")
+                if provider and model and source == "unknown":
+                    source = "config"
         except Exception:
             pass
 
-    return provider, model
+    return provider, model, source
 
 
 def _model_dict(provider: Optional[str], model: Optional[str]) -> Optional[Dict[str, str]]:
@@ -218,14 +225,20 @@ async def task_tool(
     parent_session = await Session.get_by_id(ctx.session_id)
 
     # Resolve effective model for the child agent
-    child_provider, child_model = await _resolve_child_model(
+    child_provider, child_model, child_source = await _resolve_child_model(
         normalized, parent_session, model_override=model,
+    )
+    child_model_pinned = (
+        child_source in {"explicit", "parent_session"}
+        and bool(child_provider and child_model)
     )
 
     log.info("task.model_resolved", {
         "subagent": normalized,
         "provider": child_provider,
         "model": child_model,
+        "source": child_source,
+        "model_pinned": child_model_pinned,
         "override": model,
         "parent_provider": getattr(parent_session, "provider", None) if parent_session else None,
         "parent_model": getattr(parent_session, "model", None) if parent_session else None,
@@ -289,7 +302,8 @@ async def task_tool(
                 parent_session_id=ctx.session_id,
                 parent_message_id=ctx.message_id,
                 parent_agent=ctx.agent,
-                model=_model_dict(child_provider, child_model),
+                model=_model_dict(child_provider, child_model) if child_model_pinned else None,
+                model_pinned=child_model_pinned,
             )
         )
         ctx.metadata({"title": description, "metadata": {"sessionId": task.session_id}})
@@ -309,18 +323,22 @@ async def task_tool(
         return ToolResult(success=False, error="Parent session not found")
 
     try:
-        created = await Session.create(
+        create_kwargs = dict(
             project_id=parent_session.project_id,
             directory=parent_session.directory,
             title=f"{description} (@{normalized} subagent)",
             parent_id=parent_session.id,
             agent=normalized,
-            model=child_model,
-            provider=child_provider,
-            model_pinned=bool(child_provider and child_model),
             permission=[{"permission": "question", "action": "deny", "pattern": "*"}],
             category="task",
         )
+        if child_model_pinned:
+            create_kwargs.update(
+                model=child_model,
+                provider=child_provider,
+                model_pinned=True,
+            )
+        created = await Session.create(**create_kwargs)
         await Message.create(
             session_id=created.id,
             role=MessageRole.USER,

--- a/flocks/tool/task/task.py
+++ b/flocks/tool/task/task.py
@@ -317,6 +317,7 @@ async def task_tool(
             agent=normalized,
             model=child_model,
             provider=child_provider,
+            model_pinned=bool(child_provider and child_model),
             permission=[{"permission": "question", "action": "deny", "pattern": "*"}],
             category="task",
         )

--- a/tests/agent/test_unified_session_loop.py
+++ b/tests/agent/test_unified_session_loop.py
@@ -141,3 +141,142 @@ class TestResolveModel:
                 assert provider_id == "test-provider"
                 assert model_id == "test-model"
                 assert source == "env_default"
+
+    @pytest.mark.asyncio
+    async def test_pinned_session_model_beats_agent_and_config(self):
+        """An explicit session pin should win over agent/config defaults."""
+        from types import SimpleNamespace
+        from flocks.server.routes.session import _resolve_model
+
+        request = MagicMock()
+        request.model = None
+
+        agent = MagicMock()
+        agent.name = "rex"
+        agent.model = {"providerID": "openai", "modelID": "gpt-4o"}
+
+        pinned_session = SimpleNamespace(
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+            model_pinned=True,
+            parent_id=None,
+        )
+
+        with patch("flocks.server.routes.session.Session.get_by_id", AsyncMock(return_value=pinned_session)), \
+             patch("flocks.storage.storage.Storage.read", AsyncMock(return_value={})):
+            provider_id, model_id, source = await _resolve_model(request, agent, "test-session")
+
+        assert provider_id == "anthropic"
+        assert model_id == "claude-sonnet-4-5"
+        assert source == "session"
+
+    @pytest.mark.asyncio
+    async def test_unpinned_session_model_falls_through_to_config(self):
+        """Legacy session.provider/model should not override the new default."""
+        from types import SimpleNamespace
+        from flocks.server.routes.session import _resolve_model
+
+        request = MagicMock()
+        request.model = None
+
+        agent = MagicMock()
+        agent.name = "rex"
+        agent.model = None
+
+        legacy_session = SimpleNamespace(
+            provider="anthropic",
+            model="old-sticky-model",
+            model_pinned=False,
+            parent_id=None,
+        )
+
+        with patch("flocks.server.routes.session.Session.get_by_id", AsyncMock(return_value=legacy_session)), \
+             patch("flocks.storage.storage.Storage.read", AsyncMock(return_value={})), \
+             patch("flocks.config.config.Config.resolve_default_llm", AsyncMock(return_value={
+                 "provider_id": "openai",
+                 "model_id": "gpt-4o",
+             })), \
+             patch("flocks.server.routes.session._get_last_model", AsyncMock(return_value=None)):
+            provider_id, model_id, source = await _resolve_model(request, agent, "test-session")
+
+        assert provider_id == "openai"
+        assert model_id == "gpt-4o"
+        assert source == "config"
+
+    @pytest.mark.asyncio
+    async def test_process_session_message_pins_explicit_request_model(self, monkeypatch):
+        """Explicit request.model should persist an explicit session pin."""
+        from types import SimpleNamespace
+        from flocks.server.routes import session as session_routes
+
+        request = session_routes.PromptRequest(
+            parts=[{"type": "text", "text": "hello"}],
+            model=session_routes.ModelInfo(
+                providerID="anthropic",
+                modelID="claude-sonnet-4-5",
+            ),
+            noReply=True,
+        )
+        session = SimpleNamespace(
+            id="ses_test",
+            project_id="proj",
+            directory="/tmp/project",
+            agent="rex",
+            provider=None,
+            model=None,
+            model_pinned=False,
+        )
+
+        monkeypatch.setattr(
+            "flocks.agent.registry.Agent.default_agent",
+            AsyncMock(return_value="rex"),
+        )
+        monkeypatch.setattr(
+            "flocks.agent.registry.Agent.get",
+            AsyncMock(return_value=SimpleNamespace(name="rex", model=None)),
+        )
+        update_mock = AsyncMock(
+            return_value=SimpleNamespace(
+                provider="anthropic",
+                model="claude-sonnet-4-5",
+                model_pinned=True,
+                id=session.id,
+                project_id=session.project_id,
+                directory=session.directory,
+                agent=session.agent,
+            )
+        )
+        monkeypatch.setattr("flocks.session.session.Session.update", update_mock)
+        monkeypatch.setattr("flocks.provider.provider.Provider._ensure_initialized", lambda: None)
+        monkeypatch.setattr("flocks.provider.provider.Provider.apply_config", AsyncMock())
+        monkeypatch.setattr("flocks.provider.provider.Provider.get", lambda _provider_id: object())
+        monkeypatch.setattr("flocks.config.config.Config.get", AsyncMock(return_value=SimpleNamespace()))
+        monkeypatch.setattr("flocks.tool.registry.ToolRegistry.init", lambda: None)
+        monkeypatch.setattr(
+            "flocks.session.lifecycle.revert.SessionRevert.cleanup",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
+            "flocks.session.message.Message.create",
+            AsyncMock(return_value=SimpleNamespace(id="msg_user_1")),
+        )
+        monkeypatch.setattr(
+            "flocks.server.routes.event.publish_event",
+            AsyncMock(),
+        )
+
+        result = await session_routes._process_session_message(
+            "ses_test",
+            session,
+            request,
+            "/tmp/project",
+        )
+
+        assert result["role"] == "user"
+        update_mock.assert_awaited_once_with(
+            "proj",
+            "ses_test",
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+            model_pinned=True,
+        )

--- a/tests/channel/test_channel.py
+++ b/tests/channel/test_channel.py
@@ -414,6 +414,7 @@ class TestFeishuNativeCommands:
                 {
                     "provider": "anthropic",
                     "model": "claude-sonnet-4-20250514",
+                    "model_pinned": True,
                 },
             )
         ]
@@ -481,17 +482,19 @@ class TestFeishuNativeCommands:
                     agent="rex",
                     provider="anthropic",
                     model="claude-sonnet-4-20250514",
+                    model_pinned=True,
                 )
             ),
         )
+        create_mock = AsyncMock(
+            return_value=SimpleNamespace(
+                id="session_new",
+                agent="rex",
+            )
+        )
         monkeypatch.setattr(
             "flocks.session.session.Session.create",
-            AsyncMock(
-                return_value=SimpleNamespace(
-                    id="session_new",
-                    agent="rex",
-                )
-            ),
+            create_mock,
         )
 
         handled = await dispatcher._handle_feishu_native_command(
@@ -504,8 +507,98 @@ class TestFeishuNativeCommands:
 
         assert handled is True
         dispatcher.binding_service.rebind.assert_awaited_once()
+        create_kwargs = create_mock.await_args.kwargs
+        assert create_kwargs["provider"] == "anthropic"
+        assert create_kwargs["model"] == "claude-sonnet-4-20250514"
+        assert create_kwargs["model_pinned"] is True
         assert dispatcher.binding_service.rebind.await_args.kwargs["scope_override"] == "group_topic"
         assert "session_new" in delivered[0]
+
+    @pytest.mark.asyncio
+    async def test_new_command_does_not_inherit_unpinned_model(self, monkeypatch):
+        from flocks.channel.inbound.dispatcher import InboundDispatcher
+        from flocks.channel.inbound.session_binding import SessionBinding
+
+        dispatcher = InboundDispatcher()
+        dispatcher._trigger_command_hook = AsyncMock()
+        dispatcher.binding_service.rebind = AsyncMock(
+            return_value=SessionBinding(
+                channel_id="feishu",
+                account_id="default",
+                chat_id="oc_group",
+                chat_type=ChatType.GROUP,
+                thread_id="root_1",
+                session_id="session_new",
+                agent_id="rex",
+                created_at=0,
+                last_message_at=0,
+            )
+        )
+        binding = SessionBinding(
+            channel_id="feishu",
+            account_id="default",
+            chat_id="oc_group",
+            chat_type=ChatType.GROUP,
+            thread_id="root_1",
+            session_id="session_old",
+            agent_id="rex",
+            created_at=0,
+            last_message_at=0,
+        )
+        msg = InboundMessage(
+            channel_id="feishu",
+            account_id="default",
+            message_id="msg_1",
+            sender_id="ou_user",
+            chat_id="oc_group",
+            chat_type=ChatType.GROUP,
+            text="/new",
+            mention_text="/new",
+            thread_id="root_1",
+        )
+
+        async def fake_deliver(ctx, session_id=None):
+            return None
+
+        monkeypatch.setattr(
+            "flocks.channel.outbound.deliver.OutboundDelivery.deliver",
+            fake_deliver,
+        )
+        monkeypatch.setattr(
+            "flocks.session.session.Session.get_by_id",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    id="session_old",
+                    project_id="channel",
+                    directory="/tmp/project",
+                    agent="rex",
+                    provider="anthropic",
+                    model="stale-model",
+                    model_pinned=False,
+                )
+            ),
+        )
+        create_mock = AsyncMock(
+            return_value=SimpleNamespace(
+                id="session_new",
+                agent="rex",
+            )
+        )
+        monkeypatch.setattr("flocks.session.session.Session.create", create_mock)
+
+        handled = await dispatcher._handle_feishu_native_command(
+            binding=binding,
+            msg=msg,
+            channel_config=ChannelConfig(enabled=True),
+            user_text="/new",
+            scope_override="group_topic",
+        )
+
+        assert handled is True
+        create_kwargs = create_mock.await_args.kwargs
+        assert "provider" not in create_kwargs
+        assert "model" not in create_kwargs
+        assert "model_pinned" not in create_kwargs
 
     @pytest.mark.asyncio
     async def test_append_user_message_stores_feishu_media_part(self, monkeypatch):
@@ -701,9 +794,8 @@ class TestMultimodalInput:
             ),
         )
         monkeypatch.setattr(
-            SessionRunner,
-            "_extract_pdf_text_from_bytes",
-            classmethod(lambda cls, data, max_pages=20, max_chars=12000: "PDF body text"),
+            "flocks.session.utils.file_extractor.extract_pdf_text_from_bytes",
+            lambda data, *, max_pages=20, max_chars=12000: "PDF body text",
         )
 
         chat_messages = await runner._to_chat_messages(

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -13,7 +14,7 @@ import flocks.task.manager as task_manager_module
 from flocks.server.routes import question as question_routes
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
-from flocks.task.background import BackgroundManager, BackgroundTask
+from flocks.task.background import BackgroundManager, BackgroundTask, LaunchInput
 from flocks.task.executor import TaskExecutor
 from flocks.task.manager import TaskManager
 from flocks.task.models import (
@@ -294,7 +295,12 @@ async def test_queue_status_uses_largest_elapsed_running_time(tmp_path: Path):
 async def test_background_task_fails_fast_when_user_input_is_required(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    async def fake_session_loop(_session_id: str, callbacks=None):
+    async def fake_session_loop(
+        _session_id: str,
+        provider_id=None,
+        model_id=None,
+        callbacks=None,
+    ):
         try:
             await asyncio.Event().wait()
         except asyncio.CancelledError:
@@ -332,6 +338,57 @@ async def test_background_task_fails_fast_when_user_input_is_required(
         )
 
     assert rejected == ["ses_interactive_block"]
+
+
+@pytest.mark.asyncio
+async def test_background_task_uses_unpinned_model_as_runtime_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    create_mock = AsyncMock(return_value=SimpleNamespace(id="ses_task_child"))
+    loop_run = AsyncMock(return_value=SimpleNamespace(last_message=None))
+
+    monkeypatch.setattr(background_module.Session, "create", create_mock)
+    monkeypatch.setattr(background_module.Message, "create", AsyncMock())
+    monkeypatch.setattr(background_module.SessionLoop, "run", loop_run)
+
+    manager = BackgroundManager()
+    task = BackgroundTask(
+        id="bg_test_runtime_override",
+        status="pending",
+        description="scheduled",
+        prompt="",
+        agent="rex",
+    )
+
+    await manager._run_task(
+        task,
+        LaunchInput(
+            description="scheduled",
+            prompt="Run a quick check",
+            agent="rex",
+            parent_session_id=None,
+            parent_message_id=None,
+            parent_agent=None,
+            model={
+                "providerID": "anthropic",
+                "modelID": "claude-haiku-4-5",
+            },
+            model_pinned=False,
+            directory="/tmp/project",
+            project_id="proj",
+        ),
+    )
+
+    create_kwargs = create_mock.await_args.kwargs
+    assert "provider" not in create_kwargs
+    assert "model" not in create_kwargs
+    assert "model_pinned" not in create_kwargs
+    assert loop_run.await_count == 1
+    assert loop_run.await_args.args == ("ses_task_child",)
+    assert loop_run.await_args.kwargs["provider_id"] == "anthropic"
+    assert loop_run.await_args.kwargs["model_id"] == "claude-haiku-4-5"
+    assert loop_run.await_args.kwargs["callbacks"] is not None
+    assert task.status == "completed"
 
 
 @pytest.mark.asyncio

--- a/tests/tool/test_delegate_task_batch_compat.py
+++ b/tests/tool/test_delegate_task_batch_compat.py
@@ -47,6 +47,49 @@ class TestDelegateTaskTolerance:
         launch_input = manager.launch.await_args.args[0]
         assert launch_input.description == "Investigate threatbook.cn assets"
 
+    @pytest.mark.asyncio
+    async def test_delegate_task_category_model_uses_runtime_override_without_pinning(self):
+        manager = SimpleNamespace(
+            launch=AsyncMock(return_value=SimpleNamespace(
+                id="task-2",
+                description="quick task",
+                agent="rex-junior",
+                status="running",
+                session_id="ses-quick",
+            ))
+        )
+        cfg = SimpleNamespace(categories={
+            "quick": {
+                "model": "anthropic/claude-haiku-4-5",
+                "prompt_append": None,
+            }
+        })
+
+        with patch("flocks.tool.agent.delegate_task._find_completed_delegate", AsyncMock(return_value=None)), \
+             patch("flocks.tool.agent.delegate_task.Config.get", AsyncMock(return_value=cfg)), \
+             patch("flocks.tool.agent.delegate_task._validate_category_model", return_value={
+                 "providerID": "anthropic",
+                 "modelID": "claude-haiku-4-5",
+             }), \
+             patch("flocks.tool.agent.delegate_task.get_background_manager", return_value=manager):
+            result = await ToolRegistry.execute(
+                "delegate_task",
+                ctx=_make_ctx(),
+                category="quick",
+                prompt="Summarize the diff",
+                description="quick task",
+                run_in_background=True,
+            )
+
+        assert result.success is True
+        manager.launch.assert_awaited_once()
+        launch_input = manager.launch.await_args.args[0]
+        assert launch_input.model == {
+            "providerID": "anthropic",
+            "modelID": "claude-haiku-4-5",
+        }
+        assert launch_input.model_pinned is False
+
 
 class TestBatchCompatibility:
     def test_batch_schema_allows_legacy_commands_alias(self):

--- a/tests/tool/test_task_model_pinning.py
+++ b/tests/tool/test_task_model_pinning.py
@@ -1,0 +1,117 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flocks.tool.registry import ToolContext
+from flocks.tool.task.task import _resolve_child_model, task_tool
+
+
+def _make_ctx() -> ToolContext:
+    return ToolContext(session_id="test-session", message_id="test-message", agent="rex")
+
+
+class TestTaskModelPinning:
+    @pytest.mark.asyncio
+    async def test_resolve_child_model_ignores_unpinned_parent_session_model(self):
+        parent_session = SimpleNamespace(
+            provider="anthropic",
+            model="stale-model",
+            model_pinned=False,
+        )
+
+        with patch("flocks.storage.storage.Storage.read", AsyncMock(return_value={})), \
+             patch("flocks.agent.registry.Agent.get", AsyncMock(return_value=None)), \
+             patch("flocks.config.config.Config.resolve_default_llm", AsyncMock(return_value={
+                 "provider_id": "openai",
+                 "model_id": "gpt-5",
+             })):
+            provider, model, source = await _resolve_child_model("explore", parent_session)
+
+        assert provider == "openai"
+        assert model == "gpt-5"
+        assert source == "config"
+
+    @pytest.mark.asyncio
+    async def test_task_tool_explicit_model_override_pins_child_session(self):
+        manager = SimpleNamespace(
+            launch=AsyncMock(return_value=SimpleNamespace(
+                id="bg-task",
+                description="delegate explore",
+                agent="explore",
+                status="running",
+                session_id="ses-child",
+            ))
+        )
+        parent_session = SimpleNamespace(
+            id="ses-parent",
+            project_id="proj",
+            directory="/tmp/project",
+            provider=None,
+            model=None,
+            model_pinned=False,
+        )
+
+        with patch("flocks.tool.task.task.is_delegatable", return_value=True), \
+             patch("flocks.tool.task.task.Session.get_by_id", AsyncMock(return_value=parent_session)), \
+             patch("flocks.tool.task.task.get_background_manager", return_value=manager):
+            result = await task_tool(
+                _make_ctx(),
+                description="delegate explore",
+                prompt="Inspect the repository",
+                subagent_type="explore",
+                run_in_background=True,
+                model="openai/gpt-5",
+            )
+
+        assert result.success is True
+        manager.launch.assert_awaited_once()
+        launch_input = manager.launch.await_args.args[0]
+        assert launch_input.model == {
+            "providerID": "openai",
+            "modelID": "gpt-5",
+        }
+        assert launch_input.model_pinned is True
+
+    @pytest.mark.asyncio
+    async def test_task_tool_default_resolution_does_not_pin_child_session(self):
+        manager = SimpleNamespace(
+            launch=AsyncMock(return_value=SimpleNamespace(
+                id="bg-task",
+                description="delegate explore",
+                agent="explore",
+                status="running",
+                session_id="ses-child",
+            ))
+        )
+        parent_session = SimpleNamespace(
+            id="ses-parent",
+            project_id="proj",
+            directory="/tmp/project",
+            provider="anthropic",
+            model="stale-model",
+            model_pinned=False,
+        )
+
+        with patch("flocks.tool.task.task.is_delegatable", return_value=True), \
+             patch("flocks.tool.task.task.Session.get_by_id", AsyncMock(return_value=parent_session)), \
+             patch("flocks.tool.task.task.get_background_manager", return_value=manager), \
+             patch("flocks.storage.storage.Storage.read", AsyncMock(return_value={})), \
+             patch("flocks.agent.registry.Agent.get", AsyncMock(return_value=None)), \
+             patch("flocks.config.config.Config.resolve_default_llm", AsyncMock(return_value={
+                 "provider_id": "anthropic",
+                 "model_id": "claude-sonnet-4-6",
+             })):
+            result = await task_tool(
+                _make_ctx(),
+                description="delegate explore",
+                prompt="Inspect the repository",
+                subagent_type="explore",
+                run_in_background=True,
+            )
+
+        assert result.success is True
+        manager.launch.assert_awaited_once()
+        launch_input = manager.launch.await_args.args[0]
+        assert launch_input.model is None
+        assert launch_input.model_pinned is False


### PR DESCRIPTION
## Summary

Introduces `model_pinned` on session metadata so provider/model can be explicitly locked, aligns HTTP `_resolve_model` with SessionLoop priority (including parent pinned sessions), stops persisting resolved defaults for unpinned sessions in SessionLoop, and propagates pinned models through the inbound channel dispatcher for native commands.

## Testing

`uv run pytest tests/agent/test_unified_session_loop.py tests/channel/test_channel.py -q`


Made with [Cursor](https://cursor.com)