### PR TITLE
fix(tool): preserve compact list descriptions and support long detail content

### DIFF
--- a/webui/src/pages/Tool/ToolDetailDrawer.test.tsx
+++ b/webui/src/pages/Tool/ToolDetailDrawer.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ToolDetailDrawer } from './index';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === 'toolDetail.params' && typeof options?.count === 'number') {
+        return `参数 (${options.count}个)`;
+      }
+
+      const translations: Record<string, string> = {
+        'toolDetail.tabInfo': '详情',
+        'toolDetail.tabTest': '测试',
+        'toolDetail.description': '描述',
+        'toolDetail.status': '状态',
+        'toolDetail.security': '安全',
+        'toolDetail.requiresConfirmation': '执行需确认',
+        'toolDetail.paramName': '名称',
+        'toolDetail.paramType': '类型',
+        'toolDetail.paramRequired': '必填',
+        'toolDetail.paramDesc': '描述',
+        'toolDetail.yes': '是',
+        'toolDetail.no': '否',
+        'toolDetail.close': '关闭',
+        'toolDetail.testTool': '测试工具',
+        'toolDetail.enabled': '启用',
+        'toolDetail.disabled': '禁用',
+      };
+
+      return translations[key] ?? key;
+    },
+    i18n: { language: 'zh-CN' },
+  }),
+}));
+
+vi.mock('@/api/tool', () => ({
+  canDirectlyTestTool: vi.fn(() => true),
+  toolAPI: {
+    setEnabled: vi.fn(),
+    resetSetting: vi.fn(),
+  },
+}));
+
+describe('ToolDetailDrawer', () => {
+  it('wraps long descriptions and parameter text without clipping', () => {
+    const longDescription = 'OneSEC DNS grouped tool. dns_search_blocked_queries_by_super_long_keyword_with_no_breaks_and_more_details_to_force_wrapping';
+    const longParamDescription = 'DNS 分组动作名 dns_search_blocked_queries_by_super_long_keyword_with_no_breaks_and_more_details_to_force_wrapping';
+
+    render(
+      <ToolDetailDrawer
+        tool={{
+          name: 'onesec_dns',
+          description: longDescription,
+          source: 'custom',
+          source_name: 'OneSEC',
+          category: 'custom',
+          enabled: true,
+          parameters: [
+            {
+              name: 'action',
+              type: 'string',
+              required: true,
+              description: longParamDescription,
+            },
+          ],
+        } as any}
+        testParams="{}"
+        testResult={null}
+        testing={false}
+        onClose={vi.fn()}
+        onTestParamsChange={vi.fn()}
+        onTest={vi.fn()}
+      />,
+    );
+
+    const description = screen.getByText(longDescription);
+    expect(description).toHaveClass('whitespace-pre-wrap');
+    expect(description).toHaveClass('break-words');
+
+    const table = screen.getByRole('table');
+    expect(table).toHaveClass('table-fixed');
+
+    const paramDescriptionCell = screen.getByText(longParamDescription).closest('td');
+    expect(paramDescriptionCell).not.toBeNull();
+    expect(paramDescriptionCell?.className).toContain('whitespace-pre-wrap');
+    expect(paramDescriptionCell?.className).toContain('break-words');
+    expect(paramDescriptionCell?.className).toContain('align-top');
+  });
+});

