### PR TITLE
feat(input): unify command registry and user input dispatch

### DIFF
--- a/flocks/acp/agent.py
+++ b/flocks/acp/agent.py
@@ -1299,71 +1299,14 @@ class ACPAgent:
             )
             return done_response
 
-        async def send_text_response(text: str) -> None:
-            from flocks.session.message import Message, MessageRole
-
-            message = await Message.create(
-                session_id=session_id,
-                role=MessageRole.ASSISTANT,
-                content=text,
-                agent=agent,
-                providerID=model.get("providerID", ""),
-                modelID=model.get("modelID", ""),
-                mode=agent,
-            )
-            parts = await Message.parts(message.id, session_id=session_id)
-            await self._process_message({
-                "info": message.model_dump(by_alias=True),
-                "parts": [p.model_dump(by_alias=True) for p in parts],
-            })
-
-        from flocks.command.handler import handle_slash_command
-
-        handled = await handle_slash_command(
-            text_content,
-            send_text=send_text_response,
-            send_prompt=lambda prompt: self._sdk.session.prompt(
-                session_id=session_id,
-                model={
-                    "providerID": model["providerID"],
-                    "modelID": model["modelID"],
-                },
-                parts=[{"type": "text", "text": prompt}],
-                agent=agent,
-                directory=directory,
-            ),
-            clear_screen=None,
-            restart_session=lambda: self._restart_session_state(
-                session_id=session_id,
-            ),
+        await self._sdk.session.command(
+            session_id=session_id,
+            command=cmd["name"],
+            arguments=cmd["args"],
+            model=f"{model['providerID']}/{model['modelID']}",
+            agent=agent,
+            directory=directory,
         )
-        if handled:
-            return done_response
-        
-        # Check for custom command
-        commands = await self._sdk.command.list(directory=directory)
-        command = next((c for c in commands if c.get("name") == cmd["name"]), None)
-        
-        if command:
-            await self._sdk.session.command(
-                session_id=session_id,
-                command=command["name"],
-                arguments=cmd["args"],
-                model=f"{model['providerID']}/{model['modelID']}",
-                agent=agent,
-                directory=directory,
-            )
-            return done_response
-        
-        # Built-in commands
-        if cmd["name"] == "compact":
-            await self._sdk.session.summarize(
-                session_id=session_id,
-                directory=directory,
-                provider_id=model["providerID"],
-                model_id=model["modelID"],
-            )
-        
         return done_response
 
     async def _restart_session_state(self, session_id: str) -> None:

--- a/flocks/agent/agents/rex/prompt_builder.py
+++ b/flocks/agent/agents/rex/prompt_builder.py
@@ -483,7 +483,7 @@ def _build_slash_commands_section() -> str:
     try:
         from flocks.command.command import Command
 
-        commands = Command.list()
+        commands = Command.list_for_surfaces(("webui", "tui"))
         if not commands:
             return ""
 

--- a/flocks/agent/agents/rex/prompt_builder.py
+++ b/flocks/agent/agents/rex/prompt_builder.py
@@ -507,7 +507,7 @@ When it would help the user, you may suggest these commands proactively.
 - Suggest `/plan` when the user wants to design before implementing
 - Suggest `/ask` when the user wants read-only analysis without changes
 - Suggest `/tools` or `/skills` when the user asks what capabilities are available
-- Suggest `/clear` or `/restart` when the user wants a fresh start
+- Suggest `/clear` when the user wants to clear the current UI output
 </Slash_Commands>"""
     except Exception:
         return ""

--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -628,7 +628,6 @@ class InboundDispatcher:
                     msg=msg,
                     callbacks=callbacks,
                     scope_override=scope_override,
-                    action=parsed.command_name,
                 )
                 return True
             return False
@@ -762,20 +761,19 @@ class InboundDispatcher:
         msg: InboundMessage,
         callbacks: ChannelDeliveryCallbacks,
         scope_override: Optional[str],
-        action: str,
     ) -> None:
         from flocks.session.session import Session
+        from flocks.channel.inbound.session_binding import _build_title
 
         session = await Session.get_by_id(binding.session_id)
         if not session:
             await callbacks.deliver_text("当前会话不存在，请发送一条普通消息后重试。")
             return
 
-        parent_id = session.id if action == "new" else None
         new_session = await Session.create(
             project_id=session.project_id,
             directory=session.directory,
-            parent_id=parent_id,
+            title=_build_title(msg),
             agent=session.agent,
             provider=session.provider,
             model=session.model,
@@ -787,7 +785,7 @@ class InboundDispatcher:
             scope_override=scope_override,
         )
         await self._trigger_command_hook(
-            action,
+            "new",
             session.id,
             {
                 "previous_session_id": session.id,
@@ -797,11 +795,10 @@ class InboundDispatcher:
             },
         )
         new_callbacks = self._build_callbacks(new_binding, msg)
-        action_text = "已创建新会话。" if action == "new" else "已重置当前会话。"
         await new_callbacks.deliver_text(
             "\n".join(
                 [
-                    action_text,
+                    "已开始全新对话。",
                     f"Session: `{new_session.id}`",
                     f"Agent: `{new_session.agent or 'default'}`",
                 ]

--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -592,43 +592,70 @@ class InboundDispatcher:
         user_text: str,
         scope_override: Optional[str],
     ) -> bool:
-        if msg.channel_id != "feishu":
-            return False
-
         command_name, command_args = _parse_slash_command(user_text)
         if not command_name:
             return False
 
+        from flocks.command.command import Command
+        from flocks.input.dispatcher import dispatch_user_input
+        from flocks.input.events import UserInputEvent
+        from flocks.input.output import ChannelOutputSink
+
+        command_def = Command.resolve(command_name)
+        if command_def is None:
+            return False
+
         callbacks = self._build_callbacks(binding, msg)
 
-        if command_name == "help":
-            from flocks.command.handler import handle_slash_command
+        async def _publish_direct_response(_event, text: str) -> None:
+            await callbacks.deliver_text(text)
 
-            return await handle_slash_command(
-                user_text,
-                send_text=callbacks.deliver_text,
-                send_prompt=callbacks.deliver_text,
+        async def _run_llm(_event, prompt_text: str, display_text: Optional[str] = None) -> None:
+            await callbacks.deliver_text(
+                f"命令 `{display_text or prompt_text}` 暂不支持在当前渠道中以 slash 形式执行。"
             )
 
-        if command_name == "status":
-            await self._handle_status_command(binding, msg, callbacks)
-            return True
+        async def _run_session_control(_event, parsed) -> bool:
+            if parsed.canonical_name == "status":
+                await self._handle_status_command(binding, msg, callbacks)
+                return True
+            if parsed.canonical_name == "model":
+                await self._handle_model_command(binding, callbacks, command_args)
+                return True
+            if parsed.canonical_name == "new":
+                await self._handle_session_command(
+                    binding=binding,
+                    msg=msg,
+                    callbacks=callbacks,
+                    scope_override=scope_override,
+                    action=parsed.command_name,
+                )
+                return True
+            return False
 
-        if command_name == "model":
-            await self._handle_model_command(binding, callbacks, command_args)
-            return True
-
-        if command_name in {"new", "reset"}:
-            await self._handle_session_command(
-                binding=binding,
-                msg=msg,
-                callbacks=callbacks,
-                scope_override=scope_override,
-                action=command_name,
-            )
-            return True
-
-        return False
+        event = UserInputEvent(
+            source_type=msg.channel_id if msg.channel_id in {"feishu", "wecom", "telegram"} else "channel",
+            sessionID=binding.session_id,
+            text=user_text,
+            parts=[{"type": "text", "text": user_text}],
+            agent=binding.agent_id,
+            display_text=user_text,
+            working_directory=channel_config.workspace_dir,
+            metadata={
+                "channel_id": msg.channel_id,
+                "chat_id": msg.chat_id or msg.sender_id,
+            },
+        )
+        await dispatch_user_input(
+            event,
+            ChannelOutputSink(
+                "channel",
+                direct_response=_publish_direct_response,
+                run_llm=_run_llm,
+                session_control=_run_session_control,
+            ),
+        )
+        return True
 
     async def _handle_status_command(self, binding, msg: InboundMessage, callbacks: ChannelDeliveryCallbacks) -> None:
         from flocks.session.core.status import SessionStatus

--- a/flocks/cli/session_runner.py
+++ b/flocks/cli/session_runner.py
@@ -367,11 +367,6 @@ class CLISessionRunner:
                         dispatch_commands=False,
                     ),
                     clear_screen=self._clear_screen,
-                    restart_session=lambda: self._restart_session(
-                        agent.name,
-                        provider_id,
-                        model_id,
-                    ),
                 ),
             )
             if handled.handled:
@@ -521,24 +516,6 @@ class CLISessionRunner:
 
     async def _clear_screen(self) -> None:
         self.console.clear()
-
-    async def _restart_session(
-        self,
-        agent_name: str,
-        provider_id: str,
-        model_id: str,
-    ) -> None:
-        from flocks.session.message import Message
-        from flocks.session.features.todo import Todo
-        from flocks.session.core.status import SessionStatus
-
-        await Message.clear(self._session.id)
-        await Todo.clear(self._session.id)
-        SessionStatus.clear(self._session.id)
-        self._content_buffer = []
-        self._has_content = False
-        self.console.clear()
-        await self._emit_assistant_text("会话已重置。", agent_name, provider_id, model_id)
 
     
     def _flush_content(self) -> None:
@@ -800,7 +777,6 @@ class CLISessionRunner:
   /skills list     List skills
   /skills refresh  Refresh skills
   /clear           Clear screen
-  /restart         Restart session
   /exit            Exit session
   /quit            Exit session
   /q               Exit session

--- a/flocks/cli/session_runner.py
+++ b/flocks/cli/session_runner.py
@@ -298,7 +298,13 @@ class CLISessionRunner:
             except EOFError:
                 break
     
-    async def _process_message(self, content: str) -> None:
+    async def _process_message(
+        self,
+        content: str,
+        *,
+        display_text: Optional[str] = None,
+        dispatch_commands: bool = True,
+    ) -> None:
         """Process a user message using unified SessionLoop."""
         stripped = content.strip()
         # Parse model: CLI flag > default_models.llm > config.model > env vars > defaults
@@ -331,26 +337,44 @@ class CLISessionRunner:
         agent_name = self.agent_name or await Agent.default_agent()
         agent = await Agent.get(agent_name) or await Agent.get("rex")
 
-        if stripped.startswith("/"):
-            from flocks.command.handler import handle_slash_command
+        if dispatch_commands and stripped.startswith("/"):
+            from flocks.input.dispatcher import dispatch_user_input
+            from flocks.input.events import UserInputEvent
+            from flocks.input.output import CliOutputSink
 
-            handled = await handle_slash_command(
-                stripped,
-                send_text=lambda text: self._emit_assistant_text(
-                    text,
-                    agent.name,
-                    provider_id,
-                    model_id,
-                ),
-                send_prompt=lambda prompt: self._process_message(prompt),
-                clear_screen=self._clear_screen,
-                restart_session=lambda: self._restart_session(
-                    agent.name,
-                    provider_id,
-                    model_id,
+            event = UserInputEvent(
+                source_type="cli",
+                sessionID=self._session.id,
+                text=stripped,
+                parts=[{"type": "text", "text": stripped}],
+                agent=agent.name,
+                model={"providerID": provider_id, "modelID": model_id},
+                display_text=stripped,
+            )
+            handled = await dispatch_user_input(
+                event,
+                CliOutputSink(
+                    "cli",
+                    direct_response=lambda _event, text: self._emit_assistant_text(
+                        text,
+                        agent.name,
+                        provider_id,
+                        model_id,
+                    ),
+                    run_llm=lambda _event, prompt, dispatch_display_text: self._process_message(
+                        prompt,
+                        display_text=dispatch_display_text,
+                        dispatch_commands=False,
+                    ),
+                    clear_screen=self._clear_screen,
+                    restart_session=lambda: self._restart_session(
+                        agent.name,
+                        provider_id,
+                        model_id,
+                    ),
                 ),
             )
-            if handled:
+            if handled.handled:
                 return
         
         # Check provider configuration
@@ -369,7 +393,7 @@ class CLISessionRunner:
         await Message.create(
             session_id=self._session.id,
             role=MessageRole.USER,
-            content=content,
+            content=display_text or content,
             agent=agent.name,
             model={"providerID": provider_id, "modelID": model_id},
         )

--- a/flocks/command/command.py
+++ b/flocks/command/command.py
@@ -5,13 +5,20 @@ Ported from original command/index.ts Command namespace.
 Handles slash command registration and execution.
 """
 
-from typing import Optional, Dict, Any, List
 from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Literal, Optional, Tuple
+
+CommandSurface = Literal["webui", "tui", "channel", "cli", "acp"]
+CommandExecutionKind = Literal["direct", "llm", "session_control"]
+
+API_SURFACES: Tuple[CommandSurface, ...] = ("webui", "tui", "acp")
+ALL_SURFACES: Tuple[CommandSurface, ...] = ("webui", "tui", "channel", "cli", "acp")
 
 
 @dataclass
-class CommandInfo:
-    """Command definition"""
+class CommandDef:
+    """Structured slash command definition."""
+
     name: str
     description: str
     template: str
@@ -19,184 +26,319 @@ class CommandInfo:
     model: Optional[str] = None
     subtask: Optional[bool] = None
     hidden: bool = False
+    aliases: Tuple[str, ...] = field(default_factory=tuple)
+    visible_surfaces: Tuple[CommandSurface, ...] = ("webui", "tui", "acp", "cli")
+    execution_kind: CommandExecutionKind = "llm"
+    allow_attachments: bool = True
+    requires_existing_session: bool = True
+    channel_safe: bool = False
+
+    @property
+    def canonical_name(self) -> str:
+        return self.name
+
+    def is_visible_on(self, surface: CommandSurface) -> bool:
+        return surface in self.visible_surfaces
+
+
+# Backwards-compatible alias used across the codebase.
+CommandInfo = CommandDef
+
+
+class CommandRegistry:
+    """Single source of truth for slash command metadata."""
+
+    def __init__(self) -> None:
+        self._commands: Dict[str, CommandDef] = {}
+        self._lookup: Dict[str, CommandDef] = {}
+
+    def register(self, command: CommandDef) -> None:
+        canonical = command.name.lower()
+        self._commands[canonical] = command
+        self._rebuild_lookup()
+
+    def get(self, name: str) -> Optional[CommandDef]:
+        return self.resolve(name)
+
+    def resolve(self, name: Optional[str]) -> Optional[CommandDef]:
+        if not name:
+            return None
+        return self._lookup.get(name.lower().lstrip("/"))
+
+    def list(
+        self,
+        *,
+        surface: Optional[CommandSurface] = None,
+        include_hidden: bool = False,
+    ) -> List[CommandDef]:
+        commands = list(self._commands.values())
+        if surface is not None:
+            commands = [cmd for cmd in commands if cmd.is_visible_on(surface)]
+        if not include_hidden:
+            commands = [cmd for cmd in commands if not cmd.hidden]
+        return commands
+
+    def list_for_surfaces(
+        self,
+        surfaces: Iterable[CommandSurface],
+        *,
+        include_hidden: bool = False,
+    ) -> List[CommandDef]:
+        surface_set = {surface for surface in surfaces}
+        commands = [
+            cmd for cmd in self._commands.values()
+            if set(cmd.visible_surfaces) & surface_set
+        ]
+        if not include_hidden:
+            commands = [cmd for cmd in commands if not cmd.hidden]
+        return commands
+
+    def list_all(self) -> List[CommandDef]:
+        return list(self._commands.values())
+
+    def _rebuild_lookup(self) -> None:
+        lookup: Dict[str, CommandDef] = {}
+        for command in self._commands.values():
+            lookup[command.name.lower()] = command
+            for alias in command.aliases:
+                lookup[alias.lower().lstrip("/")] = command
+        self._lookup = lookup
 
 
 class Command:
     """
     Command namespace.
-    
+
     Manages slash commands like /init, /help, /model, etc.
     Ported from original Command namespace.
     """
-    
-    # Default commands
+
+    _registry = CommandRegistry()
     _commands: Dict[str, CommandInfo] = {}
-    
-    # Default command names
+    _defaults_loaded = False
+
     class Default:
         """Default command names"""
+
         INIT = "init"
         HELP = "help"
         MODEL = "model"
         COMPACT = "compact"
         CLEAR = "clear"
         BUG = "bug"
-    
+
     @classmethod
     def _ensure_defaults(cls) -> None:
         """Ensure default commands are registered"""
-        if cls._commands:
+        if cls._registry._commands is not cls._commands:
+            cls._registry._commands = cls._commands
+            cls._registry._rebuild_lookup()
+        if not cls._commands:
+            cls._defaults_loaded = False
+        if cls._defaults_loaded:
             return
-        
-        # Register built-in commands
-        cls.register(CommandInfo(
-            name="init",
-            description="Analyze and create AGENTS.md for the project",
-            template="Analyze this codebase and create an AGENTS.md file with project-specific configurations. $ARGUMENTS",
-            agent="rex",
-        ))
-        
-        cls.register(CommandInfo(
-            name="help",
-            description="Show available commands",
-            template="List all available slash commands and their descriptions.",
-            agent="rex",
-        ))
 
-        cls.register(CommandInfo(
-            name="tools",
-            description="List available tools",
-            template="List all available tools with their names, categories, and descriptions.",
-            agent="rex",
-        ))
+        builtins = [
+            CommandDef(
+                name="init",
+                description="Analyze and create AGENTS.md for the project",
+                template="Analyze this codebase and create an AGENTS.md file with project-specific configurations. $ARGUMENTS",
+                agent="rex",
+                execution_kind="llm",
+                allow_attachments=True,
+            ),
+            CommandDef(
+                name="help",
+                description="Show available commands",
+                template="List all available slash commands and their descriptions.",
+                agent="rex",
+                execution_kind="direct",
+                allow_attachments=False,
+                visible_surfaces=ALL_SURFACES,
+                channel_safe=True,
+            ),
+            CommandDef(
+                name="tools",
+                description="List available tools",
+                template="List all available tools with their names, categories, and descriptions.",
+                agent="rex",
+                execution_kind="direct",
+                allow_attachments=False,
+                visible_surfaces=("webui", "tui", "acp", "cli"),
+            ),
+            CommandDef(
+                name="skills",
+                description="List available skills",
+                template="List all available skills with their names and descriptions.",
+                agent="rex",
+                execution_kind="direct",
+                allow_attachments=False,
+                visible_surfaces=("webui", "tui", "acp", "cli"),
+            ),
+            CommandDef(
+                name="workflows",
+                description="List available workflows",
+                template="List all available workflows with their names, descriptions, and file paths.",
+                agent="rex",
+                execution_kind="direct",
+                allow_attachments=False,
+                visible_surfaces=("webui", "tui", "acp", "cli"),
+            ),
+            CommandDef(
+                name="mcp",
+                description="Inspect or refresh MCP servers",
+                template="Inspect MCP servers and tools.",
+                agent="rex",
+                execution_kind="direct",
+                allow_attachments=False,
+                visible_surfaces=("webui", "tui", "acp", "cli"),
+            ),
+            CommandDef(
+                name="model",
+                description="Change or inspect the current model",
+                template="Switch to model: $1",
+                execution_kind="session_control",
+                allow_attachments=False,
+                hidden=False,
+                visible_surfaces=("channel",),
+                channel_safe=True,
+            ),
+            CommandDef(
+                name="status",
+                description="Show current session status",
+                template="Show the current session status.",
+                execution_kind="session_control",
+                allow_attachments=False,
+                hidden=False,
+                visible_surfaces=("channel",),
+                channel_safe=True,
+            ),
+            CommandDef(
+                name="new",
+                description="Start a fresh conversation session",
+                template="Start a fresh session.",
+                execution_kind="session_control",
+                allow_attachments=False,
+                hidden=False,
+                aliases=("reset",),
+                visible_surfaces=("channel",),
+                channel_safe=True,
+            ),
+            CommandDef(
+                name="compact",
+                description="Summarize the conversation (optionally /compact <focus>)",
+                template="Summarize this conversation while preserving key context and decisions.",
+                agent="rex",
+                execution_kind="session_control",
+                allow_attachments=False,
+                visible_surfaces=("webui", "tui", "acp"),
+            ),
+            CommandDef(
+                name="clear",
+                description="Clear screen output",
+                template="Clear the conversation history and start fresh.",
+                execution_kind="direct",
+                allow_attachments=False,
+            ),
+            CommandDef(
+                name="restart",
+                description="Restart agent session",
+                template="Restart the current session and clear history.",
+                agent="rex",
+                execution_kind="direct",
+                allow_attachments=False,
+            ),
+            CommandDef(
+                name="bug",
+                description="Report a bug or issue",
+                template="I found a bug: $ARGUMENTS",
+                agent="rex",
+                execution_kind="llm",
+                allow_attachments=True,
+            ),
+            CommandDef(
+                name="plan",
+                description="Create a plan for a task",
+                template="Create a detailed plan for: $ARGUMENTS",
+                agent="plan",
+                execution_kind="llm",
+                allow_attachments=True,
+            ),
+            CommandDef(
+                name="ask",
+                description="Ask a question without making changes",
+                template="$ARGUMENTS",
+                agent="ask",
+                execution_kind="llm",
+                allow_attachments=True,
+            ),
+            CommandDef(
+                name="tasks",
+                description="Show task center overview",
+                template="Use the task_list tool to show the current task center overview including running, queued, and recently completed tasks. Present the results clearly.",
+                execution_kind="llm",
+                allow_attachments=True,
+            ),
+            CommandDef(
+                name="queue",
+                description="Show task queue status",
+                template="Use the task_list tool with status filter to show the current task queue status: running tasks, queued tasks, and queue configuration. Present the results clearly.",
+                execution_kind="llm",
+                allow_attachments=True,
+            ),
+        ]
 
-        cls.register(CommandInfo(
-            name="skills",
-            description="List available skills",
-            template="List all available skills with their names and descriptions.",
-            agent="rex",
-        ))
+        for command in builtins:
+            cls.register(command)
 
-        cls.register(CommandInfo(
-            name="workflows",
-            description="List available workflows",
-            template="List all available workflows with their names, descriptions, and file paths.",
-            agent="rex",
-        ))
-        
-        cls.register(CommandInfo(
-            name="model",
-            description="Change the current model",
-            template="Switch to model: $1",
-            hidden=True,
-        ))
-        
-        cls.register(CommandInfo(
-            name="compact",
-            description="Summarize the conversation (optionally /compact <focus>)",
-            template="Summarize this conversation while preserving key context and decisions.",
-            agent="rex",
-        ))
-        
-        cls.register(CommandInfo(
-            name="clear",
-            description="Clear screen output",
-            template="Clear the conversation history and start fresh.",
-            hidden=False,
-        ))
-
-        cls.register(CommandInfo(
-            name="restart",
-            description="Restart agent session",
-            template="Restart the current session and clear history.",
-            agent="rex",
-        ))
-        
-        cls.register(CommandInfo(
-            name="bug",
-            description="Report a bug or issue",
-            template="I found a bug: $ARGUMENTS",
-            agent="rex",
-        ))
-        
-        cls.register(CommandInfo(
-            name="plan",
-            description="Create a plan for a task",
-            template="Create a detailed plan for: $ARGUMENTS",
-            agent="plan",
-        ))
-        
-        cls.register(CommandInfo(
-            name="ask",
-            description="Ask a question without making changes",
-            template="$ARGUMENTS",
-            agent="ask",
-        ))
-
-        cls.register(CommandInfo(
-            name="tasks",
-            description="Show task center overview",
-            template="Use the task_list tool to show the current task center overview including running, queued, and recently completed tasks. Present the results clearly.",
-        ))
-
-        cls.register(CommandInfo(
-            name="queue",
-            description="Show task queue status",
-            template="Use the task_list tool with status filter to show the current task queue status: running tasks, queued tasks, and queue configuration. Present the results clearly.",
-        ))
-
-        # Load external commands (Flocks/Claude-compatible)
         try:
             from flocks.command.command_loader import discover_commands
+
             discovered = discover_commands()
             for cmd in discovered.values():
                 cls.register(cmd)
         except Exception:
-            # Avoid failing command registry if external discovery fails
             pass
-    
+
+        cls._defaults_loaded = True
+
     @classmethod
     def register(cls, command: CommandInfo) -> None:
-        """
-        Register a command.
-        
-        Args:
-            command: Command to register
-        """
-        cls._commands[command.name] = command
-    
+        """Register a command."""
+        cls._registry.register(command)
+        cls._commands = cls._registry._commands
+
+    @classmethod
+    def resolve(cls, name: Optional[str]) -> Optional[CommandInfo]:
+        cls._ensure_defaults()
+        return cls._registry.resolve(name)
+
     @classmethod
     def get(cls, name: str) -> Optional[CommandInfo]:
-        """
-        Get a command by name.
-        
-        Args:
-            name: Command name
-            
-        Returns:
-            Command info or None
-        """
         cls._ensure_defaults()
-        return cls._commands.get(name)
-    
+        return cls._registry.get(name)
+
     @classmethod
-    def list(cls) -> List[CommandInfo]:
-        """
-        List all registered commands.
-        
-        Returns:
-            List of commands
-        """
+    def list(
+        cls,
+        *,
+        surface: Optional[CommandSurface] = None,
+        include_hidden: bool = False,
+    ) -> List[CommandInfo]:
         cls._ensure_defaults()
-        return [c for c in cls._commands.values() if not c.hidden]
-    
+        return cls._registry.list(surface=surface, include_hidden=include_hidden)
+
+    @classmethod
+    def list_for_surfaces(
+        cls,
+        surfaces: Iterable[CommandSurface],
+        *,
+        include_hidden: bool = False,
+    ) -> List[CommandInfo]:
+        cls._ensure_defaults()
+        return cls._registry.list_for_surfaces(surfaces, include_hidden=include_hidden)
+
     @classmethod
     def list_all(cls) -> List[CommandInfo]:
-        """
-        List all commands including hidden ones.
-        
-        Returns:
-            List of all commands
-        """
         cls._ensure_defaults()
-        return list(cls._commands.values())
+        return cls._registry.list_all()

--- a/flocks/command/command.py
+++ b/flocks/command/command.py
@@ -216,7 +216,7 @@ class Command:
             CommandDef(
                 name="new",
                 description="Start a fresh conversation session",
-                template="Start a fresh session.",
+                template="Start a fresh conversation.",
                 execution_kind="session_control",
                 allow_attachments=False,
                 hidden=False,
@@ -236,15 +236,7 @@ class Command:
             CommandDef(
                 name="clear",
                 description="Clear screen output",
-                template="Clear the conversation history and start fresh.",
-                execution_kind="direct",
-                allow_attachments=False,
-            ),
-            CommandDef(
-                name="restart",
-                description="Restart agent session",
-                template="Restart the current session and clear history.",
-                agent="rex",
+                template="Clear the current UI output only.",
                 execution_kind="direct",
                 allow_attachments=False,
             ),

--- a/flocks/command/handler.py
+++ b/flocks/command/handler.py
@@ -14,7 +14,6 @@ from flocks.skill.skill import Skill
 SendText = Callable[[str], Awaitable[None]]
 SendPrompt = Callable[[str], Awaitable[None]]
 ClearScreen = Callable[[], Awaitable[None]]
-RestartSession = Callable[[], Awaitable[None]]
 
 
 async def handle_slash_command(
@@ -23,7 +22,6 @@ async def handle_slash_command(
     send_text: SendText,
     send_prompt: SendPrompt,
     clear_screen: Optional[ClearScreen] = None,
-    restart_session: Optional[RestartSession] = None,
     surface: Optional[CommandSurface] = None,
 ) -> bool:
     """
@@ -58,7 +56,6 @@ async def handle_slash_command(
             "",
             "Tips:",
             "- /clear clears the screen",
-            "- /restart resets the session",
             "- /tools [list|refresh|info <name>|create <requirement>]",
             "- /skills [list|refresh]",
             "- /workflows — list all available workflows",
@@ -72,13 +69,6 @@ async def handle_slash_command(
             await clear_screen()
         else:
             await send_text("Screen cleared.")
-        return True
-
-    if name == "restart":
-        if restart_session:
-            await restart_session()
-        else:
-            await send_text("This environment does not support /restart.")
         return True
 
     if name == "tools":

--- a/flocks/command/handler.py
+++ b/flocks/command/handler.py
@@ -6,7 +6,7 @@ Provides shared, code-driven handling for /help, /tools, /skills.
 
 from typing import Awaitable, Callable, Optional
 
-from flocks.command.command import Command
+from flocks.command.command import API_SURFACES, Command, CommandSurface
 from flocks.tool.registry import ToolRegistry
 from flocks.skill.skill import Skill
 
@@ -24,6 +24,7 @@ async def handle_slash_command(
     send_prompt: SendPrompt,
     clear_screen: Optional[ClearScreen] = None,
     restart_session: Optional[RestartSession] = None,
+    surface: Optional[CommandSurface] = None,
 ) -> bool:
     """
     Handle supported slash commands.
@@ -38,11 +39,18 @@ async def handle_slash_command(
     if not cmd_parts:
         return False
 
-    name = cmd_parts[0].lower()
+    resolved = Command.resolve(cmd_parts[0].lower())
+    if not resolved or resolved.execution_kind != "direct":
+        return False
+
+    name = resolved.name
     args = cmd_parts[1].strip() if len(cmd_parts) > 1 else ""
 
     if name == "help":
-        commands = Command.list()
+        if surface:
+            commands = Command.list(surface=surface)
+        else:
+            commands = Command.list_for_surfaces(API_SURFACES)
         lines = ["Available / commands:", ""]
         for command in commands:
             lines.append(f"- /{command.name}: {command.description}")

--- a/flocks/input/__init__.py
+++ b/flocks/input/__init__.py
@@ -1,0 +1,1 @@
+"""Unified command and input dispatch helpers."""

--- a/flocks/input/dispatcher.py
+++ b/flocks/input/dispatcher.py
@@ -111,7 +111,6 @@ async def dispatch_user_input(event: UserInputEvent, sink: OutputSink) -> Dispat
             send_text=_collect_text,
             send_prompt=_collect_prompt,
             clear_screen=sink.clear_screen,
-            restart_session=sink.restart_session,
             surface=sink.surface,
         )
         if handled:

--- a/flocks/input/dispatcher.py
+++ b/flocks/input/dispatcher.py
@@ -1,0 +1,129 @@
+"""Unified command and prompt dispatch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from flocks.command.command import Command
+from flocks.command.handler import handle_slash_command
+from flocks.input.events import ParsedCommand, UserInputEvent
+from flocks.input.output import OutputSink
+
+
+@dataclass
+class DispatchResult:
+    """Result of dispatching a user input event."""
+
+    action: str
+    command_name: Optional[str] = None
+    handled: bool = True
+
+
+def parse_slash_command(text: str) -> Optional[ParsedCommand]:
+    """Parse slash text into a command and registry metadata."""
+    stripped = (text or "").strip()
+    if not stripped.startswith("/"):
+        return None
+
+    without_slash = stripped[1:]
+    if not without_slash:
+        return None
+
+    command_name, _, raw_args = without_slash.partition(" ")
+    command_def = Command.resolve(command_name)
+    canonical_name = command_def.canonical_name if command_def else command_name.lower()
+    return ParsedCommand(
+        raw_text=stripped,
+        command_name=command_name.lower(),
+        canonical_name=canonical_name,
+        args=raw_args.strip(),
+        command_def=command_def,
+    )
+
+
+def _has_non_text_parts(event: UserInputEvent) -> bool:
+    return any(part.get("type") != "text" for part in (event.parts or []))
+
+
+async def dispatch_user_input(event: UserInputEvent, sink: OutputSink) -> DispatchResult:
+    """Route a normalized user input through direct / llm / session-control paths."""
+    parsed = parse_slash_command(event.text)
+    if parsed is None:
+        await sink.run_llm(event, event.text, event.display_text)
+        return DispatchResult(action="llm", handled=False)
+
+    command_def = parsed.command_def
+    if command_def is None:
+        await sink.run_llm(event, parsed.raw_text, event.display_text or parsed.raw_text)
+        return DispatchResult(action="llm", command_name=parsed.command_name, handled=False)
+
+    if not command_def.is_visible_on(sink.surface):
+        await sink.publish_direct_response(
+            event,
+            f"命令 `/{command_def.name}` 在当前入口不可用。",
+        )
+        return DispatchResult(action="rejected", command_name=command_def.name)
+
+    if sink.surface == "channel" and not command_def.channel_safe:
+        await sink.publish_direct_response(
+            event,
+            f"命令 `/{command_def.name}` 不支持在渠道会话中执行。",
+        )
+        return DispatchResult(action="rejected", command_name=command_def.name)
+
+    if command_def.requires_existing_session and not event.session_id:
+        await sink.publish_direct_response(
+            event,
+            f"命令 `/{command_def.name}` 需要先有一个会话。",
+        )
+        return DispatchResult(action="rejected", command_name=command_def.name)
+
+    if _has_non_text_parts(event) and not command_def.allow_attachments:
+        await sink.publish_direct_response(
+            event,
+            f"命令 `/{command_def.name}` 不支持附件。",
+        )
+        return DispatchResult(action="rejected", command_name=command_def.name)
+
+    if command_def.execution_kind == "session_control":
+        handled = await sink.execute_session_control(event, parsed)
+        if not handled:
+            await sink.publish_direct_response(
+                event,
+                f"命令 `/{command_def.name}` 在当前环境不可用。",
+            )
+            return DispatchResult(action="rejected", command_name=command_def.name)
+        return DispatchResult(action="session_control", command_name=command_def.name)
+
+    if command_def.execution_kind == "direct":
+        direct_texts: list[str] = []
+        llm_prompts: list[str] = []
+
+        async def _collect_text(text: str) -> None:
+            direct_texts.append(text)
+
+        async def _collect_prompt(prompt: str) -> None:
+            llm_prompts.append(prompt)
+
+        handled = await handle_slash_command(
+            parsed.raw_text,
+            send_text=_collect_text,
+            send_prompt=_collect_prompt,
+            clear_screen=sink.clear_screen,
+            restart_session=sink.restart_session,
+            surface=sink.surface,
+        )
+        if handled:
+            if llm_prompts:
+                await sink.run_llm(
+                    event,
+                    llm_prompts[0],
+                    event.display_text or parsed.raw_text,
+                )
+                return DispatchResult(action="llm", command_name=command_def.name)
+            await sink.publish_direct_response(event, "\n".join(direct_texts))
+            return DispatchResult(action="direct", command_name=command_def.name)
+
+    await sink.run_llm(event, parsed.raw_text, event.display_text or parsed.raw_text)
+    return DispatchResult(action="llm", command_name=command_def.name)

--- a/flocks/input/events.py
+++ b/flocks/input/events.py
@@ -1,0 +1,53 @@
+"""Unified user-input events for command and prompt dispatch."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from flocks.command.command import CommandInfo
+from flocks.input.types import InputSourceType, surface_for_source
+
+
+class UserInputEvent(BaseModel):
+    """Normalized input event shared by WebUI, TUI, CLI, ACP, and channels."""
+
+    model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
+
+    source_type: InputSourceType
+    session_id: Optional[str] = Field(None, alias="sessionID")
+    text: str
+    parts: List[Dict[str, Any]] = Field(default_factory=list)
+    agent: Optional[str] = None
+    model: Optional[Any] = None
+    variant: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    delivery_context: Dict[str, Any] = Field(default_factory=dict)
+    display_text: Optional[str] = None
+    message_id: Optional[str] = Field(None, alias="messageID")
+    working_directory: Optional[str] = None
+    no_reply: Optional[bool] = Field(None, alias="noReply")
+    mock_reply: Optional[str] = Field(None, alias="mockReply")
+    system: Optional[str] = None
+    tools: Optional[Dict[str, bool]] = None
+
+    @property
+    def surface(self) -> str:
+        return surface_for_source(self.source_type)
+
+    @property
+    def user_visible_text(self) -> str:
+        return self.display_text or self.text
+
+
+class ParsedCommand(BaseModel):
+    """Parsed slash command enriched with registry metadata."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    raw_text: str
+    command_name: str
+    canonical_name: str
+    args: str = ""
+    command_def: Optional[CommandInfo] = None

--- a/flocks/input/output.py
+++ b/flocks/input/output.py
@@ -1,0 +1,107 @@
+"""Output sink abstractions for unified input dispatch."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Awaitable, Callable, Optional
+
+from flocks.input.events import ParsedCommand, UserInputEvent
+
+DirectResponseCallback = Callable[[UserInputEvent, str], Awaitable[None]]
+RunLlmCallback = Callable[[UserInputEvent, str, Optional[str]], Awaitable[None]]
+SessionControlCallback = Callable[[UserInputEvent, ParsedCommand], Awaitable[bool]]
+SideEffectCallback = Callable[[], Awaitable[None]]
+
+
+class OutputSink(ABC):
+    """Surface-specific bridge used by the dispatcher."""
+
+    def __init__(self, surface: str) -> None:
+        self.surface = surface
+
+    @abstractmethod
+    async def publish_direct_response(self, event: UserInputEvent, text: str) -> None:
+        """Emit a direct assistant response for a handled command."""
+
+    @abstractmethod
+    async def run_llm(
+        self,
+        event: UserInputEvent,
+        prompt_text: str,
+        display_text: Optional[str] = None,
+    ) -> None:
+        """Route a prompt through the normal session/LLM pipeline."""
+
+    async def execute_session_control(
+        self,
+        event: UserInputEvent,
+        parsed: ParsedCommand,
+    ) -> bool:
+        return False
+
+    async def clear_screen(self) -> None:
+        return None
+
+    async def restart_session(self) -> None:
+        return None
+
+
+class CallbackOutputSink(OutputSink):
+    """Simple sink backed by async callbacks from each surface adapter."""
+
+    def __init__(
+        self,
+        surface: str,
+        *,
+        direct_response: DirectResponseCallback,
+        run_llm: RunLlmCallback,
+        session_control: Optional[SessionControlCallback] = None,
+        clear_screen: Optional[SideEffectCallback] = None,
+        restart_session: Optional[SideEffectCallback] = None,
+    ) -> None:
+        super().__init__(surface)
+        self._direct_response = direct_response
+        self._run_llm = run_llm
+        self._session_control = session_control
+        self._clear_screen = clear_screen
+        self._restart_session = restart_session
+
+    async def publish_direct_response(self, event: UserInputEvent, text: str) -> None:
+        await self._direct_response(event, text)
+
+    async def run_llm(
+        self,
+        event: UserInputEvent,
+        prompt_text: str,
+        display_text: Optional[str] = None,
+    ) -> None:
+        await self._run_llm(event, prompt_text, display_text)
+
+    async def execute_session_control(
+        self,
+        event: UserInputEvent,
+        parsed: ParsedCommand,
+    ) -> bool:
+        if self._session_control is None:
+            return False
+        return await self._session_control(event, parsed)
+
+    async def clear_screen(self) -> None:
+        if self._clear_screen is not None:
+            await self._clear_screen()
+
+    async def restart_session(self) -> None:
+        if self._restart_session is not None:
+            await self._restart_session()
+
+
+class SSEOutputSink(CallbackOutputSink):
+    """Output sink for SSE-backed surfaces such as WebUI/TUI/ACP."""
+
+
+class ChannelOutputSink(CallbackOutputSink):
+    """Output sink for IM/channel adapters."""
+
+
+class CliOutputSink(CallbackOutputSink):
+    """Output sink for the local Python CLI."""

--- a/flocks/input/output.py
+++ b/flocks/input/output.py
@@ -42,9 +42,6 @@ class OutputSink(ABC):
     async def clear_screen(self) -> None:
         return None
 
-    async def restart_session(self) -> None:
-        return None
-
 
 class CallbackOutputSink(OutputSink):
     """Simple sink backed by async callbacks from each surface adapter."""
@@ -57,14 +54,12 @@ class CallbackOutputSink(OutputSink):
         run_llm: RunLlmCallback,
         session_control: Optional[SessionControlCallback] = None,
         clear_screen: Optional[SideEffectCallback] = None,
-        restart_session: Optional[SideEffectCallback] = None,
     ) -> None:
         super().__init__(surface)
         self._direct_response = direct_response
         self._run_llm = run_llm
         self._session_control = session_control
         self._clear_screen = clear_screen
-        self._restart_session = restart_session
 
     async def publish_direct_response(self, event: UserInputEvent, text: str) -> None:
         await self._direct_response(event, text)
@@ -89,10 +84,6 @@ class CallbackOutputSink(OutputSink):
     async def clear_screen(self) -> None:
         if self._clear_screen is not None:
             await self._clear_screen()
-
-    async def restart_session(self) -> None:
-        if self._restart_session is not None:
-            await self._restart_session()
 
 
 class SSEOutputSink(CallbackOutputSink):

--- a/flocks/input/types.py
+++ b/flocks/input/types.py
@@ -1,0 +1,25 @@
+"""Shared input-dispatch type helpers."""
+
+from typing import Literal
+
+from flocks.command.command import CommandSurface
+
+InputSourceType = Literal[
+    "webui",
+    "tui",
+    "cli",
+    "acp",
+    "channel",
+    "feishu",
+    "wecom",
+    "telegram",
+]
+
+
+def surface_for_source(source_type: str) -> CommandSurface:
+    """Map a transport/source type onto a command surface."""
+    if source_type in {"feishu", "wecom", "telegram", "channel"}:
+        return "channel"
+    if source_type in {"webui", "tui", "cli", "acp"}:
+        return source_type
+    return "webui"

--- a/flocks/server/routes/misc.py
+++ b/flocks/server/routes/misc.py
@@ -142,16 +142,23 @@ async def list_commands() -> List[Dict[str, Any]]:
     Flocks compatible endpoint.
     """
     try:
-        commands = Command.list()
+        commands = Command.list_for_surfaces(("webui", "tui", "acp"))
         return [
             {
                 "name": cmd.name,
+                "canonical_name": cmd.canonical_name,
                 "description": cmd.description,
                 "template": cmd.template,
                 "agent": cmd.agent,
                 "model": cmd.model,
                 "subtask": cmd.subtask,
                 "hidden": cmd.hidden,
+                "aliases": list(cmd.aliases),
+                "visible_surfaces": list(cmd.visible_surfaces),
+                "execution_kind": cmd.execution_kind,
+                "allow_attachments": cmd.allow_attachments,
+                "requires_existing_session": cmd.requires_existing_session,
+                "channel_safe": cmd.channel_safe,
             }
             for cmd in commands
             if not cmd.hidden
@@ -180,12 +187,19 @@ async def get_command(name: str) -> Dict[str, Any]:
         
         return {
             "name": cmd.name,
+            "canonical_name": cmd.canonical_name,
             "description": cmd.description,
             "template": cmd.template,
             "agent": cmd.agent,
             "model": cmd.model,
             "subtask": cmd.subtask,
             "hidden": cmd.hidden,
+            "aliases": list(cmd.aliases),
+            "visible_surfaces": list(cmd.visible_surfaces),
+            "execution_kind": cmd.execution_kind,
+            "allow_attachments": cmd.allow_attachments,
+            "requires_existing_session": cmd.requires_existing_session,
+            "channel_safe": cmd.channel_safe,
         }
     except Exception as e:
         log.error("command.get.error", {"error": str(e), "name": name})

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -2399,6 +2399,211 @@ async def _resolve_model(request, agent, sessionID: str):
     return provider_id, model_id, source
 
 
+def _extract_text_from_parts(parts: List[Dict[str, Any]]) -> str:
+    return "".join(part.get("text", "") for part in parts if part.get("type") == "text")
+
+
+def _replace_text_parts(parts: Optional[List[Dict[str, Any]]], text: str) -> List[Dict[str, Any]]:
+    updated_parts: List[Dict[str, Any]] = []
+    replaced = False
+    for part in parts or []:
+        if part.get("type") == "text" and not replaced:
+            next_part = dict(part)
+            next_part["text"] = text
+            updated_parts.append(next_part)
+            replaced = True
+            continue
+        if part.get("type") == "text":
+            continue
+        updated_parts.append(dict(part))
+
+    if not replaced:
+        updated_parts.insert(0, {"type": "text", "text": text})
+    return updated_parts
+
+
+def _coerce_model_for_prompt_request(model: Any):
+    import types
+
+    if not model:
+        return None
+    if isinstance(model, str):
+        if "/" not in model:
+            return None
+        provider_id, model_id = model.split("/", 1)
+        return types.SimpleNamespace(providerID=provider_id, modelID=model_id)
+    if isinstance(model, dict):
+        provider_id = model.get("providerID") or model.get("provider_id")
+        model_id = model.get("modelID") or model.get("model_id")
+        if provider_id and model_id:
+            return types.SimpleNamespace(providerID=provider_id, modelID=model_id)
+        return None
+    return model
+
+
+def _build_prompt_request_from_event(event, prompt_text: str, display_text: Optional[str] = None):
+    import types
+
+    return types.SimpleNamespace(
+        parts=_replace_text_parts(event.parts, prompt_text),
+        display_text=display_text,
+        agent=event.agent,
+        model=_coerce_model_for_prompt_request(event.model),
+        variant=event.variant,
+        messageID=event.message_id,
+        mockReply=event.mock_reply,
+        noReply=event.no_reply,
+        tools=event.tools,
+        system=event.system,
+    )
+
+
+async def _dispatch_sse_input(sessionID: str, session, event, working_directory: str) -> None:
+    import time as _time
+
+    from flocks.input.dispatcher import dispatch_user_input
+    from flocks.input.output import SSEOutputSink
+    from flocks.server.routes.event import publish_event
+    from flocks.session.message import Message, MessageRole
+    from flocks.utils.id import Identifier
+
+    agent_name = event.agent or "rex"
+
+    async def _create_user_message(
+        user_text: str,
+        model_info: Optional[Dict[str, str]] = None,
+        *,
+        agent_override: Optional[str] = None,
+    ) -> str:
+        now_ms = int(_time.time() * 1000)
+        user_msg_id = event.message_id or Identifier.create("message")
+        user_part_id = Identifier.create("part")
+        message_agent = agent_override or agent_name
+        await Message.create(
+            session_id=sessionID,
+            role=MessageRole.USER,
+            content=user_text,
+            id=user_msg_id,
+            time={"created": now_ms},
+            agent=message_agent,
+            **({"model": model_info} if model_info else {}),
+            part_id=user_part_id,
+        )
+        await publish_event("message.updated", {
+            "info": {
+                "id": user_msg_id,
+                "sessionID": sessionID,
+                "role": "user",
+                "time": {"created": now_ms},
+                "agent": message_agent,
+                **({"model": model_info} if model_info else {}),
+            }
+        })
+        await publish_event("message.part.updated", {
+            "part": {
+                "id": user_part_id,
+                "messageID": user_msg_id,
+                "sessionID": sessionID,
+                "type": "text",
+                "text": user_text,
+                "time": {"start": now_ms},
+            }
+        })
+        return user_msg_id
+
+    async def _publish_direct_response(output_event, text: str) -> None:
+        user_text = output_event.user_visible_text
+        parent_msg_id = await _create_user_message(user_text)
+        asst_now = int(_time.time() * 1000)
+        asst_msg_id = Identifier.ascending("message")
+        asst_part_id = Identifier.ascending("part")
+        await Message.create(
+            session_id=sessionID,
+            role=MessageRole.ASSISTANT,
+            content=text,
+            id=asst_msg_id,
+            time={"created": asst_now, "completed": asst_now},
+            parentID=parent_msg_id,
+            modelID="command",
+            providerID="builtin",
+            agent=agent_name,
+            finish="stop",
+            part_id=asst_part_id,
+        )
+        await publish_event("message.updated", {
+            "info": {
+                "id": asst_msg_id,
+                "sessionID": sessionID,
+                "role": "assistant",
+                "time": {"created": asst_now, "completed": asst_now},
+                "parentID": parent_msg_id,
+                "modelID": "command",
+                "providerID": "builtin",
+                "agent": agent_name,
+                "mode": agent_name,
+                "finish": "stop",
+                "tokens": {
+                    "input": 0,
+                    "output": 0,
+                    "reasoning": 0,
+                    "cache": {"read": 0, "write": 0},
+                },
+            }
+        })
+        await publish_event("message.part.updated", {
+            "part": {
+                "id": asst_part_id,
+                "messageID": asst_msg_id,
+                "sessionID": sessionID,
+                "type": "text",
+                "text": text,
+                "time": {"start": asst_now, "end": asst_now},
+            }
+        })
+
+    async def _run_llm(output_event, prompt_text: str, display_text: Optional[str] = None) -> None:
+        request = _build_prompt_request_from_event(output_event, prompt_text, display_text)
+        await _process_session_message(sessionID, session, request, working_directory)
+
+    async def _run_session_control(output_event, parsed) -> bool:
+        if parsed.canonical_name != "compact":
+            return False
+
+        focus_instruction = parsed.args.strip() or None
+        compact_agent, compact_provider_id, compact_model_id = await _resolve_compaction_context(
+            sessionID,
+            requested_agent=output_event.agent,
+            requested_model=output_event.model,
+        )
+        parent_msg_id = await _create_user_message(
+            output_event.user_visible_text,
+            {
+                "providerID": compact_provider_id,
+                "modelID": compact_model_id,
+            },
+            agent_override=compact_agent,
+        )
+        await _run_session_compaction(
+            sessionID,
+            requested_agent=compact_agent,
+            explicit_provider_id=compact_provider_id,
+            explicit_model_id=compact_model_id,
+            parent_message_id=parent_msg_id,
+            auto=False,
+            event_publish_callback=publish_event,
+            focus_instruction=focus_instruction,
+        )
+        return True
+
+    sink = SSEOutputSink(
+        "webui",
+        direct_response=_publish_direct_response,
+        run_llm=_run_llm,
+        session_control=_run_session_control,
+    )
+    await dispatch_user_input(event, sink)
+
+
 @router.post(
     "/{sessionID}/prompt_async",
     status_code=status.HTTP_202_ACCEPTED,
@@ -2411,7 +2616,8 @@ async def send_session_message_async(
 ):
     """Send message asynchronously - returns 202 immediately, response via SSE"""
     import os
-    
+    from flocks.input.events import UserInputEvent
+
     session = await Session.get_by_id(sessionID)
     if not session:
         raise HTTPException(
@@ -2425,6 +2631,23 @@ async def send_session_message_async(
         "sessionID": sessionID,
         "directory": working_directory,
     })
+
+    event = UserInputEvent(
+        source_type="webui",
+        sessionID=sessionID,
+        text=_extract_text_from_parts(request.parts),
+        parts=[dict(part) for part in request.parts],
+        agent=request.agent,
+        model=request.model.model_dump(by_alias=True) if request.model else None,
+        variant=request.variant,
+        display_text=None,
+        messageID=request.messageID,
+        noReply=request.noReply,
+        mockReply=request.mockReply,
+        tools=request.tools,
+        system=request.system,
+        working_directory=working_directory,
+    )
     
     # Use the same synchronous processing path as send_session_message
     # but run it as a background task via asyncio.ensure_future
@@ -2444,9 +2667,7 @@ async def send_session_message_async(
             await Instance.provide(
                 directory=working_directory,
                 init=instance_bootstrap,
-                fn=lambda: _process_session_message(
-                    sessionID, session, request, working_directory
-                ),
+                fn=lambda: _dispatch_sse_input(sessionID, session, event, working_directory),
             )
             log.info("session.prompt_async.processing_complete", {
                 "sessionID": sessionID,
@@ -2521,12 +2742,9 @@ async def send_session_command(sessionID: str, request: CommandRequest):
     that is replaced as soon as the real SSE event arrives.
     """
     import asyncio
-    import time as _time
     import os
-    from flocks.session.message import Message, MessageRole
-    from flocks.server.routes.event import publish_event
-    from flocks.utils.id import Identifier
-    from flocks.command.handler import handle_slash_command
+
+    from flocks.input.events import UserInputEvent
 
     session = await Session.get_by_id(sessionID)
     if not session:
@@ -2536,228 +2754,41 @@ async def send_session_command(sessionID: str, request: CommandRequest):
         )
 
     working_directory = session.directory or os.getcwd()
-    agent_name = request.agent or "rex"
 
     # The text the user typed, shown verbatim in the chat bubble
     slash_text = f"/{request.command}"
     if request.arguments:
         slash_text += f" {request.arguments}"
 
-    # ── Helper: create user message + publish SSE ───────────────────────────
-    async def _create_user_message(
-        model_info: Optional[Dict[str, str]] = None,
-        *,
-        agent_override: Optional[str] = None,
-    ) -> str:
-        now_ms = int(_time.time() * 1000)
-        user_msg_id = Identifier.create("message")
-        user_part_id = Identifier.create("part")
-        message_agent = agent_override or agent_name
-        await Message.create(
-            session_id=sessionID,
-            role=MessageRole.USER,
-            content=slash_text,
-            id=user_msg_id,
-            time={"created": now_ms},
-            agent=message_agent,
-            **({"model": model_info} if model_info else {}),
-            part_id=user_part_id,
-        )
-        await publish_event("message.updated", {
-            "info": {
-                "id": user_msg_id,
-                "sessionID": sessionID,
-                "role": "user",
-                "time": {"created": now_ms},
-                "agent": message_agent,
-                **({"model": model_info} if model_info else {}),
-            }
-        })
-        await publish_event("message.part.updated", {
-            "part": {
-                "id": user_part_id,
-                "messageID": user_msg_id,
-                "sessionID": sessionID,
-                "type": "text",
-                "text": slash_text,
-                "time": {"start": now_ms},
-            }
-        })
-        return user_msg_id
-
-    # ── Helper: publish a direct (non-LLM) assistant message ────────────────
-    async def _publish_direct_response(text: str, parent_msg_id: str) -> None:
-        asst_now = int(_time.time() * 1000)
-        asst_msg_id = Identifier.ascending("message")
-        asst_part_id = Identifier.ascending("part")
-        await Message.create(
-            session_id=sessionID,
-            role=MessageRole.ASSISTANT,
-            content=text,
-            id=asst_msg_id,
-            time={"created": asst_now, "completed": asst_now},
-            parentID=parent_msg_id,
-            modelID="command",
-            providerID="builtin",
-            agent=agent_name,
-            finish="stop",
-            part_id=asst_part_id,
-        )
-        await publish_event("message.updated", {
-            "info": {
-                "id": asst_msg_id,
-                "sessionID": sessionID,
-                "role": "assistant",
-                "time": {"created": asst_now, "completed": asst_now},
-                "parentID": parent_msg_id,
-                "modelID": "command",
-                "providerID": "builtin",
-                "agent": agent_name,
-                "mode": agent_name,
-                "finish": "stop",
-                "tokens": {"input": 0, "output": 0, "reasoning": 0,
-                           "cache": {"read": 0, "write": 0}},
-            }
-        })
-        await publish_event("message.part.updated", {
-            "part": {
-                "id": asst_part_id,
-                "messageID": asst_msg_id,
-                "sessionID": sessionID,
-                "type": "text",
-                "text": text,
-                "time": {"start": asst_now, "end": asst_now},
-            }
-        })
-
-    # ── Helper: run a prompt through the LLM (session loop) ─────────────────
-    async def _run_via_llm(prompt_text: str, display_text: str | None = None) -> None:
-        """
-        Route a prompt through the LLM pipeline via _process_session_message.
-        This creates its own user message, so call ONLY when no user message
-        has been created yet for this command invocation.
-
-        display_text: optional override for the user-visible message bubble.
-        When provided (e.g. "/tools create foo"), the user message stored in
-        the DB and shown in the chat shows display_text, while the LLM still
-        receives the full prompt_text (e.g. the tool-builder skill content).
-        """
-        import types
-        from flocks.project.instance import Instance
-        from flocks.project.bootstrap import instance_bootstrap
-
-        cmd_request = types.SimpleNamespace(
-            parts=[{"type": "text", "text": prompt_text}],
-            display_text=display_text,
+    # ── Background task ──────────────────────────────────────────────────────
+    async def _handle_command() -> None:
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID=sessionID,
+            text=slash_text,
+            parts=[dict(part) for part in (request.parts or [])],
             agent=request.agent,
             model=request.model,
             variant=request.variant,
-            messageID=None,
-            mockReply=None,
-            noReply=False,
+            display_text=slash_text,
+            messageID=request.messageID,
+            working_directory=working_directory,
         )
-
-        await Instance.provide(
-            directory=working_directory,
-            init=instance_bootstrap,
-            fn=lambda: _process_session_message(
-                sessionID, session, cmd_request, working_directory
-            ),
-        )
-
-    async def _run_compaction_command(
-        parent_msg_id: str,
-        *,
-        agent_for_compaction: Optional[str],
-        provider_id: str,
-        model_id: str,
-        focus_instruction: Optional[str] = None,
-    ) -> None:
-        from flocks.project.bootstrap import instance_bootstrap
-        from flocks.project.instance import Instance
-
-        await Instance.provide(
-            directory=working_directory,
-            init=instance_bootstrap,
-            fn=lambda: _run_session_compaction(
-                sessionID,
-                requested_agent=agent_for_compaction,
-                explicit_provider_id=provider_id,
-                explicit_model_id=model_id,
-                parent_message_id=parent_msg_id,
-                auto=False,
-                event_publish_callback=publish_event,
-                focus_instruction=focus_instruction,
-            ),
-        )
-
-    # ── Background task ──────────────────────────────────────────────────────
-    async def _handle_command() -> None:
-        result_texts: list[str] = []
-        llm_prompts: list[str] = []
-
-        async def _send_text(text: str) -> None:
-            result_texts.append(text)
-
-        async def _send_prompt(prompt: str) -> None:
-            llm_prompts.append(prompt)
 
         try:
-            if request.command.lower() == "compact":
-                # Manual compaction trigger.  ``request.arguments`` is
-                # treated as a free-form "focus instruction" appended to
-                # the summarisation prompt — e.g. ``/compact focus on
-                # unresolved decisions``.  Empty arguments preserve the
-                # legacy default-prompt behaviour.
-                focus_instruction = request.arguments.strip() or None
-                compact_agent, compact_provider_id, compact_model_id = await _resolve_compaction_context(
-                    sessionID,
-                    requested_agent=request.agent,
-                    requested_model=request.model,
-                )
-                user_msg_id = await _create_user_message(
-                    {
-                        "providerID": compact_provider_id,
-                        "modelID": compact_model_id,
-                    },
-                    agent_override=compact_agent,
-                )
-                await _run_compaction_command(
-                    user_msg_id,
-                    agent_for_compaction=compact_agent,
-                    provider_id=compact_provider_id,
-                    model_id=compact_model_id,
-                    focus_instruction=focus_instruction,
-                )
-                return
+            from flocks.project.instance import Instance
+            from flocks.project.bootstrap import instance_bootstrap
 
-            handled = await handle_slash_command(
-                slash_text,
-                send_text=_send_text,
-                send_prompt=_send_prompt,
+            await Instance.provide(
+                directory=working_directory,
+                init=instance_bootstrap,
+                fn=lambda: _dispatch_sse_input(sessionID, session, event, working_directory),
             )
-
-            if handled:
-                if llm_prompts:
-                    # Command collected a prompt to run through LLM
-                    # (e.g., "/tools create <requirement>" → tool-builder skill).
-                    # display_text=slash_text ensures the user bubble shows the
-                    # original slash command, while the LLM receives the full
-                    # skill/tool prompt.
-                    await _run_via_llm(llm_prompts[0], display_text=slash_text)
-                elif result_texts:
-                    # Direct text response — create the user+assistant pair now
-                    user_msg_id = await _create_user_message()
-                    await _publish_direct_response("\n".join(result_texts), user_msg_id)
-                # else: handled but produced nothing (rare edge case)
-            else:
-                # Not handled directly (e.g. /plan, /ask, /init, /compact …)
-                # _process_session_message creates the user message; pass the raw
-                # slash text so Rex can interpret it via its slash-command knowledge.
-                await _run_via_llm(slash_text)
 
         except Exception as exc:
             import traceback
+            from flocks.server.routes.event import publish_event
+
             log.error("session.command.error", {
                 "sessionID": sessionID,
                 "command": request.command,

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -2729,7 +2729,7 @@ async def send_session_command(sessionID: str, request: CommandRequest):
     """
     Execute a slash command.
 
-    Direct commands (/tools, /skills, /help, /mcp, /clear, /restart) are handled
+    Direct commands (/tools, /skills, /help, /mcp, /clear) are handled
     without calling the LLM.  Their output is pushed as an assistant message
     directly via SSE.
 

--- a/flocks/server/routes/skill.py
+++ b/flocks/server/routes/skill.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 
 from flocks.skill.skill import Skill, SkillInfo
 from flocks.skill.installer import SkillInstaller, SkillInstallResult, DepInstallResult
-from flocks.command.command import Command, CommandInfo
+from flocks.command.command import API_SURFACES, Command, CommandInfo
 from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 
@@ -148,12 +148,38 @@ class DepInstallRequest(BaseModel):
 class CommandResponse(BaseModel):
     """Command response"""
     name: str = Field(..., description="Command name")
+    canonical_name: str = Field(..., description="Canonical command name")
     description: str = Field(..., description="Command description")
     template: str = Field(..., description="Command template")
     agent: Optional[str] = Field(None, description="Preferred agent")
     model: Optional[str] = Field(None, description="Preferred model")
     subtask: Optional[bool] = Field(None, description="Run as subtask")
     hidden: bool = Field(False, description="Hidden from UI")
+    aliases: List[str] = Field(default_factory=list, description="Alternate slash aliases")
+    visible_surfaces: List[str] = Field(default_factory=list, description="Surfaces where the command is visible")
+    execution_kind: str = Field(..., description="Execution mode: direct, llm, or session_control")
+    allow_attachments: bool = Field(False, description="Whether command accepts attachments")
+    requires_existing_session: bool = Field(True, description="Whether command requires an existing session")
+    channel_safe: bool = Field(False, description="Whether the command is safe to expose on channel surfaces")
+
+
+def _command_to_response(cmd: CommandInfo) -> CommandResponse:
+    return CommandResponse(
+        name=cmd.name,
+        canonical_name=cmd.canonical_name,
+        description=cmd.description,
+        template=cmd.template,
+        agent=cmd.agent,
+        model=cmd.model,
+        subtask=cmd.subtask,
+        hidden=cmd.hidden,
+        aliases=list(cmd.aliases),
+        visible_surfaces=list(cmd.visible_surfaces),
+        execution_kind=cmd.execution_kind,
+        allow_attachments=cmd.allow_attachments,
+        requires_existing_session=cmd.requires_existing_session,
+        channel_safe=cmd.channel_safe,
+    )
 
 
 # =============================================================================
@@ -507,19 +533,11 @@ async def list_commands():
     Returns list of all registered slash commands.
     """
     try:
-        commands = Command.list()
+        commands = Command.list_for_surfaces(API_SURFACES)
 
         result = []
         for cmd in commands:
-            result.append(CommandResponse(
-                name=cmd.name,
-                description=cmd.description,
-                template=cmd.template,
-                agent=cmd.agent,
-                model=cmd.model,
-                subtask=cmd.subtask,
-                hidden=cmd.hidden,
-            ))
+            result.append(_command_to_response(cmd))
 
         log.info("commands.list", {"count": len(result)})
         return result
@@ -540,15 +558,7 @@ async def get_command(name: str):
         if not cmd:
             raise HTTPException(status_code=404, detail=f"Command not found: {name}")
 
-        return CommandResponse(
-            name=cmd.name,
-            description=cmd.description,
-            template=cmd.template,
-            agent=cmd.agent,
-            model=cmd.model,
-            subtask=cmd.subtask,
-            hidden=cmd.hidden,
-        )
+        return _command_to_response(cmd)
     except HTTPException:
         raise
     except Exception as e:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,6 +2,7 @@
 # 本地开发脚本：支持单独启动前端、后端，或同时启动。
 
 set -euo pipefail
+set -m
 
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
@@ -24,6 +25,9 @@ fi
 
 BACKEND_BASE_URL="http://${BACKEND_ACCESS_HOST}:${BACKEND_PORT}"
 BACKEND_WS_URL="ws://${BACKEND_ACCESS_HOST}:${BACKEND_PORT}"
+BACKEND_PID=""
+BACKEND_PGID=""
+CLEANUP_DONE=0
 
 usage() {
     cat <<'EOF'
@@ -39,6 +43,162 @@ Environment variables:
   FRONTEND_HOST  默认 127.0.0.1
   FRONTEND_PORT  默认 5173
 EOF
+}
+
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+process_group_id() {
+    local pid="$1"
+    ps -o pgid= -p "${pid}" 2>/dev/null | tr -d '[:space:]'
+}
+
+collect_descendant_pids() {
+    local pid="$1"
+    local children=""
+    local child_pid=""
+
+    if command_exists pgrep; then
+        children="$(pgrep -P "${pid}" 2>/dev/null || true)"
+    else
+        children="$(ps -eo pid=,ppid= | awk -v target_ppid="${pid}" '$2 == target_ppid { print $1 }')"
+    fi
+
+    if [ -z "${children}" ]; then
+        return
+    fi
+
+    while IFS= read -r child_pid; do
+        if [ -z "${child_pid}" ]; then
+            continue
+        fi
+        collect_descendant_pids "${child_pid}"
+        printf '%s\n' "${child_pid}"
+    done <<EOF
+${children}
+EOF
+}
+
+collect_process_group_pids() {
+    local pgid="$1"
+
+    if [ -z "${pgid}" ]; then
+        return
+    fi
+
+    if command_exists pgrep; then
+        pgrep -g "${pgid}" 2>/dev/null || true
+        return
+    fi
+
+    ps -eo pid=,pgid= | awk -v target_pgid="${pgid}" '$2 == target_pgid { print $1 }'
+}
+
+stop_process_tree() {
+    local pid="$1"
+    local label="$2"
+    local child_pid=""
+    local current_pid=""
+    local -a kill_targets=()
+    local -a remaining=()
+
+    if [ -z "${pid}" ] || ! kill -0 "${pid}" 2>/dev/null; then
+        return
+    fi
+
+    while IFS= read -r child_pid; do
+        if [ -n "${child_pid}" ]; then
+            kill_targets+=("${child_pid}")
+        fi
+    done <<EOF
+$(collect_descendant_pids "${pid}")
+EOF
+    kill_targets+=("${pid}")
+
+    kill -TERM "${kill_targets[@]}" 2>/dev/null || true
+
+    for _ in 1 2 3 4 5; do
+        remaining=()
+        for current_pid in "${kill_targets[@]}"; do
+            if kill -0 "${current_pid}" 2>/dev/null; then
+                remaining+=("${current_pid}")
+            fi
+        done
+        if [ "${#remaining[@]}" -eq 0 ]; then
+            wait "${pid}" 2>/dev/null || true
+            return
+        fi
+        sleep 1
+    done
+
+    echo -e "${YELLOW}${label} 未在预期时间内退出，强制终止...${NC}"
+    kill -KILL "${remaining[@]}" 2>/dev/null || true
+    wait "${pid}" 2>/dev/null || true
+}
+
+stop_process_group() {
+    local pgid="$1"
+    local label="$2"
+    local current_pid=""
+    local member_pid=""
+    local -a remaining=()
+
+    if [ -z "${pgid}" ]; then
+        return 1
+    fi
+
+    while IFS= read -r member_pid; do
+        if [ -n "${member_pid}" ]; then
+            remaining+=("${member_pid}")
+        fi
+    done <<EOF
+$(collect_process_group_pids "${pgid}")
+EOF
+
+    if [ "${#remaining[@]}" -eq 0 ]; then
+        return 1
+    fi
+
+    kill -TERM -- "-${pgid}" 2>/dev/null || true
+
+    for _ in 1 2 3 4 5; do
+        remaining=()
+        while IFS= read -r current_pid; do
+            if [ -n "${current_pid}" ] && kill -0 "${current_pid}" 2>/dev/null; then
+                remaining+=("${current_pid}")
+            fi
+        done <<EOF
+$(collect_process_group_pids "${pgid}")
+EOF
+        if [ "${#remaining[@]}" -eq 0 ]; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo -e "${YELLOW}${label} 未在预期时间内退出，强制终止...${NC}"
+    kill -KILL -- "-${pgid}" 2>/dev/null || true
+    return 0
+}
+
+cleanup() {
+    local shell_pgid=""
+
+    if [ "${CLEANUP_DONE}" -eq 1 ]; then
+        return
+    fi
+    CLEANUP_DONE=1
+
+    if [ -n "${BACKEND_PID}" ]; then
+        echo -e "${YELLOW}\n🛑 停止后端服务...${NC}"
+        shell_pgid="$(process_group_id "$$")"
+        if [ -n "${BACKEND_PGID}" ] && [ "${BACKEND_PGID}" != "${shell_pgid}" ]; then
+            stop_process_group "${BACKEND_PGID}" "后端服务" || stop_process_tree "${BACKEND_PID}" "后端服务"
+        else
+            stop_process_tree "${BACKEND_PID}" "后端服务"
+        fi
+    fi
 }
 
 start_backend() {
@@ -69,7 +229,8 @@ start_all() {
         --reload-dir flocks &
 
     BACKEND_PID=$!
-    trap 'echo -e "${YELLOW}\n🛑 停止后端服务...${NC}"; kill "${BACKEND_PID}" 2>/dev/null || true' EXIT
+    BACKEND_PGID="$(process_group_id "${BACKEND_PID}")"
+    trap cleanup EXIT
 
     echo -e "${YELLOW}后端 PID: ${BACKEND_PID}${NC}"
     echo -e "${YELLOW}前端将连接到: ${BACKEND_BASE_URL}${NC}"

--- a/tests/channel/test_channel.py
+++ b/tests/channel/test_channel.py
@@ -508,6 +508,56 @@ class TestFeishuNativeCommands:
         assert "session_new" in delivered[0]
 
     @pytest.mark.asyncio
+    async def test_help_command_works_for_non_feishu_channel(self, monkeypatch):
+        from flocks.channel.inbound.dispatcher import InboundDispatcher
+        from flocks.channel.inbound.session_binding import SessionBinding
+
+        dispatcher = InboundDispatcher()
+        binding = SessionBinding(
+            channel_id="wecom",
+            account_id="default",
+            chat_id="room_1",
+            chat_type=ChatType.DIRECT,
+            thread_id=None,
+            session_id="session_1",
+            agent_id="rex",
+            created_at=0,
+            last_message_at=0,
+        )
+        msg = InboundMessage(
+            channel_id="wecom",
+            account_id="default",
+            message_id="msg_1",
+            sender_id="user_1",
+            chat_id="room_1",
+            chat_type=ChatType.DIRECT,
+            text="/help",
+            mention_text="/help",
+        )
+
+        delivered: list[str] = []
+
+        async def fake_deliver(ctx, session_id=None):
+            delivered.append(ctx.text)
+
+        monkeypatch.setattr(
+            "flocks.channel.outbound.deliver.OutboundDelivery.deliver",
+            fake_deliver,
+        )
+
+        handled = await dispatcher._handle_feishu_native_command(
+            binding=binding,
+            msg=msg,
+            channel_config=ChannelConfig(enabled=True),
+            user_text="/help",
+            scope_override=None,
+        )
+
+        assert handled is True
+        assert delivered
+        assert "Available / commands:" in delivered[0]
+
+    @pytest.mark.asyncio
     async def test_append_user_message_stores_feishu_media_part(self, monkeypatch):
         from flocks.channel.inbound.dispatcher import InboundDispatcher
         from flocks.config.config import ChannelConfig

--- a/tests/channel/test_channel.py
+++ b/tests/channel/test_channel.py
@@ -484,15 +484,13 @@ class TestFeishuNativeCommands:
                 )
             ),
         )
-        monkeypatch.setattr(
-            "flocks.session.session.Session.create",
-            AsyncMock(
-                return_value=SimpleNamespace(
-                    id="session_new",
-                    agent="rex",
-                )
-            ),
+        create_mock = AsyncMock(
+            return_value=SimpleNamespace(
+                id="session_new",
+                agent="rex",
+            )
         )
+        monkeypatch.setattr("flocks.session.session.Session.create", create_mock)
 
         handled = await dispatcher._handle_feishu_native_command(
             binding=binding,
@@ -505,7 +503,100 @@ class TestFeishuNativeCommands:
         assert handled is True
         dispatcher.binding_service.rebind.assert_awaited_once()
         assert dispatcher.binding_service.rebind.await_args.kwargs["scope_override"] == "group_topic"
+        create_kwargs = create_mock.await_args.kwargs
+        assert "parent_id" not in create_kwargs or create_kwargs["parent_id"] is None
+        assert create_kwargs["title"] == "[Feishu] oc_group"
         assert "session_new" in delivered[0]
+        assert "已开始全新对话。" in delivered[0]
+
+    @pytest.mark.asyncio
+    async def test_reset_alias_matches_new_semantics(self, monkeypatch):
+        from flocks.channel.inbound.dispatcher import InboundDispatcher
+        from flocks.channel.inbound.session_binding import SessionBinding
+
+        dispatcher = InboundDispatcher()
+        dispatcher._trigger_command_hook = AsyncMock()
+        dispatcher.binding_service.rebind = AsyncMock(
+            return_value=SessionBinding(
+                channel_id="wecom",
+                account_id="default",
+                chat_id="room_1",
+                chat_type=ChatType.DIRECT,
+                thread_id=None,
+                session_id="session_new",
+                agent_id="rex",
+                created_at=0,
+                last_message_at=0,
+            )
+        )
+        binding = SessionBinding(
+            channel_id="wecom",
+            account_id="default",
+            chat_id="room_1",
+            chat_type=ChatType.DIRECT,
+            thread_id=None,
+            session_id="session_old",
+            agent_id="rex",
+            created_at=0,
+            last_message_at=0,
+        )
+        msg = InboundMessage(
+            channel_id="wecom",
+            account_id="default",
+            message_id="msg_1",
+            sender_id="user_1",
+            chat_id="room_1",
+            chat_type=ChatType.DIRECT,
+            text="/reset",
+            mention_text="/reset",
+        )
+
+        delivered: list[str] = []
+
+        async def fake_deliver(ctx, session_id=None):
+            delivered.append(ctx.text)
+
+        create_mock = AsyncMock(
+            return_value=SimpleNamespace(
+                id="session_new",
+                agent="rex",
+            )
+        )
+
+        monkeypatch.setattr(
+            "flocks.channel.outbound.deliver.OutboundDelivery.deliver",
+            fake_deliver,
+        )
+        monkeypatch.setattr(
+            "flocks.session.session.Session.get_by_id",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    id="session_old",
+                    project_id="channel",
+                    directory="/tmp/project",
+                    agent="rex",
+                    provider="anthropic",
+                    model="claude-sonnet-4-20250514",
+                )
+            ),
+        )
+        monkeypatch.setattr("flocks.session.session.Session.create", create_mock)
+
+        handled = await dispatcher._handle_feishu_native_command(
+            binding=binding,
+            msg=msg,
+            channel_config=ChannelConfig(enabled=True),
+            user_text="/reset",
+            scope_override=None,
+        )
+
+        assert handled is True
+        create_kwargs = create_mock.await_args.kwargs
+        assert "parent_id" not in create_kwargs or create_kwargs["parent_id"] is None
+        assert create_kwargs["title"] == "[Wecom] DM — user_1"
+        dispatcher._trigger_command_hook.assert_awaited_once()
+        assert dispatcher._trigger_command_hook.await_args.args[0] == "new"
+        assert "已开始全新对话。" in delivered[0]
 
     @pytest.mark.asyncio
     async def test_help_command_works_for_non_feishu_channel(self, monkeypatch):

--- a/tests/command/test_workflows_command.py
+++ b/tests/command/test_workflows_command.py
@@ -96,6 +96,9 @@ class TestWorkflowsCommandRegistration:
         for name in ("tools", "skills", "workflows"):
             assert Command.get(name) is not None, f"Command '/{name}' not registered"
 
+    def test_restart_command_removed(self):
+        assert Command.get("restart") is None
+
 
 # ===========================================================================
 # /workflows handler — happy path
@@ -111,6 +114,11 @@ class TestWorkflowsHandler:
         with patch(self._SCAN_WF_CENTER, new_callable=AsyncMock, return_value=entries):
             texts, handled = await _collect_text("/workflows")
         assert handled
+
+    async def test_removed_restart_command_not_handled(self):
+        texts, handled = await _collect_text("/restart")
+        assert handled is False
+        assert texts == []
 
     async def test_workflow_names_in_output(self):
         entries = [

--- a/tests/scripts/test_bash_scripts.py
+++ b/tests/scripts/test_bash_scripts.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / "scripts"
-BASH_SCRIPTS = ("install.sh",)
+BASH_SCRIPTS = ("install.sh", "dev.sh")
 
 
 def test_bash_scripts_parse_without_errors() -> None:
@@ -14,3 +14,23 @@ def test_bash_scripts_parse_without_errors() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_dev_script_stops_backend_process_tree_on_exit() -> None:
+    script = (SCRIPT_DIR / "dev.sh").read_text(encoding="utf-8")
+
+    assert "set -m" in script
+    assert 'BACKEND_PGID="$(process_group_id "${BACKEND_PID}")"' in script
+    assert "process_group_id()" in script
+    assert "collect_process_group_pids()" in script
+    assert "stop_process_group()" in script
+    assert 'kill -TERM -- "-${pgid}"' in script
+    assert 'kill -KILL -- "-${pgid}"' in script
+    assert 'if [ -n "${BACKEND_PGID}" ] && [ "${BACKEND_PGID}" != "${shell_pgid}" ]; then' in script
+    assert "collect_descendant_pids()" in script
+    assert "stop_process_tree()" in script
+    assert "trap cleanup EXIT" in script
+    assert 'stop_process_group "${BACKEND_PGID}" "后端服务" || stop_process_tree "${BACKEND_PID}" "后端服务"' in script
+    assert 'kill -TERM "${kill_targets[@]}"' in script
+    assert 'kill -KILL "${remaining[@]}"' in script
+    assert 'kill "${BACKEND_PID}" 2>/dev/null || true' not in script

--- a/tests/server/test_input_dispatcher.py
+++ b/tests/server/test_input_dispatcher.py
@@ -19,6 +19,12 @@ class TestParseSlashCommand:
         assert parsed.command_name == "reset"
         assert parsed.canonical_name == "new"
 
+    def test_removed_restart_command_no_longer_resolves(self):
+        parsed = parse_slash_command("/restart")
+        assert parsed is not None
+        assert parsed.command_name == "restart"
+        assert parsed.command_def is None
+
 
 class TestDispatchUserInput:
     @pytest.mark.asyncio
@@ -63,6 +69,28 @@ class TestDispatchUserInput:
 
         assert result.action == "llm"
         assert llm == [("/plan investigate routing", "/plan investigate routing")]
+        assert not direct
+
+    @pytest.mark.asyncio
+    async def test_removed_restart_command_falls_back_to_llm(self):
+        direct = []
+        llm = []
+        sink = CallbackOutputSink(
+            "webui",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append(llm, (prompt, display)),
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_test",
+            text="/restart",
+            parts=[{"type": "text", "text": "/restart"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "llm"
+        assert llm == [("/restart", "/restart")]
         assert not direct
 
     @pytest.mark.asyncio

--- a/tests/server/test_input_dispatcher.py
+++ b/tests/server/test_input_dispatcher.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from flocks.command.command import Command, CommandDef
+from flocks.input.dispatcher import dispatch_user_input, parse_slash_command
+from flocks.input.events import UserInputEvent
+from flocks.input.output import CallbackOutputSink
+
+
+class TestParseSlashCommand:
+    def test_resolves_alias_to_canonical_name(self):
+        parsed = parse_slash_command("/reset")
+        assert parsed is not None
+        assert parsed.command_name == "reset"
+        assert parsed.canonical_name == "new"
+
+
+class TestDispatchUserInput:
+    @pytest.mark.asyncio
+    async def test_direct_command_uses_direct_response(self):
+        direct = []
+        llm = []
+        sink = CallbackOutputSink(
+            "webui",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append(llm, (prompt, display)),
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_test",
+            text="/help",
+            parts=[{"type": "text", "text": "/help"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "direct"
+        assert direct and "Available / commands:" in direct[0]
+        assert not llm
+
+    @pytest.mark.asyncio
+    async def test_llm_command_routes_raw_slash_text(self):
+        direct = []
+        llm = []
+        sink = CallbackOutputSink(
+            "webui",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append(llm, (prompt, display)),
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_test",
+            text="/plan investigate routing",
+            parts=[{"type": "text", "text": "/plan investigate routing"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "llm"
+        assert llm == [("/plan investigate routing", "/plan investigate routing")]
+        assert not direct
+
+    @pytest.mark.asyncio
+    async def test_known_command_rejected_on_wrong_surface(self):
+        direct = []
+        sink = CallbackOutputSink(
+            "webui",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append([], (prompt, display)),
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_test",
+            text="/model anthropic/claude-sonnet-4-5",
+            parts=[{"type": "text", "text": "/model anthropic/claude-sonnet-4-5"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "rejected"
+        assert "当前入口不可用" in direct[0]
+
+    @pytest.mark.asyncio
+    async def test_command_rejects_attachments_when_not_allowed(self):
+        direct = []
+        sink = CallbackOutputSink(
+            "webui",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append([], (prompt, display)),
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_test",
+            text="/help",
+            parts=[
+                {"type": "text", "text": "/help"},
+                {"type": "file", "url": "file:///tmp/demo.txt"},
+            ],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "rejected"
+        assert "不支持附件" in direct[0]
+
+    @pytest.mark.asyncio
+    async def test_channel_unsafe_command_is_rejected(self):
+        Command.register(
+            CommandDef(
+                name="channel-unsafe-test",
+                description="unsafe",
+                template="unsafe",
+                hidden=True,
+                execution_kind="direct",
+                allow_attachments=False,
+                visible_surfaces=("channel",),
+                channel_safe=False,
+            )
+        )
+        direct = []
+        sink = CallbackOutputSink(
+            "channel",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append([], (prompt, display)),
+        )
+        event = UserInputEvent(
+            source_type="wecom",
+            sessionID="ses_test",
+            text="/channel-unsafe-test",
+            parts=[{"type": "text", "text": "/channel-unsafe-test"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "rejected"
+        assert "不支持在渠道会话中执行" in direct[0]
+
+
+class TestSessionRoutesUseDispatcher:
+    @pytest.mark.asyncio
+    async def test_prompt_async_routes_through_dispatcher(self, monkeypatch):
+        from flocks.server.routes import session as session_routes
+
+        dispatch_mock = AsyncMock()
+        session_id = "ses_dispatcher"
+
+        async def fake_provide(*, directory, init, fn):
+            await fn()
+
+        monkeypatch.setattr(session_routes, "_dispatch_sse_input", dispatch_mock)
+        monkeypatch.setattr("flocks.project.instance.Instance.provide", fake_provide)
+        monkeypatch.setattr(
+            "flocks.session.session.Session.get_by_id",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    id=session_id,
+                    directory="/tmp/project",
+                )
+            ),
+        )
+        request = session_routes.PromptRequest(
+            parts=[{"type": "text", "text": "/plan investigate"}],
+        )
+
+        resp = await session_routes.send_session_message_async(session_id, request)
+        assert resp["status"] == "accepted"
+        await asyncio.sleep(0)
+        dispatch_mock.assert_awaited_once()
+        event = dispatch_mock.await_args.args[2]
+        assert event.text == "/plan investigate"
+
+    @pytest.mark.asyncio
+    async def test_command_route_routes_through_dispatcher(self, monkeypatch):
+        from flocks.server.routes import session as session_routes
+
+        dispatch_mock = AsyncMock()
+        session_id = "ses_dispatcher"
+
+        async def fake_provide(*, directory, init, fn):
+            await fn()
+
+        monkeypatch.setattr(session_routes, "_dispatch_sse_input", dispatch_mock)
+        monkeypatch.setattr("flocks.project.instance.Instance.provide", fake_provide)
+        monkeypatch.setattr(
+            "flocks.session.session.Session.get_by_id",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    id=session_id,
+                    directory="/tmp/project",
+                )
+            ),
+        )
+        request = session_routes.CommandRequest(command="plan", arguments="investigate")
+
+        resp = await session_routes.send_session_command(session_id, request)
+        assert resp["status"] == "accepted"
+        await asyncio.sleep(0)
+        dispatch_mock.assert_awaited_once()
+        event = dispatch_mock.await_args.args[2]
+        assert event.text == "/plan investigate"
+        assert event.display_text == "/plan investigate"
+
+
+async def _append(target: list, value):
+    target.append(value)

--- a/tui/flocks/cli/cmd/tui/component/prompt/index.tsx
+++ b/tui/flocks/cli/cmd/tui/component/prompt/index.tsx
@@ -547,14 +547,7 @@ export function Prompt(props: PromptProps) {
         command: inputText,
       })
       setStore("mode", "normal")
-    } else if (
-      inputText.startsWith("/") &&
-      iife(() => {
-        const command = inputText.split(" ")[0].slice(1)
-        console.log(command)
-        return sync.data.command.some((x) => x.name === command)
-      })
-    ) {
+    } else if (inputText.startsWith("/")) {
       let [command, ...args] = inputText.split(" ")
       sdk.client.session.command({
         sessionID,

--- a/webui/src/api/skill.ts
+++ b/webui/src/api/skill.ts
@@ -32,12 +32,19 @@ export interface Skill {
 
 export interface Command {
   name: string;
+  canonical_name: string;
   description: string;
   template: string;
   agent?: string;
   model?: string;
   subtask?: boolean;
   hidden: boolean;
+  aliases: string[];
+  visible_surfaces: string[];
+  execution_kind: 'direct' | 'llm' | 'session_control';
+  allow_attachments: boolean;
+  requires_existing_session: boolean;
+  channel_safe: boolean;
 }
 
 export interface SkillInstallRequest {


### PR DESCRIPTION
## Summary
Unifies slash/command handling across WebUI, TUI, CLI, channel, and ACP by introducing `flocks.input` (`UserInputEvent`, `dispatch_user_input`, `OutputSink`) and extending `CommandDef` / `CommandRegistry`.

## Follow-up commit
Removes redundant CLI `/restart` wiring, trims unused helpers, and expands channel / input dispatcher / workflows tests.

## Testing
- Extended `tests/channel/test_channel.py`, `tests/server/test_input_dispatcher.py`, `tests/command/test_workflows_command.py`
