### PR TITLE
feat(wecom): support inbound and outbound file attachments

### DIFF
--- a/flocks/channel/builtin/wecom/channel.py
+++ b/flocks/channel/builtin/wecom/channel.py
@@ -190,6 +190,65 @@ class WeComChannel(ChannelPlugin):
                 success=False, error=str(e), retryable=retryable,
             )
 
+    async def send_media(self, ctx: OutboundContext) -> DeliveryResult:
+        if not self._ws_client:
+            return DeliveryResult(
+                channel_id="wecom", message_id="",
+                success=False, error="WebSocket not connected",
+            )
+        if not ctx.media_url:
+            return await self.send_text(ctx)
+
+        try:
+            from flocks.channel.builtin.wecom.media import prepare_wecom_media
+
+            media = await prepare_wecom_media(ctx.media_url)
+            upload = await self._ws_client.upload_media(
+                media.data,
+                type=media.media_type,
+                filename=media.filename,
+            )
+            media_id = upload.get("media_id", "")
+            if not media_id:
+                raise RuntimeError(f"WeCom media upload failed: {upload}")
+
+            frame = (
+                self._frame_cache.pop(ctx.reply_to_id, None)
+                if ctx.reply_to_id else None
+            )
+            if frame:
+                sent = await self._ws_client.reply_media(
+                    frame,
+                    media.media_type,
+                    media_id,
+                    video_title=media.filename if media.media_type == "video" else None,
+                )
+            else:
+                sent = await self._ws_client.send_media_message(
+                    ctx.to,
+                    media.media_type,
+                    media_id,
+                    video_title=media.filename if media.media_type == "video" else None,
+                )
+
+            # WeCom's media payload does not carry companion text. Keep the
+            # attachment first, then send text as a separate message.
+            if ctx.text:
+                await self.send_text(OutboundContext(**{**vars(ctx), "media_url": None}))
+
+            self.record_message()
+            return DeliveryResult(
+                channel_id="wecom",
+                message_id=_extract_sent_message_id(sent),
+                chat_id=ctx.to,
+            )
+        except Exception as e:
+            retryable = "timeout" in str(e).lower() or "rate limit" in str(e).lower()
+            return DeliveryResult(
+                channel_id="wecom", message_id="",
+                success=False, error=str(e), retryable=retryable,
+            )
+
     def format_message(self, text: str, format_hint: str = "markdown") -> str:
         return text
 
@@ -404,6 +463,15 @@ def _parse_frame(frame: dict, config: dict) -> Optional[InboundMessage]:
     )
 
 
+def _extract_sent_message_id(frame: Any) -> str:
+    if not isinstance(frame, dict):
+        return ""
+    body = frame.get("body") or {}
+    if not isinstance(body, dict):
+        return ""
+    return str(body.get("msgid") or body.get("message_id") or "")
+
+
 def _extract_content(body: dict) -> tuple[str, Optional[str]]:
     """Extract ``(text, media_url)`` from the frame body."""
     msg_type = body.get("msgtype", "")
@@ -444,6 +512,13 @@ def _extract_mixed(mixed: dict) -> tuple[str, Optional[str]]:
         elif item_type == "image":
             parts.append("[图片]")
             url = item.get("image", {}).get("url", "")
+            if not first_media_url and url:
+                first_media_url = url
+        elif item_type == "file":
+            file_block = item.get("file", {})
+            filename = str(file_block.get("filename", "") or "").strip()
+            parts.append(f"[文件: {filename}]" if filename else "[文件]")
+            url = file_block.get("url", "")
             if not first_media_url and url:
                 first_media_url = url
     return " ".join(parts).strip(), first_media_url

--- a/flocks/channel/builtin/wecom/channel.py
+++ b/flocks/channel/builtin/wecom/channel.py
@@ -419,22 +419,31 @@ def _extract_content(body: dict) -> tuple[str, Optional[str]]:
         return body.get("voice", {}).get("content", "[语音消息]"), None
 
     if msg_type == "file":
-        url = body.get("file", {}).get("url", "")
+        file_block = body.get("file", {})
+        url = file_block.get("url", "")
+        filename = str(file_block.get("filename", "") or "").strip()
+        if filename:
+            return f"[文件消息: {filename}]", url or None
         return "[文件消息]", url or None
 
     if msg_type == "mixed":
-        return _extract_mixed(body.get("mixed", {})), None
+        text, media_url = _extract_mixed(body.get("mixed", {}))
+        return text, media_url
 
     return "", None
 
 
-def _extract_mixed(mixed: dict) -> str:
-    """Flatten a mixed (图文混排) message into text."""
+def _extract_mixed(mixed: dict) -> tuple[str, Optional[str]]:
+    """Flatten a mixed (图文混排) message into text + first media URL."""
     parts: list[str] = []
+    first_media_url: Optional[str] = None
     for item in mixed.get("msg_item", []):
         item_type = item.get("msgtype", "")
         if item_type == "text":
             parts.append(item.get("text", {}).get("content", ""))
         elif item_type == "image":
             parts.append("[图片]")
-    return " ".join(parts).strip()
+            url = item.get("image", {}).get("url", "")
+            if not first_media_url and url:
+                first_media_url = url
+    return " ".join(parts).strip(), first_media_url

