### PR TITLE
fix(cli): probe backend root status during startup

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -29,7 +29,6 @@ except ImportError:  # pragma: no cover - unavailable on Windows
     fcntl = None
 
 MIN_NODE_MAJOR = 22
-BACKEND_HEALTH_PATHS = ("/api/health", "/health")
 FOLLOW_POLL_INTERVAL = 0.5
 
 
@@ -45,11 +44,6 @@ class ServiceConfig:
     frontend_port: int = 5173
     no_browser: bool = False
     skip_frontend_build: bool = False
-
-    @property
-    def backend_urls(self) -> list[str]:
-        base = backend_access_base_url(self)
-        return [f"{base}{path}" for path in BACKEND_HEALTH_PATHS]
 
     @property
     def frontend_url(self) -> str:
@@ -677,22 +671,20 @@ def port_owner_pids(port: int) -> list[int]:
     raise ServiceError("未检测到 lsof 或 fuser，无法检查端口占用。")
 
 
-def _is_expected_health_response(response: httpx.Response) -> bool:
-    """Return True when the response matches a Flocks health payload."""
+def _is_reachable_response(response: httpx.Response) -> bool:
+    """Return True when an HTTP endpoint is reachable enough for startup checks."""
+    return response.status_code < 500
+
+
+def _is_running_status_response(response: httpx.Response) -> bool:
+    """Return True when the backend root endpoint reports a running status."""
     if response.status_code != 200:
         return False
     try:
         payload = response.json()
     except ValueError:
         return False
