### PR TITLE
fix(cli): preserve remote backend routing for webui access

### DIFF
--- a/.github/workflows/windows-packaging.yml
+++ b/.github/workflows/windows-packaging.yml
@@ -7,9 +7,6 @@ on:
       - "packaging/windows/**"
       - "scripts/install.ps1"
       - "scripts/install_zh.ps1"
-      - "flocks/cli/service_manager.py"
-      - ".github/workflows/windows-packaging.yml"
-      - ".github/workflows/windows-packaging-release.yml"
 
 permissions:
   contents: read

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -747,6 +747,8 @@ def start_backend(config: ServiceConfig, console) -> None:
     ]
 
     backend_env = os.environ.copy()
+    backend_env["_FLOCKS_SERVER_HOST"] = config.backend_host
+    backend_env["_FLOCKS_SERVER_PORT"] = str(config.backend_port)
     backend_env["_FLOCKS_WEBUI_HOST"] = config.frontend_host
     backend_env["_FLOCKS_WEBUI_PORT"] = str(config.frontend_port)
 
@@ -1358,10 +1360,25 @@ def backend_access_base_url(config: ServiceConfig) -> str:
     return f"http://{access_host(config.backend_host)}:{config.backend_port}"
 
 
+def websocket_access_base_url(config: ServiceConfig) -> str:
+    """Return the websocket base URL matching ``backend_access_base_url()``."""
+    return _http_to_ws_url(backend_access_base_url(config))
+
+
 def build_frontend_env(config: ServiceConfig) -> dict[str, str]:
     """Build frontend proxy environment variables from backend service settings."""
     env = os.environ.copy()
-    env["FLOCKS_API_PROXY_TARGET"] = backend_access_base_url(config)
+    backend_url = backend_access_base_url(config)
+    env["FLOCKS_API_PROXY_TARGET"] = backend_url
+
+    # Avoid leaking a stale Vite API target from the parent shell into a new
+    # build/start cycle.  For localhost or wildcard backends we intentionally
+    # stay on same-origin proxy mode, so the VITE_* overrides must be absent.
+    env.pop("VITE_API_BASE_URL", None)
+    env.pop("VITE_WS_BASE_URL", None)
+    if _should_inject_direct_backend_urls(config.backend_host):
+        env["VITE_API_BASE_URL"] = backend_url
+        env["VITE_WS_BASE_URL"] = websocket_access_base_url(config)
 
     # When using the bundled toolchain (Windows installer), npm/node spawned by
     # `npm run build/preview` must be able to locate the bundled node.exe via
@@ -1460,3 +1477,15 @@ def _join_pids(pids: Iterable[int]) -> str:
 
 def _loopback_host(host: str) -> str:
     return "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+
+
+def _http_to_ws_url(url: str) -> str:
+    if url.startswith("https://"):
+        return url.replace("https://", "wss://", 1)
+    if url.startswith("http://"):
+        return url.replace("http://", "ws://", 1)
+    return url
+
+
+def _should_inject_direct_backend_urls(host: str) -> bool:
+    return host not in {"127.0.0.1", "localhost", "::1", "0.0.0.0", "::"}

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -747,8 +747,6 @@ def start_backend(config: ServiceConfig, console) -> None:
     ]
 
     backend_env = os.environ.copy()
-    backend_env["_FLOCKS_SERVER_HOST"] = config.backend_host
-    backend_env["_FLOCKS_SERVER_PORT"] = str(config.backend_port)
     backend_env["_FLOCKS_WEBUI_HOST"] = config.frontend_host
     backend_env["_FLOCKS_WEBUI_PORT"] = str(config.frontend_port)
 
@@ -1355,9 +1353,16 @@ def access_host(host: str) -> str:
     return _loopback_host(host)
 
 
+def _format_host_for_url(host: str) -> str:
+    """Wrap IPv6 literals in brackets before composing URLs."""
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 def backend_access_base_url(config: ServiceConfig) -> str:
     """Return the backend base URL that the local WebUI should connect to."""
-    return f"http://{access_host(config.backend_host)}:{config.backend_port}"
+    return f"http://{_format_host_for_url(access_host(config.backend_host))}:{config.backend_port}"
 
 
 def websocket_access_base_url(config: ServiceConfig) -> str:

--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -299,9 +299,8 @@ log = Log.create(service="server")
 # CORS Configuration
 #
 # Priority order:
