### PR TITLE
feat(onesec): align tool schemas, docs, and registry startup validation

### DIFF
--- a/.flocks/plugins/skills/onesec-use/references/api-reference.md
+++ b/.flocks/plugins/skills/onesec-use/references/api-reference.md
@@ -58,6 +58,11 @@ OneSEC 高频查询动作通常使用：
 | 查最近 24 小时增量 | `edr_get_recent_incidents` | 显式传 `time_from`、`time_to`，且跨度不超过 24 小时 | 仅增量同步 |
 | 未传时间兜底查询 | `edr_get_incidents` | 不传时间 | 返回范围由服务端默认窗口决定，不推荐依赖 |
 
+补充规则：
+
+- 若用户说“recent 事件”但时间范围是本周、最近 7 天、最近 30 天，agent 应主动改用 `edr_get_incidents`
+- `edr_get_recent_incidents` 只用于最近 24 小时增量，不要拿它做历史回溯
+
 ## 标准时间模板
 
 以下模板仅用于给 agent 组装请求时参考：
@@ -190,6 +195,13 @@ OneSEC 中几个相邻页面经常被混用，建议先按语义路由：
 - `edr_get_recent_threat_files`
 - `edr_get_recent_threat_activities`
 - `edr_get_recent_threat_timeline`
+
+其中时间线类 action 需要额外注意：
+
+- `edr_get_threat_timeline` 需要 `incident_id`
+- `edr_get_recent_threat_timeline` 也需要 `incident_id`
+- 如果还没有 `incident_id`，应先调用 `edr_get_incidents`
+- `edr_get_recent_threat_timeline` 仅适合最近 24 小时内的增量时间线查询
 
 ### 4. 查询威胁处置清单
 

--- a/.flocks/plugins/skills/onesec-use/references/api-reference.md
+++ b/.flocks/plugins/skills/onesec-use/references/api-reference.md
@@ -6,7 +6,7 @@ OneSEC 当前优先复用 grouped tool，而不是直接从页面做数据获取
 
 | 用户意图 | 推荐 tool | 推荐 action | 最小参数 |
 |---|---|---|---|
-| 查威胁事件 | `onesec_edr` | `edr_get_incidents` / `edr_get_recent_incidents` | 常见至少带 `time_from`、`time_to` |
+| 查威胁事件 | `onesec_edr` | `edr_get_incidents`（默认） / `edr_get_recent_incidents`（仅最近 24 小时增量） | 建议显式带 `time_from`、`time_to` |
 | 查终端告警 | `onesec_edr` | `edr_get_endpoint_alerts` / `edr_get_recent_endpoint_alerts` | 常见至少带 `time_from`、`time_to` |
 | 查恶意文件 / 威胁行为 / 时间线 / IOC | `onesec_edr` | 对应 `edr_get_*` action | 时间范围、分页、筛选字段 |
 | 查 DNS 拦截 / 解析日志 / 受威胁终端 | `onesec_dns` | `dns_search_blocked_queries` / `dns_search_queries` / `dns_search_threatened_endpoint` | 多数需要 `time_from`、`time_to` |
@@ -32,6 +32,10 @@ OneSEC 高频查询动作通常使用：
 
 - 秒级时间戳，不是毫秒
 
+- 分页接口建议显式传 `time_from`、`time_to`
+- `recent` 系列只适合最近 24 小时的增量查询
+- 未传时间时，返回范围由服务端默认窗口决定，仅作兜底，不推荐依赖
+
 示例：
 
 ```json
@@ -43,6 +47,25 @@ OneSEC 高频查询动作通常使用：
   "page_size": 20
 }
 ```
+
+## 时间窗口选择表
+
+| 查询目标 | 推荐 action | 时间参数策略 | 备注 |
+|---|---|---|---|
+| 查本周事件 | `edr_get_incidents` | 显式传 `time_from`、`time_to` | 默认做法 |
+| 查最近 7 天事件 | `edr_get_incidents` | 显式传 `time_from`、`time_to` | 适合历史回溯 |
+| 查最近 30 天事件 | `edr_get_incidents` | 显式传 `time_from`、`time_to` | 适合历史回溯 |
+| 查最近 24 小时增量 | `edr_get_recent_incidents` | 显式传 `time_from`、`time_to`，且跨度不超过 24 小时 | 仅增量同步 |
+| 未传时间兜底查询 | `edr_get_incidents` | 不传时间 | 返回范围由服务端默认窗口决定，不推荐依赖 |
+
+## 标准时间模板
+
+以下模板仅用于给 agent 组装请求时参考：
+
+- 时间戳单位一律是秒
+- 以下示例按 `Asia/Shanghai` 计算
+- 以下示例假设当前时间是 `2026-04-23 10:00:00 +08:00`
+- 实际调用时，应按执行当时的业务时区重新计算
 
 ## 先区分事件、告警、DNS 和资产
 