--- a/flocks/channel/builtin/wecom/inbound_media.py
+++ b/flocks/channel/builtin/wecom/inbound_media.py
@@ -1,0 +1,164 @@
+"""
+WeCom inbound media download helpers.
+
+Downloads and decrypts file/image media received via the WeCom AI Bot
+WebSocket channel.  WeCom encrypts all media with AES-256-CBC; the
+decryption key (``aeskey``) is provided in the message frame alongside
+the download URL.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+import re
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+from flocks.channel.base import InboundMessage
+from flocks.utils.log import Log
+
+log = Log.create(service="channel.wecom.media")
+
+_DEFAULT_MAX_INBOUND_MEDIA_BYTES = 30 * 1024 * 1024
+
+
+@dataclass
+class DownloadedInboundMedia:
+    filename: str
+    mime: str
+    url: str
+    source: dict
+
+
+def _media_storage_dir(account_id: str) -> Path:
+    return (
+        Path.home()
+        / ".flocks"
+        / "data"
+        / "channel_media"
+        / "wecom"
+        / account_id
+        / datetime.date.today().isoformat()
+    )
+
+
+def _sanitize_filename(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", name.strip())
+    return cleaned[:120] or "attachment"
+
+
+def _guess_mime_from_ext(filename: str) -> Optional[str]:
+    _, ext = os.path.splitext(filename)
+    if ext:
+        return mimetypes.guess_type(filename)[0]
+    return None
+
+
+def _guess_filename(msg: InboundMessage, media_url: str, cd_filename: Optional[str] = None) -> str:
+    raw_body = msg.raw if isinstance(msg.raw, dict) else {}
+    msg_type = raw_body.get("msgtype", "")
+
+    if msg_type == "file":
+        raw_name = str(raw_body.get("file", {}).get("filename", "") or "").strip()
+        if raw_name:
+            return _sanitize_filename(raw_name)
+
+    if msg_type == "image":
+        raw_name = str(raw_body.get("image", {}).get("filename", "") or "").strip()
+        if raw_name:
+            return _sanitize_filename(raw_name)
+
+    if cd_filename:
+        return _sanitize_filename(cd_filename)
+
+    url_path = urlparse(media_url).path
+    url_filename = os.path.basename(url_path)
+    if url_filename and "." in url_filename:
+        return _sanitize_filename(url_filename)
+
+    prefix = "image" if msg_type == "image" else "file"
+    msg_id = msg.message_id or "unknown"
+    return _sanitize_filename(f"{prefix}_{msg_id[:12]}")
+
+
+def _extract_aes_key(msg: InboundMessage) -> Optional[str]:
+    raw_body = msg.raw if isinstance(msg.raw, dict) else {}
+    msg_type = raw_body.get("msgtype", "")
+
+    if msg_type == "file":
+        return str(raw_body.get("file", {}).get("aeskey", "") or "").strip() or None
+    if msg_type == "image":
+        return str(raw_body.get("image", {}).get("aeskey", "") or "").strip() or None
+    return None
+
+
+async def download_inbound_media(
+    msg: InboundMessage,
+    config: dict,
+    *,
+    max_bytes: int = _DEFAULT_MAX_INBOUND_MEDIA_BYTES,
+) -> Optional[DownloadedInboundMedia]:
+    media_url = msg.media_url
+    if not media_url:
+        return None
+
+    aes_key = _extract_aes_key(msg)
+
+    try:
+        from wecom_aibot_sdk import WeComApiClient, decrypt_file
+        api_client = WeComApiClient(log, timeout=30000)
+        result = await api_client.download_file_raw(media_url)
+        buffer: bytes = result["buffer"]
+        cd_filename: Optional[str] = result.get("filename")
+        await api_client._client.aclose()
+
+        if aes_key:
+            buffer = decrypt_file(buffer, aes_key)
+
+    except ImportError:
+        log.warning("wecom.media.sdk_not_available")
+        return None
+
+    except Exception as e:
+        log.warning("wecom.media.download_failed", {
+            "url": media_url[:200],
+            "error": str(e),
+        })
+        return None
+
+    if len(buffer) > max_bytes:
+        raise ValueError(
+            f"WeCom inbound media too large: >{max_bytes // (1024 * 1024)}MB"
+        )
+
+    filename = _guess_filename(msg, media_url, cd_filename)
+
+    if not filename or "." not in filename:
+        guessed_mime = _guess_mime_from_ext(filename or "")
+        ext = mimetypes.guess_extension(guessed_mime) if guessed_mime else ""
+        if ext:
+            filename = f"{filename}{ext}"
+
+    mime = _guess_mime_from_ext(filename) or "application/octet-stream"
+
+    storage_dir = _media_storage_dir(msg.account_id or "default")
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    msg_id = msg.message_id or "unknown"
+    file_path = storage_dir / _sanitize_filename(f"{msg_id}_{filename}")
+    file_path.write_bytes(buffer)
+
+    return DownloadedInboundMedia(
+        filename=filename,
+        mime=mime,
+        url=file_path.resolve().as_uri(),
+        source={
+            "channel": "wecom",
+            "account_id": msg.account_id,
+            "message_id": msg.message_id,
+            "media_url": msg.media_url,
+        },
+    )

--- a/flocks/channel/builtin/wecom/inbound_media.py
+++ b/flocks/channel/builtin/wecom/inbound_media.py
@@ -13,10 +13,11 @@ import mimetypes
 import os
 import re
 import datetime
+import importlib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
-from urllib.parse import urlparse
+from typing import Any, Optional
+from urllib.parse import unquote, urlparse
 
 from flocks.channel.base import InboundMessage
 from flocks.utils.log import Log
@@ -24,6 +25,10 @@ from flocks.utils.log import Log
 log = Log.create(service="channel.wecom.media")
 
 _DEFAULT_MAX_INBOUND_MEDIA_BYTES = 30 * 1024 * 1024
+
+
+class WeComInboundMediaTooLarge(ValueError):
+    """企微入站媒体超过允许大小。"""
 
 
 @dataclass
@@ -58,6 +63,19 @@ def _guess_mime_from_ext(filename: str) -> Optional[str]:
     return None
 
 
+def _filename_from_content_disposition(value: str) -> Optional[str]:
+    match = re.search(r'filename\*?=(?:UTF-8\'\')?"?([^";]+)"?', value, re.I)
+    if not match:
+        return None
+    return unquote(match.group(1).strip())
+
+
+def _max_size_error(max_bytes: int) -> ValueError:
+    return WeComInboundMediaTooLarge(
+        f"WeCom inbound media too large: >{max_bytes // (1024 * 1024)}MB"
+    )
+
+
 def _guess_filename(msg: InboundMessage, media_url: str, cd_filename: Optional[str] = None) -> str:
     raw_body = msg.raw if isinstance(msg.raw, dict) else {}
     msg_type = raw_body.get("msgtype", "")
@@ -71,6 +89,18 @@ def _guess_filename(msg: InboundMessage, media_url: str, cd_filename: Optional[s
         raw_name = str(raw_body.get("image", {}).get("filename", "") or "").strip()
         if raw_name:
             return _sanitize_filename(raw_name)
+
+    if msg_type == "mixed":
+        for item in raw_body.get("mixed", {}).get("msg_item", []):
+            item_type = item.get("msgtype", "")
+            if item_type == "file":
+                raw_name = str(item.get("file", {}).get("filename", "") or "").strip()
+                if raw_name:
+                    return _sanitize_filename(raw_name)
+            if item_type == "image":
+                raw_name = str(item.get("image", {}).get("filename", "") or "").strip()
+                if raw_name:
+                    return _sanitize_filename(raw_name)
 
     if cd_filename:
         return _sanitize_filename(cd_filename)
@@ -93,7 +123,71 @@ def _extract_aes_key(msg: InboundMessage) -> Optional[str]:
         return str(raw_body.get("file", {}).get("aeskey", "") or "").strip() or None
     if msg_type == "image":
         return str(raw_body.get("image", {}).get("aeskey", "") or "").strip() or None
+    if msg_type == "mixed":
+        for item in raw_body.get("mixed", {}).get("msg_item", []):
+            item_type = item.get("msgtype", "")
+            if item_type == "file":
+                key = str(item.get("file", {}).get("aeskey", "") or "").strip()
+                if key:
+                    return key
+            if item_type == "image":
+                key = str(item.get("image", {}).get("aeskey", "") or "").strip()
+                if key:
+                    return key
     return None
+
+
+async def _close_api_client(api_client: Any) -> None:
+    client = getattr(api_client, "_client", None)
+    close = getattr(client, "aclose", None)
+    if close:
+        try:
+            await close()
+        except Exception as e:
+            log.warning("wecom.media.client_close_failed", {"error": str(e)})
+
+
+async def _download_file_limited(
+    api_client: Any,
+    media_url: str,
+    max_bytes: int,
+) -> tuple[bytes, Optional[str]]:
+    client = getattr(api_client, "_client", None)
+    stream = getattr(client, "stream", None)
+    if callable(stream):
+        chunks: list[bytes] = []
+        total = 0
+        filename: Optional[str] = None
+        async with stream("GET", media_url) as resp:
+            if hasattr(resp, "raise_for_status"):
+                resp.raise_for_status()
+            headers = getattr(resp, "headers", {}) or {}
+            content_length = headers.get("content-length") or headers.get("Content-Length")
+            if content_length:
+                try:
+                    if int(content_length) > max_bytes:
+                        raise _max_size_error(max_bytes)
+                except ValueError as e:
+                    if "invalid literal" not in str(e):
+                        raise
+            content_disposition = (
+                headers.get("content-disposition")
+                or headers.get("Content-Disposition")
+                or ""
+            )
+            filename = _filename_from_content_disposition(content_disposition)
+            async for chunk in resp.aiter_bytes(8192):
+                total += len(chunk)
+                if total > max_bytes:
+                    raise _max_size_error(max_bytes)
+                chunks.append(chunk)
+        return b"".join(chunks), filename
+
+    result = await api_client.download_file_raw(media_url)
+    buffer: bytes = result["buffer"]
+    if len(buffer) > max_bytes:
+        raise _max_size_error(max_bytes)
+    return buffer, result.get("filename")
 
 
 async def download_inbound_media(
@@ -108,32 +202,52 @@ async def download_inbound_media(
 
     aes_key = _extract_aes_key(msg)
 
+    api_client = None
     try:
-        from wecom_aibot_sdk import WeComApiClient, decrypt_file
-        api_client = WeComApiClient(log, timeout=30000)
-        result = await api_client.download_file_raw(media_url)
-        buffer: bytes = result["buffer"]
-        cd_filename: Optional[str] = result.get("filename")
-        await api_client._client.aclose()
+        sdk = importlib.import_module("wecom_aibot_sdk")
+        api_client = sdk.WeComApiClient(log, timeout=30000)
+        buffer, cd_filename = await _download_file_limited(
+            api_client,
+            media_url,
+            max_bytes,
+        )
 
         if aes_key:
-            buffer = decrypt_file(buffer, aes_key)
+            try:
+                buffer = sdk.decrypt_file(buffer, aes_key)
+            except Exception as e:
+                log.warning("wecom.media.decrypt_failed", {
+                    "url": media_url[:200],
+                    "message_id": msg.message_id,
+                    "error": str(e),
+                })
+                return None
+            if len(buffer) > max_bytes:
+                raise _max_size_error(max_bytes)
 
     except ImportError:
         log.warning("wecom.media.sdk_not_available")
         return None
 
-    except Exception as e:
-        log.warning("wecom.media.download_failed", {
+    except WeComInboundMediaTooLarge as e:
+        log.warning("wecom.media.file_too_large", {
             "url": media_url[:200],
+            "message_id": msg.message_id,
             "error": str(e),
         })
         return None
 
-    if len(buffer) > max_bytes:
-        raise ValueError(
-            f"WeCom inbound media too large: >{max_bytes // (1024 * 1024)}MB"
-        )
+    except Exception as e:
+        log.warning("wecom.media.download_failed", {
+            "url": media_url[:200],
+            "message_id": msg.message_id,
+            "error": str(e),
+        })
+        return None
+
+    finally:
+        if api_client is not None:
+            await _close_api_client(api_client)
 
     filename = _guess_filename(msg, media_url, cd_filename)
 

--- a/flocks/channel/builtin/wecom/media.py
+++ b/flocks/channel/builtin/wecom/media.py
@@ -1,0 +1,106 @@
+"""
+WeCom outbound media helpers.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from urllib.parse import unquote, urlparse
+
+import httpx
+
+_DEFAULT_MAX_MEDIA_BYTES = 50 * 1024 * 1024
+WeComOutboundMediaType = Literal["file", "image", "voice", "video"]
+
+
+@dataclass
+class PreparedWeComMedia:
+    data: bytes
+    filename: str
+    media_type: WeComOutboundMediaType
+
+
+def _sanitize_filename(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", name.strip())
+    return cleaned[:120] or "attachment"
+
+
+def _media_type_from_filename(filename: str) -> WeComOutboundMediaType:
+    mime = mimetypes.guess_type(filename)[0] or ""
+    if mime.startswith("image/"):
+        return "image"
+    if mime.startswith("audio/"):
+        return "voice"
+    if mime.startswith("video/"):
+        return "video"
+    return "file"
+
+
+def _filename_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    basename = os.path.basename(parsed.path)
+    return _sanitize_filename(unquote(basename)) if basename else "attachment"
+
+
+def _path_from_media_url(media_url: str) -> Path | None:
+    parsed = urlparse(media_url)
+    if parsed.scheme == "file":
+        return Path(unquote(parsed.path))
+    if parsed.scheme:
+        return None
+    return Path(media_url)
+
+
+def _read_local_file_limited(path: Path, max_bytes: int) -> bytes:
+    if not path.is_file():
+        raise FileNotFoundError(f"WeCom media file not found: {path}")
+    size = path.stat().st_size
+    if size > max_bytes:
+        raise ValueError(f"WeCom outbound media too large: >{max_bytes // (1024 * 1024)}MB")
+    return path.read_bytes()
+
+
+async def _fetch_http_file_limited(url: str, max_bytes: int) -> tuple[bytes, str]:
+    async with httpx.AsyncClient(timeout=60) as client:
+        async with client.stream("GET", url, follow_redirects=True) as resp:
+            resp.raise_for_status()
+            content_length = resp.headers.get("content-length")
+            if content_length and int(content_length) > max_bytes:
+                raise ValueError(f"WeCom outbound media too large: >{max_bytes // (1024 * 1024)}MB")
+
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in resp.aiter_bytes(8192):
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError(f"WeCom outbound media too large: >{max_bytes // (1024 * 1024)}MB")
+                chunks.append(chunk)
+
+    return b"".join(chunks), _filename_from_url(url)
+
+
+async def prepare_wecom_media(
+    media_url: str,
+    *,
+    max_bytes: int = _DEFAULT_MAX_MEDIA_BYTES,
+) -> PreparedWeComMedia:
+    parsed = urlparse(media_url)
+    if parsed.scheme in ("http", "https"):
+        data, filename = await _fetch_http_file_limited(media_url, max_bytes)
+    else:
+        path = _path_from_media_url(media_url)
+        if path is None:
+            raise ValueError(f"Unsupported WeCom media URL scheme: {parsed.scheme}")
+        data = _read_local_file_limited(path, max_bytes)
+        filename = _sanitize_filename(path.name)
+
+    return PreparedWeComMedia(
+        data=data,
+        filename=filename,
+        media_type=_media_type_from_filename(filename),
+    )

--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -1023,6 +1023,14 @@ class InboundDispatcher:
                             text=new_text,
                         )
                         await Message.store_part(session_id, message.id, updated)