-#   1. Runtime env vars exported by ``start_backend()`` → add concrete
-#      ``_FLOCKS_WEBUI_*`` / ``_FLOCKS_SERVER_*`` origins inferred from the
-#      current CLI launch.
+#   1. Runtime env vars exported by ``start_backend()`` → add the concrete
+#      ``_FLOCKS_WEBUI_*`` origin inferred from the current CLI launch.
 #   2. Explicit ``server.cors`` in flocks.json → append user-configured
 #      origins without discarding the runtime ones.
 #   3. Fallback → only localhost (any port) via regex.
@@ -328,10 +327,17 @@ def _is_localhost(host: str) -> bool:
     return host in _LOCALHOST_HOSTS
 
 
+def _format_host_for_url(host: str) -> str:
+    """Wrap IPv6 literals in brackets before composing origins."""
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 def _append_origin(origins: list[str], host: str, port: str) -> None:
     if not host or not port or _is_localhost(host) or host in _WILDCARD_HOSTS:
         return
-    origin = f"http://{host}:{port}"
+    origin = f"http://{_format_host_for_url(host)}:{port}"
     if origin not in origins:
         origins.append(origin)
 
@@ -350,11 +356,6 @@ def _read_cors_config() -> tuple[list[str], Optional[str]]:
         origins,
         os.environ.get("_FLOCKS_WEBUI_HOST", ""),
         os.environ.get("_FLOCKS_WEBUI_PORT", ""),
-    )
-    _append_origin(
-        origins,
-        os.environ.get("_FLOCKS_SERVER_HOST", ""),
-        os.environ.get("_FLOCKS_SERVER_PORT", ""),
     )
 
     try:

--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -299,16 +299,17 @@ log = Log.create(service="server")
 # CORS Configuration
 #
 # Priority order:
-#   1. Explicit ``server.cors`` in flocks.json  → use those origins (plus
-#      the localhost fallback regex).
-#   2. ``_FLOCKS_WEBUI_HOST`` / ``_FLOCKS_WEBUI_PORT`` env vars set by
-#      ``start_backend()`` for a concrete IP → auto-whitelist that single
-#      origin.  We deliberately do NOT auto-whitelist when the WebUI binds
-#      to ``0.0.0.0``: matching ``[^/]+:<port>`` would accept every host on
-#      that port, effectively disabling CORS.  Remote deployments that run
-#      ``--webui-host 0.0.0.0`` must set ``server.cors`` explicitly in
-#      ``flocks.json``.
+#   1. Runtime env vars exported by ``start_backend()`` → add concrete
+#      ``_FLOCKS_WEBUI_*`` / ``_FLOCKS_SERVER_*`` origins inferred from the
+#      current CLI launch.
+#   2. Explicit ``server.cors`` in flocks.json → append user-configured
+#      origins without discarding the runtime ones.
 #   3. Fallback → only localhost (any port) via regex.
+#
+# We deliberately do NOT auto-whitelist wildcard binds such as ``0.0.0.0``:
+# matching ``[^/]+:<port>`` would accept every host on that port, effectively
+# disabling CORS.  Remote deployments that bind to wildcard hosts must keep
+# using explicit ``server.cors`` entries or start with a concrete IP/hostname.
 #
 # Config is read lazily on the first request via
 # :class:`_DeferredCORSMiddleware` so that importing ``app`` in an async
@@ -320,10 +321,19 @@ log = Log.create(service="server")
 _LOCALHOST_ORIGIN_RE = r"^https?://(127\.0\.0\.1|localhost)(:\d+)?$"
 
 _LOCALHOST_HOSTS = {"127.0.0.1", "localhost", "::1"}
+_WILDCARD_HOSTS = {"0.0.0.0", "::"}
 
 
 def _is_localhost(host: str) -> bool:
     return host in _LOCALHOST_HOSTS
+
+
+def _append_origin(origins: list[str], host: str, port: str) -> None:
+    if not host or not port or _is_localhost(host) or host in _WILDCARD_HOSTS:
+        return
+    origin = f"http://{host}:{port}"
+    if origin not in origins:
+        origins.append(origin)
 
 
 def _read_cors_config() -> tuple[list[str], Optional[str]]:
@@ -335,6 +345,18 @@ def _read_cors_config() -> tuple[list[str], Optional[str]]:
     """
     import json
 
+    origins: list[str] = []
+    _append_origin(
+        origins,
+        os.environ.get("_FLOCKS_WEBUI_HOST", ""),
+        os.environ.get("_FLOCKS_WEBUI_PORT", ""),
+    )
+    _append_origin(
+        origins,
+        os.environ.get("_FLOCKS_SERVER_HOST", ""),
+        os.environ.get("_FLOCKS_SERVER_PORT", ""),
+    )
+
     try:
         cfg_file = Config.get_config_file()
         if cfg_file.exists():
@@ -343,25 +365,13 @@ def _read_cors_config() -> tuple[list[str], Optional[str]]:
             server_cfg = data.get("server") or {}
             cors = server_cfg.get("cors")
             if isinstance(cors, list):
-                origins = [c for c in cors if isinstance(c, str) and c]
-                if origins:
-                    return origins, _LOCALHOST_ORIGIN_RE
+                for candidate in cors:
+                    if isinstance(candidate, str) and candidate and candidate not in origins:
+                        origins.append(candidate)
     except Exception:
         pass
 
-    webui_host = os.environ.get("_FLOCKS_WEBUI_HOST", "")
-    webui_port = os.environ.get("_FLOCKS_WEBUI_PORT", "")
-
-    if (
-        webui_host
-        and webui_port
-        and not _is_localhost(webui_host)
-        and webui_host != "0.0.0.0"
-    ):
-        extra_origin = f"http://{webui_host}:{webui_port}"
-        return [extra_origin], _LOCALHOST_ORIGIN_RE
-
-    return [], _LOCALHOST_ORIGIN_RE
+    return origins, _LOCALHOST_ORIGIN_RE
 
 
 class _DeferredCORSMiddleware:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -889,8 +889,6 @@ def test_start_backend_reports_started_after_probe_succeeds(monkeypatch, tmp_pat
     assert record is not None
     assert record.pid == 2468
     backend_env = spawn_calls[0]["kwargs"]["env"]
-    assert backend_env["_FLOCKS_SERVER_HOST"] == "127.0.0.1"
-    assert backend_env["_FLOCKS_SERVER_PORT"] == "8000"
     assert backend_env["_FLOCKS_WEBUI_HOST"] == "127.0.0.1"
     assert backend_env["_FLOCKS_WEBUI_PORT"] == "5173"
     assert console.messages[-1] == f"[flocks] 后端已启动，日志: {paths.backend_log}"
@@ -907,6 +905,19 @@ def test_build_frontend_env_uses_backend_host_and_port() -> None:
     assert env["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
     assert env["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
     assert env["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
+
+
+def test_build_frontend_env_brackets_ipv6_backend_host() -> None:
+    config = service_manager.ServiceConfig(
+        backend_host="2001:db8::1",
+        backend_port=9000,
+    )
+
+    env = service_manager.build_frontend_env(config)
+
+    assert env["FLOCKS_API_PROXY_TARGET"] == "http://[2001:db8::1]:9000"
+    assert env["VITE_API_BASE_URL"] == "http://[2001:db8::1]:9000"
+    assert env["VITE_WS_BASE_URL"] == "ws://[2001:db8::1]:9000"
 
 
 def test_build_frontend_env_uses_loopback_for_wildcard_backend_host() -> None:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -860,6 +860,7 @@ def test_start_backend_reports_started_after_probe_succeeds(monkeypatch, tmp_pat
     paths.run_dir.mkdir(parents=True)
     paths.log_dir.mkdir(parents=True)
     console = DummyConsole()
+    spawn_calls: list[dict[str, object]] = []
 
     monkeypatch.setattr(service_manager, "ensure_install_layout", lambda: tmp_path)
     monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
@@ -874,7 +875,7 @@ def test_start_backend_reports_started_after_probe_succeeds(monkeypatch, tmp_pat
     monkeypatch.setattr(
         service_manager,
         "_spawn_process",
-        lambda *_args, **_kwargs: SimpleNamespace(pid=2468),
+        lambda *args, **kwargs: spawn_calls.append({"args": args, "kwargs": kwargs}) or SimpleNamespace(pid=2468),
     )
     monkeypatch.setattr(
         service_manager,
@@ -887,6 +888,11 @@ def test_start_backend_reports_started_after_probe_succeeds(monkeypatch, tmp_pat
     record = service_manager.read_runtime_record(paths.backend_pid)
     assert record is not None
     assert record.pid == 2468
+    backend_env = spawn_calls[0]["kwargs"]["env"]
+    assert backend_env["_FLOCKS_SERVER_HOST"] == "127.0.0.1"
+    assert backend_env["_FLOCKS_SERVER_PORT"] == "8000"
+    assert backend_env["_FLOCKS_WEBUI_HOST"] == "127.0.0.1"
+    assert backend_env["_FLOCKS_WEBUI_PORT"] == "5173"
     assert console.messages[-1] == f"[flocks] 后端已启动，日志: {paths.backend_log}"
 
 
@@ -899,8 +905,8 @@ def test_build_frontend_env_uses_backend_host_and_port() -> None:
     env = service_manager.build_frontend_env(config)
 
     assert env["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
-    assert "VITE_API_BASE_URL" not in env
-    assert "VITE_WS_BASE_URL" not in env
+    assert env["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
+    assert env["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
 
 
 def test_build_frontend_env_uses_loopback_for_wildcard_backend_host() -> None:
@@ -913,6 +919,22 @@ def test_build_frontend_env_uses_loopback_for_wildcard_backend_host() -> None:
 
     assert env["FLOCKS_API_PROXY_TARGET"] == "http://127.0.0.1:9000"
     assert "VITE_API_BASE_URL" not in env
+    assert "VITE_WS_BASE_URL" not in env
+
+
+def test_build_frontend_env_keeps_proxy_mode_for_loopback_backend_host(monkeypatch) -> None:
+    monkeypatch.setenv("VITE_API_BASE_URL", "http://stale.example:9000")
+    monkeypatch.setenv("VITE_WS_BASE_URL", "ws://stale.example:9000")
+    config = service_manager.ServiceConfig(
+        backend_host="127.0.0.1",
+        backend_port=9000,
+    )
+
+    env = service_manager.build_frontend_env(config)
+
+    assert env["FLOCKS_API_PROXY_TARGET"] == "http://127.0.0.1:9000"
+    assert "VITE_API_BASE_URL" not in env
+    assert "VITE_WS_BASE_URL" not in env
 
 
 def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tmp_path: Path) -> None:
@@ -962,7 +984,8 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
     assert build_calls[0]["command"] == ["/usr/bin/npm", "run", "build"]
     assert build_calls[0]["kwargs"]["env"]["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
     assert build_calls[0]["kwargs"]["env"]["__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS"] == "preview.example.com"
-    assert "VITE_API_BASE_URL" not in build_calls[0]["kwargs"]["env"]
+    assert build_calls[0]["kwargs"]["env"]["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
+    assert build_calls[0]["kwargs"]["env"]["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
 
     assert preview_calls[0]["command"] == [
         "/usr/bin/npm",
@@ -976,7 +999,8 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
     ]
     assert preview_calls[0]["kwargs"]["env"]["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
     assert preview_calls[0]["kwargs"]["env"]["__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS"] == "preview.example.com"
-    assert "VITE_API_BASE_URL" not in preview_calls[0]["kwargs"]["env"]
+    assert preview_calls[0]["kwargs"]["env"]["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
+    assert preview_calls[0]["kwargs"]["env"]["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
     record = service_manager.read_runtime_record(paths.frontend_pid)
     assert record is not None
     assert record.host == "0.0.0.0"

--- a/tests/server/test_app_cors.py
+++ b/tests/server/test_app_cors.py
@@ -1,0 +1,48 @@
+import json
+
+from flocks.server import app as app_module
+
+
+def test_read_cors_config_merges_runtime_and_configured_origins(monkeypatch, tmp_path) -> None:
+    config_file = tmp_path / "flocks.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "server": {
+                    "cors": [
+                        "https://configured.example",
+                        "http://10.0.0.9:5173",
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(app_module.Config, "get_config_file", lambda: config_file)
+    monkeypatch.setenv("_FLOCKS_WEBUI_HOST", "10.0.0.9")
+    monkeypatch.setenv("_FLOCKS_WEBUI_PORT", "5173")
+    monkeypatch.setenv("_FLOCKS_SERVER_HOST", "10.0.0.8")
+    monkeypatch.setenv("_FLOCKS_SERVER_PORT", "8000")
+
+    allow_origins, allow_origin_regex = app_module._read_cors_config()
+
+    assert allow_origins == [
+        "http://10.0.0.9:5173",
+        "http://10.0.0.8:8000",
+        "https://configured.example",
+    ]
+    assert allow_origin_regex == app_module._LOCALHOST_ORIGIN_RE
+
+
+def test_read_cors_config_ignores_localhost_and_wildcard_runtime_hosts(monkeypatch, tmp_path) -> None:
+    config_file = tmp_path / "missing.json"
+    monkeypatch.setattr(app_module.Config, "get_config_file", lambda: config_file)
+    monkeypatch.setenv("_FLOCKS_WEBUI_HOST", "127.0.0.1")
+    monkeypatch.setenv("_FLOCKS_WEBUI_PORT", "5173")
+    monkeypatch.setenv("_FLOCKS_SERVER_HOST", "0.0.0.0")
+    monkeypatch.setenv("_FLOCKS_SERVER_PORT", "8000")
+
+    allow_origins, allow_origin_regex = app_module._read_cors_config()
+
+    assert allow_origins == []
+    assert allow_origin_regex == app_module._LOCALHOST_ORIGIN_RE

--- a/tests/server/test_app_cors.py
+++ b/tests/server/test_app_cors.py
@@ -21,14 +21,11 @@ def test_read_cors_config_merges_runtime_and_configured_origins(monkeypatch, tmp
     monkeypatch.setattr(app_module.Config, "get_config_file", lambda: config_file)
     monkeypatch.setenv("_FLOCKS_WEBUI_HOST", "10.0.0.9")
     monkeypatch.setenv("_FLOCKS_WEBUI_PORT", "5173")
-    monkeypatch.setenv("_FLOCKS_SERVER_HOST", "10.0.0.8")
-    monkeypatch.setenv("_FLOCKS_SERVER_PORT", "8000")
 
     allow_origins, allow_origin_regex = app_module._read_cors_config()
 
     assert allow_origins == [
         "http://10.0.0.9:5173",
-        "http://10.0.0.8:8000",
         "https://configured.example",
     ]
     assert allow_origin_regex == app_module._LOCALHOST_ORIGIN_RE
@@ -39,10 +36,20 @@ def test_read_cors_config_ignores_localhost_and_wildcard_runtime_hosts(monkeypat
     monkeypatch.setattr(app_module.Config, "get_config_file", lambda: config_file)
     monkeypatch.setenv("_FLOCKS_WEBUI_HOST", "127.0.0.1")
     monkeypatch.setenv("_FLOCKS_WEBUI_PORT", "5173")
-    monkeypatch.setenv("_FLOCKS_SERVER_HOST", "0.0.0.0")
-    monkeypatch.setenv("_FLOCKS_SERVER_PORT", "8000")
 
     allow_origins, allow_origin_regex = app_module._read_cors_config()
 
     assert allow_origins == []
+    assert allow_origin_regex == app_module._LOCALHOST_ORIGIN_RE
+
+
+def test_read_cors_config_brackets_ipv6_webui_origin(monkeypatch, tmp_path) -> None:
+    config_file = tmp_path / "missing.json"
+    monkeypatch.setattr(app_module.Config, "get_config_file", lambda: config_file)
+    monkeypatch.setenv("_FLOCKS_WEBUI_HOST", "2001:db8::2")
+    monkeypatch.setenv("_FLOCKS_WEBUI_PORT", "5173")
+
+    allow_origins, allow_origin_regex = app_module._read_cors_config()
+
+    assert allow_origins == ["http://[2001:db8::2]:5173"]
     assert allow_origin_regex == app_module._LOCALHOST_ORIGIN_RE


### PR DESCRIPTION
## Summary
- keep remote backend hosts reachable by injecting direct WebUI API and websocket URLs only for concrete non-local backend hosts
- merge runtime CORS origins inferred from CLI startup with configured allowlists instead of letting config override runtime access
- add regression tests covering backend env injection, loopback proxy preservation, and CORS origin merging

## Test plan
- [x] `uv run pytest tests/cli/test_service_manager.py tests/server/test_app_cors.py -q`
- [ ] Manual verification: `flocks start --server-host <remote-ip> --webui-host <remote-ip>` and open from another machine
- [ ] Manual verification: localhost proxy mode still works with `127.0.0.1`

Made with [Cursor](https://cursor.com)