--- a/webui/src/pages/Tool/components/APITabContent.tsx
+++ b/webui/src/pages/Tool/components/APITabContent.tsx
@@ -493,7 +493,7 @@ export default function APITabContent({
         return (
           <>
             <div className="fixed inset-0 bg-black/40 z-40" onClick={() => setSelectedServiceId(null)} />
-            <div className="fixed right-0 top-0 bottom-0 z-50 flex flex-col w-full bg-white shadow-2xl" style={{ maxWidth: DETAIL_DRAWER_WIDTH }} onClick={(e) => e.stopPropagation()}>
+            <div className="fixed right-0 top-0 bottom-0 z-50 flex min-h-0 flex-col w-full bg-white shadow-2xl" style={{ maxWidth: DETAIL_DRAWER_WIDTH }} onClick={(e) => e.stopPropagation()}>
               <div className="flex-shrink-0 border-b border-gray-200">
                 <div className="flex items-center gap-3 px-6 py-4">
                   <div className="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 bg-purple-50">
@@ -508,10 +508,10 @@ export default function APITabContent({
                   </button>
                 </div>
               </div>
-              <div className="flex-1 overflow-y-auto">
+              <div className="min-h-0 flex-1 overflow-y-auto">
                 {catalogEntry && (
                   <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
-                    <p className="text-sm text-gray-600">{getCatalogDescription(catalogEntry, i18n.language)}</p>
+                    <p className="text-sm text-gray-600 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{getCatalogDescription(catalogEntry, i18n.language)}</p>
                   </div>
                 )}
                 <APIServiceDetailPanel

--- a/webui/src/pages/Tool/components/ServiceDetailPanel.tsx
+++ b/webui/src/pages/Tool/components/ServiceDetailPanel.tsx
@@ -212,7 +212,7 @@ export function MCPServerDetailPanel({
         ))}
       </div>
 
-      <div className="p-5">
+      <div className="p-5 min-h-0">
         {detailLoading ? (
           <div className="flex justify-center py-8"><LoadingSpinner /></div>
         ) : detailTab === 'overview' ? (

--- a/webui/src/pages/Tool/components/ServiceDetailPanelApi.test.tsx
+++ b/webui/src/pages/Tool/components/ServiceDetailPanelApi.test.tsx
@@ -66,6 +66,7 @@ vi.mock('react-i18next', () => ({
         'serviceInfo.enterBaseUrl': '输入 API 地址',
         'serviceInfo.enterSecret': '输入密钥',
         'serviceInfo.enterUsername': '输入用户名',
+        'serviceInfo.enterPassword': '输入密码',
         'detail.hide': '隐藏',
         'detail.show': '显示',
         'alert.unknownError': '未知错误',
@@ -451,5 +452,34 @@ describe('APIServiceDetailPanel', () => {
         },
       }));
     });
+  });
+
+  it('keeps service tool descriptions compact in the tools tab', async () => {
+    const user = userEvent.setup();
+    const longDescription = 'OneSEC DNS grouped tool. dns_search_blocked_queries_by_super_long_keyword_with_no_breaks_and_more_details_to_force_wrapping';
+
+    render(
+      <APIServiceDetailPanel
+        serviceName="onesec_api"
+        serviceTools={[
+          {
+            name: 'onesec_dns',
+            description: longDescription,
+            enabled: true,
+          } as any,
+        ]}
+        onSelectTool={vi.fn()}
+        enabled
+        onToggleEnabled={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: '工具' }));
+
+    const description = await screen.findByText(longDescription);
+    expect(description).toHaveClass('line-clamp-1');
+    expect(description).not.toHaveClass('whitespace-pre-wrap');
+    expect(description.parentElement).not.toHaveClass('overflow-y-auto');
   });
 });

--- a/webui/src/pages/Tool/components/ToolDetailModal.tsx
+++ b/webui/src/pages/Tool/components/ToolDetailModal.tsx
@@ -66,7 +66,7 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
 
   return (
     <div className="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center z-50" onClick={onClose}>
-      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full mx-4 max-h-[85vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
+      <div className="bg-white rounded-xl shadow-2xl max-w-2xl w-full mx-4 max-h-[85vh] min-h-0 flex flex-col" onClick={(e) => e.stopPropagation()}>
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200 flex-shrink-0">
           <div className="flex items-center justify-between">
@@ -110,12 +110,12 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
         </div>
 
         {/* Body */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="min-h-0 flex-1 overflow-y-auto p-6">
           {section === 'info' ? (
             <div className="space-y-5">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1.5">{t('toolDetail.description')}</label>
-                <p className="text-sm text-gray-600 leading-relaxed">{tool.description}</p>
+                <p className="text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{tool.description}</p>
               </div>
               <div className="flex flex-wrap gap-4">
                 <div>
@@ -135,32 +135,34 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">{t('toolDetail.params', { count: tool.parameters.length })}</label>
                   <div className="bg-gray-50 rounded-lg border border-gray-200 overflow-hidden">
-                    <table className="min-w-full divide-y divide-gray-200">
+                    <div className="overflow-x-auto">
+                      <table className="min-w-full table-fixed divide-y divide-gray-200">
                       <thead className="bg-gray-100">
                         <tr>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramName')}</th>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramType')}</th>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramRequired')}</th>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramDesc')}</th>
+                          <th className="w-[28%] px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramName')}</th>
+                          <th className="w-[16%] px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramType')}</th>
+                          <th className="w-[14%] px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramRequired')}</th>
+                          <th className="w-[42%] px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramDesc')}</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-gray-200">
                         {tool.parameters.map((param, idx) => (
                           <tr key={idx}>
-                            <td className="px-4 py-2">
-                              <code className="text-xs font-mono text-gray-900 bg-white px-1.5 py-0.5 rounded border border-gray-200">{param.name}</code>
+                            <td className="px-4 py-2 align-top">
+                              <code className="text-xs font-mono text-gray-900 bg-white px-1.5 py-0.5 rounded border border-gray-200 break-all">{param.name}</code>
                             </td>
-                            <td className="px-4 py-2 text-xs text-gray-600">{param.type}</td>
-                            <td className="px-4 py-2">
+                            <td className="px-4 py-2 align-top text-xs text-gray-600 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{param.type}</td>
+                            <td className="px-4 py-2 align-top">
                               {param.required
                                 ? <span className="text-xs text-red-600 font-medium">{t('toolDetail.yes')}</span>
                                 : <span className="text-xs text-gray-400">{t('toolDetail.no')}</span>}
                             </td>
-                            <td className="px-4 py-2 text-xs text-gray-600">{param.description}</td>
+                            <td className="px-4 py-2 align-top text-xs text-gray-600 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{param.description}</td>
                           </tr>
                         ))}
                       </tbody>
-                    </table>
+                      </table>
+                    </div>
                   </div>
                 </div>
               )}

