### PR TITLE
fix(tool): enforce strict schema precheck for all tools

### DIFF
--- a/flocks/session/prompt_strings.py
+++ b/flocks/session/prompt_strings.py
@@ -249,6 +249,9 @@ IMPORTANT RULES:
 - After calling a tool, wait for its result before proceeding
 - After receiving a tool result, respond to the user with a direct answer
 - Do not repeat tool calls just to explain what you're doing - call the tool once and explain after
+- Schema precheck before calling a tool: read the callable schema for that tool and copy parameter names EXACTLY (including case).
+- Never guess parameter names from semantics. If uncertain, use `tool_search` first, then call only with names shown in the callable schema.
+- For all tools, treat schema as strict: unknown parameter names will fail.
 {windows_rules}- On Windows, any Python command that reads text files must explicitly specify encoding. Never generate commands like `yaml.safe_load(open(path))`, `json.load(open(path))`, or `open(path).read()` without `encoding=...`; prefer `Path(path).read_text(encoding="utf-8-sig")`.
 
 CRITICAL - TOOL CALLING FORMAT:

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -303,6 +303,60 @@ def _coerce_params(
     return coerced
 
 
+def _normalize_param_key(name: str) -> str:
+    """Normalize parameter keys for conservative alias matching."""
+    return "".join(ch for ch in str(name).lower() if ch.isalnum())
+
+
+def _remap_schema_kwargs(
+    kwargs: Dict[str, Any],
+    declared_param_names: List[str],
+) -> tuple[Dict[str, Any], Dict[str, str]]:
+    """Remap guessed argument keys to declared schema keys when unambiguous.
+
+    Only applies conservative normalization (case / separators), and only when
+    a normalized key maps to exactly one declared parameter name.
+    """
+    declared_lookup: Dict[str, List[str]] = {}
+    for name in declared_param_names:
+        declared_lookup.setdefault(_normalize_param_key(name), []).append(name)
+
+    remapped: Dict[str, Any] = {}
+    aliases: Dict[str, str] = {}
+
+    for key, value in kwargs.items():
+        if key in declared_param_names:
+            remapped[key] = value
+            continue
+        normalized = _normalize_param_key(key)
+        candidates = declared_lookup.get(normalized, [])
+        if len(candidates) == 1:
+            target = candidates[0]
+            if target not in remapped:
+                remapped[target] = value
+                aliases[key] = target
+                continue
+        remapped[key] = value
+
+    return remapped, aliases
+
+
+def _schema_hint_from_properties(
+    declared_param_names: List[str],
+    required: List[str],
+    *,
+    max_items: int = 20,
+) -> str:
+    """Build a compact schema hint string for argument-validation errors."""
+    allowed_preview = ", ".join(declared_param_names[:max_items]) or "(none)"
+    if len(declared_param_names) > max_items:
+        allowed_preview += ", ..."
+    required_preview = ", ".join(required[:max_items]) or "(none)"
+    if len(required) > max_items:
+        required_preview += ", ..."
+    return f"Allowed parameters: {allowed_preview}. Required: {required_preview}."
+
+
 class Tool:
     """Tool wrapper class"""
 
@@ -325,21 +379,83 @@ class Tool:
                 "params": list(kwargs.keys()),
             })
 
-            # Validate required parameters
             schema = self.info.get_schema()
+            schema_properties = schema.properties if isinstance(schema.properties, dict) else {}
+            declared_param_names = list(schema_properties.keys())
+
+            # Strict schema precheck: remap obvious aliases first, then validate.
+            # This reduces first-call failures caused by case/separator drift
+            # (e.g. file_path -> filePath) without allowing speculative params.
+            remap_aliases: Dict[str, str] = {}
+            effective_kwargs = dict(kwargs)
+            if declared_param_names:
+                effective_kwargs, remap_aliases = _remap_schema_kwargs(
+                    effective_kwargs,
+                    declared_param_names,
+                )
+                if remap_aliases:
+                    log.info("tool.execute.param_remapped", {
+                        "tool": self.info.name,
+                        "aliases": remap_aliases,
+                    })
+
+                unknown = sorted(
+                    key for key in effective_kwargs.keys() if key not in schema_properties
+                )
+                if unknown:
+                    schema_hint = _schema_hint_from_properties(
+                        declared_param_names,
+                        list(schema.required),
+                    )
+                    return ToolResult(
+                        success=False,
+                        error=(
+                            f"Invalid arguments for {self.info.name}: unknown parameters: "
+                            f"{', '.join(unknown)}. {schema_hint}"
+                        ),
+                        metadata={
+                            "schema_precheck": {
+                                "tool": self.info.name,
+                                "source": self.info.source,
+                                "unknown": unknown,
+                                "allowed": declared_param_names,
+                                "required": list(schema.required),
+                                "aliases": remap_aliases,
+                            }
+                        },
+                    )
+
+            # Validate required parameters
             for required_param in schema.required:
