### PR TITLE
fix(tool): honor SSL verify toggles for API services

### DIFF
--- a/.flocks/plugins/tools/api/ngtip_api/ngtip.handler.py
+++ b/.flocks/plugins/tools/api/ngtip_api/ngtip.handler.py
@@ -37,6 +37,22 @@ def _service_config() -> dict[str, Any]:
     return raw if isinstance(raw, dict) else {}
 
 
+def _resolve_verify_ssl(raw: dict[str, Any]) -> bool:
+    # "verify_ssl" is canonical; "ssl_verify" is accepted for backward compatibility.
+    value = raw.get("verify_ssl")
+    if value is None:
+        value = raw.get("ssl_verify")
+    if value is None:
+        custom_settings = raw.get("custom_settings", {})
+        if isinstance(custom_settings, dict):
+            value = custom_settings.get("verify_ssl", False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def _ensure_scheme(url: str) -> str:
     """Auto-prepend https:// if the URL has no scheme."""
     if url and not url.startswith(("http://", "https://")):
@@ -44,8 +60,8 @@ def _ensure_scheme(url: str) -> str:
     return url
 
 
-def _resolve_runtime_config() -> tuple[str, str, int, str]:
-    """Returns (platform_base_url, query_base_url, timeout, apikey)."""
+def _resolve_runtime_config() -> tuple[str, str, int, str, bool]:
+    """Returns (platform_base_url, query_base_url, timeout, apikey, verify_ssl)."""
     raw = _service_config()
 
     platform_base_url = _ensure_scheme(
@@ -88,7 +104,7 @@ def _resolve_runtime_config() -> tuple[str, str, int, str]:
             "NGTIP API key not found. Configure ngtip_api.apiKey in your service settings "
             "or set the NGTIP_APIKEY environment variable."
         )
-    return platform_base_url, query_base_url, timeout, apikey
+    return platform_base_url, query_base_url, timeout, apikey, _resolve_verify_ssl(raw)
 
 
 # ─── helpers ──────────────────────────────────────────────────────────────────
@@ -121,13 +137,14 @@ async def _get_request(
     url: str,
     params: dict[str, Any],
     timeout: int,
+    verify_ssl: bool,
     action: str,
 ) -> ToolResult:
     try:
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=timeout)
         ) as session:
-            async with session.get(url, params=params) as resp:
+            async with session.get(url, params=params, ssl=verify_ssl) as resp:
                 if resp.status >= 400:
                     text = await resp.text()
                     return ToolResult(success=False, error=f"HTTP {resp.status}: {text[:500]}")
@@ -143,6 +160,7 @@ async def _post_request(
     url: str,
     body: dict[str, Any],
     timeout: int,
+    verify_ssl: bool,
     action: str,
 ) -> ToolResult:
     headers = {"Content-Type": "application/json"}
@@ -150,7 +168,7 @@ async def _post_request(
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=timeout)
         ) as session:
-            async with session.post(url, json=body, headers=headers) as resp:
+            async with session.post(url, json=body, headers=headers, ssl=verify_ssl) as resp:
                 if resp.status >= 400:
                     text = await resp.text()
                     return ToolResult(success=False, error=f"HTTP {resp.status}: {text[:500]}")
@@ -451,13 +469,13 @@ async def query(ctx: ToolContext, action: str, **params: Any) -> ToolResult:
         return ToolResult(success=False, error=err)
 
     try:
-        _, query_base_url, timeout, apikey = _resolve_runtime_config()
+        _, query_base_url, timeout, apikey, verify_ssl = _resolve_runtime_config()
     except ValueError as exc:
         return ToolResult(success=False, error=str(exc))
 
     url = f"{query_base_url}{spec.path}"
     query_params = {"apikey": apikey, **spec.param_builder(params)}
-    result = await _get_request(url, query_params, timeout, action)
+    result = await _get_request(url, query_params, timeout, verify_ssl, action)
     if result.success:
         result.metadata = {**(result.metadata or {}), "api": action}
     return result
@@ -477,7 +495,7 @@ async def platform(ctx: ToolContext, action: str, **params: Any) -> ToolResult:
         return ToolResult(success=False, error=err)
 
     try:
-        platform_base_url, _, timeout, apikey = _resolve_runtime_config()
+        platform_base_url, _, timeout, apikey, verify_ssl = _resolve_runtime_config()
     except ValueError as exc:
         return ToolResult(success=False, error=str(exc))
 