@@ -70,6 +93,9 @@ OneSEC 中几个相邻页面经常被混用，建议先按语义路由：
 
 - `onesec_edr`
 - `action=edr_get_incidents`
+- 历史回溯场景显式传 `time_from` + `time_to`
+- 仅最近 24 小时增量才使用 `edr_get_recent_incidents`
+- 未传时间只作为兜底，不要把它当成稳定窗口
 
 最小示例：
 

--- a/.flocks/plugins/tools/api/onesec/onesec.handler.py
+++ b/.flocks/plugins/tools/api/onesec/onesec.handler.py
@@ -605,7 +605,7 @@ def _validate_action_params(action: str, params: dict[str, Any]) -> Optional[str
         missing.extend(_require_fields(params, "task_id"))
     elif action == "edr_delete_registry_startup":
         missing.extend(_validate_non_empty_aliases(params, ("agent_list", "umid_list"), "agent_list"))
-        missing.extend(_require_fields(params, "registry_path"))
+        missing.extend(_require_fields(params, "registry_path", "registry_type"))
     elif action == "edr_delete_ioc":
         missing.extend(_require_fields(params, "iocs"))
     elif action == "edr_add_ioc":

--- a/.flocks/plugins/tools/api/onesec/onesec.handler.py
+++ b/.flocks/plugins/tools/api/onesec/onesec.handler.py
@@ -612,6 +612,8 @@ def _validate_action_params(action: str, params: dict[str, Any]) -> Optional[str
         missing.extend(_require_fields(params, "iocs", "severity", "threatName"))
     elif action in {"edr_get_threat_disposals", "edr_get_recent_threat_disposals"}:
         missing.extend(_require_fields(params, "incident_id", "umid"))
+    elif action in {"edr_get_threat_timeline", "edr_get_recent_threat_timeline"}:
+        missing.extend(_require_fields(params, "incident_id"))
     elif action == "ops_edit_agent_info":
         if not _has_value(params.get("umid")) and not _has_value(params.get("mac")):
             missing.append("umid/mac")
@@ -763,12 +765,12 @@ ACTION_SPECS: dict[str, ActionSpec] = {
     "edr_get_threat_timeline": ActionSpec(
         "POST",
         "/api/saasedr/api/client/v1/getThreatTimeline",
-        lambda p: {**_pick(p, "time_from", "time_to"), "page": _page(p)},
+        lambda p: {**_pick(p, "incident_id", "time_from", "time_to"), "page": _page(p)},
     ),
     "edr_get_recent_threat_timeline": ActionSpec(
         "POST",
         "/api/saasedr/api/client/v1/getRecentThreatTimeline",
-        lambda p: _pick(p, "time_from", "time_to"),
+        lambda p: _pick(p, "incident_id", "time_from", "time_to"),
     ),
     "edr_get_ioc_list": ActionSpec(
         "POST",

--- a/.flocks/plugins/tools/api/onesec/onesec_dns.yaml
+++ b/.flocks/plugins/tools/api/onesec/onesec_dns.yaml
@@ -1,11 +1,11 @@
 name: onesec_dns
 description: >
   OneSEC DNS grouped tool. Use the `action` parameter to access DNS security
-  query and policy APIs. Credentials note: enter `api_key|secret` in the API
-  Key field of the service configuration.
+  query and policy APIs. Configure the OneSEC service with separate API Key and
+  Secret credentials.
 description_cn: >
-  OneSEC DNS 分组工具。通过 `action` 参数调用 DNS 安全防护相关接口。配置时请在
-  服务的 API Key 输入框填写 `api_key|secret`。
+  OneSEC DNS 分组工具。通过 `action` 参数调用 DNS 安全防护相关接口。请在 OneSEC
+  服务配置中分别填写 API Key、Secret，Base URL 可按需覆盖。
 category: custom
 enabled: true
 requires_confirmation: true
@@ -169,6 +169,11 @@ inputSchema:
       items:
         type: string
       description: 域名列表
+    domain_list:
+      type: array
+      items:
+        type: string
+      description: 域名列表别名，兼容旧调用方式
     target_list:
       type: string
       description: 目标地址列表名称

--- a/.flocks/plugins/tools/api/onesec/onesec_edr.yaml
+++ b/.flocks/plugins/tools/api/onesec/onesec_edr.yaml
@@ -57,7 +57,7 @@ inputSchema:
           必填: 无
           常用: `time_from`、`time_to`、`params`
           ⚠️ 限制: 仅支持最近 24 小时的数据；超出范围将被服务器拒绝
-          ⚠️ 推荐: 通用查询请优先使用 `edr_get_incidents`
+          ⚠️ 推荐: 仅最近 24 小时增量才使用；若用户请求本周、最近 7 天或更长时间窗，应改用 `edr_get_incidents`
           是否任务型: 否
         - edr_get_endpoint_alerts
           用途: 分页查询终端告警日志（通用查询首选，适合历史回溯）
@@ -85,17 +85,17 @@ inputSchema:
           风险提示: 实网通常要求 `incident_id` 与 `umid` 一起传
           是否任务型: 否
         - edr_get_threat_timeline
-          用途: 分页查询威胁事件时间线（通用查询首选，适合历史回溯）
-          必填: 无
-          常用: `time_from`、`time_to`、`cur_page`、`page_size`
-          风险提示: 建议限定时间范围避免结果过大
+          用途: 分页查询指定威胁事件的时间线
+          必填: `incident_id`
+          常用: `incident_id`、`time_from`、`time_to`、`cur_page`、`page_size`
+          风险提示: 需要先拿到 `incident_id`；若只知道事件列表，应先调用 `edr_get_incidents`
           是否任务型: 否
         - edr_get_recent_threat_timeline
-          用途: 查询近期威胁事件时间线（仅适用于增量同步，有严格时间限制）
-          必填: 无
-          常用: `time_from`、`time_to`
+          用途: 查询指定威胁事件的近期时间线（仅适用于增量同步，有严格时间限制）
+          必填: `incident_id`
+          常用: `incident_id`、`time_from`、`time_to`
           ⚠️ 限制: 仅支持最近 24 小时的数据；超出范围将被服务器拒绝
-          ⚠️ 推荐: 通用查询请优先使用 `edr_get_threat_timeline`
+          ⚠️ 推荐: 需要先拿到 `incident_id`；若时间窗超过 24 小时或需要历史回溯，请改用 `edr_get_threat_timeline`
           是否任务型: 否
         - edr_get_ioc_list
           用途: 分页查询 IOC 名单

--- a/.flocks/plugins/tools/api/onesec/onesec_edr.yaml
+++ b/.flocks/plugins/tools/api/onesec/onesec_edr.yaml
@@ -1,14 +1,14 @@
 name: onesec_edr
 description: >
   OneSEC EDR grouped tool. Use the `action` parameter to access endpoint
-  detection, response, IOC, and action-status APIs. Credentials note: enter
-  `api_key|secret` in the API Key field of the service configuration.
+  detection, response, IOC, and action-status APIs. Configure the OneSEC
+  service with separate API Key and Secret credentials.
 description_cn: >
   OneSEC EDR 分组工具。通过 `action` 参数调用终端检测与响应、IOC 和动作状态相关接口。
-  【选用原则】通用告警/事件查询首选分页接口（edr_get_endpoint_alerts、edr_get_threat_files 等），
-  不传时间参数即可获取最新数据；`edr_get_recent_*` 系列接口仅适用于增量同步场景，
-  且严格限制只能查询最近 24 小时内的数据，超出范围会被服务器拒绝。
-  配置时请在服务的 API Key 输入框填写 `api_key|secret`。
+  【选用原则】通用事件/告警查询优先使用分页接口，并显式传 `time_from`、`time_to`；
+  若不传时间，返回范围由服务端默认窗口决定，仅作兜底，不建议依赖。
+  `edr_get_recent_*` 系列接口仅适用于最近 24 小时内的增量查询。
+  请在 OneSEC 服务配置中分别填写 API Key、Secret，Base URL 可按需覆盖。
 category: custom
 enabled: true
 requires_confirmation: true
@@ -21,7 +21,7 @@ inputSchema:
       description: |
         EDR 分组动作名，可选值：
         - edr_get_threat_files
-          用途: 分页查询恶意文件（通用查询首选，不传时间参数可获取最新数据）
+          用途: 分页查询恶意文件（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`group_list`、`umid_list`、`cur_page`、`page_size`
           风险提示: 更适合全量回溯；如需排序扩展需结合后端实现
@@ -34,7 +34,7 @@ inputSchema:
           ⚠️ 推荐: 通用查询请优先使用 `edr_get_threat_files`
           是否任务型: 否
         - edr_get_threat_activities
-          用途: 分页查询威胁行为（通用查询首选，不传时间参数可获取最新数据）
+          用途: 分页查询威胁行为（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`group_list`、`threat_phase_list`、`cur_page`、`page_size`
           风险提示: 行为筛选条件较多，优先显式传时间范围
@@ -47,7 +47,7 @@ inputSchema:
           ⚠️ 推荐: 通用查询请优先使用 `edr_get_threat_activities`
           是否任务型: 否
         - edr_get_incidents
-          用途: 分页查询威胁事件（通用查询首选，不传时间参数可获取最新数据）
+          用途: 分页查询威胁事件（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`params`、`cur_page`、`page_size`
           风险提示: 返回事件对象较复杂，后续常用于提取 `incident_id`
@@ -60,7 +60,7 @@ inputSchema:
           ⚠️ 推荐: 通用查询请优先使用 `edr_get_incidents`
           是否任务型: 否
         - edr_get_endpoint_alerts
-          用途: 分页查询终端告警日志（通用查询首选，不传时间参数可获取最新数据）
+          用途: 分页查询终端告警日志（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`sql`、`search_fields`、`cur_page`、`page_size`
           风险提示: 若返回字段过多可能导致接口耗时增加
@@ -70,7 +70,7 @@ inputSchema:
           必填: 无
           常用: `time_from`、`time_to`、`sql`、`search_fields`
           ⚠️ 限制: 仅支持最近 24 小时的数据；time_from 距当前时间超过 24 小时将被服务器拒绝
-          ⚠️ 推荐: 通用查询请优先使用 `edr_get_endpoint_alerts`（无需时间参数）
+          ⚠️ 推荐: 通用查询请优先使用 `edr_get_endpoint_alerts`，并显式传 `time_from`、`time_to`
           是否任务型: 否
         - edr_get_threat_disposals
           用途: 分页查询威胁处置清单
@@ -85,7 +85,7 @@ inputSchema:
           风险提示: 实网通常要求 `incident_id` 与 `umid` 一起传
           是否任务型: 否
         - edr_get_threat_timeline
-          用途: 分页查询威胁事件时间线（通用查询首选，不传时间参数可获取最新数据）
+          用途: 分页查询威胁事件时间线（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`cur_page`、`page_size`
           风险提示: 建议限定时间范围避免结果过大
@@ -165,8 +165,8 @@ inputSchema:
           是否任务型: 否
         - edr_delete_registry_startup
           用途: 下发删除注册表启动项任务
-          必填: `agent_list`、`registry_path`
-          常用: `registry_type`
+          必填: `agent_list`、`registry_path`、`registry_type`
+          常用: `registry_path`、`registry_type`
           风险提示: 高风险写操作；会修改终端启动项
           是否任务型: 是
         - edr_delete_ioc
@@ -214,13 +214,12 @@ inputSchema:
         开始时间戳，Unix 秒级时间戳。
         注意：传入前请确认 time_from < time_to；对于 recent 系列接口，
         time_from 距当前时间不能超过 24 小时，否则服务器会拒绝请求。可以使用python datetime动态计算。
-        对于分页接口（如 edr_get_endpoint_alerts），time_from 可不传，
-        不传时服务器默认返回最新数据。
+        分页接口可不传，但此时返回范围由服务端默认窗口决定，仅作兜底，不建议依赖。
     time_to:
       type: integer
       description: >
         结束时间戳，Unix 秒级时间戳。必须大于 time_from。可以使用python datetime动态计算。
-        对于分页接口，time_to 可不传，不传时服务器默认返回最新数据。
+        分页接口可不传，但此时返回范围由服务端默认窗口决定，仅作兜底，不建议依赖。
     group_list:
       type: array
       items:
@@ -331,11 +330,11 @@ inputSchema:
       type: integer
       description: 任务状态排序
     registry_path:
-      type: string
-      description: 注册表路径
-    registry_type:
       type: integer
-      description: 注册表类型
+      description: 注册表类型，`1` 表示注册表项，`2` 表示注册表值
+    registry_type:
+      type: string
+      description: 注册表项或注册表值的完整路径
     iocs:
       type: array
       items:

--- a/.flocks/plugins/tools/api/onesec/onesec_ops.yaml
+++ b/.flocks/plugins/tools/api/onesec/onesec_ops.yaml
@@ -1,11 +1,11 @@
 name: onesec_ops
 description: >
   OneSEC operations grouped tool. Use the `action` parameter to access endpoint
-  management, audit, task, and strategy APIs. Credentials note: enter
-  `api_key|secret` in the API Key field of the service configuration.
+  management, audit, task, and strategy APIs. Configure the OneSEC service with
+  separate API Key and Secret credentials.
 description_cn: >
   OneSEC 运营管理分组工具。通过 `action` 参数调用终端管理、审计、任务和策略相关
-  接口。配置时请在服务的 API Key 输入框填写 `api_key|secret`。
+  接口。请在 OneSEC 服务配置中分别填写 API Key、Secret，Base URL 可按需覆盖。
 category: custom
 enabled: true
 requires_confirmation: true
@@ -26,19 +26,19 @@ inputSchema:
         - ops_edit_agent_info
           用途: 编辑终端管理信息
           必填: `umid` 或 `mac` 其一
-          常用: `hostname`、`alias`、`group_id`、`organization_user_id`、`update_type`
+          常用: `name`、`department`、`job_number`、`group_path`、`organization_user_id`、`update_type`
           风险提示: 写操作；会直接修改终端基础信息与归属
           是否任务型: 否
         - ops_query_audit_log
           用途: 分页查询审计日志
           必填: `begin_time`、`end_time`
-          常用: `cur_page`、`page_size`、`operator`、`module`、`operation`
+          常用: `cur_page`、`page_size`、`operate_list`、`role_list`、`group_list`、`api_access_type_list`
           风险提示: 建议限定时间范围，避免返回量过大
           是否任务型: 否
         - ops_query_task_page_list
           用途: 分页查询任务列表
           必填: `time_type`、`begin_time`、`end_time`、`auto`
-          常用: `cur_page`、`page_size`、`sort_by`、`sort_order`、`task_status`、`task_type`
+          常用: `cur_page`、`page_size`、`sort_by`、`sort_order`、`task_status_list`、`task_type_list`、`group_id`
           风险提示: 分页接口通常要求排序对象；缺少关键时间条件会被工具层拦截
           是否任务型: 否
         - ops_query_task_execute_list

--- a/.flocks/plugins/tools/api/onesec/onesec_software.yaml
+++ b/.flocks/plugins/tools/api/onesec/onesec_software.yaml
@@ -1,11 +1,11 @@
 name: onesec_software
 description: >
   OneSEC software grouped tool. Use the `action` parameter to access installed
-  software inventory APIs. Credentials note: enter `api_key|secret` in the API
-  Key field of the service configuration.
+  software inventory APIs. Configure the OneSEC service with separate API Key
+  and Secret credentials.
 description_cn: >
-  OneSEC 软件管理分组工具。通过 `action` 参数调用软件资产相关接口。配置时请在
-  服务的 API Key 输入框填写 `api_key|secret`。
+  OneSEC 软件管理分组工具。通过 `action` 参数调用软件资产相关接口。请在 OneSEC
+  服务配置中分别填写 API Key、Secret，Base URL 可按需覆盖。
 category: custom
 enabled: true
 requires_confirmation: false
@@ -20,7 +20,7 @@ inputSchema:
         - software_query_page_list
           用途: 分页查询已安装软件列表
           必填: 无
-          常用: `cur_page`、`page_size`、`sort_by`、`sort_order`、`name`、`publisher`、`agent_group_list`
+          常用: `cur_page`、`page_size`、`sort_by`、`sort_order`、`fuzzy`、`condition`、`agent_group_list`
           风险提示: 分页接口通常要求排序对象，建议显式传 `sort_by` + `sort_order`
           是否任务型: 否
         - software_query_agent_list

--- a/.flocks/plugins/tools/api/onesec/onesec_threat.yaml
+++ b/.flocks/plugins/tools/api/onesec/onesec_threat.yaml
@@ -1,11 +1,11 @@
 name: onesec_threat
 description: >
   OneSEC threat protection grouped tool. Use the `action` parameter to access
-  antivirus version and scan task APIs. Credentials note: enter
-  `api_key|secret` in the API Key field of the service configuration.
+  antivirus version and scan task APIs. Configure the OneSEC service with
+  separate API Key and Secret credentials.
 description_cn: >
   OneSEC 威胁防护分组工具。通过 `action` 参数调用病毒库版本和扫描任务相关接口。
-  配置时请在服务的 API Key 输入框填写 `api_key|secret`。
+  请在 OneSEC 服务配置中分别填写 API Key、Secret，Base URL 可按需覆盖。
 category: custom
 enabled: true
 requires_confirmation: true

--- a/tests/tool/test_onesec_api_tool.py
+++ b/tests/tool/test_onesec_api_tool.py
@@ -511,6 +511,120 @@ async def test_onesec_edr_get_threat_disposals_uses_incident_and_sort_payload():
 
 
 @pytest.mark.asyncio
+async def test_onesec_edr_recent_incidents_rejects_window_over_24_hours():
+    tool = _load_tool("onesec_edr.yaml")
+
+    result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="edr_get_recent_incidents",
+        time_from=1699395200,
+        time_to=1700000000,
+    )
+
+    assert result.success is False
+    assert "仅支持最近 24 小时的数据" in result.error
+    assert "`edr_get_incidents`" in result.error
+
+
+@pytest.mark.asyncio
+async def test_onesec_edr_threat_timeline_requires_incident_id():
+    tool = _load_tool("onesec_edr.yaml")
+
+    paged_result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="edr_get_threat_timeline",
+        time_from=1699990000,
+        time_to=1700000000,
+        cur_page=1,
+        page_size=20,
+    )
+    recent_result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="edr_get_recent_threat_timeline",
+    )
+
+    assert paged_result.success is False
+    assert paged_result.error == (
+        "Missing required parameters for edr_get_threat_timeline: incident_id"
+    )
+    assert recent_result.success is False
+    assert recent_result.error == (
+        "Missing required parameters for edr_get_recent_threat_timeline: incident_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onesec_edr_threat_timeline_uses_incident_id_payload():
+    tool = _load_tool("onesec_edr.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "response_code": 200,
+                    "verbose_msg": "success",
+                    "data": {"total": 1, "cur_page": 1, "tbBaseLogList": [{"event_time": "1"}]},
+                }
+            ),
+            _FakeResponse(
+                json_payload={
+                    "response_code": 200,
+                    "verbose_msg": "success",
+                    "data": {"tbBaseLogList": [{"event_time": "1"}]},
+                }
+            ),
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "api-key-1|secret-1"
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        paged_result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_get_threat_timeline",
+            incident_id="incident-1",
+            time_from=1699990000,
+            time_to=1700000000,
+            cur_page=1,
+            page_size=20,
+        )
+        recent_result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_get_recent_threat_timeline",
+            incident_id="incident-1",
+            time_from=1699990000,
+            time_to=1700000000,
+        )
+
+    assert paged_result.success is True
+    assert recent_result.success is True
+
+    paged_call = fake_session.calls[0]
+    assert paged_call[1] == "https://console.onesec.net/api/saasedr/api/client/v1/getThreatTimeline"
+    assert paged_call[2]["json"] == {
+        "incident_id": "incident-1",
+        "time_from": 1699990000,
+        "time_to": 1700000000,
+        "page": {"cur_page": 1, "page_size": 20},
+    }
+
+    recent_call = fake_session.calls[1]
+    assert recent_call[1] == "https://console.onesec.net/api/saasedr/api/client/v1/getRecentThreatTimeline"
+    assert recent_call[2]["json"] == {
+        "incident_id": "incident-1",
+        "time_from": 1699990000,
+        "time_to": 1700000000,
+    }
+
+
+@pytest.mark.asyncio
 async def test_onesec_software_query_page_list_uses_sort_object_payload():
     tool = _load_tool("onesec_software.yaml")
     fake_session = _FakeSession(

--- a/tests/tool/test_onesec_api_tool.py
+++ b/tests/tool/test_onesec_api_tool.py
@@ -731,3 +731,70 @@ async def test_onesec_software_query_agent_list_validates_name_and_publisher():
     assert result.error == (
         "Missing required parameters for software_query_agent_list: name, publisher"
     )
+
+
+@pytest.mark.asyncio
+async def test_onesec_edr_delete_registry_startup_validates_registry_type():
+    tool = _load_tool("onesec_edr.yaml")
+
+    result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="edr_delete_registry_startup",
+        agent_list=["umid-1"],
+        registry_path=1,
+    )
+
+    assert result.success is False
+    assert result.error == (
+        "Missing required parameters for edr_delete_registry_startup: registry_type"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onesec_edr_delete_registry_startup_uses_doc_field_names():
+    tool = _load_tool("onesec_edr.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "response_code": 200,
+                    "verbose_msg": "success",
+                    "data": {"items": [{"task_id": 1}]},
+                }
+            )
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "api-key-1|secret-1"
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_delete_registry_startup",
+            agent_list=["umid-1"],
+            registry_path=1,
+            registry_type=r"HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\Demo",
+        )
+
+    assert result.success is True
+
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "POST"
+    assert url == "https://console.onesec.net/api/saasedr/api/client/v1/actions/deleteRegistryStartup"
+    assert kwargs["json"] == {
+        "task_scope": {"agent_list": ["umid-1"]},
+        "task_content_req": [
+            {
+                "registry_path": 1,
+                "registry_type": r"HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\Demo",
+            }
+        ],
+    }