-                if required_param not in kwargs:
+                if required_param not in effective_kwargs:
                     log.error("tool.execute.missing_param", {
                         "tool": self.info.name,
                         "missing": required_param,
-                        "provided": list(kwargs.keys()),
+                        "provided": list(effective_kwargs.keys()),
                     })
+                    schema_hint = _schema_hint_from_properties(
+                        declared_param_names,
+                        list(schema.required),
+                    )
                     return ToolResult(
                         success=False,
-                        error=f"Missing required parameter: {required_param}"
+                        error=(
+                            f"Missing required parameter: {required_param}. "
+                            f"{schema_hint}"
+                        ),
+                        metadata={
+                            "schema_precheck": {
+                                "tool": self.info.name,
+                                "source": self.info.source,
+                                "provided": sorted(effective_kwargs.keys()),
+                                "allowed": declared_param_names,
+                                "required": list(schema.required),
+                                "aliases": remap_aliases,
+                            }
+                        },
                     )
 
-            coerced_kwargs = _coerce_params(kwargs, self.info.parameters, self.info.name)
+            coerced_kwargs = _coerce_params(effective_kwargs, self.info.parameters, self.info.name)
 
             # Execute handler
             result = await self.handler(ctx, **coerced_kwargs)

--- a/tests/tool/test_tools.py
+++ b/tests/tool/test_tools.py
@@ -967,6 +967,19 @@ class TestErrorHandling:
         
         assert not result.success
         assert "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_builtin_tool_rejects_unknown_parameter(self, tool_context, temp_dir):
+        """Built-in tools should reject unknown parameters via schema precheck."""
+        result = await ToolRegistry.execute(
+            "read",
+            ctx=tool_context,
+            filePath=os.path.join(temp_dir, "no-file.txt"),
+            unknownParam="x",
+        )
+        assert not result.success
+        assert "unknown parameters" in (result.error or "").lower()
+        assert "allowed parameters" in (result.error or "").lower()
     
     @pytest.mark.asyncio
     async def test_tool_handles_exceptions(self, tool_context, temp_dir):
@@ -980,6 +993,87 @@ class TestErrorHandling:
         
         # Should return error, not raise exception
         assert not result.success
+
+    @pytest.mark.asyncio
+    async def test_schema_param_alias_remap_accepts_case_separator_variants(self, tool_context):
+        """All tools should remap obvious key variants (file_path -> filePath)."""
+        async def _handler(ctx: ToolContext, filePath: str) -> ToolResult:
+            return ToolResult(success=True, output=filePath)
+
+        tool_name = "test_schema_precheck_alias"
+        ToolRegistry.register(
+            Tool(
+                info=ToolInfo(
+                    name=tool_name,
+                    description="Test schema alias remap",
+                    category=ToolCategory.CUSTOM,
+                    parameters=[
+                        ToolParameter(
+                            name="filePath",
+                            type=ParameterType.STRING,
+                            description="Path",
+                            required=True,
+                        )
+                    ],
+                    source="plugin_py",
+                    native=True,
+                    enabled=True,
+                ),
+                handler=_handler,
+            )
+        )
+        try:
+            result = await ToolRegistry.execute(
+                tool_name,
+                ctx=tool_context,
+                file_path="/tmp/demo.txt",
+            )
+            assert result.success
+            assert result.output == "/tmp/demo.txt"
+        finally:
+            ToolRegistry.unregister(tool_name)
+
+    @pytest.mark.asyncio
+    async def test_unknown_params_returns_schema_hint_for_all_tools(self, tool_context):
+        """All tools should reject unknown params with schema guidance."""
+        async def _handler(ctx: ToolContext, query: str) -> ToolResult:
+            return ToolResult(success=True, output=query)
+
+        tool_name = "test_schema_precheck_unknown"
+        ToolRegistry.register(
+            Tool(
+                info=ToolInfo(
+                    name=tool_name,
+                    description="Test unknown parameter handling",
+                    category=ToolCategory.CUSTOM,
+                    parameters=[
+                        ToolParameter(
+                            name="query",
+                            type=ParameterType.STRING,
+                            description="Query",
+                            required=True,
+                        )
+                    ],
+                    source="plugin_py",
+                    native=True,
+                    enabled=True,
+                ),
+                handler=_handler,
+            )
+        )
+        try:
+            result = await ToolRegistry.execute(
+                tool_name,
+                ctx=tool_context,
+                keyword="abc",
+            )
+            assert not result.success
+            assert "Invalid arguments" in (result.error or "")
+            assert "Allowed parameters: query" in (result.error or "")
+            assert isinstance(result.metadata, dict)
+            assert "schema_precheck" in result.metadata
+        finally:
+            ToolRegistry.unregister(tool_name)
 
 
 # =============================================================================


### PR DESCRIPTION
Block guessed or unknown tool parameters at execution time and return schema hints so first-call failures recover deterministically instead of relying on prompt compliance alone.

Made-with: Cursor