@@ -487,10 +505,10 @@ async def platform(ctx: ToolContext, action: str, **params: Any) -> ToolResult:
     if spec.method.upper() == "GET":
         if not spec.skip_apikey:
             payload = {"apikey": apikey, **payload}
-        result = await _get_request(url, payload, timeout, action)
+        result = await _get_request(url, payload, timeout, verify_ssl, action)
     else:
         body = {"apikey": apikey, **payload} if not spec.skip_apikey else payload
-        result = await _post_request(url, body, timeout, action)
+        result = await _post_request(url, body, timeout, verify_ssl, action)
 
     if result.success:
         result.metadata = {**(result.metadata or {}), "api": action}

--- a/.flocks/plugins/tools/api/onesec/onesec.handler.py
+++ b/.flocks/plugins/tools/api/onesec/onesec.handler.py
@@ -41,7 +41,23 @@ def _service_config() -> dict[str, Any]:
     return raw if isinstance(raw, dict) else {}
 
 
-def _resolve_runtime_config() -> tuple[str, int, str, str]:
+def _resolve_verify_ssl(raw: dict[str, Any]) -> bool:
+    # "verify_ssl" is canonical; "ssl_verify" remains as a backward-compatible alias.
+    value = raw.get("verify_ssl")
+    if value is None:
+        value = raw.get("ssl_verify")
+    if value is None:
+        custom_settings = raw.get("custom_settings", {})
+        if isinstance(custom_settings, dict):
+            value = custom_settings.get("verify_ssl", False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _resolve_runtime_config() -> tuple[str, int, str, str, bool]:
     raw = _service_config()
     base_url = (
         _resolve_ref(raw.get("base_url"))
@@ -60,7 +76,13 @@ def _resolve_runtime_config() -> tuple[str, int, str, str]:
     combined = _resolve_ref(api_key_ref)
     if combined and "|" in combined:
         api_key, secret = combined.split("|", 1)
-        return base_url, timeout, api_key.strip(), secret.strip()
+        return (
+            base_url,
+            timeout,
+            api_key.strip(),
+            secret.strip(),
+            _resolve_verify_ssl(raw),
+        )
 
     secret_manager = _get_secret_manager()
     combined_candidates = [
@@ -71,7 +93,13 @@ def _resolve_runtime_config() -> tuple[str, int, str, str]:
     for candidate in combined_candidates:
         if candidate and "|" in candidate:
             api_key, secret = candidate.split("|", 1)
-            return base_url, timeout, api_key.strip(), secret.strip()
+            return (
+                base_url,
+                timeout,
+                api_key.strip(),
+                secret.strip(),
+                _resolve_verify_ssl(raw),
+            )
 
     api_key = (
         combined
@@ -90,7 +118,7 @@ def _resolve_runtime_config() -> tuple[str, int, str, str]:
             "OneSEC API credentials not found. Configure onesec_credentials as "
             "'api_key|secret', or set apiKey/secret separately."
         )
-    return base_url, timeout, api_key, secret
+    return base_url, timeout, api_key, secret, _resolve_verify_ssl(raw)
 
 
 def _build_auth_params(api_key: str, secret: str) -> dict[str, str]:
@@ -973,7 +1001,7 @@ ACTION_SPECS: dict[str, ActionSpec] = {
 
 async def _call_onesec_api(method: str, path: str, payload: Optional[dict[str, Any]]) -> ToolResult:
     try:
-        base_url, timeout, api_key, secret = _resolve_runtime_config()
+        base_url, timeout, api_key, secret, verify_ssl = _resolve_runtime_config()
     except ValueError as exc:
         return ToolResult(success=False, error=str(exc))
 
@@ -990,6 +1018,7 @@ async def _call_onesec_api(method: str, path: str, payload: Optional[dict[str, A
                     url,
                     params={**auth_params, **(payload or {})},
                     headers=request_headers,
+                    ssl=verify_ssl,
                 ) as resp:
                     if resp.status >= 400:
                         text = await resp.text()
@@ -1001,6 +1030,7 @@ async def _call_onesec_api(method: str, path: str, payload: Optional[dict[str, A
                     params=auth_params,
                     json=payload or {},
                     headers=request_headers,
+                    ssl=verify_ssl,
                 ) as resp:
                     if resp.status >= 400:
                         text = await resp.text()

--- a/.flocks/plugins/tools/api/qingteng/qingteng.handler.py
+++ b/.flocks/plugins/tools/api/qingteng/qingteng.handler.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import ssl
 import time
 import urllib.parse
 import http.client as httplib
@@ -44,7 +45,24 @@ def _resolve_base_url() -> str:
     return ""
 
 
-def _split_connection_target(base_url: str) -> tuple[type[httplib.HTTPConnection], str, int, str]:
+def _resolve_verify_ssl(raw_service: dict[str, Any]) -> bool:
+    value = raw_service.get("verify_ssl")
+    if value is None:
+        value = raw_service.get("ssl_verify")
+    if value is None:
+        custom_settings = raw_service.get("custom_settings", {})
+        if isinstance(custom_settings, dict):
+            value = custom_settings.get("verify_ssl", False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _split_connection_target(
+    base_url: str,
+) -> tuple[type[httplib.HTTPConnection], str, int, str, bool]:
     parsed = urllib.parse.urlparse(base_url)
     scheme = (parsed.scheme or "http").lower()
     if scheme not in {"http", "https"}:
@@ -57,7 +75,7 @@ def _split_connection_target(base_url: str) -> tuple[type[httplib.HTTPConnection
     port = parsed.port or (443 if scheme == "https" else 80)
     base_path = parsed.path.rstrip("/")
     conn_cls = httplib.HTTPSConnection if scheme == "https" else httplib.HTTPConnection
-    return conn_cls, host, port, base_path
+    return conn_cls, host, port, base_path, scheme == "https"
 
 
 def _build_request_path(base_path: str, path: str) -> str:
@@ -66,7 +84,7 @@ def _build_request_path(base_path: str, path: str) -> str:
     return f"{base_path}{path}"
 
 
-def _load_runtime_config() -> tuple[type[httplib.HTTPConnection], str, int, str, str, str] | None:
+def _load_runtime_config() -> tuple[type[httplib.HTTPConnection], str, int, str, str, str, bool, bool] | None:
     raw_service = ConfigWriter.get_api_service_raw(SERVICE_ID) or {}
     sm = get_secret_manager()
     username = _resolve_ref(raw_service.get("username")) or sm.get("qingteng_username")
@@ -74,8 +92,30 @@ def _load_runtime_config() -> tuple[type[httplib.HTTPConnection], str, int, str,
     base_url = _resolve_base_url()
     if not base_url or not username or not password:
         return None
-    conn_cls, host, port, base_path = _split_connection_target(base_url)
-    return conn_cls, host, port, base_path, username, password
+    conn_cls, host, port, base_path, is_https = _split_connection_target(base_url)
+    return (
+        conn_cls,
+        host,
+        port,
+        base_path,
+        username,
+        password,
+        _resolve_verify_ssl(raw_service),
+        is_https,
+    )
+
+
+def _open_connection(
+    conn_cls: type[httplib.HTTPConnection],
+    host: str,
+    port: int,
+    *,
+    verify_ssl: bool,
+    is_https: bool,
+):
+    if is_https and not verify_ssl:
+        return conn_cls(host, port, context=ssl._create_unverified_context())
+    return conn_cls(host, port)
 
 
 def _parse_json_response(response: Any) -> dict[str, Any]:
@@ -128,8 +168,13 @@ def _login_request(
     base_path: str,
     username: str,
     password: str,
+    *,
+    verify_ssl: bool,
+    is_https: bool,
 ) -> tuple[bool, dict[str, Any] | str, dict[str, Any] | None]:
-    conn = conn_cls(host, port)
+    conn = _open_connection(
+        conn_cls, host, port, verify_ssl=verify_ssl, is_https=is_https
+    )
     try:
         body = json.dumps({"username": username, "password": password})
         conn.request(
@@ -208,8 +253,17 @@ def _request_signed_json(
             error="Missing configuration: qingteng base_url/qingteng_host, qingteng_username, qingteng_password",
         )
 
-    conn_cls, host, port, base_path, username, password = config
-    ok, auth_result, login_payload = _login_request(conn_cls, host, port, base_path, username, password)
+    conn_cls, host, port, base_path, username, password, verify_ssl, is_https = config
+    ok, auth_result, login_payload = _login_request(
+        conn_cls,
+        host,
+        port,
+        base_path,
+        username,
+        password,
+        verify_ssl=verify_ssl,
+        is_https=is_https,
+    )
     if not ok:
         return ToolResult(success=False, error=str(auth_result), output=login_payload)
 
@@ -240,7 +294,9 @@ def _request_signed_json(
         "Authorization": f"Bearer {auth['jwt']}",
     }
 
-    conn = conn_cls(host, port)
+    conn = _open_connection(
+        conn_cls, host, port, verify_ssl=verify_ssl, is_https=is_https
+    )
     try:
         conn.request(
             method=method,

--- a/tests/tool/test_ngtip_api_tool.py
+++ b/tests/tool/test_ngtip_api_tool.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from flocks.tool.registry import ToolContext
+from flocks.tool.tool_loader import yaml_to_tool
+
+
+def _load_tool(yaml_name: str):
+    yaml_path = (
+        Path.cwd()
+        / ".flocks"
+        / "plugins"
+        / "tools"
+        / "api"
+        / "ngtip_api"
+        / yaml_name
+    )
+    raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    return yaml_to_tool(raw, yaml_path)
+
+
+class _FakeResponse:
+    def __init__(self, *, status=200, json_payload=None, text_payload=""):
+        self.status = status
+        self._json_payload = json_payload
+        self._text_payload = text_payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def json(self, content_type=None):
+        del content_type
+        return self._json_payload
+
+    async def text(self):
+        return self._text_payload
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    def get(self, url, **kwargs):
+        self.calls.append(("GET", url, kwargs))
+        return self._responses.pop(0)
+
+    def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_ngtip_query_uses_ssl_false_by_default():
+    tool = _load_tool("ngtip_query.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "response_code": 0,
+                    "data": {"resource": "8.8.8.8", "intelligence": []},
+                }
+            )
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "apikey-1"
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={
+                "apiKey": "{secret:ngtip_apikey}",
+                "query_base_url": "https://ngtip-query.local:8090",
+            },
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="query_ip",
+            resource="8.8.8.8",
+        )
+
+    assert result.success is True
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "GET"
+    assert url == "https://ngtip-query.local:8090/tip_api/v5/ip"
+    assert kwargs["params"] == {"apikey": "apikey-1", "resource": "8.8.8.8"}
+    assert kwargs["ssl"] is False
+
+
+@pytest.mark.asyncio
+async def test_ngtip_platform_honors_verify_ssl_true():
+    tool = _load_tool("ngtip_platform.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "response_code": 0,
+                    "verbose_msg": "ok",
+                    "data": {"user_id": 1},
+                }
+            )
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "apikey-1"
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={
+                "apiKey": "{secret:ngtip_apikey}",
+                "base_url": "https://ngtip.local",
+                "verify_ssl": True,
+            },
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="platform_add_user",
+            username="alice",
+            roles=["admin"],
+        )
+
+    assert result.success is True
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "POST"
+    assert url == "https://ngtip.local/tip/v5/add_user"
+    assert kwargs["json"] == {
+        "apikey": "apikey-1",
+        "username": "alice",
+        "roles": ["admin"],
+    }
+    assert kwargs["ssl"] is True

--- a/tests/tool/test_onesec_api_tool.py
+++ b/tests/tool/test_onesec_api_tool.py
@@ -134,6 +134,7 @@ async def test_onesec_dns_search_queries_uses_signed_query_params_and_doc_payloa
         "auth_timestamp": "1700000000",
         "sign": _expected_sign("api-key-1", "secret-1", 1700000000),
     }
+    assert kwargs["ssl"] is False
     assert kwargs["json"] == {
         "condition": {
             "time_from": 1699990000,
@@ -147,6 +148,47 @@ async def test_onesec_dns_search_queries_uses_signed_query_params_and_doc_payloa
             "page_items_num": 50,
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_onesec_dns_get_public_ip_list_honors_verify_ssl_true():
+    tool = _load_tool("onesec_dns.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "response_code": 0,
+                    "verbose_msg": "SUCCESS",
+                    "data": ["1.1.1.1"],
+                }
+            )
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "api-key-1|secret-1"
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={
+                "apiKey": "{secret:onesec_credentials}",
+                "verify_ssl": True,
+            },
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="dns_get_public_ip_list",
+        )
+
+    assert result.success is True
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "GET"
+    assert url == "https://console.onesec.net/open/api/client/getPublicIPList"
+    assert kwargs["ssl"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/tool/test_qingteng_api_tool.py
+++ b/tests/tool/test_qingteng_api_tool.py
@@ -56,9 +56,10 @@ class _FakeHTTPConnection:
     responses: list["_FakeHTTPResponse"] = []
     created: list["_FakeHTTPConnection"] = []
 
-    def __init__(self, host: str, port: int):
+    def __init__(self, host: str, port: int, **kwargs):
         self.host = host
         self.port = port
+        self.context = kwargs.get("context")
         self.calls: list[dict] = []
         _FakeHTTPConnection.created.append(self)
 
@@ -99,36 +100,42 @@ async def test_qingteng_assets_tool_and_handler_use_signed_sorted_query_params()
 
     module.get_secret_manager = lambda: mock_secret_manager
     module.httplib.HTTPConnection = _FakeHTTPConnection
-    module.time.time = lambda: 1700000000
+    module.httplib.HTTPSConnection = _FakeHTTPConnection
+    original_get_api_service_raw = module.ConfigWriter.get_api_service_raw
+    try:
+        module.ConfigWriter.get_api_service_raw = lambda service_id: {}
+        module.time.time = lambda: 1700000000
 
-    result = await module.assets(
-        ToolContext(session_id="test", message_id="test"),
-        action="list",
-        resource="host",
-        os_type="linux",
-        page=0,
-        size=20,
-        sorts="-lastCheckTime",
-        groups="1,2",
-        keyword="srv",
-        businessGroupId="bg-1",
-    )
+        result = await module.assets(
+            ToolContext(session_id="test", message_id="test"),
+            action="list",
+            resource="host",
+            os_type="linux",
+            page=0,
+            size=20,
+            sorts="-lastCheckTime",
+            groups="1,2",
+            keyword="srv",
+            businessGroupId="bg-1",
+        )
 
-    assert tool.info.provider == "qingteng"
-    assert result.success is True
-    assert result.metadata["api"] == "assets.list"
-    assert result.output["total"] == 1
+        assert tool.info.provider == "qingteng"
+        assert result.success is True
+        assert result.metadata["api"] == "assets.list"
+        assert result.output["total"] == 1
 
-    query_call = _FakeHTTPConnection.created[1].calls[0]
-    assert query_call["method"] == "GET"
-    assert (
-        query_call["url"]
-        == "/external/api/assets/host/linux?page=0&size=20&sorts=-lastCheckTime&groups=1%2C2&keyword=srv&businessGroupId=bg-1"
-    )
+        query_call = _FakeHTTPConnection.created[1].calls[0]
+        assert query_call["method"] == "GET"
+        assert (
+            query_call["url"]
+            == "/external/api/assets/host/linux?page=0&size=20&sorts=-lastCheckTime&groups=1%2C2&keyword=srv&businessGroupId=bg-1"
+        )
 
-    raw_sign = "corp-1businessGroupIdbg-1groups1,2keywordsrvpage0size20sorts-lastCheckTime1700000000sign-1"
-    expected_sign = hashlib.sha1(raw_sign.encode("utf-8")).hexdigest()
-    assert query_call["headers"]["sign"] == expected_sign
+        raw_sign = "corp-1businessGroupIdbg-1groups1,2keywordsrvpage0size20sorts-lastCheckTime1700000000sign-1"
+        expected_sign = hashlib.sha1(raw_sign.encode("utf-8")).hexdigest()
+        assert query_call["headers"]["sign"] == expected_sign
+    finally:
+        module.ConfigWriter.get_api_service_raw = original_get_api_service_raw
 
 
 @pytest.mark.asyncio
@@ -222,6 +229,84 @@ async def test_qingteng_assets_reads_username_and_password_from_config_refs():
 
 
 @pytest.mark.asyncio
+async def test_qingteng_https_uses_unverified_context_when_verify_ssl_false():
+    module = _load_handler_module("qingteng.handler.py", "qingteng_https_ssl_false_test")
+    mock_secret_manager = _mock_secrets()
+
+    _FakeHTTPConnection.created = []
+    _FakeHTTPConnection.responses = [
+        _FakeHTTPResponse(
+            200,
+            {"success": True, "data": {"comId": "corp-1", "jwt": "jwt-1", "signKey": "sign-1"}},
+        ),
+        _FakeHTTPResponse(200, {"rows": [{"hostname": "srv-1"}], "total": 1}),
+    ]
+
+    module.get_secret_manager = lambda: mock_secret_manager
+    module.httplib.HTTPConnection = _FakeHTTPConnection
+    module.httplib.HTTPSConnection = _FakeHTTPConnection
+    original_get_api_service_raw = module.ConfigWriter.get_api_service_raw
+    try:
+        module.ConfigWriter.get_api_service_raw = lambda service_id: {
+            "base_url": "https://qt.example.com:8443/openapi",
+            "verify_ssl": False,
+        } if service_id == "qingteng" else {}
+        module.time.time = lambda: 1700000000
+
+        result = await module.assets(
+            ToolContext(session_id="test", message_id="test"),
+            action="list",
+            resource="host",
+            os_type="linux",
+        )
+
+        assert result.success is True
+        assert _FakeHTTPConnection.created[0].context is not None
+        assert _FakeHTTPConnection.created[1].context is not None
+    finally:
+        module.ConfigWriter.get_api_service_raw = original_get_api_service_raw
+
+
+@pytest.mark.asyncio
+async def test_qingteng_https_uses_default_context_when_verify_ssl_true():
+    module = _load_handler_module("qingteng.handler.py", "qingteng_https_ssl_true_test")
+    mock_secret_manager = _mock_secrets()
+
+    _FakeHTTPConnection.created = []
+    _FakeHTTPConnection.responses = [
+        _FakeHTTPResponse(
+            200,
+            {"success": True, "data": {"comId": "corp-1", "jwt": "jwt-1", "signKey": "sign-1"}},
+        ),
+        _FakeHTTPResponse(200, {"rows": [{"hostname": "srv-1"}], "total": 1}),
+    ]
+
+    module.get_secret_manager = lambda: mock_secret_manager
+    module.httplib.HTTPConnection = _FakeHTTPConnection
+    module.httplib.HTTPSConnection = _FakeHTTPConnection
+    original_get_api_service_raw = module.ConfigWriter.get_api_service_raw
+    try:
+        module.ConfigWriter.get_api_service_raw = lambda service_id: {
+            "base_url": "https://qt.example.com:8443/openapi",
+            "verify_ssl": True,
+        } if service_id == "qingteng" else {}
+        module.time.time = lambda: 1700000000
+
+        result = await module.assets(
+            ToolContext(session_id="test", message_id="test"),
+            action="list",
+            resource="host",
+            os_type="linux",
+        )
+
+        assert result.success is True
+        assert _FakeHTTPConnection.created[0].context is None
+        assert _FakeHTTPConnection.created[1].context is None
+    finally:
+        module.ConfigWriter.get_api_service_raw = original_get_api_service_raw
+
+
+@pytest.mark.asyncio
 async def test_qingteng_assets_process_query_only_uses_process_fields():
     module = _load_handler_module("qingteng.handler.py", "qingteng_assets_process_handler_test")
     mock_secret_manager = _mock_secrets()
@@ -237,27 +322,33 @@ async def test_qingteng_assets_process_query_only_uses_process_fields():
 
     module.get_secret_manager = lambda: mock_secret_manager
     module.httplib.HTTPConnection = _FakeHTTPConnection
-    module.time.time = lambda: 1700000000
+    module.httplib.HTTPSConnection = _FakeHTTPConnection
+    original_get_api_service_raw = module.ConfigWriter.get_api_service_raw
+    try:
+        module.ConfigWriter.get_api_service_raw = lambda service_id: {}
+        module.time.time = lambda: 1700000000
 
-    result = await module.assets(
-        ToolContext(session_id="test", message_id="test"),
-        action="list",
-        resource="process",
-        os_type="linux",
-        page=0,
-        size=20,
-        processName="sshd",
-        processPath="/usr/sbin/sshd",
-        processPid=1234,
-    )
+        result = await module.assets(
+            ToolContext(session_id="test", message_id="test"),
+            action="list",
+            resource="process",
+            os_type="linux",
+            page=0,
+            size=20,
+            processName="sshd",
+            processPath="/usr/sbin/sshd",
+            processPid=1234,
+        )
 
-    assert result.success is True
+        assert result.success is True
 
-    query_call = _FakeHTTPConnection.created[1].calls[0]
-    assert (
-        query_call["url"]
-        == "/external/api/assets/process/linux?page=0&size=20&processName=sshd&processPath=%2Fusr%2Fsbin%2Fsshd&processPid=1234"
-    )
+        query_call = _FakeHTTPConnection.created[1].calls[0]
+        assert (
+            query_call["url"]
+            == "/external/api/assets/process/linux?page=0&size=20&processName=sshd&processPath=%2Fusr%2Fsbin%2Fsshd&processPid=1234"
+        )
+    finally:
+        module.ConfigWriter.get_api_service_raw = original_get_api_service_raw
 
 
 @pytest.mark.asyncio
@@ -293,29 +384,35 @@ async def test_qingteng_risk_patch_list_uses_refined_query_fields():
 
     module.get_secret_manager = lambda: mock_secret_manager
     module.httplib.HTTPConnection = _FakeHTTPConnection
-    module.time.time = lambda: 1700000000
+    module.httplib.HTTPSConnection = _FakeHTTPConnection
+    original_get_api_service_raw = module.ConfigWriter.get_api_service_raw
+    try:
+        module.ConfigWriter.get_api_service_raw = lambda service_id: {}
+        module.time.time = lambda: 1700000000
 
-    result = await module.risk(
-        ToolContext(session_id="test", message_id="test"),
-        action="patch_list",
-        os_type="linux",
-        page=0,
-        size=10,
-        severity="high",
-        status="unfixed",
-        hostId="host-1",
-        patch_name="openssl",
-        cve="CVE-2024-0001",
-        groups="10,11",
-    )
+        result = await module.risk(
+            ToolContext(session_id="test", message_id="test"),
+            action="patch_list",
+            os_type="linux",
+            page=0,
+            size=10,
+            severity="high",
+            status="unfixed",
+            hostId="host-1",
+            patch_name="openssl",
+            cve="CVE-2024-0001",
+            groups="10,11",
+        )
 
-    assert result.success is True
+        assert result.success is True
 
-    query_call = _FakeHTTPConnection.created[1].calls[0]
-    assert (
-        query_call["url"]
-        == "/external/api/vul/patch/linux/list?page=0&size=10&severity=high&status=unfixed&hostId=host-1&groups=10%2C11&patch_name=openssl&cve=CVE-2024-0001"
-    )
+        query_call = _FakeHTTPConnection.created[1].calls[0]
+        assert (
+            query_call["url"]
+            == "/external/api/vul/patch/linux/list?page=0&size=10&severity=high&status=unfixed&hostId=host-1&groups=10%2C11&patch_name=openssl&cve=CVE-2024-0001"
+        )
+    finally:
+        module.ConfigWriter.get_api_service_raw = original_get_api_service_raw
 
 
 @pytest.mark.asyncio
@@ -350,25 +447,31 @@ async def test_qingteng_risk_weakpwd_list_uses_account_specific_field():
 
     module.get_secret_manager = lambda: mock_secret_manager
     module.httplib.HTTPConnection = _FakeHTTPConnection
-    module.time.time = lambda: 1700000000
+    module.httplib.HTTPSConnection = _FakeHTTPConnection
+    original_get_api_service_raw = module.ConfigWriter.get_api_service_raw
+    try:
+        module.ConfigWriter.get_api_service_raw = lambda service_id: {}
+        module.time.time = lambda: 1700000000
 
-    result = await module.risk(
-        ToolContext(session_id="test", message_id="test"),
-        action="weakpwd_list",
-        os_type="linux",
-        page=0,
-        size=10,
-        accountName="root",
-        severity="critical",
-    )
+        result = await module.risk(
+            ToolContext(session_id="test", message_id="test"),
+            action="weakpwd_list",
+            os_type="linux",
+            page=0,
+            size=10,
+            accountName="root",
+            severity="critical",
+        )
 
-    assert result.success is True
+        assert result.success is True
 
-    query_call = _FakeHTTPConnection.created[1].calls[0]
-    assert (
-        query_call["url"]
-        == "/external/api/vul/weakpwd/linux/list?page=0&size=10&severity=critical&accountName=root"
-    )
+        query_call = _FakeHTTPConnection.created[1].calls[0]
+        assert (
+            query_call["url"]
+            == "/external/api/vul/weakpwd/linux/list?page=0&size=10&severity=critical&accountName=root"
+        )
+    finally:
+        module.ConfigWriter.get_api_service_raw = original_get_api_service_raw
 
 
 @pytest.mark.asyncio
@@ -387,27 +490,33 @@ async def test_qingteng_detect_brutecrack_list_uses_time_range_filters():
 
     module.get_secret_manager = lambda: mock_secret_manager
     module.httplib.HTTPConnection = _FakeHTTPConnection
-    module.time.time = lambda: 1700000000
+    module.httplib.HTTPSConnection = _FakeHTTPConnection
+    original_get_api_service_raw = module.ConfigWriter.get_api_service_raw
+    try:
+        module.ConfigWriter.get_api_service_raw = lambda service_id: {}
+        module.time.time = lambda: 1700000000
 
-    result = await module.detect(
-        ToolContext(session_id="test", message_id="test"),
-        action="brutecrack_list",
-        os_type="win",
-        page=1,
-        size=50,
-        ip="1.1.1.1",
-        account="admin",
-        begin_time="2025-01-01 00:00:00",
-        end_time="2025-01-02 00:00:00",
-    )
+        result = await module.detect(
+            ToolContext(session_id="test", message_id="test"),
+            action="brutecrack_list",
+            os_type="win",
+            page=1,
+            size=50,
+            ip="1.1.1.1",
+            account="admin",
+            begin_time="2025-01-01 00:00:00",
+            end_time="2025-01-02 00:00:00",
+        )
 
-    assert result.success is True
+        assert result.success is True
 
-    query_call = _FakeHTTPConnection.created[1].calls[0]
-    assert (
-        query_call["url"]
-        == "/external/api/detect/brutecrack/win?page=1&size=50&ip=1.1.1.1&account=admin&begin_time=2025-01-01+00%3A00%3A00&end_time=2025-01-02+00%3A00%3A00"
-    )
+        query_call = _FakeHTTPConnection.created[1].calls[0]
+        assert (
+            query_call["url"]
+            == "/external/api/detect/brutecrack/win?page=1&size=50&ip=1.1.1.1&account=admin&begin_time=2025-01-01+00%3A00%3A00&end_time=2025-01-02+00%3A00%3A00"
+        )
+    finally:
+        module.ConfigWriter.get_api_service_raw = original_get_api_service_raw
 
 
 @pytest.mark.asyncio
@@ -442,25 +551,31 @@ async def test_qingteng_detect_honeypot_rule_update_uses_put_and_body_signature(
 
     module.get_secret_manager = lambda: mock_secret_manager
     module.httplib.HTTPConnection = _FakeHTTPConnection
-    module.time.time = lambda: 1700000000
+    module.httplib.HTTPSConnection = _FakeHTTPConnection
+    original_get_api_service_raw = module.ConfigWriter.get_api_service_raw
+    try:
+        module.ConfigWriter.get_api_service_raw = lambda service_id: {}
+        module.time.time = lambda: 1700000000
 
-    result = await module.detect(
-        ToolContext(session_id="test", message_id="test"),
-        action="honeypot_rule_update",
-        os_type="win",
-        id="rule-1",
-        enabled=True,
-        name="demo-rule",
-        port=8080,
-        protocol="tcp",
-    )
+        result = await module.detect(
+            ToolContext(session_id="test", message_id="test"),
+            action="honeypot_rule_update",
+            os_type="win",
+            id="rule-1",
+            enabled=True,
+            name="demo-rule",
+            port=8080,
+            protocol="tcp",
+        )
 
-    assert result.success is True
-    assert result.output == {"updated": True}
+        assert result.success is True
+        assert result.output == {"updated": True}
 
-    put_call = _FakeHTTPConnection.created[1].calls[0]
-    assert put_call["method"] == "PUT"
-    assert put_call["url"] == "/external/api/detect/honeypot/win/rule"
+        put_call = _FakeHTTPConnection.created[1].calls[0]
+        assert put_call["method"] == "PUT"
+        assert put_call["url"] == "/external/api/detect/honeypot/win/rule"
+    finally:
+        module.ConfigWriter.get_api_service_raw = original_get_api_service_raw
     assert put_call["body"] == '{"id":"rule-1","name":"demo-rule","port":8080,"protocol":"tcp","enabled":true}'
 
     raw_sign = 'corp-1{"id":"rule-1","name":"demo-rule","port":8080,"protocol":"tcp","enabled":true}1700000000sign-1'


### PR DESCRIPTION
## Summary
- wire OneSEC and NGTIP API handlers to honor the configured SSL verification toggle for outgoing HTTP requests
- add HTTPS verification control to Qingteng connections and isolate its tests from local machine config
- add regression coverage for enabled and disabled SSL verification paths across the affected API services

## Test plan
- [x] `uv run pytest tests/tool/test_onesec_api_tool.py`
- [x] `uv run pytest tests/tool/test_ngtip_api_tool.py tests/tool/test_qingteng_api_tool.py`

Made with [Cursor](https://cursor.com)