### PR TITLE
feat(webui,auth): default same-origin proxy; session auth behind proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,17 @@ flocks start --server-host 127.0.0.1 --webui-host 0.0.0.0
 ```
 If remote access from a virtual machine fails, please specify the host as the virtual machine's IP.
 
+The WebUI now defaults to same-origin `/api` proxy mode even when the backend
+binds to a non-loopback IP. This keeps browser cookies and SSE on a single
+origin, which is the safest choice for LAN access and reverse proxies.
+
+Only enable direct browser-to-backend URLs when you explicitly need them:
+
+```bash
+FLOCKS_WEBUI_DIRECT_BACKEND_URLS=1 \
+flocks start --server-host 10.0.0.8 --webui-host 0.0.0.0
+```
+
 ### 4.4 Authentication & API Token
 
 Since the local-account update, every HTTP path is protected by default — only
@@ -260,6 +271,11 @@ Reverse-proxy deployments:
   proxy is in front.
 - For HTTPS termination, also forward `X-Forwarded-Proto: https` so that
   the secure-cookie flag is set correctly.
+- Prefer same-origin proxying for browser traffic: keep the WebUI on `/` and
+  route backend traffic through `/api` (and `/event` if needed). Do not set
+  `VITE_API_BASE_URL` in reverse-proxy deployments unless you intentionally
+  want the browser to bypass the proxy and talk to the backend origin directly.
+- For SSE endpoints, disable proxy buffering and keep HTTP/1.1 enabled. 
 
 Recovery / lost password:
 

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -30,6 +30,7 @@ except ImportError:  # pragma: no cover - unavailable on Windows
 
 MIN_NODE_MAJOR = 22
 FOLLOW_POLL_INTERVAL = 0.5
+WEBUI_DIRECT_BACKEND_URLS_ENV = "FLOCKS_WEBUI_DIRECT_BACKEND_URLS"
 
 
 class ServiceError(RuntimeError):
@@ -1403,8 +1404,10 @@ def build_frontend_env(config: ServiceConfig) -> dict[str, str]:
     env["FLOCKS_API_PROXY_TARGET"] = backend_url
 
     # Avoid leaking a stale Vite API target from the parent shell into a new
-    # build/start cycle.  For localhost or wildcard backends we intentionally
-    # stay on same-origin proxy mode, so the VITE_* overrides must be absent.
+    # build/start cycle.  WebUI now defaults to same-origin proxy mode for all
+    # backend hosts so that reverse-proxy / remote access deployments keep a
+    # single browser origin and cookie scope.  Direct backend URLs remain
+    # available as an explicit opt-in via WEBUI_DIRECT_BACKEND_URLS_ENV.
     env.pop("VITE_API_BASE_URL", None)
     env.pop("VITE_WS_BASE_URL", None)
     if _should_inject_direct_backend_urls(config.backend_host):
@@ -1518,5 +1521,14 @@ def _http_to_ws_url(url: str) -> str:
     return url
 
 
+def _env_flag_enabled(name: str) -> bool:
+    value = os.getenv(name)
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _should_inject_direct_backend_urls(host: str) -> bool:
-    return host not in {"127.0.0.1", "localhost", "::1", "0.0.0.0", "::"}
+    if host in {"127.0.0.1", "localhost", "::1", "0.0.0.0", "::"}:
+        return False
+    return _env_flag_enabled(WEBUI_DIRECT_BACKEND_URLS_ENV)

--- a/flocks/server/auth.py
+++ b/flocks/server/auth.py
@@ -149,6 +149,11 @@ def password_reset_exempt(path: str) -> bool:
     return path in _PASSWORD_RESET_ALLOWED
 
 
+def _has_session_cookie(request: Request) -> bool:
+    session_id = request.cookies.get(SESSION_COOKIE_NAME)
+    return bool(session_id and session_id.strip())
+
+
 def _is_browser_like_request(request: Request) -> bool:
     """
     Identify browser-originated traffic (must keep strict login checks).
@@ -156,7 +161,9 @@ def _is_browser_like_request(request: Request) -> bool:
     Modern browsers always send `sec-fetch-*` fetch-metadata headers on
     same-origin and cross-origin fetches. We rely on those, plus `origin`
     (covers older Chromium/Safari on some same-origin cases) and `referer`.
-    This is strict: non-browser clients (curl/SDKs/TUI) don't send any of these.
+    Some browser flows seen behind reverse proxies (for example EventSource)
+    can lose a subset of these headers, so we also accept an existing session
+    cookie or a typical browser UA paired with HTML/SSE Accept headers.
     """
     headers = request.headers
     if headers.get("sec-fetch-site") or headers.get("sec-fetch-mode") or headers.get("sec-fetch-dest"):
@@ -164,6 +171,17 @@ def _is_browser_like_request(request: Request) -> bool:
     if headers.get("origin"):
         return True
     if headers.get("referer"):
+        return True
+    if _has_session_cookie(request):
+        return True
+
+    user_agent = (headers.get("user-agent") or "").lower()
+    accept = (headers.get("accept") or "").lower()
+    if "mozilla/" in user_agent and (
+        "text/html" in accept
+        or "application/xhtml+xml" in accept
+        or "text/event-stream" in accept
+    ):
         return True
     return False
 
@@ -252,6 +270,32 @@ async def apply_auth_for_request(request: Request):
     if auth_middleware_exempt(request.url.path):
         token = set_current_auth_user(None)
         return None, token, None
+
+    if _has_session_cookie(request):
+        bootstrapped = await AuthService.has_users()
+        if not bootstrapped:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="系统尚未初始化管理员账号，请先完成初始化",
+            )
+
+        session_id = request.cookies.get(SESSION_COOKIE_NAME)
+        if not session_id:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="请先登录")
+
+        user = await AuthService.get_user_by_session_id(session_id)
+        if not user:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="登录已过期，请重新登录")
+
+        auth_user = user.to_auth_user()
+        request.state.auth_user = auth_user
+        token = set_current_auth_user(auth_user)
+        if auth_user.must_reset_password and not password_reset_exempt(request.url.path):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="当前账号必须先修改密码后才能继续使用",
+            )
+        return None, token, auth_user
 
     # Non-browser clients: local loopback can run without token; remote requires API token.
     if not _is_browser_like_request(request):

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -912,8 +912,8 @@ def test_build_frontend_env_uses_backend_host_and_port() -> None:
     env = service_manager.build_frontend_env(config)
 
     assert env["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
-    assert env["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
-    assert env["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
+    assert "VITE_API_BASE_URL" not in env
+    assert "VITE_WS_BASE_URL" not in env
 
 
 def test_build_frontend_env_brackets_ipv6_backend_host() -> None:
@@ -925,8 +925,8 @@ def test_build_frontend_env_brackets_ipv6_backend_host() -> None:
     env = service_manager.build_frontend_env(config)
 
     assert env["FLOCKS_API_PROXY_TARGET"] == "http://[2001:db8::1]:9000"
-    assert env["VITE_API_BASE_URL"] == "http://[2001:db8::1]:9000"
-    assert env["VITE_WS_BASE_URL"] == "ws://[2001:db8::1]:9000"
+    assert "VITE_API_BASE_URL" not in env
+    assert "VITE_WS_BASE_URL" not in env
 
 
 def test_build_frontend_env_uses_loopback_for_wildcard_backend_host() -> None:
@@ -955,6 +955,20 @@ def test_build_frontend_env_keeps_proxy_mode_for_loopback_backend_host(monkeypat
     assert env["FLOCKS_API_PROXY_TARGET"] == "http://127.0.0.1:9000"
     assert "VITE_API_BASE_URL" not in env
     assert "VITE_WS_BASE_URL" not in env
+
+
+def test_build_frontend_env_allows_direct_backend_urls_when_opted_in(monkeypatch) -> None:
+    monkeypatch.setenv(service_manager.WEBUI_DIRECT_BACKEND_URLS_ENV, "true")
+    config = service_manager.ServiceConfig(
+        backend_host="10.0.0.8",
+        backend_port=9000,
+    )
+
+    env = service_manager.build_frontend_env(config)
+
+    assert env["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
+    assert env["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
+    assert env["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
 
 
 def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tmp_path: Path) -> None:
@@ -1004,8 +1018,8 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
     assert build_calls[0]["command"] == ["/usr/bin/npm", "run", "build"]
     assert build_calls[0]["kwargs"]["env"]["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
     assert build_calls[0]["kwargs"]["env"]["__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS"] == "preview.example.com"
-    assert build_calls[0]["kwargs"]["env"]["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
-    assert build_calls[0]["kwargs"]["env"]["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
+    assert "VITE_API_BASE_URL" not in build_calls[0]["kwargs"]["env"]
+    assert "VITE_WS_BASE_URL" not in build_calls[0]["kwargs"]["env"]
 
     assert preview_calls[0]["command"] == [
         "/usr/bin/npm",
@@ -1019,12 +1033,62 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
     ]
     assert preview_calls[0]["kwargs"]["env"]["FLOCKS_API_PROXY_TARGET"] == "http://10.0.0.8:9000"
     assert preview_calls[0]["kwargs"]["env"]["__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS"] == "preview.example.com"
-    assert preview_calls[0]["kwargs"]["env"]["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
-    assert preview_calls[0]["kwargs"]["env"]["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
+    assert "VITE_API_BASE_URL" not in preview_calls[0]["kwargs"]["env"]
+    assert "VITE_WS_BASE_URL" not in preview_calls[0]["kwargs"]["env"]
     record = service_manager.read_runtime_record(paths.frontend_pid)
     assert record is not None
     assert record.host == "0.0.0.0"
     assert record.port == 5174
+
+
+def test_start_frontend_passes_direct_backend_urls_when_opted_in(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    paths.log_dir.mkdir(parents=True)
+    console = DummyConsole()
+    build_calls: list[dict[str, object]] = []
+    preview_calls: list[dict[str, object]] = []
+
+    def fake_run(command, **kwargs):
+        build_calls.append({"command": command, "kwargs": kwargs})
+        return SimpleNamespace(returncode=0)
+
+    def fake_spawn(command, **kwargs):
+        preview_calls.append({"command": command, "kwargs": kwargs})
+        return SimpleNamespace(pid=2468)
+
+    monkeypatch.setattr(service_manager, "ensure_install_layout", lambda: tmp_path)
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _path: None)
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
+    monkeypatch.setattr(service_manager, "wait_for_http", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(service_manager.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(service_manager, "resolve_npm_executable", lambda: "/usr/bin/npm")
+    monkeypatch.setattr(service_manager, "node_version_satisfies_requirement", lambda: True)
+    monkeypatch.setattr(service_manager.subprocess, "run", fake_run)
+    monkeypatch.setattr(service_manager, "_spawn_process", fake_spawn)
+    monkeypatch.setenv(service_manager.WEBUI_DIRECT_BACKEND_URLS_ENV, "true")
+
+    config = service_manager.ServiceConfig(
+        backend_host="10.0.0.8",
+        backend_port=9000,
+        frontend_host="0.0.0.0",
+        frontend_port=5174,
+    )
+    service_manager.start_frontend(config, console)
+
+    assert build_calls[0]["kwargs"]["env"]["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
+    assert build_calls[0]["kwargs"]["env"]["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
+    assert preview_calls[0]["kwargs"]["env"]["VITE_API_BASE_URL"] == "http://10.0.0.8:9000"
+    assert preview_calls[0]["kwargs"]["env"]["VITE_WS_BASE_URL"] == "ws://10.0.0.8:9000"
 
 
 def test_start_frontend_prefers_bundled_npm_over_path_lookup(monkeypatch, tmp_path: Path) -> None:

--- a/tests/server/test_auth_compat.py
+++ b/tests/server/test_auth_compat.py
@@ -185,6 +185,90 @@ async def test_apply_auth_for_request_treats_referer_only_remote_request_as_brow
         auth_module.clear_auth_context(token)
 
 
+@pytest.mark.asyncio
+async def test_apply_auth_for_request_session_cookie_takes_precedence_over_loopback_service(monkeypatch):
+    async def _has_users():
+        return True
+
+    async def _get_user_by_session_id(_session_id: str):
+        return _FakeLocalUser(must_reset_password=False)
+
+    monkeypatch.setattr(auth_module.AuthService, "has_users", _has_users)
+    monkeypatch.setattr(auth_module.AuthService, "get_user_by_session_id", _get_user_by_session_id)
+    monkeypatch.setattr(
+        auth_module,
+        "get_secret_manager",
+        lambda: _FakeSecrets({auth_module.API_TOKEN_SECRET_ID: "abc123"}),
+    )
+
+    request = _make_request(
+        headers={
+            "user-agent": "curl/8.0",
+            "cookie": f"{auth_module.SESSION_COOKIE_NAME}=session-123",
+        },
+        path="/api/auth/me",
+    )
+    _, token, user = await auth_module.apply_auth_for_request(request)
+    try:
+        assert user is not None
+        assert user.username == "test-user"
+    finally:
+        auth_module.clear_auth_context(token)
+
+
+@pytest.mark.asyncio
+async def test_apply_auth_for_request_sse_request_with_cookie_uses_browser_session(monkeypatch):
+    async def _has_users():
+        return True
+
+    async def _get_user_by_session_id(_session_id: str):
+        return _FakeLocalUser(must_reset_password=False)
+
+    monkeypatch.setattr(auth_module.AuthService, "has_users", _has_users)
+    monkeypatch.setattr(auth_module.AuthService, "get_user_by_session_id", _get_user_by_session_id)
+    monkeypatch.setattr(
+        auth_module,
+        "get_secret_manager",
+        lambda: _FakeSecrets({auth_module.API_TOKEN_SECRET_ID: "abc123"}),
+    )
+
+    request = _make_request(
+        headers={
+            "user-agent": "Mozilla/5.0",
+            "accept": "text/event-stream",
+            "cookie": f"{auth_module.SESSION_COOKIE_NAME}=session-123",
+        },
+        client_host="10.0.0.2",
+        path="/api/event",
+    )
+    _, token, user = await auth_module.apply_auth_for_request(request)
+    try:
+        assert user is not None
+        assert user.username == "test-user"
+    finally:
+        auth_module.clear_auth_context(token)
+
+
+@pytest.mark.asyncio
+async def test_apply_auth_for_request_non_browser_forwarded_loopback_requires_token(monkeypatch):
+    monkeypatch.setattr(
+        auth_module,
+        "get_secret_manager",
+        lambda: _FakeSecrets({auth_module.API_TOKEN_SECRET_ID: "abc123"}),
+    )
+    request = _make_request(
+        headers={
+            "user-agent": "curl/8.0",
+            "x-forwarded-for": "203.0.113.10",
+        },
+        client_host="127.0.0.1",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_module.apply_auth_for_request(request)
+    assert exc_info.value.status_code == 401
+    assert "Bearer API Token" in str(exc_info.value.detail)
+
+
 class TestAuthMiddlewareExempt:
     """Cover ``auth_middleware_exempt`` — both fixed paths and regex patterns."""
 

--- a/webui/src/config/apiProxy.test.ts
+++ b/webui/src/config/apiProxy.test.ts
@@ -19,10 +19,12 @@ describe('apiProxy helpers', () => {
       '/api': {
         target: 'http://127.0.0.1:9000',
         changeOrigin: true,
+        xfwd: true,
       },
       '/event': {
         target: 'http://127.0.0.1:9000',
         changeOrigin: true,
+        xfwd: true,
       },
     });
   });

--- a/webui/src/config/apiProxy.ts
+++ b/webui/src/config/apiProxy.ts
@@ -9,10 +9,12 @@ export function createApiProxy(target: string) {
     '/api': {
       target,
       changeOrigin: true,
+      xfwd: true,
     },
     '/event': {
       target,
       changeOrigin: true,
+      xfwd: true,
     },
   };
 }


### PR DESCRIPTION
## Summary

- **WebUI / CLI**: Non-loopback backends now default to same-origin `/api` proxy mode (no `VITE_API_BASE_URL` / `VITE_WS_BASE_URL` unless `FLOCKS_WEBUI_DIRECT_BACKEND_URLS=1` is set). Documented in README.
- **Auth**: Session cookie is resolved early in `apply_auth_for_request`; browser-like detection extended for SSE / reverse-proxy (existing session cookie, Mozilla + HTML/SSE Accept).
- **WebUI dev proxy**: `xfwd: true` on `/api` and `/event` so `X-Forwarded-*` reaches the backend.

## Tests

- `uv run pytest tests/server/test_auth_compat.py tests/cli/test_service_manager.py`
- `npm test -- --run src/config/apiProxy.test.ts` (webui)


Made with [Cursor](https://cursor.com)