### PR TITLE
feat(wecom): support inbound file attachments

### DIFF
--- a/flocks/channel/builtin/wecom/channel.py
+++ b/flocks/channel/builtin/wecom/channel.py
@@ -419,22 +419,31 @@ def _extract_content(body: dict) -> tuple[str, Optional[str]]:
         return body.get("voice", {}).get("content", "[语音消息]"), None
 
     if msg_type == "file":
-        url = body.get("file", {}).get("url", "")
+        file_block = body.get("file", {})
+        url = file_block.get("url", "")
+        filename = str(file_block.get("filename", "") or "").strip()
+        if filename:
+            return f"[文件消息: {filename}]", url or None
         return "[文件消息]", url or None
 
     if msg_type == "mixed":
-        return _extract_mixed(body.get("mixed", {})), None
+        text, media_url = _extract_mixed(body.get("mixed", {}))
+        return text, media_url
 
     return "", None
 
 
-def _extract_mixed(mixed: dict) -> str:
-    """Flatten a mixed (图文混排) message into text."""
+def _extract_mixed(mixed: dict) -> tuple[str, Optional[str]]:
+    """Flatten a mixed (图文混排) message into text + first media URL."""
     parts: list[str] = []
+    first_media_url: Optional[str] = None
     for item in mixed.get("msg_item", []):
         item_type = item.get("msgtype", "")
         if item_type == "text":
             parts.append(item.get("text", {}).get("content", ""))
         elif item_type == "image":
             parts.append("[图片]")
-    return " ".join(parts).strip()
+            url = item.get("image", {}).get("url", "")
+            if not first_media_url and url:
+                first_media_url = url
+    return " ".join(parts).strip(), first_media_url