--- a/tests/tool/test_onesec_high_risk_write_operations.py
+++ b/tests/tool/test_onesec_high_risk_write_operations.py
@@ -1,0 +1,470 @@
+"""
+Test Cases 31-40: High-risk write operations for OneSEC
+Tests parameter construction and validation for:
+- Test 31: threat_virus_scan (quick scan)
+- Test 32: threat_virus_scan (custom path scan)
+- Test 33: threat_stop_virus_scan
+- Test 34: threat_upgrade_bd_version_task
+- Test 35: edr_add_ioc
+- Test 36: edr_delete_ioc
+- Test 37: edr_isolate_endpoints
+- Test 38: edr_unisolate_endpoints
+- Test 39: edr_quarantine_files
+- Test 40: edr_restore_quarantined_files
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from flocks.tool.registry import ToolContext
+from flocks.tool.tool_loader import yaml_to_tool
+
+
+TEST_UMID = "3db46bf6-1e55-47bb-89537a1e95c268f5"
+TEST_IOC_HASH = "44d88612fea8a8f36de82e1278abb02f"
+
+
+def _load_tool(yaml_name: str):
+    yaml_path = (
+        Path.cwd()
+        / ".flocks"
+        / "plugins"
+        / "tools"
+        / "api"
+        / "onesec"
+        / yaml_name
+    )
+    raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    return yaml_to_tool(raw, yaml_path)
+
+
+class _FakeResponse:
+    def __init__(self, *, status=200, json_payload=None):
+        self.status = status
+        self._json_payload = json_payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def json(self, content_type=None):
+        return self._json_payload
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        return self._responses.pop(0)
+
+
+# Test 31: Quick virus scan
+@pytest.mark.asyncio
+async def test_31_quick_virus_scan():
+    tool = _load_tool("onesec_threat.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload=12345)])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="threat_virus_scan",
+            agent_list=[TEST_UMID],
+            task_type=10110,
+            scanmode=1,
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 31: Quick virus scan on test endpoint")
+    print(f"Expected: onesec_threat.threat_virus_scan")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["task_scope"]["agent_list"] == [TEST_UMID]
+    assert params["task_type"] == 10110
+    print(f"Status: ✓ PASS")
+
+
+# Test 32: Custom path virus scan
+@pytest.mark.asyncio
+async def test_32_custom_path_virus_scan():
+    tool = _load_tool("onesec_threat.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload=12346)])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="threat_virus_scan",
+            agent_list=[TEST_UMID],
+            task_type=10130,
+            scan_paths=["C:\\Temp"],
+            scanmode=1,
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 32: Custom path virus scan on test endpoint")
+    print(f"Expected: onesec_threat.threat_virus_scan (task_type=10130)")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["task_scope"]["agent_list"] == [TEST_UMID]
+    assert params["task_type"] == 10130
+    assert params["task_content"]["scan_paths"] == ["C:\\Temp"]
+    print(f"Status: ✓ PASS")
+
+
+# Test 33: Stop virus scan
+@pytest.mark.asyncio
+async def test_33_stop_virus_scan():
+    tool = _load_tool("onesec_threat.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload={"response_code": 200})])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="threat_stop_virus_scan",
+            agent_list=[TEST_UMID],
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 33: Stop virus scan on test endpoint")
+    print(f"Expected: onesec_threat.threat_stop_virus_scan")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["task_scope"]["agent_list"] == [TEST_UMID]
+    print(f"Status: ✓ PASS")
+
+
+# Test 34: Upgrade virus database
+@pytest.mark.asyncio
+async def test_34_upgrade_bd_version():
+    tool = _load_tool("onesec_threat.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload={"response_code": 200})])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="threat_upgrade_bd_version_task",
+            agent_list=[TEST_UMID],
+            bd_upgrade_type=1,  # Cloud latest version
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 34: Upgrade virus database to latest cloud version")
+    print(f"Expected: onesec_threat.threat_upgrade_bd_version_task")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["task_scope"]["agent_list"] == [TEST_UMID]
+    assert params["task_content"]["bd_upgrade_type"] == 1
+    print(f"Status: ✓ PASS")
+
+
+# Test 35: Add IOC
+@pytest.mark.asyncio
+async def test_35_add_ioc():
+    tool = _load_tool("onesec_edr.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload={"response_code": 200})])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_add_ioc",
+            iocs=[TEST_IOC_HASH],
+            severity=4,  # High severity
+            threatName="EICAR-Test",
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 35: Add test IOC to high-risk list")
+    print(f"Expected: onesec_edr.edr_add_ioc")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["iocs"] == [TEST_IOC_HASH]
+    assert params["severity"] == 4
+    assert params["threatName"] == "EICAR-Test"
+    print(f"Status: ✓ PASS")
+
+
+# Test 36: Delete IOC
+@pytest.mark.asyncio
+async def test_36_delete_ioc():
+    tool = _load_tool("onesec_edr.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload={"response_code": 200})])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_delete_ioc",
+            iocs=[TEST_IOC_HASH],
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 36: Delete test IOC from list")
+    print(f"Expected: onesec_edr.edr_delete_ioc")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["iocs"] == [TEST_IOC_HASH]
+    print(f"Status: ✓ PASS")
+
+
+# Test 37: Isolate endpoint
+@pytest.mark.asyncio
+async def test_37_isolate_endpoint():
+    tool = _load_tool("onesec_edr.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload={"response_code": 200})])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_isolate_endpoints",
+            agent_list=[TEST_UMID],
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 37: Isolate test endpoint")
+    print(f"Expected: onesec_edr.edr_isolate_endpoints")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["task_scope"]["agent_list"] == [TEST_UMID]
+    print(f"Status: ✓ PASS")
+
+
+# Test 38: Unisolate endpoint
+@pytest.mark.asyncio
+async def test_38_unisolate_endpoint():
+    tool = _load_tool("onesec_edr.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload={"response_code": 200})])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_unisolate_endpoints",
+            agent_list=[TEST_UMID],
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 38: Unisolate test endpoint")
+    print(f"Expected: onesec_edr.edr_unisolate_endpoints")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["task_scope"]["agent_list"] == [TEST_UMID]
+    print(f"Status: ✓ PASS")
+
+
+# Test 39: Quarantine file
+@pytest.mark.asyncio
+async def test_39_quarantine_file():
+    tool = _load_tool("onesec_edr.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload={"response_code": 200})])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_quarantine_files",
+            agent_list=[TEST_UMID],
+            file_path="C:\\Temp\\bad.exe",
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 39: Quarantine file on test endpoint")
+    print(f"Expected: onesec_edr.edr_quarantine_files")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["task_scope"]["agent_list"] == [TEST_UMID]
+    assert params["task_content_req"][0]["file_path"] == "C:\\Temp\\bad.exe"
+    print(f"Status: ✓ PASS")
+
+
+# Test 40: Restore quarantined file
+@pytest.mark.asyncio
+async def test_40_restore_quarantined_file():
+    tool = _load_tool("onesec_edr.yaml")
+    fake_session = _FakeSession([_FakeResponse(json_payload={"response_code": 200})])
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {"onesec_credentials": "api-key-1|secret-1"}.get(key)
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="edr_restore_quarantined_files",
+            agent_list=[TEST_UMID],
+            file_path="C:\\Temp\\bad.exe",
+        )
+
+    method, url, kwargs = fake_session.calls[0]
+    params = kwargs.get("json")
+
+    print(f"\n{'='*60}")
+    print(f"Test 40: Restore quarantined file on test endpoint")
+    print(f"Expected: onesec_edr.edr_restore_quarantined_files")
+    print(f"URL: {url}")
+    print(f"Params: {params}")
+    print(f"Result success: {result.success}")
+
+    assert result.success is True
+    assert params["task_scope"]["agent_list"] == [TEST_UMID]
+    assert params["task_content_req"][0]["file_path"] == "C:\\Temp\\bad.exe"
+    print(f"Status: ✓ PASS")


### PR DESCRIPTION
## Summary
This PR updates OneSEC grouped tools and the `onesec-use` API reference so agents get clearer guidance on time windows, credential configuration, and field names.

## Changes
- **API reference**: Clarify paginated vs `recent` EDR actions, recommend explicit `time_from`/`time_to`, add time-window table and templates.
- **EDR YAML + handler**: Require `registry_type` for `edr_delete_registry_startup`; align `registry_path`/`registry_type` descriptions with the API payload; soften wording on optional time for paginated endpoints (server default window as fallback only).
- **All grouped tools**: Replace `api_key|secret` single-field wording with separate API Key and Secret configuration.
- **DNS**: Add `domain_list` as an alias for domain list parameters.
- **Ops / software**: Refresh "common fields" hints to match current schema names.
- **Tests**: Cover registry startup delete validation and successful request JSON.

## Testing
`uv run pytest tests/tool/test_onesec_api_tool.py -q` — 18 passed.

Made with [Cursor](https://cursor.com)