--- a/webui/src/pages/Tool/index.tsx
+++ b/webui/src/pages/Tool/index.tsx
@@ -3319,7 +3319,7 @@ function Pagination({
 // Tool Detail Drawer (cjtools-style right-side drawer)
 // ============================================================================
 
-function ToolDetailDrawer({
+export function ToolDetailDrawer({
   tool,
   testParams,
   testResult,
@@ -3407,7 +3407,7 @@ function ToolDetailDrawer({
     <>
       <div className="fixed inset-0 bg-black/40 z-40" onClick={onClose} />
 
-      <div className="fixed right-0 top-0 bottom-0 z-50 flex flex-col bg-white shadow-2xl w-[520px] max-w-full">
+      <div className="fixed right-0 top-0 bottom-0 z-50 flex min-h-0 flex-col bg-white shadow-2xl w-[520px] max-w-full">
         <div className="flex-shrink-0 border-b border-gray-200">
           <div className="flex items-center gap-3 px-6 py-4">
             <div className="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -3456,12 +3456,14 @@ function ToolDetailDrawer({
           </div>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-6 py-5">
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
           {section === 'info' ? (
             <div className="space-y-5">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1.5">{t('toolDetail.description')}</label>
-                <p className="text-sm text-gray-600 leading-relaxed">{getLocalizedToolDescription(tool, i18n.language) || t('detail.noDescription')}</p>
+                <p className="text-sm text-gray-600 leading-relaxed whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                  {getLocalizedToolDescription(tool, i18n.language) || t('detail.noDescription')}
+                </p>
               </div>
 
               <div className="flex flex-wrap gap-4 items-start">
@@ -3518,32 +3520,36 @@ function ToolDetailDrawer({
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-2">{t('toolDetail.params', { count: tool.parameters.length })}</label>
                   <div className="rounded-lg border border-gray-200 overflow-hidden">
-                    <table className="min-w-full divide-y divide-gray-200">
+                    <div className="overflow-x-auto">
+                      <table className="min-w-full table-fixed divide-y divide-gray-200">
                       <thead className="bg-gray-50">
                         <tr>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramName')}</th>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramType')}</th>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramRequired')}</th>
-                          <th className="px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramDesc')}</th>
+                          <th className="w-[28%] px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramName')}</th>
+                          <th className="w-[16%] px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramType')}</th>
+                          <th className="w-[14%] px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramRequired')}</th>
+                          <th className="w-[42%] px-4 py-2 text-left text-xs font-medium text-gray-500">{t('toolDetail.paramDesc')}</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-gray-100 bg-white">
                         {tool.parameters.map((param: any, idx: number) => (
                           <tr key={idx} className="hover:bg-gray-50">
-                            <td className="px-4 py-2.5">
-                              <code className="text-xs font-mono text-gray-900 bg-gray-100 px-1.5 py-0.5 rounded">{param.name}</code>
+                            <td className="px-4 py-2.5 align-top">
+                              <code className="text-xs font-mono text-gray-900 bg-gray-100 px-1.5 py-0.5 rounded break-all">{param.name}</code>
                             </td>
-                            <td className="px-4 py-2.5 text-xs text-gray-500">{param.type}</td>
-                            <td className="px-4 py-2.5">
+                            <td className="px-4 py-2.5 align-top text-xs text-gray-500 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{param.type}</td>
+                            <td className="px-4 py-2.5 align-top">
                               {param.required
                                 ? <span className="text-xs text-slate-700 font-medium">{t('toolDetail.yes')}</span>
                                 : <span className="text-xs text-gray-400">{t('toolDetail.no')}</span>}
                             </td>
-                            <td className="px-4 py-2.5 text-xs text-gray-600">{param.description}</td>
+                            <td className="px-4 py-2.5 align-top text-xs text-gray-600 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+                              {param.description}
+                            </td>
                           </tr>
                         ))}
                       </tbody>
-                    </table>
+                      </table>
+                    </div>
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- keep tool and API service lists compact so long descriptions do not create nested scrollbars in table cells
- fix tool detail drawers and modals so long descriptions and parameter documentation wrap correctly and remain scrollable
- add regression tests for compact list rendering and long detail content in the tool detail drawer

## Test plan
- [x] `npm --prefix webui run test:run -- src/pages/Tool/components/ServiceDetailPanelApi.test.tsx src/pages/Tool/ToolDetailDrawer.test.tsx`


Made with [Cursor](https://cursor.com)