--- a/flocks/channel/builtin/wecom/inbound_media.py
+++ b/flocks/channel/builtin/wecom/inbound_media.py
@@ -1,0 +1,164 @@
+"""
+WeCom inbound media download helpers.
+
+Downloads and decrypts file/image media received via the WeCom AI Bot
+WebSocket channel.  WeCom encrypts all media with AES-256-CBC; the
+decryption key (``aeskey``) is provided in the message frame alongside
+the download URL.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+import re
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+from flocks.channel.base import InboundMessage
+from flocks.utils.log import Log
+
+log = Log.create(service="channel.wecom.media")
+
+_DEFAULT_MAX_INBOUND_MEDIA_BYTES = 30 * 1024 * 1024
+
+
+@dataclass
+class DownloadedInboundMedia:
+    filename: str
+    mime: str
+    url: str
+    source: dict
+
+
+def _media_storage_dir(account_id: str) -> Path:
+    return (
+        Path.home()
+        / ".flocks"
+        / "data"
+        / "channel_media"
+        / "wecom"
+        / account_id
+        / datetime.date.today().isoformat()
+    )
+
+
+def _sanitize_filename(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", name.strip())
+    return cleaned[:120] or "attachment"
+
+
+def _guess_mime_from_ext(filename: str) -> Optional[str]:
+    _, ext = os.path.splitext(filename)
+    if ext:
+        return mimetypes.guess_type(filename)[0]
+    return None
+
+
+def _guess_filename(msg: InboundMessage, media_url: str, cd_filename: Optional[str] = None) -> str:
+    raw_body = msg.raw if isinstance(msg.raw, dict) else {}
+    msg_type = raw_body.get("msgtype", "")
+
+    if msg_type == "file":
+        raw_name = str(raw_body.get("file", {}).get("filename", "") or "").strip()
+        if raw_name:
+            return _sanitize_filename(raw_name)
+
+    if msg_type == "image":
+        raw_name = str(raw_body.get("image", {}).get("filename", "") or "").strip()
+        if raw_name:
+            return _sanitize_filename(raw_name)
+
+    if cd_filename:
+        return _sanitize_filename(cd_filename)
+
+    url_path = urlparse(media_url).path
+    url_filename = os.path.basename(url_path)
+    if url_filename and "." in url_filename:
+        return _sanitize_filename(url_filename)
+
+    prefix = "image" if msg_type == "image" else "file"
+    msg_id = msg.message_id or "unknown"
+    return _sanitize_filename(f"{prefix}_{msg_id[:12]}")
+
+
+def _extract_aes_key(msg: InboundMessage) -> Optional[str]:
+    raw_body = msg.raw if isinstance(msg.raw, dict) else {}
+    msg_type = raw_body.get("msgtype", "")
+
+    if msg_type == "file":
+        return str(raw_body.get("file", {}).get("aeskey", "") or "").strip() or None
+    if msg_type == "image":
+        return str(raw_body.get("image", {}).get("aeskey", "") or "").strip() or None
+    return None
+
+
+async def download_inbound_media(
+    msg: InboundMessage,
+    config: dict,
+    *,
+    max_bytes: int = _DEFAULT_MAX_INBOUND_MEDIA_BYTES,
+) -> Optional[DownloadedInboundMedia]:
+    media_url = msg.media_url
+    if not media_url:
+        return None
+
+    aes_key = _extract_aes_key(msg)
+
+    try:
+        from wecom_aibot_sdk import WeComApiClient, decrypt_file
+        api_client = WeComApiClient(log, timeout=30000)
+        result = await api_client.download_file_raw(media_url)
+        buffer: bytes = result["buffer"]
+        cd_filename: Optional[str] = result.get("filename")
+        await api_client._client.aclose()
+
+        if aes_key:
+            buffer = decrypt_file(buffer, aes_key)
+
+    except ImportError:
+        log.warning("wecom.media.sdk_not_available")
+        return None
+
+    except Exception as e:
+        log.warning("wecom.media.download_failed", {
+            "url": media_url[:200],
+            "error": str(e),
+        })
+        return None
+
+    if len(buffer) > max_bytes:
+        raise ValueError(
+            f"WeCom inbound media too large: >{max_bytes // (1024 * 1024)}MB"
+        )
+
+    filename = _guess_filename(msg, media_url, cd_filename)
+
+    if not filename or "." not in filename:
+        guessed_mime = _guess_mime_from_ext(filename or "")
+        ext = mimetypes.guess_extension(guessed_mime) if guessed_mime else ""
+        if ext:
+            filename = f"{filename}{ext}"
+
+    mime = _guess_mime_from_ext(filename) or "application/octet-stream"
+
+    storage_dir = _media_storage_dir(msg.account_id or "default")
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    msg_id = msg.message_id or "unknown"
+    file_path = storage_dir / _sanitize_filename(f"{msg_id}_{filename}")
+    file_path.write_bytes(buffer)
+
+    return DownloadedInboundMedia(
+        filename=filename,
+        mime=mime,
+        url=file_path.resolve().as_uri(),
+        source={
+            "channel": "wecom",
+            "account_id": msg.account_id,
+            "message_id": msg.message_id,
+            "media_url": msg.media_url,
+        },
+    )

--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -980,29 +980,62 @@ class InboundDispatcher:
 
         message = await Message.create(**create_kwargs)
 
-        if msg.channel_id != "feishu" or not msg.media_url or channel_config is None:
+        if not msg.media_url or channel_config is None:
             return
 
-        try:
-            from flocks.channel.builtin.feishu.inbound_media import download_inbound_media
+        raw_cfg = channel_config.model_dump(by_alias=True, exclude_none=True)
 
-            raw_cfg = channel_config.model_dump(by_alias=True, exclude_none=True)
-            media = await download_inbound_media(msg, raw_cfg)
+        try:
+            media = await _download_channel_media(msg, raw_cfg)
             if not media:
                 return
 
-            await Message.store_part(
-                session_id,
-                message.id,
-                FilePart(
-                    sessionID=session_id,
-                    messageID=message.id,
-                    mime=media.mime,
-                    filename=media.filename,
-                    url=media.url,
-                    source=media.source,
-                ),
+            file_part = FilePart(
+                sessionID=session_id,
+                messageID=message.id,
+                mime=media.mime,
+                filename=media.filename,
+                url=media.url,
+                source=media.source,
             )
+            await Message.store_part(session_id, message.id, file_part)
+
+            try:
+                from flocks.session.message import TextPart
+                parts = await Message.parts(message.id, session_id=session_id)
+                for p in parts:
+                    if p.type == "text" and hasattr(p, "text") and (
+                        p.text in ("[文件消息]", "[图片消息]")
+                        or p.text.startswith("[文件消息:")
+                    ):
+                        from pathlib import PurePosixPath
+                        file_path_str = media.url.replace("file://", "")
+                        try:
+                            display_path = str(PurePosixPath(file_path_str))
+                        except Exception:
+                            display_path = file_path_str
+                        new_text = f"Attached files:\n- {display_path}"
+                        updated = TextPart(
+                            id=p.id,
+                            sessionID=session_id,
+                            messageID=message.id,
+                            type="text",
+                            text=new_text,
+                        )
+                        await Message.store_part(session_id, message.id, updated)
+                        break
+            except Exception:
+                pass
+
+            try:
+                from flocks.server.routes.event import publish_event
+                part_event = file_part.model_dump(by_alias=True, exclude_none=True)
+                await publish_event("message.part.updated", {
+                    "part": part_event,
+                    "sessionID": session_id,
+                })
+            except Exception:
+                pass
         except Exception as e:
             log.warning("dispatcher.inbound_media_download_failed", {
                 "channel_id": msg.channel_id,
@@ -1205,3 +1238,16 @@ async def _fetch_quoted_message(
 # 权限错误通知冷却时间（同一账号 5 分钟内只通知一次）
 _PERM_NOTICE_COOLDOWN = 300
 _perm_notice_last: dict[str, float] = {}
+
+
+async def _download_channel_media(msg: InboundMessage, config: dict):
+    """Dispatch inbound media download to the appropriate channel handler."""
+    if msg.channel_id == "feishu":
+        from flocks.channel.builtin.feishu.inbound_media import download_inbound_media
+        return await download_inbound_media(msg, config)
+
+    if msg.channel_id == "wecom":
+        from flocks.channel.builtin.wecom.inbound_media import download_inbound_media
+        return await download_inbound_media(msg, config)
+
+    return None

--- a/tests/channel/test_wecom.py
+++ b/tests/channel/test_wecom.py
@@ -375,6 +375,21 @@ class TestParseFrame:
                 "chattype": "single",
                 "from": {"userid": "u1"},
                 "msgtype": "file",
+                "file": {"url": "https://example.com/file.pdf", "filename": "report.pdf"},
+            }
+        }
+        msg = _parse_frame(frame, {})
+        assert msg is not None
+        assert msg.text == "[文件消息: report.pdf]"
+        assert msg.media_url == "https://example.com/file.pdf"
+
+    def test_file_message_no_filename(self):
+        frame = {
+            "body": {
+                "msgid": "msg005b",
+                "chattype": "single",
+                "from": {"userid": "u1"},
+                "msgtype": "file",
                 "file": {"url": "https://example.com/file.pdf"},
             }
         }
@@ -453,16 +468,26 @@ class TestExtractContent:
 
 class TestExtractMixed:
     def test_mixed_text_and_image(self):
-        result = _extract_mixed({
+        result_text, result_media = _extract_mixed({
             "msg_item": [
                 {"msgtype": "text", "text": {"content": "A"}},
                 {"msgtype": "image", "image": {"url": "https://x.com/b.png"}},
                 {"msgtype": "text", "text": {"content": "B"}},
             ]
         })
-        assert "A" in result
-        assert "[图片]" in result
-        assert "B" in result
+        assert "A" in result_text
+        assert "[图片]" in result_text
+        assert "B" in result_text
+        assert result_media == "https://x.com/b.png"
+
+    def test_mixed_no_image(self):
+        result_text, result_media = _extract_mixed({
+            "msg_item": [
+                {"msgtype": "text", "text": {"content": "hello"}},
+            ]
+        })
+        assert result_text == "hello"
+        assert result_media is None
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add inbound file attachment support for WeCom channel
- download and decrypt WeCom file messages using the SDK `aeskey`
- persist downloaded files locally and expose them as `FilePart`

## Details

This PR adds actual file ingestion support for the WeCom channel.

Previously, inbound WeCom file messages were reduced to placeholder text such as `[文件消息]`, and the real file content was not available to downstream agents.

### Changes

- update `flocks/channel/builtin/wecom/channel.py`
  - preserve file metadata from inbound WeCom messages
  - extract media URL and filename from file messages

- add `flocks/channel/builtin/wecom/inbound_media.py`
  - download WeCom inbound media
  - decrypt file payloads using the message `aeskey`
  - infer filename and MIME type
  - persist files under local media storage

- update `flocks/channel/inbound/dispatcher.py`
  - route WeCom media through inbound download handling
  - store downloaded files as `FilePart`
  - replace placeholder file text with attached local file paths

- update `tests/channel/test_wecom.py`
  - add coverage for filename-aware file parsing
  - add fallback coverage when filename is missing

## Why

WeCom file messages are encrypted and require SDK-assisted download plus AES decryption before they can be used.

This change makes inbound WeCom files available to the chat/session pipeline as real local attachments rather than placeholder text only.
