### PR TITLE
Clean up orphaned multiprocessing workers

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -30,6 +30,7 @@ except ImportError:  # pragma: no cover - unavailable on Windows
 
 MIN_NODE_MAJOR = 22
 FOLLOW_POLL_INTERVAL = 0.5
+ORPHAN_WORKER_MARKER = "multiprocessing.spawn"
 
 
 class ServiceError(RuntimeError):
@@ -927,7 +928,8 @@ def _current_stop_targets(
     """Refresh the pid list that stop_one() should verify or force kill."""
     result = append_unique_pids([], tracked_pids)
     result = append_unique_pids(result, _runtime_record_pids(record))
-    return append_unique_pids(result, port_owner_pids(port))
+    result = append_unique_pids(result, port_owner_pids(port))
+    return append_unique_pids(result, orphaned_flocks_worker_pids())
 
 
 def signal_process_group(sig: signal.Signals, pgid: int | None) -> None:
@@ -951,6 +953,7 @@ def stop_one(port: int, pid_file: Path, name: str, console) -> None:
     if tracked_pid is not None:
         target_pids = append_unique_pids(target_pids, collect_process_tree_pids(tracked_pid))
     target_pids = append_unique_pids(target_pids, listeners)
+    target_pids = append_unique_pids(target_pids, orphaned_flocks_worker_pids())
 
     group_running = process_group_is_running(runtime_record.pgid if runtime_record else None)
     if not target_pids and not group_running:
@@ -1352,6 +1355,103 @@ def child_pids(pid: int) -> list[int]:
         if len(parts) == 2 and parts[0].isdigit() and parts[1].isdigit() and int(parts[1]) == pid:
             result.append(int(parts[0]))
     return result
+
+
+def _process_table_rows() -> list[tuple[int, int, str]]:
+    """Return ``(pid, ppid, command)`` rows for Unix process inspection."""
+    if sys.platform == "win32":
+        return []
+    try:
+        completed = subprocess.run(
+            ["ps", "-eo", "pid=,ppid=,command="],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return []
+    if completed.returncode != 0:
+        return []
+
+    rows: list[tuple[int, int, str]] = []
+    for line in completed.stdout.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
+            continue
+        rows.append((int(parts[0]), int(parts[1]), parts[2]))
+    return rows
+
+
+def _process_lsof_output(pid: int) -> str:
+    """Return lsof output for *pid*, or an empty string when unavailable."""
+    if sys.platform == "win32" or not which("lsof"):
+        return ""
+    try:
+        completed = subprocess.run(
+            ["lsof", "-nP", "-p", str(pid)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return ""
+    return (completed.stdout or "") + (completed.stderr or "")
+
+
+def _path_marker(path: Path) -> str:
+    """Normalize a path marker for substring checks against lsof output."""
+    try:
+        return str(path.expanduser().resolve())
+    except OSError:
+        return str(path.expanduser())
+
+
+def _flocks_process_markers() -> list[str]:
+    """Return filesystem markers that identify workers belonging to this install."""
+    root = repo_root()
+    state_root = flocks_root()
+    markers = [
+        _path_marker(root),
+        _path_marker(root / ".venv"),
+        _path_marker(state_root),
+    ]
+    return [marker for marker in dict.fromkeys(markers) if marker]
+
+
+def _is_orphaned_flocks_worker(pid: int, ppid: int, command: str, markers: Sequence[str]) -> bool:
+    """Return True for orphaned multiprocessing workers from this Flocks install."""
+    if sys.platform == "win32" or pid <= 0 or ppid != 1:
+        return False
+    if ORPHAN_WORKER_MARKER not in command:
+        return False
+    if "Python" not in command and "python" not in command:
+        return False
+
+    opened = _process_lsof_output(pid)
+    if not opened:
+        return False
+    return any(marker in opened for marker in markers)
+
+
+def orphaned_flocks_worker_pids() -> list[int]:
+    """Find orphaned Python multiprocessing workers owned by this Flocks install.
+
+    These workers can survive if the backend process exits before Python's
+    multiprocessing children are reaped.  Once reparented to PID 1 they are no
+    longer reachable through the backend pid tree or process group, and they do
+    not necessarily listen on the backend port.
+    """
+    if sys.platform == "win32":
+        return []
+    markers = _flocks_process_markers()
+    if not markers:
+        return []
+
+    pids: list[int] = []
+    for pid, ppid, command in _process_table_rows():
+        if _is_orphaned_flocks_worker(pid, ppid, command, markers):
+            pids.append(pid)
+    return pids
 
 
 def signal_pid_list(sig: signal.Signals, pids: Iterable[int]) -> None:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -1316,6 +1316,85 @@ def test_stop_one_keeps_runtime_record_when_force_kill_still_times_out(monkeypat
     assert pid_file.exists()
 
 
+def test_orphaned_flocks_worker_pids_requires_spawn_marker_and_flocks_files(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "flocks"
+    state = tmp_path / ".flocks"
+    repo.mkdir()
+    state.mkdir()
+
+    monkeypatch.setattr(service_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(service_manager, "repo_root", lambda: repo)
+    monkeypatch.setattr(service_manager, "flocks_root", lambda: state)
+    monkeypatch.setattr(
+        service_manager,
+        "_process_table_rows",
+        lambda: [
+            (
+                444,
+                1,
+                "/opt/homebrew/bin/Python -c from multiprocessing.spawn import spawn_main; "
+                "spawn_main(tracker_fd=5, pipe_handle=7) --multiprocessing-fork",
+            ),
+            (
+                555,
+                1,
+                "/opt/homebrew/bin/Python -c from multiprocessing.spawn import spawn_main; "
+                "spawn_main(tracker_fd=5, pipe_handle=7) --multiprocessing-fork",
+            ),
+            (
+                666,
+                123,
+                "/opt/homebrew/bin/Python -c from multiprocessing.spawn import spawn_main; "
+                "spawn_main(tracker_fd=5, pipe_handle=7) --multiprocessing-fork",
+            ),
+            (777, 1, "/opt/homebrew/bin/Python /tmp/other.py"),
+        ],
+    )
+    monkeypatch.setattr(
+        service_manager,
+        "_process_lsof_output",
+        lambda pid: (
+            f"Python {pid} cwd DIR {repo}\nPython {pid} txt REG {repo / '.venv' / 'lib'}\n"
+            if pid == 444
+            else f"Python {pid} cwd DIR /tmp/unrelated\n"
+        ),
+    )
+
+    assert service_manager.orphaned_flocks_worker_pids() == [444]
+
+
+def test_stop_one_cleans_orphaned_flocks_workers_without_pid_file_or_listener(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "backend.pid"
+    console = DummyConsole()
+    alive = {444}
+    pid_signals: list[tuple[signal.Signals, list[int]]] = []
+
+    monkeypatch.setattr(service_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
+    monkeypatch.setattr(service_manager, "pid_is_running", lambda pid: pid in alive)
+    monkeypatch.setattr(service_manager, "process_group_is_running", lambda _pgid: False)
+    monkeypatch.setattr(service_manager, "orphaned_flocks_worker_pids", lambda: sorted(alive))
+
+    def fake_signal_pid_list(sig, pids):
+        pid_list = list(pids)
+        pid_signals.append((sig, pid_list))
+        if sig == signal.SIGTERM:
+            alive.difference_update(pid_list)
+
+    monkeypatch.setattr(service_manager, "signal_pid_list", fake_signal_pid_list)
+
+    service_manager.stop_one(8000, pid_file, "后端", console)
+
+    assert pid_signals == [(signal.SIGTERM, [444])]
+    assert console.messages[-1] == "[flocks] 后端 已停止。"
+
+
 @contextlib.contextmanager
 def _record_call(call_order: list[str], name: str):
     call_order.append(name)


### PR DESCRIPTION
## Summary

- Detect orphaned Python multiprocessing workers that belong to the current Flocks install.
- Include those orphaned workers in `flocks stop` target discovery and force-kill refreshes.
- Add regression coverage for matching only Flocks-owned orphan workers and stopping when no pid file or port listener remains.

## Evidence

On macOS, multiple stale workers were observed with PPID 1 and sustained CPU usage after the Flocks service was no longer reachable through the tracked backend pid tree:

```text
/opt/homebrew/.../Python -c from multiprocessing.spawn import spawn_main; spawn_main(...) --multiprocessing-fork
```

`lsof -p <pid>` showed those processes had cwd/open files under a Flocks checkout and its virtualenv. Because they were reparented to PID 1 and did not own the backend port, the existing stop logic could miss them: it only gathered the tracked pid tree, runtime record pids, process group, and port listeners.

This change keeps the cleanup narrow: a candidate must be a Unix PPID=1 Python multiprocessing spawn process, and `lsof` must show open files under the current Flocks repo, `.venv`, or state directory.

## Tests

```text
python -m pytest tests/cli/test_service_manager.py
66 passed
```