-    if not isinstance(payload, dict):
-        return False
-    return payload.get("status") == "healthy" or payload.get("healthy") is True
-
-
-def _is_reachable_response(response: httpx.Response) -> bool:
-    """Return True when an HTTP endpoint is reachable enough for startup checks."""
-    return response.status_code < 500
+    return isinstance(payload, dict) and payload.get("status") == "running"
 
 
 def wait_for_http(
@@ -746,8 +738,6 @@ def start_backend(config: ServiceConfig, console) -> None:
     if runtime_record is not None:
         paths.backend_pid.unlink(missing_ok=True)
 
-    _run_legacy_task_migration(root, console)
-
     command = resolve_flocks_cli_command(root) + [
         "serve",
         "--host",
@@ -779,7 +769,11 @@ def start_backend(config: ServiceConfig, console) -> None:
     _log_startup_config(paths.backend_log, "backend", config.backend_host, config.backend_port, read_runtime_record(paths.backend_pid))
 
     try:
-        wait_for_http(config.backend_urls, "后端服务", validator=_is_expected_health_response)
+        wait_for_http(
+            [backend_access_base_url(config)],
+            "后端服务",
+            validator=_is_running_status_response,
+        )
     except ServiceError:
         stop_one(config.backend_port, paths.backend_pid, "后端", console)
         raise
@@ -1073,33 +1067,6 @@ def _log_startup_config(
     line = f"[{timestamp}] {name} starting: host={host} port={port} pid={pid}{pgid_info}\n"
     with log_path.open("a", encoding="utf-8") as handle:
         handle.write(line)
-
-
-def _run_legacy_task_migration(root: Path, console) -> None:
-    """Run the legacy task migration script before backend startup."""
-    migration_script = root / "scripts" / "migrate_legacy_task_tables.py"
-    if not migration_script.exists():
-        return
-
-    try:
-        completed = subprocess.run(
-            [sys.executable, str(migration_script)],
-            cwd=root,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-    except OSError as error:
-        if console is not None:
-            console.print(f"[flocks] 旧任务迁移脚本启动失败: {error}")
-        return
-
-    if completed.returncode != 0 and console is not None:
-        detail = (completed.stderr or completed.stdout or "").strip()
-        if detail:
-            console.print(f"[flocks] 旧任务迁移失败: {detail}")
-        else:
-            console.print("[flocks] 旧任务迁移失败，请检查日志。")
 
 
 def _resolve_stop_ports(

--- a/flocks/cli/session_runner_throttled.py
+++ b/flocks/cli/session_runner_throttled.py
@@ -7,6 +7,7 @@ while maintaining smoothness through throttling.
 To use: Replace the _on_text_delta implementation in session_runner.py
 """
 
+import asyncio
 import time
 from rich.text import Text
 

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -314,19 +314,11 @@ def test_parse_windows_netstat_output_extracts_unique_pids() -> None:
     assert service_manager._parse_windows_netstat_output(output) == [1234, 5678]
 
 
-def test_is_expected_health_response_accepts_known_payload_shapes() -> None:
-    api_health = httpx.Response(200, json={"status": "healthy", "version": "v1"})
-    global_health = httpx.Response(200, json={"healthy": True, "version": "v1"})
-
-    assert service_manager._is_expected_health_response(api_health) is True
-    assert service_manager._is_expected_health_response(global_health) is True
-
-
-def test_wait_for_http_rejects_non_flocks_health_payload(monkeypatch) -> None:
+def test_wait_for_http_rejects_unreachable_responses(monkeypatch) -> None:
     responses = iter([
-        httpx.Response(404, json={"detail": "not found"}),
-        httpx.Response(200, json={"status": "starting"}),
-        httpx.Response(200, text="ok"),
+        httpx.Response(503, json={"detail": "not found"}),
+        httpx.Response(500, json={"status": "starting"}),
+        httpx.Response(502, text="bad gateway"),
     ])
 
     class _FakeClient:
@@ -352,14 +344,13 @@ def test_wait_for_http_rejects_non_flocks_health_payload(monkeypatch) -> None:
             "后端服务",
             attempts=3,
             delay=0.0,
-            validator=service_manager._is_expected_health_response,
         )
 
 
-def test_wait_for_http_accepts_flocks_health_response(monkeypatch) -> None:
+def test_wait_for_http_accepts_reachable_json_response(monkeypatch) -> None:
     responses = iter([
         httpx.Response(503, json={"detail": "warming"}),
-        httpx.Response(200, json={"status": "healthy", "version": "v1"}),
+        httpx.Response(200, json={"name": "Flocks API", "status": "running"}),
     ])
 
     class _FakeClient:
@@ -384,8 +375,72 @@ def test_wait_for_http_accepts_flocks_health_response(monkeypatch) -> None:
         "后端服务",
         attempts=2,
         delay=0.0,
-        validator=service_manager._is_expected_health_response,
     )
+
+
+def test_wait_for_http_accepts_running_status_response(monkeypatch) -> None:
+    responses = iter([
+        httpx.Response(200, json={"name": "Flocks API", "status": "starting"}),
+        httpx.Response(200, json={"name": "Flocks API", "status": "running"}),
+    ])
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, _url):
+            return next(responses)
+
+    monkeypatch.setattr(
+        service_manager.httpx,
+        "Client",
+        lambda *, timeout, trust_env: _FakeClient(),
+    )
+    monkeypatch.setattr(service_manager.time, "sleep", lambda _delay: None)
+
+    service_manager.wait_for_http(
+        ["http://127.0.0.1:8000"],
+        "后端服务",
+        attempts=2,
+        delay=0.0,
+        validator=service_manager._is_running_status_response,
+    )
+
+
+def test_wait_for_http_rejects_missing_running_status_response(monkeypatch) -> None:
+    responses = iter([
+        httpx.Response(200, json={"name": "Flocks API", "status": "starting"}),
+        httpx.Response(200, text="<html>ok</html>"),
+    ])
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, _url):
+            return next(responses)
+
+    monkeypatch.setattr(
+        service_manager.httpx,
+        "Client",
+        lambda *, timeout, trust_env: _FakeClient(),
+    )
+    monkeypatch.setattr(service_manager.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(service_manager.ServiceError, match="启动超时"):
+        service_manager.wait_for_http(
+            ["http://127.0.0.1:8000"],
+            "后端服务",
+            attempts=2,
+            delay=0.0,
+            validator=service_manager._is_running_status_response,
+        )
 
 
 def test_wait_for_http_accepts_reachable_html_by_default(monkeypatch) -> None:
@@ -439,7 +494,6 @@ def test_wait_for_http_ignores_proxy_environment(monkeypatch) -> None:
         "后端服务",
         attempts=1,
         delay=0.0,
-        validator=service_manager._is_expected_health_response,
     )
 
     assert captured == {"timeout": 2.0, "trust_env": False}
@@ -695,7 +749,18 @@ def test_start_backend_writes_runtime_metadata(monkeypatch, tmp_path: Path) -> N
     monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
     monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _path: None)
     monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
-    monkeypatch.setattr(service_manager, "wait_for_http", lambda *_args, **_kwargs: None)
+    probe_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        service_manager,
+        "wait_for_http",
+        lambda urls, name, attempts=30, delay=1.0, validator=None: probe_calls.append({
+            "urls": list(urls),
+            "name": name,
+            "attempts": attempts,
+            "delay": delay,
+            "validator": validator,
+        }),
+    )
     monkeypatch.setattr(service_manager.os, "getpgid", lambda pid: pid)
     monkeypatch.setattr(
         service_manager,
@@ -726,9 +791,16 @@ def test_start_backend_writes_runtime_metadata(monkeypatch, tmp_path: Path) -> N
         "--port",
         "8000",
     )
+    assert probe_calls == [{
+        "urls": ["http://127.0.0.1:8000"],
+        "name": "后端服务",
+        "attempts": 30,
+        "delay": 1.0,
+        "validator": service_manager._is_running_status_response,
+    }]
 
 
-def test_start_backend_runs_legacy_migration_before_launch(monkeypatch, tmp_path: Path) -> None:
+def test_start_backend_rolls_back_when_probe_fails(monkeypatch, tmp_path: Path) -> None:
     paths = service_manager.RuntimePaths(
         root=tmp_path,
         run_dir=tmp_path / "run",
@@ -741,28 +813,81 @@ def test_start_backend_runs_legacy_migration_before_launch(monkeypatch, tmp_path
     paths.run_dir.mkdir(parents=True)
     paths.log_dir.mkdir(parents=True)
     console = DummyConsole()
-    call_order: list[str] = []
+    stop_calls: list[tuple[int, Path, str]] = []
 
     monkeypatch.setattr(service_manager, "ensure_install_layout", lambda: tmp_path)
     monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
     monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _path: None)
     monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
-    monkeypatch.setattr(service_manager, "wait_for_http", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(service_manager.os, "getpgid", lambda pid: pid)
     monkeypatch.setattr(
         service_manager,
-        "_run_legacy_task_migration",
-        lambda root, _console: call_order.append(f"migrate:{root}"),
+        "resolve_flocks_cli_command",
+        lambda root=None: ["python", "-m", "flocks.cli.main"],
     )
     monkeypatch.setattr(
         service_manager,
         "_spawn_process",
-        lambda *_args, **_kwargs: (call_order.append("spawn"), SimpleNamespace(pid=2468))[1],
+        lambda *_args, **_kwargs: SimpleNamespace(pid=2468),
+    )
+    monkeypatch.setattr(
+        service_manager,
+        "wait_for_http",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(service_manager.ServiceError("后端服务 启动超时，请检查日志。")),
+    )
+    monkeypatch.setattr(
+        service_manager,
+        "stop_one",
+        lambda port, pid_file, name, _console: stop_calls.append((port, pid_file, name)),
+    )
+
+    with pytest.raises(service_manager.ServiceError, match="启动超时"):
+        service_manager.start_backend(service_manager.ServiceConfig(), console)
+
+    assert stop_calls == [(8000, paths.backend_pid, "后端")]
+
+
+def test_start_backend_reports_started_after_probe_succeeds(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    paths.log_dir.mkdir(parents=True)
+    console = DummyConsole()
+
+    monkeypatch.setattr(service_manager, "ensure_install_layout", lambda: tmp_path)
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _path: None)
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
+    monkeypatch.setattr(service_manager.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(
+        service_manager,
+        "resolve_flocks_cli_command",
+        lambda root=None: ["python", "-m", "flocks.cli.main"],
+    )
+    monkeypatch.setattr(
+        service_manager,
+        "_spawn_process",
+        lambda *_args, **_kwargs: SimpleNamespace(pid=2468),
+    )
+    monkeypatch.setattr(
+        service_manager,
+        "wait_for_http",
+        lambda *_args, **_kwargs: None,
     )
 
     service_manager.start_backend(service_manager.ServiceConfig(), console)
 
-    assert call_order == [f"migrate:{tmp_path}", "spawn"]
+    record = service_manager.read_runtime_record(paths.backend_pid)
+    assert record is not None
+    assert record.pid == 2468
+    assert console.messages[-1] == f"[flocks] 后端已启动，日志: {paths.backend_log}"
 
 
 def test_build_frontend_env_uses_backend_host_and_port() -> None:


### PR DESCRIPTION
## Summary
- probe backend startup readiness from the root endpoint instead of legacy health URLs
- require a `status == \"running\"` response before marking the backend ready and remove the legacy migration hook from startup
- expand `service_manager` startup tests and include the missing `asyncio` import in the throttled session runner

## Test plan
- [x] `uv run pytest tests/cli/test_service_manager.py`
- [x] `uv run ruff check flocks/cli/service_manager.py flocks/cli/session_runner_throttled.py tests/cli/test_service_manager.py`

Made with [Cursor](https://cursor.com)