+                        try:
+                            from flocks.server.routes.event import publish_event
+                            await publish_event("message.part.updated", {
+                                "part": updated.model_dump(by_alias=True, exclude_none=True),
+                                "sessionID": session_id,
+                            })
+                        except Exception:
+                            pass
                         break
             except Exception:
                 pass

--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -980,29 +980,62 @@ class InboundDispatcher:
 
         message = await Message.create(**create_kwargs)
 
-        if msg.channel_id != "feishu" or not msg.media_url or channel_config is None:
+        if not msg.media_url or channel_config is None:
             return
 
-        try:
-            from flocks.channel.builtin.feishu.inbound_media import download_inbound_media
+        raw_cfg = channel_config.model_dump(by_alias=True, exclude_none=True)
 
-            raw_cfg = channel_config.model_dump(by_alias=True, exclude_none=True)
-            media = await download_inbound_media(msg, raw_cfg)
+        try:
+            media = await _download_channel_media(msg, raw_cfg)
             if not media:
                 return
 
-            await Message.store_part(
-                session_id,
-                message.id,
-                FilePart(
-                    sessionID=session_id,
-                    messageID=message.id,
-                    mime=media.mime,
-                    filename=media.filename,
-                    url=media.url,
-                    source=media.source,
-                ),
+            file_part = FilePart(
+                sessionID=session_id,
+                messageID=message.id,
+                mime=media.mime,
+                filename=media.filename,
+                url=media.url,
+                source=media.source,
             )
+            await Message.store_part(session_id, message.id, file_part)
+
+            try:
+                from flocks.session.message import TextPart
+                parts = await Message.parts(message.id, session_id=session_id)
+                for p in parts:
+                    if p.type == "text" and hasattr(p, "text") and (
+                        p.text in ("[文件消息]", "[图片消息]")
+                        or p.text.startswith("[文件消息:")
+                    ):
+                        from pathlib import PurePosixPath
+                        file_path_str = media.url.replace("file://", "")
+                        try:
+                            display_path = str(PurePosixPath(file_path_str))
+                        except Exception:
+                            display_path = file_path_str
+                        new_text = f"Attached files:\n- {display_path}"
+                        updated = TextPart(
+                            id=p.id,
+                            sessionID=session_id,
+                            messageID=message.id,
+                            type="text",
+                            text=new_text,
+                        )
+                        await Message.store_part(session_id, message.id, updated)
+                        break
+            except Exception:
+                pass
+
+            try:
+                from flocks.server.routes.event import publish_event
+                part_event = file_part.model_dump(by_alias=True, exclude_none=True)
+                await publish_event("message.part.updated", {
+                    "part": part_event,
+                    "sessionID": session_id,
+                })
+            except Exception:
+                pass
         except Exception as e:
             log.warning("dispatcher.inbound_media_download_failed", {
                 "channel_id": msg.channel_id,
@@ -1205,3 +1238,16 @@ async def _fetch_quoted_message(
 # 权限错误通知冷却时间（同一账号 5 分钟内只通知一次）
 _PERM_NOTICE_COOLDOWN = 300
 _perm_notice_last: dict[str, float] = {}
+
+
+async def _download_channel_media(msg: InboundMessage, config: dict):
+    """Dispatch inbound media download to the appropriate channel handler."""
+    if msg.channel_id == "feishu":
+        from flocks.channel.builtin.feishu.inbound_media import download_inbound_media
+        return await download_inbound_media(msg, config)
+
+    if msg.channel_id == "wecom":
+        from flocks.channel.builtin.wecom.inbound_media import download_inbound_media
+        return await download_inbound_media(msg, config)
+
+    return None

--- a/tests/channel/test_channel.py
+++ b/tests/channel/test_channel.py
@@ -700,6 +700,83 @@ class TestFeishuNativeCommands:
         assert stored_part.mime == "image/png"
         assert stored_part.url == "file:///tmp/diagram.png"
 
+    @pytest.mark.asyncio
+    async def test_append_user_message_stores_wecom_media_part(self, monkeypatch):
+        from flocks.channel.inbound.dispatcher import InboundDispatcher
+        from flocks.config.config import ChannelConfig
+        from flocks.session.message import TextPart
+
+        created_message = SimpleNamespace(id="message_user_1")
+        store_part = AsyncMock()
+        published = []
+
+        monkeypatch.setattr(
+            "flocks.session.message.Message.create",
+            AsyncMock(return_value=created_message),
+        )
+        monkeypatch.setattr(
+            "flocks.session.message.Message.store_part",
+            store_part,
+        )
+        monkeypatch.setattr(
+            "flocks.session.message.Message.parts",
+            AsyncMock(
+                return_value=[
+                    TextPart(
+                        id="part_text_1",
+                        sessionID="session_1",
+                        messageID="message_user_1",
+                        text="[文件消息: report.pdf]",
+                    )
+                ]
+            ),
+        )
+        monkeypatch.setattr(
+            "flocks.channel.builtin.wecom.inbound_media.download_inbound_media",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    filename="report.pdf",
+                    mime="application/pdf",
+                    url="file:///tmp/report.pdf",
+                    source={"channel": "wecom"},
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            "flocks.server.routes.event.publish_event",
+            AsyncMock(side_effect=lambda event, data: published.append((event, data))),
+        )
+
+        await InboundDispatcher._append_user_message(
+            "session_1",
+            "[文件消息: report.pdf]",
+            InboundMessage(
+                channel_id="wecom",
+                account_id="default",
+                message_id="wx_1",
+                sender_id="wx_user",
+                chat_id="wx_user",
+                chat_type=ChatType.DIRECT,
+                media_url="https://example.com/report.pdf",
+            ),
+            ChannelConfig(enabled=True, botId="bot-id", secret="secret"),
+        )
+
+        store_part.assert_awaited()
+        stored_part = store_part.await_args_list[0].args[2]
+        assert stored_part.type == "file"
+        assert stored_part.filename == "report.pdf"
+        assert stored_part.mime == "application/pdf"
+        assert stored_part.url == "file:///tmp/report.pdf"
+        assert store_part.await_args_list[1].args[2].type == "text"
+        assert store_part.await_args_list[1].args[2].text == "Attached files:\n- /tmp/report.pdf"
+        assert [event for event, _ in published] == [
+            "message.part.updated",
+            "message.part.updated",
+        ]
+        assert published[0][1]["part"]["type"] == "text"
+        assert published[1][1]["part"]["type"] == "file"
+
 
 class TestMultimodalInput:
     @pytest.mark.asyncio

--- a/tests/channel/test_wecom.py
+++ b/tests/channel/test_wecom.py
@@ -9,6 +9,9 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -16,6 +19,7 @@ import pytest
 from flocks.channel.base import (
     ChatType,
     DeliveryResult,
+    InboundMessage,
     OutboundContext,
 )
 from flocks.channel.builtin.wecom.channel import (
@@ -23,6 +27,10 @@ from flocks.channel.builtin.wecom.channel import (
     _extract_content,
     _extract_mixed,
     _parse_frame,
+)
+from flocks.channel.builtin.wecom.inbound_media import (
+    _filename_from_content_disposition,
+    download_inbound_media,
 )
 
 
@@ -169,6 +177,171 @@ class TestWeComSendText:
         assert result.success is False
         assert result.retryable is True
         assert "timeout" in result.error
+
+
+class TestWeComSendMedia:
+    async def test_send_media_uploads_and_sends_file(self, tmp_path: Path):
+        path = tmp_path / "report.pdf"
+        path.write_bytes(b"pdf-data")
+
+        ch = WeComChannel()
+        ch._config = {"botId": "b", "secret": "s"}
+        ch._ws_client = AsyncMock()
+        ch._ws_client.upload_media = AsyncMock(
+            return_value={"media_id": "media_1", "type": "file"},
+        )
+        ch._ws_client.send_media_message = AsyncMock(
+            return_value={"body": {"msgid": "wx_msg_1"}},
+        )
+
+        result = await ch.send_media(
+            OutboundContext(
+                channel_id="wecom",
+                to="zhangsan",
+                media_url=path.as_uri(),
+            )
+        )
+
+        assert result.success is True
+        assert result.message_id == "wx_msg_1"
+        ch._ws_client.upload_media.assert_awaited_once()
+        upload_args = ch._ws_client.upload_media.await_args
+        assert upload_args.args[0] == b"pdf-data"
+        assert upload_args.kwargs["type"] == "file"
+        assert upload_args.kwargs["filename"] == "report.pdf"
+        ch._ws_client.send_media_message.assert_awaited_once_with(
+            "zhangsan",
+            "file",
+            "media_1",
+            video_title=None,
+        )
+
+    async def test_send_media_replies_with_cached_frame(self, tmp_path: Path):
+        path = tmp_path / "image.png"
+        path.write_bytes(b"png-data")
+
+        ch = WeComChannel()
+        ch._config = {"botId": "b", "secret": "s"}
+        ch._ws_client = AsyncMock()
+        ch._ws_client.upload_media = AsyncMock(
+            return_value={"media_id": "media_img", "type": "image"},
+        )
+        ch._ws_client.reply_media = AsyncMock(
+            return_value={"body": {"msgid": "wx_reply_1"}},
+        )
+        frame = {"body": {"msgid": "incoming_1"}, "headers": {"req_id": "req_1"}}
+        ch._cache_frame("incoming_1", frame)
+
+        result = await ch.send_media(
+            OutboundContext(
+                channel_id="wecom",
+                to="zhangsan",
+                media_url=path.as_uri(),
+                reply_to_id="incoming_1",
+            )
+        )
+
+        assert result.success is True
+        assert result.message_id == "wx_reply_1"
+        ch._ws_client.reply_media.assert_awaited_once_with(
+            frame,
+            "image",
+            "media_img",
+            video_title=None,
+        )
+        assert ch._frame_cache.get("incoming_1") is None
+
+    async def test_send_media_not_connected(self, tmp_path: Path):
+        path = tmp_path / "report.pdf"
+        path.write_bytes(b"pdf-data")
+
+        ch = WeComChannel()
+        result = await ch.send_media(
+            OutboundContext(
+                channel_id="wecom",
+                to="zhangsan",
+                media_url=path.as_uri(),
+            )
+        )
+
+        assert result.success is False
+        assert "not connected" in result.error.lower()
+
+    async def test_send_media_upload_missing_media_id(self, tmp_path: Path):
+        path = tmp_path / "report.pdf"
+        path.write_bytes(b"pdf-data")
+
+        ch = WeComChannel()
+        ch._config = {"botId": "b", "secret": "s"}
+        ch._ws_client = AsyncMock()
+        ch._ws_client.upload_media = AsyncMock(return_value={"type": "file"})
+
+        result = await ch.send_media(
+            OutboundContext(
+                channel_id="wecom",
+                to="zhangsan",
+                media_url=path.as_uri(),
+            )
+        )
+
+        assert result.success is False
+        assert "media upload failed" in result.error
+        ch._ws_client.send_media_message.assert_not_awaited()
+
+    async def test_send_media_upload_exception(self, tmp_path: Path):
+        path = tmp_path / "report.pdf"
+        path.write_bytes(b"pdf-data")
+
+        ch = WeComChannel()
+        ch._config = {"botId": "b", "secret": "s"}
+        ch._ws_client = AsyncMock()
+        ch._ws_client.upload_media = AsyncMock(side_effect=RuntimeError("timeout"))
+
+        result = await ch.send_media(
+            OutboundContext(
+                channel_id="wecom",
+                to="zhangsan",
+                media_url=path.as_uri(),
+            )
+        )
+
+        assert result.success is False
+        assert result.retryable is True
+        assert "timeout" in result.error
+
+    async def test_send_media_with_text_sends_text_after_media(self, tmp_path: Path):
+        path = tmp_path / "report.pdf"
+        path.write_bytes(b"pdf-data")
+
+        ch = WeComChannel()
+        ch._config = {"botId": "b", "secret": "s"}
+        ch._ws_client = AsyncMock()
+        ch._ws_client.upload_media = AsyncMock(
+            return_value={"media_id": "media_1", "type": "file"},
+        )
+        ch._ws_client.send_media_message = AsyncMock(
+            return_value={"body": {"msgid": "wx_media_1"}},
+        )
+        ch._ws_client.send_message = AsyncMock(
+            return_value={"body": {"msgid": "wx_text_1"}},
+        )
+
+        result = await ch.send_media(
+            OutboundContext(
+                channel_id="wecom",
+                to="zhangsan",
+                text="这是附件说明",
+                media_url=path.as_uri(),
+            )
+        )
+
+        assert result.success is True
+        assert result.message_id == "wx_media_1"
+        ch._ws_client.send_media_message.assert_awaited_once()
+        ch._ws_client.send_message.assert_awaited_once_with(
+            "zhangsan",
+            {"msgtype": "markdown", "markdown": {"content": "这是附件说明"}},
+        )
 
 
 # ------------------------------------------------------------------
@@ -418,6 +591,34 @@ class TestParseFrame:
         assert "看这个" in msg.text
         assert "[图片]" in msg.text
 
+    def test_mixed_file_message(self):
+        frame = {
+            "body": {
+                "msgid": "msg006b",
+                "chattype": "single",
+                "from": {"userid": "u1"},
+                "msgtype": "mixed",
+                "mixed": {
+                    "msg_item": [
+                        {"msgtype": "text", "text": {"content": "看附件"}},
+                        {
+                            "msgtype": "file",
+                            "file": {
+                                "url": "https://example.com/file.bin",
+                                "filename": "report.bin",
+                                "aeskey": "k1",
+                            },
+                        },
+                    ]
+                },
+            }
+        }
+        msg = _parse_frame(frame, {})
+        assert msg is not None
+        assert "看附件" in msg.text
+        assert "[文件: report.bin]" in msg.text
+        assert msg.media_url == "https://example.com/file.bin"
+
     def test_stream_type_ignored(self):
         frame = {
             "body": {
@@ -488,6 +689,352 @@ class TestExtractMixed:
         })
         assert result_text == "hello"
         assert result_media is None
+
+    def test_mixed_text_and_file(self):
+        result_text, result_media = _extract_mixed({
+            "msg_item": [
+                {"msgtype": "text", "text": {"content": "A"}},
+                {
+                    "msgtype": "file",
+                    "file": {
+                        "url": "https://x.com/report.pdf",
+                        "filename": "report.pdf",
+                    },
+                },
+            ]
+        })
+        assert "A" in result_text
+        assert "[文件: report.pdf]" in result_text
+        assert result_media == "https://x.com/report.pdf"
+
+
+class TestContentDispositionFilename:
+    def test_filename_from_content_disposition_plain(self):
+        filename = _filename_from_content_disposition(
+            'attachment; filename="report.pdf"',
+        )
+        assert filename == "report.pdf"
+
+    def test_filename_from_content_disposition_utf8(self):
+        filename = _filename_from_content_disposition(
+            "attachment; filename*=UTF-8''%E6%8A%A5%E5%91%8A.pdf",
+        )
+        assert filename == "报告.pdf"
+
+
+# ------------------------------------------------------------------
+# 入站媒体下载
+# ------------------------------------------------------------------
+
+class TestWeComInboundMedia:
+    @pytest.mark.asyncio
+    async def test_download_inbound_media_streams_decrypts_and_closes(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        class FakeResponse:
+            headers = {
+                "content-disposition": 'attachment; filename="from-header.bin"',
+            }
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self, _size):
+                yield b"hello"
+
+        class FakeStream:
+            async def __aenter__(self):
+                return FakeResponse()
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class FakeClient:
+            def __init__(self):
+                self.closed = False
+
+            def stream(self, method, url):
+                assert method == "GET"
+                assert url == "https://example.com/file.bin"
+                return FakeStream()
+
+            async def aclose(self):
+                self.closed = True
+
+        class FakeWeComApiClient:
+            last_instance = None
+
+            def __init__(self, *_args, **_kwargs):
+                self._client = FakeClient()
+                FakeWeComApiClient.last_instance = self
+
+            async def download_file_raw(self, _url):
+                raise AssertionError("stream path should be used")
+
+        fake_sdk = types.SimpleNamespace(
+            WeComApiClient=FakeWeComApiClient,
+            decrypt_file=lambda data, key: data + key.encode(),
+        )
+        monkeypatch.setitem(sys.modules, "wecom_aibot_sdk", fake_sdk)
+        monkeypatch.setattr(
+            "flocks.channel.builtin.wecom.inbound_media._media_storage_dir",
+            lambda _account_id: tmp_path,
+        )
+
+        media = await download_inbound_media(
+            InboundMessage(
+                channel_id="wecom",
+                account_id="main",
+                message_id="msg_1",
+                sender_id="u1",
+                media_url="https://example.com/file.bin",
+                raw={
+                    "msgtype": "file",
+                    "file": {
+                        "filename": "../report.bin",
+                        "aeskey": "k1",
+                    },
+                },
+            ),
+            {},
+            max_bytes=20,
+        )
+
+        assert media is not None
+        assert media.filename == ".._report.bin"
+        assert media.mime == "application/octet-stream"
+        assert Path(media.url.removeprefix("file://")).read_bytes() == b"hellok1"
+        assert FakeWeComApiClient.last_instance._client.closed is True
+
+    @pytest.mark.asyncio
+    async def test_download_inbound_media_rejects_large_content_length(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        class FakeResponse:
+            headers = {"content-length": "30"}
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self, _size):
+                yield b"too-large"
+
+        class FakeStream:
+            async def __aenter__(self):
+                return FakeResponse()
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class FakeClient:
+            def __init__(self):
+                self.closed = False
+
+            def stream(self, *_args, **_kwargs):
+                return FakeStream()
+
+            async def aclose(self):
+                self.closed = True
+
+        class FakeWeComApiClient:
+            last_instance = None
+
+            def __init__(self, *_args, **_kwargs):
+                self._client = FakeClient()
+                FakeWeComApiClient.last_instance = self
+
+        fake_sdk = types.SimpleNamespace(
+            WeComApiClient=FakeWeComApiClient,
+            decrypt_file=lambda data, _key: data,
+        )
+        warnings = []
+        monkeypatch.setitem(sys.modules, "wecom_aibot_sdk", fake_sdk)
+        monkeypatch.setattr(
+            "flocks.channel.builtin.wecom.inbound_media._media_storage_dir",
+            lambda _account_id: tmp_path,
+        )
+        monkeypatch.setattr(
+            "flocks.channel.builtin.wecom.inbound_media.log.warning",
+            lambda event, data=None: warnings.append((event, data or {})),
+        )
+
+        media = await download_inbound_media(
+            InboundMessage(
+                channel_id="wecom",
+                account_id="main",
+                message_id="msg_2",
+                sender_id="u1",
+                media_url="https://example.com/big.bin",
+                raw={"msgtype": "file", "file": {"filename": "big.bin"}},
+            ),
+            {},
+            max_bytes=10,
+        )
+
+        assert media is None
+        assert list(tmp_path.iterdir()) == []
+        assert FakeWeComApiClient.last_instance._client.closed is True
+        assert warnings[0][0] == "wecom.media.file_too_large"
+
+    @pytest.mark.asyncio
+    async def test_download_inbound_media_decrypt_failure_returns_none(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        class FakeResponse:
+            headers = {}
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self, _size):
+                yield b"encrypted"
+
+        class FakeStream:
+            async def __aenter__(self):
+                return FakeResponse()
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class FakeClient:
+            def __init__(self):
+                self.closed = False
+
+            def stream(self, *_args, **_kwargs):
+                return FakeStream()
+
+            async def aclose(self):
+                self.closed = True
+
+        class FakeWeComApiClient:
+            last_instance = None
+
+            def __init__(self, *_args, **_kwargs):
+                self._client = FakeClient()
+                FakeWeComApiClient.last_instance = self
+
+        def fail_decrypt(_data, _key):
+            raise RuntimeError("bad aes key")
+
+        fake_sdk = types.SimpleNamespace(
+            WeComApiClient=FakeWeComApiClient,
+            decrypt_file=fail_decrypt,
+        )
+        warnings = []
+        monkeypatch.setitem(sys.modules, "wecom_aibot_sdk", fake_sdk)
+        monkeypatch.setattr(
+            "flocks.channel.builtin.wecom.inbound_media._media_storage_dir",
+            lambda _account_id: tmp_path,
+        )
+        monkeypatch.setattr(
+            "flocks.channel.builtin.wecom.inbound_media.log.warning",
+            lambda event, data=None: warnings.append((event, data or {})),
+        )
+
+        media = await download_inbound_media(
+            InboundMessage(
+                channel_id="wecom",
+                account_id="main",
+                message_id="msg_decrypt",
+                sender_id="u1",
+                media_url="https://example.com/file.bin",
+                raw={"msgtype": "file", "file": {"filename": "file.bin", "aeskey": "bad"}},
+            ),
+            {},
+            max_bytes=20,
+        )
+
+        assert media is None
+        assert list(tmp_path.iterdir()) == []
+        assert FakeWeComApiClient.last_instance._client.closed is True
+        assert warnings[0][0] == "wecom.media.decrypt_failed"
+
+    @pytest.mark.asyncio
+    async def test_download_inbound_media_mixed_file_uses_nested_aeskey(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ):
+        class FakeResponse:
+            headers = {}
+
+            def raise_for_status(self):
+                return None
+
+            async def aiter_bytes(self, _size):
+                yield b"encrypted"
+
+        class FakeStream:
+            async def __aenter__(self):
+                return FakeResponse()
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class FakeClient:
+            def stream(self, *_args, **_kwargs):
+                return FakeStream()
+
+            async def aclose(self):
+                return None
+
+        class FakeWeComApiClient:
+            def __init__(self, *_args, **_kwargs):
+                self._client = FakeClient()
+
+        captured = {}
+
+        def decrypt(data, key):
+            captured["key"] = key
+            return data + b"-ok"
+
+        fake_sdk = types.SimpleNamespace(
+            WeComApiClient=FakeWeComApiClient,
+            decrypt_file=decrypt,
+        )
+        monkeypatch.setitem(sys.modules, "wecom_aibot_sdk", fake_sdk)
+        monkeypatch.setattr(
+            "flocks.channel.builtin.wecom.inbound_media._media_storage_dir",
+            lambda _account_id: tmp_path,
+        )
+
+        media = await download_inbound_media(
+            InboundMessage(
+                channel_id="wecom",
+                account_id="main",
+                message_id="msg_mixed",
+                sender_id="u1",
+                media_url="https://example.com/file.bin",
+                raw={
+                    "msgtype": "mixed",
+                    "mixed": {
+                        "msg_item": [
+                            {"msgtype": "text", "text": {"content": "见附件"}},
+                            {
+                                "msgtype": "file",
+                                "file": {
+                                    "filename": "nested.bin",
+                                    "aeskey": "nested-key",
+                                },
+                            },
+                        ]
+                    },
+                },
+            ),
+            {},
+            max_bytes=20,
+        )
+
+        assert media is not None
+        assert captured["key"] == "nested-key"
+        assert media.filename == "nested.bin"
+        assert Path(media.url.removeprefix("file://")).read_bytes() == b"encrypted-ok"
 
 
 # ------------------------------------------------------------------

--- a/tests/channel/test_wecom.py
+++ b/tests/channel/test_wecom.py
@@ -375,6 +375,21 @@ class TestParseFrame:
                 "chattype": "single",
                 "from": {"userid": "u1"},
                 "msgtype": "file",
+                "file": {"url": "https://example.com/file.pdf", "filename": "report.pdf"},
+            }
+        }
+        msg = _parse_frame(frame, {})
+        assert msg is not None
+        assert msg.text == "[文件消息: report.pdf]"
+        assert msg.media_url == "https://example.com/file.pdf"
+
+    def test_file_message_no_filename(self):
+        frame = {
+            "body": {
+                "msgid": "msg005b",
+                "chattype": "single",
+                "from": {"userid": "u1"},
+                "msgtype": "file",
                 "file": {"url": "https://example.com/file.pdf"},
             }
         }
@@ -453,16 +468,26 @@ class TestExtractContent:
 
 class TestExtractMixed:
     def test_mixed_text_and_image(self):
-        result = _extract_mixed({
+        result_text, result_media = _extract_mixed({
             "msg_item": [
                 {"msgtype": "text", "text": {"content": "A"}},
                 {"msgtype": "image", "image": {"url": "https://x.com/b.png"}},
                 {"msgtype": "text", "text": {"content": "B"}},
             ]
         })
-        assert "A" in result
-        assert "[图片]" in result
-        assert "B" in result
+        assert "A" in result_text
+        assert "[图片]" in result_text
+        assert "B" in result_text
+        assert result_media == "https://x.com/b.png"
+
+    def test_mixed_no_image(self):
+        result_text, result_media = _extract_mixed({
+            "msg_item": [
+                {"msgtype": "text", "text": {"content": "hello"}},
+            ]
+        })
+        assert result_text == "hello"
+        assert result_media is None
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add inbound and outbound file attachment support for the WeCom channel
- download and decrypt inbound WeCom media using the SDK aeskey
- upload and send outbound WeCom media with follow-up text handling
- improve mixed message parsing and attachment-related test coverage

## Details

This PR upgrades the WeCom channel from placeholder-only file handling to a more complete attachment flow covering both inbound and outbound scenarios.

### Inbound changes

- update `flocks/channel/builtin/wecom/channel.py`
  - preserve file metadata from inbound file and mixed messages
  - extract file media URLs from mixed message items

- update `flocks/channel/builtin/wecom/inbound_media.py`
  - download inbound WeCom media with bounded size checks
  - decrypt encrypted media using the message aeskey
  - handle mixed message nested aeskey
  - improve filename extraction from Content-Disposition
  - classify failure logs for decrypt / too-large / download failures

- update `flocks/channel/inbound/dispatcher.py`
  - publish SSE updates for both `FilePart` and the rewritten text part
  - replace placeholder file text with attached local file paths

### Outbound changes

- add `flocks/channel/builtin/wecom/media.py`
  - prepare local media payloads for WeCom upload
  - infer media type and filename from outbound media paths

- update `flocks/channel/builtin/wecom/channel.py`
  - add `send_media()` support using WeCom upload + send/reply media APIs
  - handle media send followed by companion text when text is provided

### Tests

- expand `tests/channel/test_wecom.py`
  - outbound media upload / reply / missing media id / exception / text+media cases
  - mixed file parsing
  - content-disposition filename parsing
  - inbound decrypt failure / size limit / mixed nested aeskey

- update `tests/channel/test_channel.py`
  - align channel-level expectations for WeCom media capability

## Why

Previously, WeCom file messages were reduced to placeholder text and outbound file sending was not supported.

This change makes WeCom attachments usable in both directions:
- inbound files become decrypted local attachments available to the session pipeline
- outbound files can be uploaded and sent through the WeCom channel