### PR TITLE
fix(tool): preserve object and array parameter schemas

### DIFF
--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -275,6 +275,18 @@ def _coerce_params(
     """
     param_type_map = {p.name: p.type for p in parameters}
     coerced: Dict[str, Any] = {}
+
+    def _coerce_json_string(value: Any, expected_type: type[Any]) -> Any:
+        if not isinstance(value, str):
+            return value
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return value
+        if isinstance(parsed, expected_type):
+            return parsed
+        return value
+
     for k, v in kwargs.items():
         declared = param_type_map.get(k)
         if declared == ParameterType.STRING and not isinstance(v, str):
@@ -299,6 +311,22 @@ def _coerce_params(
                 v = float(v)
             except (TypeError, ValueError):
                 pass
+        elif declared == ParameterType.OBJECT and isinstance(v, str):
+            coerced_value = _coerce_json_string(v, dict)
+            if coerced_value is not v:
+                v = coerced_value
+                log.debug("tool.execute.coerce_param", {
+                    "tool": tool_name, "param": k,
+                    "original_type": "str", "coerced_to": "dict",
+                })
+        elif declared == ParameterType.ARRAY and isinstance(v, str):
+            coerced_value = _coerce_json_string(v, list)
+            if coerced_value is not v:
+                v = coerced_value
+                log.debug("tool.execute.coerce_param", {
+                    "tool": tool_name, "param": k,
+                    "original_type": "str", "coerced_to": "list",
+                })
         coerced[k] = v
     return coerced
 

--- a/flocks/tool/tool_loader.py
+++ b/flocks/tool/tool_loader.py
@@ -227,6 +227,7 @@ def _json_schema_to_params(schema: dict) -> List[ToolParameter]:
     result = []
     for name, prop in properties.items():
         json_type = prop.get("type", "string")
+        json_schema = dict(prop) if json_type in {"object", "array"} else None
         result.append(ToolParameter(
             name=name,
             type=_TYPE_MAP.get(json_type, ParameterType.STRING),
@@ -234,6 +235,7 @@ def _json_schema_to_params(schema: dict) -> List[ToolParameter]:
             required=name in required_set,
             default=prop.get("default"),
             enum=prop.get("enum"),
+            json_schema=json_schema,
         ))
     return result
 

--- a/tests/tool/test_tool_plugin.py
+++ b/tests/tool/test_tool_plugin.py
@@ -32,7 +32,10 @@ from flocks.tool.registry import (
     Tool,
     ToolCategory,
     ToolContext,
+    ToolInfo,
+    ToolParameter,
     ToolResult,
+    _coerce_params,
 )
 
 
@@ -159,6 +162,96 @@ class TestJsonSchemaToParams:
         assert types["b"] == ParameterType.BOOLEAN
         assert types["a"] == ParameterType.ARRAY
         assert types["o"] == ParameterType.OBJECT
+
+    def test_preserves_object_and_array_subschemas(self):
+        schema = {
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "description": "List of item ids",
+                    "items": {"type": "integer"},
+                    "minItems": 1,
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Configuration map",
+                    "additionalProperties": True,
+                    "properties": {
+                        "mode": {"type": "string"},
+                    },
+                },
+            },
+            "required": ["config"],
+        }
+
+        params = _json_schema_to_params(schema)
+        params_by_name = {param.name: param for param in params}
+
+        assert params_by_name["items"].json_schema == schema["properties"]["items"]
+        assert params_by_name["config"].json_schema == schema["properties"]["config"]
+
+        tool_info = ToolInfo(
+            name="test_complex_schema",
+            description="Test tool",
+            category=ToolCategory.CUSTOM,
+            parameters=params,
+        )
+        json_schema = tool_info.get_schema().to_json_schema()
+
+        assert json_schema["properties"]["items"]["items"]["type"] == "integer"
+        assert json_schema["properties"]["items"]["minItems"] == 1
+        assert json_schema["properties"]["config"]["additionalProperties"] is True
+        assert json_schema["properties"]["config"]["properties"]["mode"]["type"] == "string"
+
+
+class TestCoerceParams:
+    def test_coerces_object_and_array_json_strings(self):
+        parameters = [
+            ToolParameter(
+                name="config",
+                type=ParameterType.OBJECT,
+            ),
+            ToolParameter(
+                name="items",
+                type=ParameterType.ARRAY,
+            ),
+        ]
+
+        result = _coerce_params(
+            {
+                "config": '{"enabled": true, "retries": 3}',
+                "items": '["a", "b"]',
+            },
+            parameters,
+            tool_name="test_tool",
+        )
+
+        assert result["config"] == {"enabled": True, "retries": 3}
+        assert result["items"] == ["a", "b"]
+
+    def test_keeps_non_json_or_type_mismatch_strings(self):
+        parameters = [
+            ToolParameter(
+                name="workflow",
+                type=ParameterType.OBJECT,
+            ),
+            ToolParameter(
+                name="items",
+                type=ParameterType.ARRAY,
+            ),
+        ]
+
+        result = _coerce_params(
+            {
+                "workflow": "/tmp/workflow.json",
+                "items": '{"not": "a list"}',
+            },
+            parameters,
+            tool_name="test_tool",
+        )
+
+        assert result["workflow"] == "/tmp/workflow.json"
+        assert result["items"] == '{"not": "a list"}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve object and array child schemas when loading YAML tools so models receive the intended nested parameter structure
- coerce JSON string inputs back into dict/list values for `OBJECT` and `ARRAY` parameters without changing plain-string fallback behavior
- add regression tests for schema preservation and compatibility cases such as workflow path strings

Fixes #182.

## Test plan
- [x] `uv run pytest tests/tool/test_tool_plugin.py tests/tool/test_tool_schema_generation.py tests/workflow/test_tool_run_workflow.py -q`
