### PR TITLE
feat/onesig api integration

### DIFF
--- a/.flocks/plugins/skills/onesig-use/SKILL.md
+++ b/.flocks/plugins/skills/onesig-use/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: onesig-use
+description: 用于处理 OneSIG（安全互联网网关 / Secure Internet Gateway）相关任务，适合通过 API 或者结合浏览器进行以下任务：威胁监控（仪表盘、防护大屏、失陷主机、入站/出站威胁事件、报告管理）、防护策略（全局白/黑名单、多维封锁、IPS、HTTP 黑名单、高危端口防护、API 联动、Syslog 自动封禁、FTP/SFTP 联动）、资产管理、平台管理（告警/审计/用户、HTTPS 解密、网口路由 DNS、HA、OneCC、设备升级与备份、license、MDR、诊断）、登录会话与改密、帮助文档。只要用户提到 OneSIG、SIG、安全互联网网关、微步互联网网关等相关操作时，必须先加载本 skill。本 skill 是 OneSIG 平台操作的唯一决策入口：在未阅读本 skill 并完成模式判断前，不要直接调用任何 `onesig_*` tool。
+---
+
+# OneSIG Use
+
+## First
+
+操作模式 API V.S Browser
+
+### 何时使用 API
+
+- 默认模式，默认使用 API
+- !!! important: 如果已经进入了浏览器模式，就不要走 API 了
+- 查询类请求与处置 / 配置写入类请求要严格区分；用户没有明确要求执行写操作时，默认只使用只读查询能力
+
+### 何时使用浏览器
+
+- 现有 API 没有覆盖目标能力
+- 未检测到对应 API 工具
+- API 当前不可用，例如未配置、未开通、无权限、认证失败、Cookie 过期、SSL 验证失败或服务不可达
+- 任务必须查看页面级详情、攻击链、威胁图、报表预览或人工确认弹窗
+- 页面需要人工登录、图形验证码、TOTP、强制改密或页面级确认
+- 用户明确要求使用浏览器，或者已经在浏览器操作过程中
+
+### 请求确认
+
+除非是用户要求使用浏览器，否则提示用户 API 不可用，请检查 API 配置或直接使用浏览器模式。
+
+当确定操作模式后：
+
+- API 模式：请阅读 API 模式使用指南
+- 浏览器模式：请阅读浏览器模式使用指南
+
+## API 模式使用指南
+
+OneSIG 一共 6 个 grouped tool，按用户语义分流：
+
+- 用户说"仪表盘""威胁防护大屏""失陷主机""入站/出站威胁事件""设备状态""报告""导出报表"时，优先走 `onesig_monitoring`
+- 用户说"白名单""黑名单""多维封锁""API 联动密钥""Syslog 自动封禁""FTP/SFTP 联动""IPS 规则""HTTP 黑名单""端口防护组""一键 bypass""防护策略"时，优先走 `onesig_strategy`
+- 用户说"资产""资产组""资产类型""资产导入/导出"时，优先走 `onesig_assets`
+- 用户说"告警/通知配置""管理日志/审计""用户管理/登录策略""HTTPS 解密""网口/部署引导""路由 / DNS / 代理""HA 高可用""集中管控/OneCC""设备升级/重启/备份/恢复""日志外发""license""MDR""coredump""pcap""设备诊断"时，优先走 `onesig_device`
+- 用户说"登录""退出""改密""账户信息""图形验证码""TOTP""恢复码""产品动态红点"时，优先走 `onesig_login`
+- 用户说"帮助文档""产品版本""提交问题反馈"时，优先走 `onesig_helper`
+
+OneSIG 与 OneSEC 在调用约定上有几个**关键差异**，agent 不要混用：
+
+- 时间字段是 `startTime` / `endTime`（不是 OneSEC 的 `time_from` / `time_to`），单位 **Unix 秒**
+- 分页字段是 `pageNo` / `pageSize`（不是 `cur_page` / `page_size`，也不是 `page_items_num`）
+- OneSIG 主要走 **Cookie 会话** + RSA-OAEP 加密密码登录，处理器会自动登录、会话过期会自动重登；只有当设备启用了图形验证码或 TOTP 时才需要显式调 `onesig_login` 的 `login` 动作，并把 `captcha` / `totp` 作为入参传入
+- 每个 grouped tool 的 action 除了 `action` 都按业务键平铺；POST 类 action 多数走 passthrough body，把所有筛选 / 分页字段直接放在请求体顶层即可
+
+高风险写操作要特别谨慎，例如：
+
+- 设备级动作：`device_onekey_bypass` / `device_quick_bypass`（流量直通）、`device_reboot` / `device_shutdown` / `device_reinit`、`device_upgrade` / `device_upgrade_upload` / `system_upgrade`
+- 用户与口令：`user_create` / `user_delete` / `user_update` / `user_secret_reset`、`change_password`、`regenerate_recovery_code`
+- 黑白名单与封禁：`whitelist_*` / `blacklist_*` 系列写操作、`multiblock_rule_create` / `multiblock_rule_update` / `multiblock_rule_delete` / `multiblock_rule_active`、`auto_blacklist_create` / `auto_blacklist_update` / `auto_blacklist_delete`
+- IPS / HTTP / 端口防护：`ips_rule_create` / `ips_rule_apply` / `ips_rule_all`、`ips_ruleset_create` / `ips_ruleset_update` / `ips_ruleset_delete`、`http_blacklist_*` 写操作、`port_protect_group_*` / `port_protect_port_*` 写操作、`protection_policy_update` / `protection_policy_delete`
+- HTTPS 解密：`tls_decrypt_policy_create` / `_update` / `_enable` / `_delete` / `_batch`、`tls_cert_create` / `_update` / `_delete` / `_set_default`、`tls_detect_delete` / `set_decrypt_config`
+- 网口 / 路由 / 网络：`interface_update`（涉及启停时需 password）、`interface_*_create/update/delete`（virtualLine / listen / bridge）、`route_static_*` / `ipv6_route_static_*` 写操作、`set_dns_config` / `set_proxy_config`、`hosts_create/update/delete`
+- 高可用 / 集中管控：`set_ha_config` / `ha_switching` / `ha_sync_config`、`set_onecc_config` / `set_onecc_status`
+- 备份与升级：`backup_create` / `backup_recover` / `backup_delete` / `backup_import` / `backup_update`、`device_download_package`
+- 离线情报库 / 授权：`basic_information_import` / `basic_information_enable`、`basic_license_upload`、`mdr_service_enable`
+- 诊断写操作：`device_pcap_set`、`device_coredump_delete` / `device_pcap_file_delete`
+- 报表与日志外发：`report_form_create` / `report_form_delete`、`report_task_create` / `_update` / `_delete` / `_test`、`logaccess_create` / `_update` / `_delete`、`set_dnslog_config`、`set_clean_config` / `set_storage_config`
+- API Key 与密钥：`apikey_create` / `apikey_update` / `apikey_delete`、`apikey_secret`（会回吐明文 secret，需当前用户密码二次校验）
+
+必须阅读：
+
+各 grouped tool 与 action 的详细说明、必填参数、最小调用示例见 [references/api-reference.md](references/api-reference.md)。
+
+## 浏览器模式使用指南
+
+- ⚠️ 如果 OneSIG 设备的访问地址不清楚，请先询问用户，不要擅自填写域名。
+- ⚠️ 用 `--headed` 打开浏览器，人工完成登录（OneSIG 多数部署启用了图形验证码 / TOTP / 强制改密策略）。
+- ⚠️ OneSIG 控制台与 OneSEC / 青藤是不同产品；不要把 OneSEC 的页面路径或 OneSEC 的 API 套用到 OneSIG。
+
+只要进入浏览器模式，就请阅读并按照 browser-workflow 操作，不要直接跳过本 skill 去套用其他通用浏览器 skill。
+
+请严格按照以下文档执行：
+
+- [references/browser-workflow.md](references/browser-workflow.md)

--- a/.flocks/plugins/skills/onesig-use/references/api-reference.md
+++ b/.flocks/plugins/skills/onesig-use/references/api-reference.md
@@ -1,0 +1,695 @@
+# OneSIG API 调用指南
+
+OneSIG 当前的 6 个 grouped tool（`onesig_login` / `onesig_assets` / `onesig_device` / `onesig_helper` / `onesig_monitoring` / `onesig_strategy`）都遵循"`action` + 业务键平铺"的调用模式。处理器会自动登录、自动续会话、自动按需做 RSA-OAEP 密码加密，所以业务调用通常**不需要**先单独调登录接口。
+
+## 先看这张路由表
+
+| 用户意图 | 推荐 tool | 推荐 action | 必备参数 |
+|---|---|---|---|
+| 看仪表盘总览 / 出入站 / 零日 | `onesig_monitoring` | `dashboard_overview` / `dashboard_outbound` / `dashboard_inbound` / `dashboard_zeroday` | 通常空参，部分需 `startTime`/`endTime` |
+| 看威胁防护大屏（事件/资产/趋势/占比） | `onesig_monitoring` | `overview_*` 系列 | 多数必填 `startTime`+`endTime`，部分要 `incIntervalSec` 或 `interval` |
+| 看入站/出站威胁事件列表与详情 | `onesig_monitoring` | `event_inbound_*` / `event_outbound_*` | 列表与详情类必填 `startTime`+`endTime` |
+| 看失陷主机统计 / 列表 / 详情 | `onesig_monitoring` | `alert_host_*` | 列表与详情类必填 `startTime`+`endTime`，详情类还要 `source` |
+| 看 / 改报表 | `onesig_monitoring` | `report_form_*` / `report_task_*` | 下载需 `uniqueId`+`fileName`，删除需 `uniqueId` |
+| 看设备状态（CPU/内存/网口/平台） | `onesig_monitoring` | `device_platform_status` / `device_system_status` / `device_network_status` / `common_interface_list` / `basic_cpu_attr` | `device_system_status` 必填 `time` |
+| 改 / 查白黑名单 | `onesig_strategy` | `whitelist_*` / `blacklist_*` | 列表用 `*_list`，删除用 `uniqueIds` |
+| 多维封锁规则 | `onesig_strategy` | `multiblock_rule_*` / `multiblock_executelog_*` | 单条规则用 `name` 做主键 |
+| API 联动密钥 | `onesig_strategy` | `apikey_*` | `apikey_secret` 必填 `key`+`password` |
+| Syslog 自动封禁 | `onesig_strategy` | `auto_blacklist_*` | `auto_blacklist_trend`/`_sample` 必填 `srcIp`（+组合键） |
+| FTP/SFTP 联动 | `onesig_strategy` | `linkage_*` | `linkage_info` 必填 `uniqueId` |
+| IPS 规则 / 规则集 | `onesig_strategy` | `ips_rule_*` / `ips_ruleset_*` / `ips_threat_types` | 单条规则集查询用 `name`，引用关系用 `ruleId`+`assetIp` |
+| HTTP 黑名单 / 高级 / XFF | `onesig_strategy` | `http_blacklist_*` / `*_advanced_config` / `*_xff_config` | 列表 `_list`、写操作走 `_create` / `_update` / `_delete` |
+| 高危端口防护 | `onesig_strategy` | `port_protect_group_*` / `port_protect_port_*` | 端口列表 `port_protect_port_list` 必填 `groupName`+`pageNo`+`pageSize` |
+| 防护策略首页 | `onesig_strategy` | `protection_policy_*` / `device_onekey_bypass` | `protection_policy_get` 必填 `uniqueId` |
+| 资产 / 资产组 / 资产类型 | `onesig_assets` | `asset_*` / `asset_group_*` / `asset_type_*` / `common_asset_group_tree` | 资产用 `uniqueId`（删除还需 `password`）；资产组写操作用 `uid`（新增是 `pid`+`name`）；导入用 `file_path` |
+| 告警 / 通知策略 | `onesig_device` | `alert_policy_*` / `*_notice_config` / `test_email/syslog/webhook` | `alert_policy_find_by_config` 必填 `search`+`type` |
+| 管理日志（审计） | `onesig_device` | `aclog_*` / `*_clean_config` | 列表 / 导出常需 `startTime`+`endTime`；删除需 `password` |
+| 用户与登录策略 | `onesig_device` | `user_*` / `*_login_config` | 改密 / 删除 / 重置密码需 `password`（自动 RSA 加密） |
+| HTTPS 解密 | `onesig_device` | `tls_decrypt_policy_*` / `tls_cert_*` / `tls_detect_*` | TLS 详情必填 `server`+`port`+`orderBy`+`sortBy` |
+| 网口 / 部署引导 | `onesig_device` | `interface_*` | `interface_select_list` 必填 `workMode` |
+| 路由（v4/v6） | `onesig_device` | `route_*` / `ipv6_route_*` | 写操作要带完整路由项 |
+| DNS / 代理 / 网络测试 | `onesig_device` | `*_dns_config` / `hosts_*` / `*_proxy_config` / `test_network` / `test_proxy` | hosts 写操作走 create/update/delete |
+| 高可用 HA | `onesig_device` | `ha_*` / `*_ha_config` | `ha_sync_status` 必填 `syncId`（前置 `ha_sync_config` 返回） |
+| 集中管控 OneCC | `onesig_device` | `*_onecc_config` / `onecc_status` / `set_onecc_status` / `test_onecc` | 写操作前先看 status |
+| 设备升级 / 重启 / 备份 / 恢复 | `onesig_device` | `device_upgrade*` / `device_reboot/shutdown/reinit` / `backup_*` / `system_upgrade` | 升级 / 上传备份用 `file_path`，敏感写操作需 `password` |
+| 日志外发 | `onesig_device` | `logaccess_*` | 列表必填 `pageNo`+`pageSize`+`type`；样例必填 `srcIp`+`protocol`+`type` |
+| 基本信息 / license / MDR | `onesig_device` | `basic_*` / `mdr_service_*` | license / 离线情报库导入用 `file_path` |
+| 设备诊断 | `onesig_device` | `device_coredump_*` / `device_pcap_*` | coredump/pcap 删除走 DELETE |
+| 帮助文档 / 产品反馈 | `onesig_helper` | `document_list` / `document_preview` / `product_*` | `document_preview` 必填 `id`（来自 `document_list`） |
+| 登录 / 退出 / 改密 / 账户 | `onesig_login` | `login` / `logout` / `change_password` / `get_account` 等 | 改密必填 `new_password`，启用 captcha/TOTP 时 `login` 要传 `captcha`/`totp` |
+
+## 通用规则
+
+- OneSIG 全部 grouped tool 的入参形态：`{action: "...", ...业务字段}`（不像 TDP 把所有筛选放进统一 `body`，也不像 OneSEC 用 `time_from`/`time_to`）
+- 时间字段统一是 **Unix 秒**：`startTime` / `endTime` / `time`，没有"recent"系列接口
+- 分页字段统一是 `pageNo`（默认 1）+ `pageSize`（默认 20）；不要传 `cur_page` / `page_size` / `page_items_num`
+- 排序统一是 `sortBy`（字段名）+ `orderBy`（`asc` / `desc`）
+- POST 类 action 多数 passthrough body —— 任何过滤字段直接放在请求体顶层即可，与 Web 控制台抓包字段一一对应
+- 查询类 action 默认优先；写操作只有用户明确授权时才执行（特别是黑白名单批量写、设备升级、HTTPS 解密策略、HA / OneCC 配置）
+- 业务键参考第二节的"业务 ID 字段"；如果没有 ID，应先调对应列表 / namelist / tree 接口拿主键
+
+## 业务 ID 字段对照（`required` 主键）
+
+OneSIG 不同模块用不同字段做"主键"，没有 ID 是无法调单条接口的。如果 agent 拿不到主键，应该**先调对应的列表 / namelist / tree** action 取得主键，再调单条接口。
+
+| 字段 | 用在哪些 action | 含义 |
+|---|---|---|
+| `id` | `document_preview` | 帮助文档主键（先 `document_list`） |
+| `key` + `password` | `apikey_secret` | API Key 名称 + 当前用户登录密码（自动 RSA 加密） |
+| `uniqueId` | `asset_update` / `asset_delete`（+`password`）/ `linkage_info` / `protection_policy_get` / `report_form_download` / 多数 `*_delete` 单条目 / 多数全局白黑名单 `*_update` | 资源唯一 ID，先调列表/树拿到 |
+| `uniqueIds` | 批量删除（`whitelist_remove_batch` 等于 `globalWhitelist` DELETE、`blacklist_remove_batch` 等于 `globalBlacklist` DELETE、`*_delete` 批量） | 数组形式，多个资源一起删 |
+| `uid` | `asset_group_update` / `asset_group_delete`（+`password`） | **资产组**主键（不是 `uniqueId`！） |
+| `pid` + `name` | `asset_group_create` | 父级资产组 ID（根 = `0`） + 新组名 |
+| `syncId` | `ha_sync_status` | HA 配置同步任务 ID（由前置 `ha_sync_config` 返回） |
+| `name` | `multiblock_rule_get` / `multiblock_rule_preview` / `multiblock_executelog_list` / `ips_ruleset_info` / `ips_ruleset_delete` / `asset_type_delete` | OneSIG 用对象名当主键，没有独立数字 ID |
+| `groupId` | `port_protect_group_update` / `_delete` / `_clone` 的 `fromGroupId`、`port_protect_port_*` 写操作、`port_protect_portinfo` | 端口防护**组**主键（写操作用） |
+| `groupName` | `port_protect_port_list`（端口列表）/ `port_protect_port_export` | 端口防护组**名**（仅查列表 / 导出用，注意与 `groupId` 区分） |
+| `ruleId` | `ips_rule_create`（**实际是查单条规则详情**，文档名为「新增 IPS 自定义规则」与实际语义不符）、`ips_ruleset_referred` 的一半 | IPS 规则 ID |
+| `ruleId` + `assetIp` | `ips_ruleset_referred` | 单条 IPS 规则 + 涉事资产 IP，反查规则在哪台资产上命中 |
+| `srcIp`(+`protocol`+`direction`) | `auto_blacklist_trend` / `auto_blacklist_sample` | 来自 syslog 自动黑名单的源 IP 复合主键 |
+| `server` + `port` + `orderBy` + `sortBy` | `tls_detect_list_detail` | TLS 解密目标"主机:端口"复合键 |
+| `workMode` | `interface_select_list` | 网口选择列表必须先选定工作模式（内联/旁路） |
+| `search` + `type` | `alert_policy_find_by_config` | 按配置反查告警策略 |
+| `time` | `device_system_status` | 系统资源采样时间窗（Unix 秒） |
+| `incIntervalSec` / `interval` | `overview_asset_brief` / `overview_event_trend` / `overview_stat` | 聚合粒度（秒） |
+| `key` (Body) + Query `type=physical` | `apikey_delete` / `_update`，新增 `apikey_create` 也要 `type=physical` | API 联动密钥的接口要求 Query `?type=physical`（厂商文档强制）—— 当前 handler 走 passthrough body，按目前实测把 `type:"physical"` 一起放进 body 即可，但若服务端严格要求 query，请改用浏览器流程 |
+
+## 时间窗口与时区
+
+- 时间戳一律 Unix **秒**（不是毫秒）
+- 文档示例按 `Asia/Shanghai`，实际调用时按业务时区计算
+- OneSIG 没有"最近 24 小时增量"专用接口；要"最近一段"统一用 `now - 24*3600`、`now - 7*86400` 之类自行算
+- 未传时间走服务端默认窗口，仅作兜底，不推荐依赖
+
+## 高频场景
+
+### 1. 看入站 / 出站威胁事件
+
+推荐：`onesig_monitoring` + `event_inbound_list` 或 `event_outbound_list`。
+
+最小示例（查最近 24 小时入站事件）：
+
+```json
+{
+  "action": "event_inbound_list",
+  "startTime": 1745683200,
+  "endTime": 1745769600,
+  "pageNo": 1,
+  "pageSize": 20
+}
+```
+
+后续动作：
+
+- 拿到事件后调 `event_inbound_detail` / `_detail_trend` / `_detail_list` 看详情、趋势、关联记录
+- 导出文件用 `event_inbound_export` / `event_inbound_detail_export`（返回的是文件，不是 JSON）
+
+返回结果重点关注：
+
+- 事件 `uniqueId`、源/目的 IP、威胁类型 `threatType`、威胁等级 `severity`、威胁标签 `threatLabel`、是否 TLS `isTls`
+
+何时回退浏览器：需要事件原始报文、PCAP 取证、详情页攻击链。
+
+### 2. 失陷主机调查
+
+推荐：`onesig_monitoring` + `alert_host_*`。
+
+```json
+{
+  "action": "alert_host_list",
+  "startTime": 1745683200,
+  "endTime": 1745769600,
+  "pageNo": 1,
+  "pageSize": 20
+}
+```
+
+详情维度：
+
+```json
+{
+  "action": "alert_host_detail",
+  "startTime": 1745683200,
+  "endTime": 1745769600,
+  "source": "10.0.0.5"
+}
+```
+
+`source` 是失陷主机的 IP（必填）。`alert_host_detail_list` / `_export` 同步要求 `startTime` / `endTime` / `source`。
+
+### 3. 看仪表盘 / 大屏
+
+仪表盘：`dashboard_overview` / `dashboard_outbound` / `dashboard_inbound` / `dashboard_zeroday` / `dashboard_status` / `dashboard_ioc_type_sum` —— 通常空参或只需时间窗。
+
+威胁防护大屏（`overview_*`）—— 多数需要时间窗 + 聚合粒度：
+
+```json
+{
+  "action": "overview_asset_brief",
+  "startTime": 1745683200,
+  "endTime": 1745769600,
+  "incIntervalSec": 3600
+}
+```
+
+```json
+{
+  "action": "overview_event_trend",
+  "startTime": 1745683200,
+  "endTime": 1745769600,
+  "interval": 3600
+}
+```
+
+```json
+{
+  "action": "overview_event_inbound_agg",
+  "startTime": 1745683200,
+  "endTime": 1745769600,
+  "type": "threatType",
+  "pageNo": 1,
+  "pageSize": 20
+}
+```
+
+注意：`overview_*_export` 系列返回文件，不要拿来在 chat 里展开。
+
+### 4. 资产管理
+
+推荐：`onesig_assets`。
+
+查列表：
+
+```json
+{
+  "action": "asset_list",
+  "pageNo": 1,
+  "pageSize": 20,
+  "search": "10.0.0."
+}
+```
+
+新增 / 更新 / 删除（参数严格按厂商 `assetsSegment.md`）：
+
+```json
+{
+  "action": "asset_create",
+  "name": "host-1",
+  "type": "服务器",
+  "groupId": 101,
+  "ip": ["10.0.0.1", "10.0.0.2"],
+  "remark": "生产环境"
+}
+```
+
+`type` 是字符串字段（不是 `assetType`），`ip` 必须是**字符串数组**（支持单 IP / 网段 / 区间），`groupId` 是数字（先调 `asset_group_get` 拿）。
+
+```json
+{
+  "action": "asset_update",
+  "uniqueId": "asset-id-1",
+  "name": "host-1-renamed",
+  "type": "服务器",
+  "groupId": 101,
+  "ip": ["10.0.0.1"]
+}
+```
+
+更新接口必填 `uniqueId` + `name` + `type` + `groupId` + `ip`（厂商文档要求**全量**字段，不是部分更新）。
+
+```json
+{ "action": "asset_delete", "uniqueId": "asset-id-1", "password": "<当前登录用户密码>" }
+```
+
+⚠️ **删除资产是单条调用**（仅 `uniqueId`），并且**必须带 `password`**（当前登录用户密码），处理器会自动 RSA-OAEP 加密。要批量删，请按行循环调用。
+
+资产组：`asset_group_get`（拿整树）/ `asset_group_create`（`pid`+`name`）/ `asset_group_update`（`uid`+`name`）/ `asset_group_delete`（`uid`+`password`）。注意资产组主键叫 `uid`，**不是** `uniqueId`。整树缓存用 `common_asset_group_tree`。
+
+资产导入：
+
+```json
+{ "action": "asset_import", "file_path": "/abs/path/to/assets.csv" }
+```
+
+`asset_template` / `asset_export` 返回文件（CSV）。
+
+### 5. 黑白名单 / 多维封锁 / API 联动
+
+白名单（写）—— 注意 `condition` / `comments` 与 `whiteList` **平级**，不是嵌进数组元素：
+
+```json
+{
+  "action": "whitelist_add",
+  "whiteList": [{ "direction": "inbound" }],
+  "condition": [{ "type": "srcIp", "cond": "equal", "value": "10.0.0.1" }],
+  "comments": "策略备注"
+}
+```
+
+新增时 `whiteList` 数组每项**只含 `direction`**（值为 `inbound` / `outbound` / `both`），`condition` 与 `comments` 在顶层。
+
+```json
+{
+  "action": "whitelist_update",
+  "uniqueId": "id-1",
+  "direction": "inbound",
+  "condition": [{ "type": "srcIp", "cond": "equal", "value": "10.0.0.1" }],
+  "comments": "更新备注"
+}
+```
+
+更新时**没有** `whiteList` 字段，只有 `uniqueId` + 单值 `direction` + `condition` + `comments`。
+
+```json
+{ "action": "whitelist_remove_batch", "uniqueIds": ["id-1", "id-2"] }
+```
+
+黑名单（同 OneSIG `globalBlacklist`）：
+
+```json
+{
+  "action": "blacklist_add",
+  "blackList": [
+    { "object": "1.1.1.1", "direction": "inbound", "threatName": "", "sLifeCycle": "", "comments": "" }
+  ]
+}
+```
+
+新增时整批用 `blackList` 数组；写入前可先 `blacklist_check`（IP 类冲突校验）。`_update` / `_delete`（按 `uniqueIds` 批量）/ `_list` 用法与白名单类似。
+
+多维封锁：
+
+```json
+{
+  "action": "multiblock_executelog_list",
+  "name": "rule-A",
+  "startTime": 1745683200,
+  "endTime": 1745769600,
+  "pageNo": 1,
+  "pageSize": 20
+}
+```
+
+`multiblock_rule_get` / `_preview` 必填 `name`；`_create` / `_update` 是写操作，要谨慎。
+
+API 联动：
+
+```json
+{ "action": "apikey_list", "pageNo": 1, "pageSize": 20 }
+```
+
+`apikey_list` 必填 `pageNo`+`pageSize`，否则服务端回 `responseCode=1004`。
+
+```json
+{ "action": "apikey_secret", "key": "my-key", "password": "<当前登录密码>" }
+```
+
+`apikey_secret` 会回吐明文 secret，处理器自动用 RSA-OAEP 加密 `password` 后发送（注意：`password` 在该接口走 Query 而非 Body）—— 不要替用户保存这个值，更不要回显在 chat 里。
+
+写操作（创建 / 更新 / 删除）：厂商接口要求带 Query `?type=physical`。当前 handler 走 passthrough body，请把 `type:"physical"` 一起放进 body 顶层（实测多数实例服务端会接受），如果遇到 `responseCode=1004` 提示 `type` 缺失则回退浏览器模式：
+
+```json
+{ "action": "apikey_create", "type": "physical", "name": "soc-bridge" }
+```
+
+```json
+{ "action": "apikey_update", "type": "physical", "name": "soc-bridge", "key": "k1", "status": 1 }
+```
+
+```json
+{ "action": "apikey_delete", "type": "physical", "key": "k1" }
+```
+
+### 6. IPS 规则 / 规则集
+
+```json
+{ "action": "ips_ruleset_namelist" }
+```
+
+```json
+{ "action": "ips_ruleset_info", "name": "default-ruleset" }
+```
+
+```json
+{ "action": "ips_ruleset_referred", "ruleId": "rule-001", "assetIp": "10.0.0.5" }
+```
+
+⚠️ 注意 `ips_rule_create`（厂商 `POST /v3/ips/rule`）**实际语义是「查单条规则详情」**，body 必填 `ruleId`，不会真的"新增"自定义规则；这是 yaml/handler 命名遗留问题。需要新增/编辑规则集请走 `ips_ruleset_create` / `_update`。`ips_rule_apply` 才是"应用规则变更到目标规则集"的写操作（body：`rulesetsName`数组+`rules`数组），调用前确认变更已就绪。
+
+### 7. HTTP 黑名单 / 端口防护
+
+HTTP 黑：`http_blacklist_list` / `_create` / `_update` / `_delete` / `_enable` / `_export`。
+
+端口防护组：
+
+```json
+{ "action": "port_protect_group_list_full" }
+```
+
+```json
+{
+  "action": "port_protect_port_list",
+  "groupName": "默认高危端口组",
+  "pageNo": 1,
+  "pageSize": 20,
+  "sortBy": "updateTime",
+  "orderBy": "desc"
+}
+```
+
+⚠️ action 名是 `port_protect_port_list`（**不是** `port_protect_group_port_list`），必填 `groupName`+`pageNo`+`pageSize`；响应里总数字段叫 `data.totalCount`（不是 `data.total`）。
+
+写操作：
+
+- `port_protect_group_create` Body `groupName`；`_update` Body `groupId`+`groupName`；`_delete` Body `groupId`；`_clone` Body `fromGroupId`+`groupName`
+- 端口规则：`port_protect_port_create` / `_update` Body `groupId`+`ports`(字符串)+`serviceName`(可选)+`comments`(可选)；`_delete` Body `groupId`+`ports`(数组)；`_onekey_import` Body `groupId`+`ports`(对象数组 `[{ports, serviceName, comments}]`)
+- 端口占用预查：`port_protect_portinfo` Body `groupId`+`ports`
+
+### 8. Syslog 自动封禁
+
+```json
+{ "action": "auto_blacklist_list", "pageNo": 1, "pageSize": 20 }
+```
+
+```json
+{ "action": "auto_blacklist_trend", "srcIp": "1.2.3.4", "startTime": 1745683200, "endTime": 1745769600 }
+```
+
+```json
+{ "action": "auto_blacklist_sample", "srcIp": "1.2.3.4", "protocol": "tcp", "direction": "inbound" }
+```
+
+`auto_blacklist_check`（必填 `name` / `port` / `srcIp` / `protocol` / `direction`）是冲突校验，写入前调用。
+
+### 9. 用户管理与改密
+
+查询：`user_list` / `user_export`。
+
+新增用户（写，敏感）—— 字段严格按 `deviceLoginManagement.md`：
+
+```json
+{
+  "action": "user_create",
+  "username": "alice",
+  "role": 2,
+  "nickname": "",
+  "phone": "",
+  "expireTime": 0,
+  "loginLimit": [],
+  "password": "<明文新密码>",
+  "dupPassword": "<明文新密码>"
+}
+```
+
+字段说明：
+
+- `username`（必填，**不是 `name`**）：1～20 字符，符合 `userEditor` 用户名正则
+- `role`（必填）：数字角色（如 `0`/`2`/`3`/`4`，`role=3` 跳审计页、`role=4` 跳大屏）
+- `expireTime`（必填）：到期时间 Unix 秒；选「长期」时填 `0`
+- `loginLimit`（必填）：可登录 IP 字符串数组，ALL 时填 `[]`
+- `password` / `dupPassword`（必填）：明文新密码，处理器自动 RSA-OAEP 加密。注意 **handler 只对 `password` 与 `dupPassword`（驼峰）做加密**，不要传 `dup_password`（蛇形不会被加密）
+
+更新用户用 `user_update`，必填 `username`（定位主键，**不可改**）+ `expireTime` + `loginLimit`，可选 `nickname` / `phone`；改密**不在** `user_update` 路径，要走 `Main/changePwdModalData`（即顶栏改密弹窗，agent 用 `change_password` 走 `onesig_login`）。
+
+改密（当前用户）走 `onesig_login`：
+
+```json
+{
+  "action": "change_password",
+  "old_password": "<明文旧>",
+  "new_password": "<明文新>",
+  "dup_password": "<明文新>"
+}
+```
+
+`user_secret_reset` / `user_delete` / `aclog_delete` / `interface_update`（启停场景）/ `device_upgrade*` 同样要传 `password`，规则一致。
+
+如果 `POST /v3/login` 返回 responseCode `1009` / `1017` 但密码确实正确，先把 `oaep_hash` 切到 `sha256` 重试 —— OneSIG v2.5.x 多数走 SHA-1（JSEncrypt 默认），但有个别部署是 SHA-256。
+
+### 10. HTTPS 解密
+
+策略：`tls_decrypt_policy_list` / `_create` / `_update` / `_enable` / `_delete` / `_batch`。
+
+证书：`tls_cert_list` / `_create`（multipart：`file_path` 指向 `.crt`/`.pem`）/ `_update` / `_delete` / `_set_default`。
+
+检测对象：
+
+```json
+{
+  "action": "tls_detect_list_detail",
+  "server": "internal-svc.example.com",
+  "port": 443,
+  "orderBy": "desc",
+  "sortBy": "lastSeenTime"
+}
+```
+
+`server` + `port` + `orderBy` + `sortBy` 这 4 个是必填的复合主键。
+
+### 11. 网口 / 部署引导 / 路由 / DNS
+
+网口：`interface_list` / `interface_select_list`（必填 `workMode`，"内联"/"旁路"二选一）/ `interface_update`（启停时 `password` 必填）/ `interface_check_loop` / `interface_relation_list`。
+
+虚拟线 / 监听 / 桥：`interface_virtual_line_*` / `interface_listen_*` / `interface_bridge_*`。
+
+路由：`route_outif_list` / `route_static_list` / `_create` / `_update` / `_delete` / `route_table_list`，IPv6 同名加 `ipv6_` 前缀。
+
+DNS：`get_dns_config` / `set_dns_config` / `hosts_get` / `hosts_create` / `_update` / `_delete` / `test_network`。
+
+### 12. HA 高可用
+
+```json
+{ "action": "ha_status" }
+```
+
+```json
+{ "action": "ha_sync_config" }
+```
+
+```json
+{ "action": "ha_sync_status", "syncId": "<上一步返回的 syncId>" }
+```
+
+`ha_switching` 是主备切换，**强破坏性写操作**，没有用户明确授权不要调。
+
+### 13. 集中管控 OneCC
+
+```json
+{ "action": "onecc_status" }
+```
+
+```json
+{ "action": "test_onecc", "...": "..." }
+```
+
+`set_onecc_config` / `set_onecc_status` 都会改设备纳管状态，调用前先用 `get_onecc_config` / `onecc_status` 看清当前形态。
+
+### 14. 设备配置 / 升级 / 备份
+
+升级：
+
+- `basic_version` / `device_upgrade_info` —— 看版本与可升级状态
+- `get_upgrade_config` / `set_upgrade_config` —— 在线升级源配置
+- `device_download_package` —— 触发后台下载升级包（写）
+- `device_upgrade` —— 已下载的包升级（写，敏感，`password` 必填）
+- `device_upgrade_upload` —— 本地上传升级包（multipart：`file_path`，`password` 必填）
+- `system_upgrade` —— 系统级升级（multipart：`file_path`）
+
+备份：
+
+```json
+{ "action": "backup_list", "pageNo": 1, "pageSize": 20 }
+```
+
+```json
+{ "action": "backup_create", "name": "manual-2026-04-27" }
+```
+
+```json
+{ "action": "backup_recover", "uniqueId": "<backup id>" }
+```
+
+```json
+{ "action": "backup_import", "file_path": "/abs/path/to/backup.tar" }
+```
+
+`backup_recover` / `backup_import` / `backup_delete` 都强破坏性，确认后再调。
+
+设备其它：`device_quick_bypass` / `device_onekey_bypass`（流量直通）、`device_reboot` / `device_shutdown` / `device_reinit`（重启 / 关机 / 出厂重置）—— 全是高风险，不要在不需要的时候触发。
+
+### 15. 日志外发
+
+```json
+{
+  "action": "logaccess_list",
+  "pageNo": 1,
+  "pageSize": 20,
+  "type": "syslog"
+}
+```
+
+```json
+{
+  "action": "logaccess_sample",
+  "srcIp": "10.0.0.1",
+  "protocol": "udp",
+  "type": "syslog"
+}
+```
+
+`logaccess_check` 用来诊断外发链路是否正常。
+
+### 16. 基本信息 / license / MDR
+
+- `basic_information` —— 设备基础信息
+- `basic_information_enable` —— 启用模块（写）
+- `basic_information_import` —— 离线情报库更新（multipart：`file_path` + Query 需 `name`）
+- `basic_license_get` —— 查 license
+- `basic_license_upload` —— 授权 license 文件上传（multipart：`file_path`）
+- `mdr_service_status` / `mdr_service_enable` —— MDR 服务
+
+### 17. 设备诊断
+
+- `device_coredump_list` / `_download` / `_delete`
+- `device_pcap_get` / `_set` / `_file_list` / `_download` / `_file_delete`
+
+抓包写 (`device_pcap_set`) 与删除 (`*_delete`) 是写操作。
+
+### 18. 帮助文档与产品反馈
+
+```json
+{ "action": "document_list", "pageNo": 1, "pageSize": 20, "search": "ips" }
+```
+
+```json
+{ "action": "document_preview", "id": "<文档列表项里的 id>" }
+```
+
+⚠️ `document_preview` 必填 Query `id`（**不是 `fileName`**），其值来自 `document_list` 返回的 `data.list[].id`。返回的 `data` 是**路径字符串**（不是对象），前端会拼到 `window.location.origin` 后用 `window.open` 打开 —— agent 拿到这个路径后通常需要走浏览器模式才能查看 PDF/HTML 内容。
+
+`product_news_get` / `product_news_mark_read` / `product_version` / `product_issue` 用于看红点 / 标已读 / 看版本 / 提反馈。其中 `product_news_mark_read` 的 body 应是先 `product_news_get` 返回对象的副本，再把要清除的标记位（如 `documentUpdate`）置 `false`，其它字段保持原值。
+
+### 19. 登录 / 会话
+
+绝大多数业务场景**不需要**显式登录 —— 处理器会按需自动登录、Cookie 过期会自动重登。下面这些场景才需要主动调 `onesig_login`：
+
+- 设备启用了图形验证码（`GET /v3/captcha` 返回 `enableCaptcha=true`）：
+
+  ```json
+  { "action": "login", "captcha": "xyzw" }
+  ```
+
+  前端校验长度恰为 4。
+
+- 设备启用了 TOTP / 双因素（`enableTotp=true` 或 `POST /v3/login` 返回 `responseCode=1012` 进入扫码页）：
+
+  ```json
+  { "action": "login", "totp": "123456" }
+  ```
+
+  注意：handler 入参统一叫 `totp`（**不要传 `checksum`**），底层会按场景自动映射 —— inline 模式（`/v3/login` 同屏 TOTP）作为 `checksum` 字段拼进登录 body；扫码模式（先 `/v3/login` 拿到 `responseCode=1012`、再补一次 `/v3/login/totp`）作为 `{"checksum": "..."}` 体提交。也可以传恢复码（最长 12 字符）。
+
+- 想立刻拿账户信息：
+
+  ```json
+  { "action": "get_account" }
+  ```
+
+- 改当前用户密码：
+
+  ```json
+  {
+    "action": "change_password",
+    "old_password": "<明文旧>",
+    "new_password": "<明文新>",
+    "dup_password": "<明文新>"
+  }
+  ```
+
+- 显式退出（调试 / 切换账号）：
+
+  ```json
+  { "action": "logout" }
+  ```
+
+注意：
+
+- `logout` 会清空内存里的会话**和**已落盘的 Cookie 持久化（`~/.flocks/config/.secret.json` 中以 `onesig_session_cookie__<sha1[:12]>` 命名的条目），下次调用会从 captcha → pubkey → /v3/login 重走完整链路
+- `regenerate_recovery_code` 一旦调用，旧恢复码立即失效，请在用户明确授权后再用
+- `get_pubkey` / `get_captcha` 通常不需要手动调 —— 处理器在登录前与每次发送 RSA 加密字段前都会自动拉
+
+## 文件类返回 / 上传
+
+下列 action 返回的是**二进制文件**（导出 / 模板 / 下载），不应该在 chat 里直接展开：
+
+- 导出：`asset_export` / `whitelist_export` / `blacklist_export` / `http_blacklist_export` / `port_protect_port_export` / `event_inbound_export` / `event_inbound_detail_export` / `event_outbound_export` / `event_outbound_detail_export` / `alert_host_export` / `alert_host_detail_export` / `tls_detect_group_export` / `tls_detect_list_export` / `aclog_export` / `user_export` / `alert_policy_export` / `multiblock_executelog_export` / `overview_export_*`
+- 模板：`asset_template` / `whitelist_template` / `blacklist_template` / `linkage_template`
+- 下载：`backup_download` / `report_form_download`（必填 `uniqueId`+`fileName`）/ `device_coredump_download` / `device_pcap_download`
+
+下列 action 是 **multipart 上传**，需要 `file_path` 指向本地绝对路径：
+
+- `asset_import`（CSV）
+- `tls_cert_create` / `tls_cert_update`（`.crt`/`.pem`）
+- `basic_information_import`（离线情报库包，Query 需 `name`）
+- `basic_license_upload` / `system_upgrade` / `device_upgrade_upload`（升级 / 授权包）
+- `backup_import`（备份包）
+
+## 高风险写操作清单
+
+以下 action 默认视为高风险，agent 在执行前**必须**先确认用户授权：
+
+- `device_onekey_bypass` / `device_quick_bypass`
+- `device_reboot` / `device_shutdown` / `device_reinit`
+- `device_upgrade` / `device_upgrade_upload` / `system_upgrade`
+- `ha_switching` / `ha_sync_config`（同步会改对端）
+- `set_ha_config` / `set_onecc_config` / `set_onecc_status`
+- `user_create` / `user_delete` / `user_update` / `user_secret_reset` / `change_password`
+- `aclog_delete`
+- `whitelist_add` / `whitelist_update` / `whitelist_delete` / `whitelist_remove_batch` / `whitelist_import`
+- `blacklist_add` / `blacklist_update` / `blacklist_delete` / `blacklist_remove_batch` / `blacklist_import`
+- `multiblock_rule_create` / `multiblock_rule_update` / `multiblock_rule_delete` / `multiblock_rule_active`
+- `auto_blacklist_create` / `auto_blacklist_update` / `auto_blacklist_delete`
+- `linkage_create` / `linkage_update` / `linkage_delete` / `linkage_enable`
+- `ips_rule_create` / `ips_rule_apply` / `ips_rule_all` / `ips_ruleset_create` / `ips_ruleset_update` / `ips_ruleset_delete`
+- `http_blacklist_create` / `http_blacklist_update` / `http_blacklist_delete` / `http_blacklist_enable`
+- `port_protect_group_create` / `_update` / `_delete` / `_clone`、`port_protect_port_create` / `_update` / `_delete` / `_onekey_import`
+- `protection_policy_update` / `protection_policy_delete`
+- `tls_decrypt_policy_create` / `_update` / `_enable` / `_delete` / `_batch`
+- `tls_cert_create` / `_update` / `_delete` / `_set_default`、`tls_detect_delete`
+- `set_decrypt_config` / `set_detect_config`
+- `interface_update`（启停）/ `interface_*_create/update/delete`
+- `route_static_create` / `_update` / `_delete`、`ipv6_route_static_create` / `_update` / `_delete`
+- `set_dns_config` / `hosts_create` / `_update` / `_delete`、`set_proxy_config`
+- `backup_create` / `backup_recover` / `backup_delete` / `backup_update` / `backup_import`
+- `set_storage_config` / `set_clean_config` / `set_dnslog_config`
+- `logaccess_create` / `_update` / `_delete`
+- `basic_information_enable` / `basic_information_import` / `basic_license_upload`
+- `mdr_service_enable`
+- `device_pcap_set` / `device_coredump_delete` / `device_pcap_file_delete`
+- `apikey_create` / `apikey_update` / `apikey_delete` / `apikey_secret`（回吐明文 secret，需 `password`）
+- `regenerate_recovery_code`
+- `report_form_create` / `_delete`、`report_task_create` / `_update` / `_delete` / `_test`
+- `set_advanced_config` / `set_xff_config` / `set_scan_config` / `set_login_config` / `set_upgrade_config` / `set_overview_config` / `set_custom_config` / `web_custom_column_set`
+
+## 常见失败原因
+
+- 时间戳传成毫秒（要用秒）
+- 错传 `cur_page` / `page_size` / `page_items_num`（应为 `pageNo` / `pageSize`）
+- 漏传 OneSIG 必填的"业务 ID"主键 —— `name` / `uniqueId` / `srcIp` / `groupName` / `server`+`port` / `ruleId`+`assetIp` 任意一个缺失都会回 `responseCode=1004`（请求数据非法）
+- 单条 GET 类接口忘了先调列表拿主键
+- 改密 / 删除 / 启停接口手动加密了 `password` —— 处理器会自己加密，要传**明文**
+- `oaep_hash` 配置和设备实际不匹配（多数 v2.5.x 走 SHA-1，少数走 SHA-256），登录返回 `responseCode=1009`/`1017` 时优先怀疑这里
+- `api_prefix` 与设备反代部署形态不一致 —— 厂商前端代码里写的是 `/api/v3/...`，但接口规范文档里去掉了 `/api`。我们 v2.5.x 实测的实例多数是直连后端（`/v3/...`），所以 handler 的 `DEFAULT_API_PREFIX=""`；如果换到一个走 nginx 代理的实例，需要把 `api_prefix` 设成 `"/api"`。**现象**：登录前的 `/v3/pubkey` 直接 404，handler 会在错误信息里给出对应提示
+- `verify_ssl` 与设备证书不匹配（OneSIG 多用自签证书，默认应**关闭**）—— 现象是 SSL handshake 失败
+- 报错"Cookie 过期"：调一下 `onesig_login` 的 `logout` 再让处理器自动重登
+- API Key 写操作返回 `responseCode=1004` 提示 `type` 缺失：服务端要求 Query `type=physical`；先尝试把 `type:"physical"` 放进 body 透传，如果仍然 1004 请回退浏览器模式
+
+## 何时回退浏览器
+
+以下情况优先回退浏览器（参考 [browser-workflow.md](browser-workflow.md)）：
+
+- 需要威胁防护大屏的可视化、IOC 关系图、攻击链
+- 需要看事件 / 失陷主机的页面级详情、报文 hex view、PCAP 在线播放
+- 需要点表格右侧抽屉、复杂筛选弹窗、一些深层报表预览
+- 需要图形验证码 / TOTP / 强制改密之类的人工交互
+- 需要看 Web 控制台原生导出文件并下载

--- a/.flocks/plugins/skills/onesig-use/references/browser-workflow.md
+++ b/.flocks/plugins/skills/onesig-use/references/browser-workflow.md
@@ -1,0 +1,163 @@
+# OneSIG 浏览器自动化
+
+只在以下情况进入浏览器模式：
+
+- API 不可用（未配置 / 未开通 / 认证失败 / Cookie 持久反复过期 / SSL 校验失败 / 网络不通）
+- 任务必须看页面级详情（攻击链、威胁图、报表预览、报文 hex view、PCAP 在线播放）
+- 需要图形验证码 / TOTP / 强制改密之类的人工交互
+- 用户明确要求使用浏览器，或者已经在浏览器操作过程中
+
+如果走 API 能完成，请回到 [api-reference.md](api-reference.md) —— 浏览器操作不稳定、不可批量、字段不一定完整。
+
+> ⚠️ OneSIG 的 Web 控制台与 OneSEC、青藤是不同产品；不要把 OneSEC / 青藤的页面路径或 API 套用到 OneSIG。
+
+## 零、登录认证
+
+State 文件路径：`~/.flocks/browser/onesig/auth-state.json`（固定，全局唯一）。
+
+### 首次登录 / Session 过期重新登录
+
+```bash
+agent-browser close
+agent-browser --headed open "https://<onesig-domain>/login"
+```
+
+OneSIG 多数部署启用了图形验证码 + TOTP + 强制改密：
+
+- 图形验证码：在登录框内手动输入即可
+- TOTP：从用户的 Authenticator 里读取 6 位动态码，必要时让用户出示恢复码
+- 强制改密：首次登录或密码到期时会被网关强制要求改密，按页面提示完成
+
+等用户登录结束、收到通知后保存 state：
+
+```bash
+agent-browser state save ~/.flocks/browser/onesig/auth-state.json
+```
+
+### Session 失效恢复
+
+当出现以下任一情况，优先判定为认证问题：
+
+- 页面被重定向到 `/login`
+- 后台请求 HTTP `401`，或响应里 `responseCode` 是 `1019` / `1020` / `1021` / `1022`（会话相关）
+- 页面提示"登录失效""请重新登录""未授权"
+
+恢复步骤（最多尝试 1 次）：
+
+```bash
+# 1) close 并重新加载 state
+agent-browser close
+agent-browser state load ~/.flocks/browser/onesig/auth-state.json
+
+# 2) 打开受保护页面验证 session
+agent-browser open "https://<onesig-domain>/monitoring/dashboard"
+agent-browser wait --load networkidle
+
+# 3) 根据结果决策
+URL=$(agent-browser get url)
+if [[ "$URL" == *"/login"* ]]; then
+  echo "Session 仍无效，需重新登录"
+else
+  agent-browser state save ~/.flocks/browser/onesig/auth-state.json
+  echo "Session 已恢复，可重试页面操作"
+fi
+```
+
+如果仍然落回登录页，再要求用户重新登录，**不要无限循环重试**。
+
+## 一、控制台导航
+
+> ⚠️ 如果 OneSIG 域名不清楚，请先询问用户，不要擅自填写域名。
+> 进入页面首选直接拼接 URL（比菜单点击更稳定）。
+
+```bash
+agent-browser open "https://<onesig-domain>/<path>"
+agent-browser wait --load networkidle
+agent-browser get text body
+```
+
+| 模块 | 子功能 | URL 路径 | 主要用途 |
+|---|---|---|---|
+| **监控** | 仪表盘 | `/monitoring/dashboard` | 总览 / 出入站 / 零日数据 |
+| | 威胁防护大屏 | `/monitoring/overview` | 事件、资产、趋势、占比可视化 |
+| | 设备状态 | `/monitoring/status` | CPU / 内存 / 网口 / 平台运行状态 |
+| | 失陷主机 | `/monitoring/hosts` | 失陷主机列表 |
+| | 失陷主机详情 | `/monitoring/hostdetail` | 单台主机的关联事件、命中规则、趋势 |
+| | 入站威胁 | `/monitoring/inbound_threat` | 入站事件列表与详情 |
+| | 出站威胁 | `/monitoring/outbound_threat` | 出站事件列表与详情 |
+| | 报告管理 | `/monitoring/report` | 报表表单、任务配置与下载 |
+| **防护策略** | 策略首页 | `/strategy/strategy` | 总览所有防护策略 |
+| | 白名单 | `/strategy/whitelist` | 全局白名单（多方向、按条件） |
+| | 黑名单 | `/strategy/blacklist` | 全局黑名单（地理位置、批量校验） |
+| | 多维封锁 | `/strategy/multi_block` | 多维封锁规则与执行日志 |
+| | 新建多维封锁 | `/strategy/add_multi_block` | 创建多维封锁规则的向导页 |
+| | API 联动 | `/strategy/api` | API Key 管理（看 secret 时需当前用户密码） |
+| | Syslog 自动封禁 | `/strategy/syslog` | 基于 syslog 的自动黑名单 |
+| | FTP/SFTP 联动 | `/strategy/ftp` | FTP/SFTP 设备联动 |
+| | 入侵防护 | `/strategy/intrusion_prevention` | IPS 规则与规则集管理 |
+| | HTTP 防护 | `/strategy/httpProtect` | HTTP 黑名单、XFF / 高级配置 |
+| | 高危端口防护 | `/strategy/portProtect` | 端口防护组与端口列表 |
+| **资产** | 资产管理 | `/assets/segment` | 资产 / 资产组 / 资产类型 / 导入导出 |
+| **平台管理** | 通知配置 | `/device/alert` | 告警策略、邮件 / Syslog / Webhook 测试 |
+| | 审计日志 | `/device/audit` | 管理日志、清理配置 |
+| | 登录管理 | `/device/loginManagement` | 用户、登录策略 |
+| | HTTPS 解密 | `/device/httpsDecryption` | 解密策略、证书、检测对象 |
+| | 接口 | `/device/interface` | 网口列表、虚拟线、监听口、桥 |
+| | 部署引导 | `/device/deployguide` | 网口部署模式向导 |
+| | 路由 | `/device/route` | IPv4 / IPv6 静态路由、路由表 |
+| | 系统 DNS | `/device/system_dns` | DNS / Hosts / 网络测试 |
+| | 代理 | `/device/agent` | HTTP 代理配置 |
+| | 高可用 | `/device/high_availability` | HA 状态、模块、配置同步、主备切换 |
+| | 集中管控 | `/device/centralized_control` | OneCC 配置与状态 |
+| | 设备配置 | `/device/deviceConfig` | 升级、备份、重启、关机、出厂重置、日志外发 |
+| | 基本信息 | `/device/system_info` | 设备信息、license、离线情报库、MDR |
+| | 设备诊断 | `/device/system_diagnosis` | coredump、pcap |
+| **帮助** | 帮助中心 | `/helper/docs` | 帮助文档列表与预览 |
+| | 版本更新 | `/helper/update` | 软件版本与更新说明 |
+| | 产品反馈 | `/helper/issue` | 提交产品问题 |
+
+> 子页路径来自 OneSIG v2.5.x Web 控制台的当前路由约定；个别版本可能微调，看到 404 时再回到对应模块的根目录手动找一遍。
+
+## 二、浏览器与 API 的互补建议
+
+进入浏览器模式后，对于"查询类"诉求，应该**优先回到 API**（除非 API 真的不可用）：
+
+| 任务 | 优先方案 |
+|---|---|
+| 列威胁事件 / 失陷主机 / 趋势数据 | API（`onesig_monitoring`） —— 浏览器只在需要威胁图、报文 hex 时用 |
+| 增删改黑白名单 / IPS 规则 / 多维封锁 | API（`onesig_strategy`），写操作前要二次确认 |
+| 看资产清单、增改资产 | API（`onesig_assets`） —— 浏览器仅做导入文件预览 |
+| 设备升级 / 重启 / HA 切换 | 浏览器 + API 并用：先在浏览器里走完确认弹窗、备份提示，再用 API 触发；或者全程在浏览器里完成（更稳） |
+| 看证书 / 解密策略详情 | 浏览器（API 返回的字段比页面少） |
+| 看页面级图表 / 攻击链 / IOC 关联 | 浏览器（API 没有） |
+| 处理图形验证码 / TOTP / 强制改密 | 浏览器（API 不能完成人工交互） |
+
+## 三、写操作的安全护栏
+
+在浏览器里执行下列动作前，必须显式取得用户授权：
+
+- 一键 bypass / 流量直通（`策略首页` 或 `设备配置` 里的"Bypass / 直通"按钮）
+- 重启 / 关机 / 出厂重置（`设备配置` 顶部按钮）
+- 设备升级 / 系统升级（上传升级包、点"升级"）
+- HA 主备切换、HA 配置同步
+- 用户增删改密、改当前用户密码
+- 黑白名单批量导入 / 批量删除
+- IPS 规则集启停、HTTPS 解密策略启停
+- 数据库 license / 离线情报库导入
+- 备份恢复（会覆盖当前配置）
+
+如果用户只是想"看一眼"，就只点列表 / 详情，不要去碰任何"启停 / 导入 / 删除 / 升级"按钮。
+
+## 四、文件下载与导出
+
+OneSIG 控制台的导出按钮（资产 / 黑白名单 / 报表 / 审计 / coredump / pcap）多数会触发浏览器下载。在 `agent-browser` 模式下：
+
+```bash
+# 触发下载
+agent-browser click "<导出 / 下载 按钮的 selector>"
+# 等下载完成 —— OneSIG 服务端通常 < 30s
+agent-browser wait --download
+agent-browser download list
+```
+
+建议优先用 API 的导出 / 下载 action（参见 [api-reference.md](api-reference.md) "文件类返回 / 上传"小节）。

--- a/.flocks/plugins/tools/api/onesig/_provider.yaml
+++ b/.flocks/plugins/tools/api/onesig/_provider.yaml
@@ -1,0 +1,106 @@
+name: onesig
+service_id: onesig_api
+description: >
+  OneSIG (Secure Internet Gateway) Web API service. Authentication uses cookie
+  session: the handler logs in with username + RSA-OAEP encrypted password and
+  reuses the resulting session cookie across subsequent calls. Configure host
+  base URL, username and password separately in the credentials form. The
+  optional captcha / TOTP fields are only required when the device has captcha
+  or two-factor authentication enabled.
+description_cn: >
+  OneSIG（安全互联网网关）Web API 服务。认证采用 Cookie 会话：处理器先用
+  `用户名 + RSA-OAEP 加密的密码` 登录，建立 Cookie 后复用同一会话调用业务接口。
+  配置页需分别填写 Base URL、用户名、密码；当设备开启图形验证码或 TOTP 时，
+  对应字段可在调用 `onesig_login` 时按需传入。
+auth:
+  type: custom
+  secret: onesig_password
+credential_fields:
+  - key: base_url
+    label: Base URL
+    storage: config
+    config_key: base_url
+    input_type: url
+    required: true
+    placeholder: "https://device.example.com"
+  - key: api_prefix
+    label: API Prefix
+    storage: config
+    config_key: api_prefix
+    input_type: text
+    required: false
+    default: "/api"
+    placeholder: "/api 或留空"
+  - key: username
+    label: Username
+    storage: config
+    config_key: username
+    input_type: text
+    required: true
+  - key: password
+    label: Password
+    storage: secret
+    config_key: password
+    secret_id: onesig_password
+    input_type: password
+    required: true
+  - key: oaep_hash
+    label: RSA-OAEP Hash
+    storage: config
+    config_key: oaep_hash
+    input_type: text
+    required: false
+    default: "sha1"
+    placeholder: "sha1 或 sha256"
+  - key: verify_ssl
+    label: Verify SSL
+    storage: config
+    config_key: verify_ssl
+    input_type: text
+    required: false
+    default: "true"
+    placeholder: "true / false"
+defaults:
+  api_prefix: "/api"
+  oaep_hash: "sha1"
+  verify_ssl: "true"
+  timeout: 60
+  category: custom
+notes: |
+  OneSIG Web API 使用 Cookie 会话鉴权。
+
+  常见配置示例：
+    - api_services.onesig_api.base_url     = "https://device.example.com"
+    - api_services.onesig_api.api_prefix   = "/api"
+    - api_services.onesig_api.username     = "admin"
+    - api_services.onesig_api.password     = "{secret:onesig_password}"
+    - api_services.onesig_api.oaep_hash    = "sha1"           # JSEncrypt 默认；联调失败可改为 sha256
+    - api_services.onesig_api.verify_ssl   = "true"
+
+  说明：
+    - 文档接口路径形如 `/v3/...`，前端实际请求会带 `/api` 前缀。处理器在拼接 URL 时会自动加上
+      `api_prefix`，请按部署环境调整。
+    - 当设备启用图形验证码或 TOTP 时，可在 `onesig_login` 工具的 `login` 动作中传入 `captcha`
+      和 `totp` 参数，否则会因 responseCode 1012/验证码错误而失败。
+    - 处理器会在 401 / responseCode 1019 等会话失效场景自动重新登录并重试一次；
+      也可以手动调用 `onesig_login` 的 `login` / `logout` 动作管理会话。
+
+  RSA-OAEP 与 oaep_hash 联调指引：
+    - JSEncrypt（前端默认）使用 SHA-1 + MGF1-SHA1，因此本插件默认 `oaep_hash: sha1`。
+    - 若 `POST /v3/login` 返回 responseCode `1009`（密码无效）或 `1017`（密码错误）但
+      用户名/口令确实正确，先优先怀疑 OAEP 哈希不匹配；将 oaep_hash 切换为 `sha256`
+      重试一次：
+        api_services.onesig_api.oaep_hash = "sha256"
+    - 改密、删除用户、清空审计、接口启停、设备升级等敏感写操作的 `password` 字段
+      也使用同一份公钥与同一组哈希参数加密；切换 oaep_hash 时这些动作会同步生效。
+    - 如果对接遇到「公钥过期」型报错，可直接重发；处理器在改密/敏感字段加密前会
+      重新拉取 `/v3/pubkey`（与前端 clearRSACache 行为一致）。
+
+  multipart 上传与 RSA 字段（与 onesig_device / onesig_assets 工具配合）：
+    - 多个 `导入 / 上传 / 升级` 类接口（如 asset_import、tls_cert_create、system_upgrade、
+      device_upgrade_upload、basic_information_import、basic_license_upload、backup_import）
+      会以 `multipart/form-data` 提交本地文件，调用方需提供 `file_path` 指向本地绝对路径。
+    - 删除/启停/改密类敏感写操作（aclog_delete、user_delete、user_secret_reset、user_create、
+      interface_update、device_upgrade、device_upgrade_upload）需要传入**明文**
+      `password`（user_create 还需 `dupPassword`），处理器会自动用最新公钥做 RSA-OAEP 加密
+      后再发送，请勿手动加密。

--- a/.flocks/plugins/tools/api/onesig/_provider.yaml
+++ b/.flocks/plugins/tools/api/onesig/_provider.yaml
@@ -52,18 +52,9 @@ credential_fields:
     required: false
     default: "sha1"
     placeholder: "sha1 或 sha256"
-  - key: verify_ssl
-    label: Verify SSL
-    storage: config
-    config_key: verify_ssl
-    input_type: text
-    required: false
-    default: "true"
-    placeholder: "true / false"
 defaults:
   api_prefix: "/api"
   oaep_hash: "sha1"
-  verify_ssl: "true"
   timeout: 60
   category: custom
 notes: |
@@ -71,11 +62,52 @@ notes: |
 
   常见配置示例：
     - api_services.onesig_api.base_url     = "https://device.example.com"
-    - api_services.onesig_api.api_prefix   = "/api"
+    - api_services.onesig_api.api_prefix   = ""               # 大部分 v2.5.x 部署留空；reverse-proxy 部署才填 "/api"
     - api_services.onesig_api.username     = "admin"
     - api_services.onesig_api.password     = "{secret:onesig_password}"
     - api_services.onesig_api.oaep_hash    = "sha1"           # JSEncrypt 默认；联调失败可改为 sha256
-    - api_services.onesig_api.verify_ssl   = "true"
+
+  `api_prefix` 选取建议：
+    - 默认值 `""`（空）。绝大多数 OneSIG v2.5.x 设备 nginx 已经把 `/v3/`
+      直接路由到后端，因此 `https://host/v3/captcha` 这样的 URL 才能拿到
+      JSON。把 `api_prefix` 留空即可。
+    - 如果设备前面挂了反向代理（路径是 `https://host/api/v3/...`），把
+      `api_prefix` 显式改成 `"/api"`。
+    - 看到日志 `无法从 .../v3/pubkey 获取 RSA 公钥（HTTP 404 ...）` 几乎都是
+      `api_prefix` 没对齐：把当前值取反（空 ↔ "/api"）再试。
+
+  `verify_ssl` 由表单底部「SSL 验证」开关控制，与 onesec / ngtip / qingteng 一致，
+  下列字段都会被识别为 SSL 验证开关，按以下优先级取值：
+    1. `verify_ssl`                         （主键）
+    2. `ssl_verify`                         （兼容别名）
+    3. `verifySsl`                          （onesig 历史 camelCase 别名）
+    4. `custom_settings.verify_ssl`         （WebUI 表单写入位置）
+    5. 环境变量 `ONESIG_VERIFY_SSL`         （CLI / 容器场景兜底）
+    6. 兜底默认值 `False`（**默认关闭证书验证**）
+
+  关于默认值：OneSIG 设备绝大多数情况以私有网关形式部署，使用自签证书。为了开盒
+  即用，默认与 onesec / ngtip / qingteng 保持一致，**默认关闭证书校验**。在
+  公网或使用受信任 CA 的部署上，请显式打开 UI「SSL 验证」开关或在配置中设置
+  `verify_ssl: true` 以启用严格证书校验。
+
+  Cookie 会话持久化（`persist_cookies`）：
+    - 处理器会在登录成功后把 aiohttp CookieJar 序列化成 JSON 写入
+      `~/.flocks/config/.secret.json`（与口令同居一份 0600 权限文件），
+      key 形如 `onesig_session_cookie__<sha1[:12](base_url|username)>`。
+    - 进程重启时若该条 secret 还在且至少有一个 cookie 未过期，会直接灌回
+      jar 并跳过 captcha→pubkey→/v3/login→/v3/account 整条链路；如果设备
+      已经吊销该 cookie，首次业务请求拿到 401 / responseCode 1019..1022
+      时会触发自动重登一次（与原行为一致）。
+    - `logout` 动作会同步删除磁盘上的 cookie；`close` 不会删（用于优雅
+      关停时保留持久化数据）。
+    - 字段优先级与 `verify_ssl` 完全一致：
+        1. `persist_cookies`
+        2. `persistCookies`
+        3. `custom_settings.persist_cookies`
+        4. 环境变量 `ONESIG_PERSIST_COOKIES`
+        5. 兜底默认值 `True`（**默认开启持久化**）
+    - 关闭场景：在严格安全或多用户共享同一 `~/.flocks` 的部署上想退回
+      纯内存模式时，把 `persist_cookies: false` 写到 service config 即可。
 
   说明：
     - 文档接口路径形如 `/v3/...`，前端实际请求会带 `/api` 前缀。处理器在拼接 URL 时会自动加上

--- a/.flocks/plugins/tools/api/onesig/onesig.handler.py
+++ b/.flocks/plugins/tools/api/onesig/onesig.handler.py
@@ -1,0 +1,1690 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import ssl
+from typing import Any, Optional
+
+import aiohttp
+
+from flocks.config.config_writer import ConfigWriter
+from flocks.tool.registry import ToolContext, ToolResult
+
+
+SERVICE_ID = "onesig_api"
+
+DEFAULT_API_PREFIX = "/api"
+DEFAULT_OAEP_HASH = "sha1"
+DEFAULT_TIMEOUT = 60
+DEFAULT_VERIFY_SSL = True
+
+_RESPONSE_CODE_OK = 0
+_RESPONSE_CODE_TOTP_REQUIRED = 1012
+_RESPONSE_CODE_DEFAULT_PWD = 1010
+_RESPONSE_CODE_PWD_EXPIRED = 1011
+
+_SESSION_EXPIRED_RESPONSE_CODES = frozenset({1019, 1020, 1021, 1022})
+_SESSION_EXPIRED_HTTP_STATUSES = frozenset({401, 403})
+
+
+def _get_secret_manager() -> Any:
+    from flocks.security import get_secret_manager
+
+    return get_secret_manager()
+
+
+def _resolve_ref(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return str(value)
+    if value.startswith("{secret:") and value.endswith("}"):
+        return _get_secret_manager().get(value[len("{secret:") : -1])
+    if value.startswith("{env:") and value.endswith("}"):
+        return os.getenv(value[len("{env:") : -1])
+    return value
+
+
+def _service_config() -> dict[str, Any]:
+    raw = ConfigWriter.get_api_service_raw(SERVICE_ID)
+    return raw if isinstance(raw, dict) else {}
+
+
+def _coerce_bool(value: Any, default: bool = True) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+class OneSIGRuntimeConfig:
+    """Resolved runtime configuration for a single OneSIG service entry."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_prefix: str,
+        username: str,
+        password: str,
+        oaep_hash: str,
+        verify_ssl: bool,
+        timeout: int,
+    ) -> None:
+        self.base_url = base_url
+        self.api_prefix = api_prefix
+        self.username = username
+        self.password = password
+        self.oaep_hash = oaep_hash
+        self.verify_ssl = verify_ssl
+        self.timeout = timeout
+
+    @property
+    def session_key(self) -> str:
+        return f"{self.base_url}|{self.username}"
+
+    def build_url(self, path: str) -> str:
+        path = path if path.startswith("/") else "/" + path
+        prefix = self.api_prefix.rstrip("/")
+        return f"{self.base_url}{prefix}{path}"
+
+
+def _resolve_runtime_config() -> OneSIGRuntimeConfig:
+    raw = _service_config()
+    base_url = (
+        _resolve_ref(raw.get("base_url"))
+        or _resolve_ref(raw.get("baseUrl"))
+        or os.getenv("ONESIG_BASE_URL")
+    )
+    if not base_url:
+        raise ValueError(
+            "OneSIG base_url not configured. Set api_services.onesig_api.base_url or ONESIG_BASE_URL."
+        )
+    base_url = base_url.rstrip("/")
+
+    api_prefix = (
+        _resolve_ref(raw.get("api_prefix"))
+        or _resolve_ref(raw.get("apiPrefix"))
+        or os.getenv("ONESIG_API_PREFIX")
+        or DEFAULT_API_PREFIX
+    )
+    if api_prefix and not api_prefix.startswith("/"):
+        api_prefix = "/" + api_prefix
+    api_prefix = api_prefix.rstrip("/")
+
+    username = (
+        _resolve_ref(raw.get("username"))
+        or _resolve_ref(raw.get("user"))
+        or os.getenv("ONESIG_USERNAME")
+    )
+    if not username:
+        raise ValueError(
+            "OneSIG username not configured. Set api_services.onesig_api.username or ONESIG_USERNAME."
+        )
+
+    secret_manager = _get_secret_manager()
+    password = (
+        _resolve_ref(raw.get("password"))
+        or secret_manager.get("onesig_password")
+        or secret_manager.get(f"{SERVICE_ID}_password")
+        or os.getenv("ONESIG_PASSWORD")
+    )
+    if not password:
+        raise ValueError(
+            "OneSIG password not configured. Save it as the onesig_password secret or set ONESIG_PASSWORD."
+        )
+
+    oaep_hash = (
+        _resolve_ref(raw.get("oaep_hash"))
+        or _resolve_ref(raw.get("oaepHash"))
+        or os.getenv("ONESIG_OAEP_HASH")
+        or DEFAULT_OAEP_HASH
+    ).lower()
+    if oaep_hash not in {"sha1", "sha256"}:
+        oaep_hash = DEFAULT_OAEP_HASH
+
+    verify_ssl = _coerce_bool(
+        raw.get("verify_ssl", raw.get("verifySsl", os.getenv("ONESIG_VERIFY_SSL"))),
+        default=DEFAULT_VERIFY_SSL,
+    )
+
+    timeout_raw = raw.get("timeout", DEFAULT_TIMEOUT)
+    try:
+        timeout = int(timeout_raw)
+    except (TypeError, ValueError):
+        timeout = DEFAULT_TIMEOUT
+
+    return OneSIGRuntimeConfig(
+        base_url=base_url,
+        api_prefix=api_prefix,
+        username=username,
+        password=password,
+        oaep_hash=oaep_hash,
+        verify_ssl=verify_ssl,
+        timeout=timeout,
+    )
+
+
+def _rsa_oaep_encrypt(pem_pubkey: str, plain: str, oaep_hash: str) -> str:
+    """Encrypt `plain` with RSA-OAEP using the provided PEM public key."""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding
+
+    hash_alg = hashes.SHA1() if oaep_hash == "sha1" else hashes.SHA256()
+    pub = serialization.load_pem_public_key(
+        pem_pubkey.encode("utf-8"), backend=default_backend()
+    )
+    cipher = pub.encrypt(
+        plain.encode("utf-8"),
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hash_alg),
+            algorithm=hash_alg,
+            label=None,
+        ),
+    )
+    return base64.b64encode(cipher).decode("ascii")
+
+
+def _ssl_context(verify_ssl: bool) -> Any:
+    if verify_ssl:
+        return None
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+class OneSIGSession:
+    """Cookie-based session for a OneSIG device.
+
+    A single instance owns an aiohttp ClientSession with its own cookie jar and
+    handles the captcha → pubkey → login flow. Concurrent callers reuse the
+    same logged-in session and share the auto-relogin lock.
+    """
+
+    def __init__(self, config: OneSIGRuntimeConfig) -> None:
+        self.config = config
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._logged_in = False
+        self._login_lock = asyncio.Lock()
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            jar = aiohttp.CookieJar(unsafe=True)
+            self._session = aiohttp.ClientSession(cookie_jar=jar)
+        return self._session
+
+    async def close(self) -> None:
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+        self._session = None
+        self._logged_in = False
+
+    async def login(
+        self,
+        *,
+        captcha: Optional[str] = None,
+        totp: Optional[str] = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Run the captcha → pubkey → /v3/login → optional /v3/login/totp flow.
+
+        Returns the final account info on success. Raises ValueError on failure
+        with a human-readable explanation.
+        """
+        async with self._login_lock:
+            if self._logged_in and not force:
+                account = await self._raw_request_json("GET", "/v3/account")
+                if isinstance(account, dict) and account.get("responseCode") == _RESPONSE_CODE_OK:
+                    return account.get("data", {}) or {}
+                self._logged_in = False
+
+            captcha_info = await self._raw_request_json("GET", "/v3/captcha")
+            captcha_data = (
+                captcha_info.get("data", {}) if isinstance(captcha_info, dict) else {}
+            )
+            enable_captcha = bool(captcha_data.get("enableCaptcha"))
+            enable_totp_inline = bool(captcha_data.get("enableTotp"))
+            if enable_captcha and not captcha:
+                raise ValueError(
+                    "OneSIG 设备已启用图形验证码，请通过 onesig_login(action='login', captcha='...') 提供。"
+                )
+            if enable_totp_inline and not totp:
+                # Inline mode: the captcha endpoint already advertises
+                # `enableTotp=true`, meaning the device wants the TOTP code on
+                # the same login form (the `checksum` field) rather than the
+                # post-login QR-scan flow. Refuse early so the caller does not
+                # see an opaque 1017 / "checksum 不能为空" later.
+                raise ValueError(
+                    "OneSIG 设备已启用 inline TOTP（同屏「用户口令」），请通过 "
+                    "onesig_login(action='login', totp='...') 提供动态口令或恢复码。"
+                )
+
+            pubkey_info = await self._raw_request_json("GET", "/v3/pubkey")
+            pubkey_data = (
+                pubkey_info.get("data", {}) if isinstance(pubkey_info, dict) else {}
+            )
+            pubkey = pubkey_data.get("pubkey")
+            if not pubkey:
+                raise ValueError(
+                    f"无法从 /v3/pubkey 获取 RSA 公钥：{pubkey_info!r}"
+                )
+
+            try:
+                encrypted_password = _rsa_oaep_encrypt(
+                    pubkey, self.config.password, self.config.oaep_hash
+                )
+            except Exception as exc:
+                raise ValueError(
+                    f"使用 OAEP({self.config.oaep_hash}) 加密密码失败：{exc}"
+                ) from exc
+
+            payload: dict[str, Any] = {
+                "username": self.config.username,
+                "password": encrypted_password,
+            }
+            if enable_captcha and captcha:
+                payload["captcha"] = captcha
+            if enable_totp_inline and totp:
+                payload["checksum"] = totp
+
+            login_resp = await self._raw_request_json(
+                "POST", "/v3/login", json_body=payload
+            )
+            if not isinstance(login_resp, dict):
+                raise ValueError(f"登录返回非 JSON：{login_resp!r}")
+
+            response_code = login_resp.get("responseCode")
+            if response_code == _RESPONSE_CODE_TOTP_REQUIRED:
+                if not totp:
+                    raise ValueError(
+                        "OneSIG 设备要求扫码 TOTP 二次验证，请在 login 调用中传入 `totp` 参数。"
+                    )
+                totp_resp = await self._raw_request_json(
+                    "POST",
+                    "/v3/login/totp",
+                    json_body={"checksum": totp},
+                )
+                if (
+                    not isinstance(totp_resp, dict)
+                    or totp_resp.get("responseCode") != _RESPONSE_CODE_OK
+                ):
+                    raise ValueError(
+                        f"TOTP 二次验证失败：{(totp_resp or {}).get('verboseMsg', totp_resp)}"
+                    )
+            elif response_code in (_RESPONSE_CODE_DEFAULT_PWD, _RESPONSE_CODE_PWD_EXPIRED):
+                raise ValueError(
+                    f"OneSIG 要求修改密码（responseCode={response_code}：{login_resp.get('verboseMsg')})。"
+                    " 请先通过控制台或 `onesig_login(action='change_password', ...)` 修改密码。"
+                )
+            elif response_code != _RESPONSE_CODE_OK:
+                raise ValueError(
+                    f"OneSIG 登录失败（responseCode={response_code}）：{login_resp.get('verboseMsg')}"
+                )
+
+            self._logged_in = True
+            account_resp = await self._raw_request_json("GET", "/v3/account")
+            if (
+                isinstance(account_resp, dict)
+                and account_resp.get("responseCode") == _RESPONSE_CODE_OK
+            ):
+                return account_resp.get("data", {}) or {}
+            return {}
+
+    async def logout(self) -> dict[str, Any]:
+        try:
+            resp = await self._raw_request_json("POST", "/v3/logout", json_body={})
+        finally:
+            self._logged_in = False
+        if isinstance(resp, dict):
+            return resp
+        return {}
+
+    async def _raw_request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Optional[Any] = None,
+    ) -> Any:
+        """Issue a raw request and parse the JSON envelope. Used for login/logout/account."""
+        session = await self._ensure_session()
+        url = self.config.build_url(path)
+        request_params = {"lang": "zh"}
+        if params:
+            request_params.update({k: v for k, v in params.items() if v is not None})
+        kwargs: dict[str, Any] = {
+            "params": request_params,
+            "timeout": aiohttp.ClientTimeout(total=self.config.timeout),
+            "ssl": _ssl_context(self.config.verify_ssl),
+        }
+        if json_body is not None:
+            kwargs["json"] = json_body
+            kwargs["headers"] = {"Content-Type": "application/json"}
+        async with session.request(method.upper(), url, **kwargs) as resp:
+            text = await resp.text()
+            try:
+                return await resp.json(content_type=None)
+            except Exception:
+                return {"_status": resp.status, "_text": text[:500]}
+
+    async def encrypt_with_pubkey(self, plain: str) -> str:
+        """Fetch the latest /v3/pubkey and RSA-OAEP encrypt the given plaintext.
+
+        Mirrors the front-end "clearRSACache → fresh pubkey → encrypt" pattern
+        (`@/util/rsa.js`) used for sensitive write operations.
+        """
+        pubkey_resp = await self._raw_request_json("GET", "/v3/pubkey")
+        pubkey = (pubkey_resp or {}).get("data", {}).get("pubkey")
+        if not pubkey:
+            raise ValueError(
+                f"无法从 /v3/pubkey 获取 RSA 公钥用于字段加密：{pubkey_resp!r}"
+            )
+        return _rsa_oaep_encrypt(pubkey, plain, self.config.oaep_hash)
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Optional[Any] = None,
+        form_data: Optional["aiohttp.FormData"] = None,
+        captcha: Optional[str] = None,
+        totp: Optional[str] = None,
+        _retry: bool = True,
+    ) -> tuple[int, dict[str, Any], bytes, str]:
+        """Issue an authenticated request, auto-relogin on session expiry.
+
+        Pass either ``json_body`` (JSON request) or ``form_data``
+        (``multipart/form-data`` upload). Passing both raises ValueError.
+
+        Returns ``(status, json_envelope, body_bytes, content_type)``. When the
+        response is JSON, ``json_envelope`` contains the parsed payload and
+        ``body_bytes`` is empty. When the response is binary, ``body_bytes``
+        carries the raw bytes for the caller to persist.
+        """
+        if json_body is not None and form_data is not None:
+            raise ValueError("request() cannot accept both json_body and form_data")
+
+        if not self._logged_in:
+            await self.login(captcha=captcha, totp=totp)
+
+        session = await self._ensure_session()
+        url = self.config.build_url(path)
+        request_params: dict[str, Any] = {"lang": "zh"}
+        if params:
+            request_params.update({k: v for k, v in params.items() if v is not None})
+
+        kwargs: dict[str, Any] = {
+            "params": request_params,
+            "timeout": aiohttp.ClientTimeout(total=self.config.timeout),
+            "ssl": _ssl_context(self.config.verify_ssl),
+        }
+        if json_body is not None:
+            kwargs["json"] = json_body
+            kwargs["headers"] = {"Content-Type": "application/json"}
+        elif form_data is not None:
+            # aiohttp sets Content-Type with the boundary for FormData
+            # automatically; do not override.
+            kwargs["data"] = form_data
+
+        async with session.request(method.upper(), url, **kwargs) as resp:
+            status = resp.status
+            content_type = resp.headers.get("Content-Type", "") or ""
+            if "application/json" in content_type:
+                envelope = await resp.json(content_type=None)
+                body_bytes = b""
+            else:
+                body_bytes = await resp.read()
+                envelope = {}
+
+        envelope_dict = envelope if isinstance(envelope, dict) else {"data": envelope}
+        response_code = envelope_dict.get("responseCode") if envelope_dict else None
+        session_expired = (
+            status in _SESSION_EXPIRED_HTTP_STATUSES
+            or response_code in _SESSION_EXPIRED_RESPONSE_CODES
+        )
+        if session_expired and _retry:
+            self._logged_in = False
+            await self.login(captcha=captcha, totp=totp, force=True)
+            # form_data is single-shot; caller must rebuild on retry. We can
+            # only retransmit JSON requests automatically.
+            if form_data is not None:
+                return status, envelope_dict, body_bytes, content_type
+            return await self.request(
+                method,
+                path,
+                params=params,
+                json_body=json_body,
+                captcha=captcha,
+                totp=totp,
+                _retry=False,
+            )
+        return status, envelope_dict, body_bytes, content_type
+
+
+_SESSIONS: dict[str, OneSIGSession] = {}
+_SESSIONS_LOCK = asyncio.Lock()
+
+
+async def _get_session(config: OneSIGRuntimeConfig) -> OneSIGSession:
+    async with _SESSIONS_LOCK:
+        sess = _SESSIONS.get(config.session_key)
+        if sess is None:
+            sess = OneSIGSession(config)
+            _SESSIONS[config.session_key] = sess
+        else:
+            sess.config = config
+        return sess
+
+
+# ---------------------------------------------------------------------------
+# Action specifications
+# ---------------------------------------------------------------------------
+
+
+_RESERVED_PARAM_KEYS = frozenset({"action", "captcha", "totp", "file_path"})
+
+
+class ActionSpec:
+    """Declarative spec for a single OneSIG endpoint action."""
+
+    def __init__(
+        self,
+        method: str,
+        path: str,
+        *,
+        body_keys: Optional[list[str]] = None,
+        query_keys: Optional[list[str]] = None,
+        passthrough_body: bool = False,
+        binary: bool = False,
+        required: Optional[list[str]] = None,
+        multipart: bool = False,
+        multipart_file_field: str = "file",
+        encrypt_fields: Optional[tuple[str, ...]] = None,
+    ) -> None:
+        self.method = method.upper()
+        self.path = path
+        self.body_keys = body_keys or []
+        self.query_keys = query_keys or []
+        self.passthrough_body = passthrough_body
+        self.binary = binary
+        self.required = required or []
+        # multipart=True: send the body as multipart/form-data; the local file
+        # path comes from the reserved `file_path` param and is uploaded under
+        # `multipart_file_field` (default `file`, per OneSIG docs).
+        self.multipart = multipart
+        self.multipart_file_field = multipart_file_field
+        # Body fields whose plaintext value must be RSA-OAEP encrypted with the
+        # current /v3/pubkey before being sent (typical: ("password",) or
+        # ("password", "dupPassword")).
+        self.encrypt_fields = tuple(encrypt_fields or ())
+
+    def build_request(
+        self, params: dict[str, Any]
+    ) -> tuple[Optional[dict[str, Any]], Optional[Any]]:
+        query = {k: params[k] for k in self.query_keys if params.get(k) is not None}
+
+        body: Optional[Any] = None
+        if self.method == "GET" and not self.multipart:
+            for key in self.body_keys:
+                if params.get(key) is not None:
+                    query[key] = params[key]
+        else:
+            if self.passthrough_body:
+                body = {
+                    k: v
+                    for k, v in params.items()
+                    if k not in _RESERVED_PARAM_KEYS
+                    and k not in self.query_keys
+                    and v is not None
+                }
+            else:
+                body = {k: params[k] for k in self.body_keys if params.get(k) is not None}
+        return (query or None), body
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) > 0
+    return True
+
+
+def _validate_required(spec: ActionSpec, action: str, params: dict[str, Any]) -> Optional[str]:
+    missing = [k for k in spec.required if not _has_value(params.get(k))]
+    if missing:
+        return f"Missing required parameters for {action}: {', '.join(missing)}"
+    return None
+
+
+# Login / Account / Password ------------------------------------------------
+
+LOGIN_ACTION_SPECS: dict[str, ActionSpec] = {
+    "get_captcha": ActionSpec("GET", "/v3/captcha"),
+    "get_pubkey": ActionSpec("GET", "/v3/pubkey"),
+    "get_account": ActionSpec("GET", "/v3/account"),
+    "get_recovery_code": ActionSpec("GET", "/v3/user/recoveryCode"),
+    "regenerate_recovery_code": ActionSpec("PUT", "/v3/user/recoveryCode"),
+    "get_product_news": ActionSpec("GET", "/v3/product/news"),
+    "mark_product_news_read": ActionSpec(
+        "PUT", "/v3/product/news", passthrough_body=True
+    ),
+}
+
+# Monitoring ---------------------------------------------------------------
+
+MONITORING_ACTION_SPECS: dict[str, ActionSpec] = {
+    # dashboard
+    "dashboard_overview": ActionSpec("POST", "/v3/dashboard/overview", passthrough_body=True),
+    "dashboard_outbound": ActionSpec("POST", "/v3/dashboard/outbound", passthrough_body=True),
+    "dashboard_inbound": ActionSpec("POST", "/v3/dashboard/inbound", passthrough_body=True),
+    "dashboard_zeroday": ActionSpec("POST", "/v3/dashboard/zeroday", passthrough_body=True),
+    "dashboard_status": ActionSpec("GET", "/v3/dashboard/status"),
+    "dashboard_ioc_type_sum": ActionSpec("GET", "/v3/dashboard/ioctypesum"),
+    "set_custom_config": ActionSpec("PUT", "/v3/setting/customConfig", passthrough_body=True),
+    # overview
+    "common_threat_type_list": ActionSpec("GET", "/v3/common/threatTypeList"),
+    "overview_event_inbound": ActionSpec("POST", "/v3/overview/eventInbound", passthrough_body=True),
+    "overview_event_outbound": ActionSpec("POST", "/v3/overview/eventOutbound", passthrough_body=True),
+    "overview_export_event_inbound": ActionSpec(
+        "POST", "/v3/overview/exportEventInbound", passthrough_body=True, binary=True
+    ),
+    "overview_export_event_outbound": ActionSpec(
+        "POST", "/v3/overview/exportEventOutbound", passthrough_body=True, binary=True
+    ),
+    "overview_asset_brief": ActionSpec("POST", "/v3/overview/assetBrief", passthrough_body=True),
+    "overview_asset_top": ActionSpec("POST", "/v3/overview/assetTop", passthrough_body=True),
+    "overview_event_inbound_agg": ActionSpec("POST", "/v3/overview/eventInboundAgg", passthrough_body=True),
+    "overview_export_event_inbound_agg": ActionSpec(
+        "POST", "/v3/overview/exportEventInboundAgg", passthrough_body=True, binary=True
+    ),
+    "overview_event_outbound_agg": ActionSpec("POST", "/v3/overview/eventOutboundAgg", passthrough_body=True),
+    "overview_export_event_outbound_agg": ActionSpec(
+        "POST", "/v3/overview/exportEventOutboundAgg", passthrough_body=True, binary=True
+    ),
+    "overview_event_recent_agg": ActionSpec("POST", "/v3/overview/eventRecentAgg", passthrough_body=True),
+    "overview_event_trend": ActionSpec("POST", "/v3/overview/eventTrend", passthrough_body=True),
+    "overview_traffic_trend": ActionSpec("POST", "/v3/overview/trafficTrend", passthrough_body=True),
+    "overview_stat": ActionSpec("POST", "/v3/overview/stat", passthrough_body=True),
+    "overview_threat_type_proportion": ActionSpec(
+        "POST", "/v3/overview/threatTypeProportion", passthrough_body=True
+    ),
+    "overview_ioc_type_proportion": ActionSpec(
+        "POST", "/v3/overview/iocTypeProportion", passthrough_body=True
+    ),
+    "overview_export_threat_type_proportion": ActionSpec(
+        "POST", "/v3/overview/exportThreatTypeProportion", passthrough_body=True, binary=True
+    ),
+    "overview_export_ioc_type_proportion": ActionSpec(
+        "POST", "/v3/overview/exportIocTypeProportion", passthrough_body=True, binary=True
+    ),
+    "get_overview_config": ActionSpec("GET", "/v3/setting/overviewConfig"),
+    "set_overview_config": ActionSpec("PUT", "/v3/setting/overviewConfig", passthrough_body=True),
+    # status
+    "device_platform_status": ActionSpec("GET", "/v3/device/platformStatus"),
+    "device_system_status": ActionSpec("GET", "/v3/device/systemStatus"),
+    "device_network_status": ActionSpec("GET", "/v3/device/networkStatus"),
+    "common_interface_list": ActionSpec("GET", "/v3/common/interfaceList"),
+    "basic_cpu_attr": ActionSpec("GET", "/v3/basic/cpuAttr"),
+    # alert hosts
+    "alert_host_stat": ActionSpec(
+        "GET", "/v3/alertHost/stat", body_keys=["startTime", "endTime", "assetGroup"]
+    ),
+    "alert_host_tree": ActionSpec("POST", "/v3/alertHost/tree", passthrough_body=True),
+    "alert_host_list": ActionSpec(
+        "POST",
+        "/v3/alertHost/list",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
+    ),
+    "alert_host_export": ActionSpec(
+        "POST", "/v3/alertHost/export", passthrough_body=True, binary=True
+    ),
+    "alert_host_detail": ActionSpec("POST", "/v3/alertHost/detail", passthrough_body=True),
+    "alert_host_detail_list": ActionSpec(
+        "POST", "/v3/alertHost/detail/list", passthrough_body=True
+    ),
+    "alert_host_detail_export": ActionSpec(
+        "POST", "/v3/alertHost/detail/export", passthrough_body=True, binary=True
+    ),
+    "common_asset_type_list": ActionSpec("GET", "/v3/common/assetTypeList"),
+    # inbound / outbound threats
+    "event_inbound_stat": ActionSpec(
+        "GET", "/v3/event/inbound/stat", body_keys=["startTime", "endTime", "assetGroup"]
+    ),
+    "event_inbound_list": ActionSpec(
+        "POST",
+        "/v3/event/inbound/list",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
+    ),
+    "event_inbound_export": ActionSpec(
+        "POST", "/v3/event/inbound/export", passthrough_body=True, binary=True
+    ),
+    "event_inbound_detail": ActionSpec("POST", "/v3/event/inbound/detail", passthrough_body=True),
+    "event_inbound_detail_trend": ActionSpec(
+        "POST", "/v3/event/inbound/detail/trend", passthrough_body=True
+    ),
+    "event_inbound_detail_list": ActionSpec(
+        "POST", "/v3/event/inbound/detail/list", passthrough_body=True
+    ),
+    "event_inbound_detail_export": ActionSpec(
+        "POST", "/v3/event/inbound/detail/export", passthrough_body=True, binary=True
+    ),
+    "port_protect_group_list": ActionSpec(
+        "POST", "/v3/portProtectGroup/list", passthrough_body=True
+    ),
+    "web_custom_column_set": ActionSpec(
+        "PUT", "/v3/webCustomColumn/set", passthrough_body=True
+    ),
+    "event_outbound_stat": ActionSpec(
+        "GET", "/v3/event/outbound/stat", body_keys=["startTime", "endTime", "assetGroup"]
+    ),
+    "event_outbound_list": ActionSpec(
+        "POST",
+        "/v3/event/outbound/list",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
+    ),
+    "event_outbound_export": ActionSpec(
+        "POST", "/v3/event/outbound/export", passthrough_body=True, binary=True
+    ),
+    "event_outbound_detail": ActionSpec("POST", "/v3/event/outbound/detail", passthrough_body=True),
+    "event_outbound_detail_trend": ActionSpec(
+        "POST", "/v3/event/outbound/detail/trend", passthrough_body=True
+    ),
+    "event_outbound_detail_list": ActionSpec(
+        "POST", "/v3/event/outbound/detail/list", passthrough_body=True
+    ),
+    "event_outbound_detail_export": ActionSpec(
+        "POST", "/v3/event/outbound/detail/export", passthrough_body=True, binary=True
+    ),
+    "set_dnslog_config": ActionSpec(
+        "PUT", "/v3/setting/dnslogConfig", passthrough_body=True
+    ),
+    # report
+    "get_notice_config": ActionSpec("GET", "/v3/setting/noticeConfig"),
+    "report_form_create": ActionSpec("POST", "/v3/report/form", passthrough_body=True),
+    "report_form_list": ActionSpec(
+        "POST", "/v3/report/form/list", passthrough_body=True
+    ),
+    "report_form_download": ActionSpec(
+        "GET",
+        "/v3/report/form/download",
+        body_keys=["uniqueId", "fileName"],
+        binary=True,
+    ),
+    "report_form_delete": ActionSpec("DELETE", "/v3/report/form", passthrough_body=True),
+    "report_task_list": ActionSpec(
+        "POST", "/v3/report/task/list", passthrough_body=True
+    ),
+    "report_task_create": ActionSpec("POST", "/v3/report/task", passthrough_body=True),
+    "report_task_update": ActionSpec("PUT", "/v3/report/task", passthrough_body=True),
+    "report_task_delete": ActionSpec("DELETE", "/v3/report/task", passthrough_body=True),
+    "report_task_test": ActionSpec("POST", "/v3/report/task/test", passthrough_body=True),
+    # shared monitoring
+    "common_asset_group_tree": ActionSpec("GET", "/v3/common/assetGroupTree"),
+    "ips_rule_create": ActionSpec("POST", "/v3/ips/rule", passthrough_body=True),
+    "ips_rule_apply": ActionSpec("POST", "/v3/ips/rule/apply", passthrough_body=True),
+    "ips_ruleset_namelist": ActionSpec("POST", "/v3/ips/ruleset/namelist", passthrough_body=True),
+    "ips_ruleset_referred": ActionSpec("POST", "/v3/ips/ruleset/referred", passthrough_body=True),
+    "logaccess_stat": ActionSpec("GET", "/v3/logAccess/stat"),
+    "get_dnslog_config": ActionSpec("GET", "/v3/setting/dnslogConfig"),
+}
+
+# Strategy ----------------------------------------------------------------
+
+STRATEGY_ACTION_SPECS: dict[str, ActionSpec] = {
+    # whitelist
+    "whitelist_add": ActionSpec("POST", "/v3/globalWhitelist", passthrough_body=True),
+    "whitelist_update": ActionSpec("PUT", "/v3/globalWhitelist", passthrough_body=True),
+    "whitelist_delete": ActionSpec("DELETE", "/v3/globalWhitelist", passthrough_body=True),
+    "whitelist_export": ActionSpec(
+        "POST", "/v3/globalWhitelist/export", passthrough_body=True, binary=True
+    ),
+    "whitelist_import": ActionSpec(
+        "POST", "/v3/globalWhitelist/import", passthrough_body=True
+    ),
+    "whitelist_template": ActionSpec(
+        "GET", "/v3/globalWhitelist/template", binary=True
+    ),
+    "whitelist_list": ActionSpec("POST", "/v3/globalWhitelist/list", passthrough_body=True),
+    "whitelist_remove_batch": ActionSpec(
+        "DELETE", "/v3/globalWhitelist/remove", passthrough_body=True
+    ),
+    # blacklist
+    "blacklist_location_options": ActionSpec("GET", "/v3/blacklist/location"),
+    "blacklist_add": ActionSpec("POST", "/v3/globalBlacklist", passthrough_body=True),
+    "blacklist_update": ActionSpec("PUT", "/v3/globalBlacklist", passthrough_body=True),
+    "blacklist_delete": ActionSpec("DELETE", "/v3/globalBlacklist", passthrough_body=True),
+    "blacklist_check": ActionSpec("POST", "/v3/globalBlacklist/check", passthrough_body=True),
+    "blacklist_export": ActionSpec(
+        "POST", "/v3/globalBlacklist/export", passthrough_body=True, binary=True
+    ),
+    "blacklist_import": ActionSpec("POST", "/v3/globalBlacklist/import", passthrough_body=True),
+    "blacklist_template": ActionSpec("GET", "/v3/globalBlacklist/template", binary=True),
+    "blacklist_list": ActionSpec("POST", "/v3/globalBlacklist/list", passthrough_body=True),
+    "blacklist_remove_batch": ActionSpec(
+        "DELETE", "/v3/globalBlacklist/remove", passthrough_body=True
+    ),
+    # multi-block
+    "multiblock_executelog_list": ActionSpec(
+        "POST", "/v3/multiblock/executelog", passthrough_body=True
+    ),
+    "multiblock_executelog_export": ActionSpec(
+        "POST", "/v3/multiblock/executelog/export", passthrough_body=True, binary=True
+    ),
+    "multiblock_rule_delete": ActionSpec(
+        "DELETE", "/v3/multiblock/rule", passthrough_body=True
+    ),
+    "multiblock_rule_active": ActionSpec(
+        "POST", "/v3/multiblock/rule/active", passthrough_body=True
+    ),
+    "multiblock_rule_dict": ActionSpec(
+        "POST", "/v3/multiblock/rule/dict", passthrough_body=True
+    ),
+    "multiblock_rule_list": ActionSpec(
+        "POST", "/v3/multiblock/rule/list", passthrough_body=True
+    ),
+    "multiblock_rule_get": ActionSpec(
+        "POST", "/v3/multiblock/rule/get", passthrough_body=True
+    ),
+    "multiblock_rule_preview": ActionSpec(
+        "POST", "/v3/multiblock/rule/preview", passthrough_body=True
+    ),
+    "multiblock_rule_create": ActionSpec(
+        "POST", "/v3/multiblock/rule", passthrough_body=True
+    ),
+    "multiblock_rule_update": ActionSpec(
+        "PUT", "/v3/multiblock/rule", passthrough_body=True
+    ),
+    # api keys
+    "apikey_delete": ActionSpec("DELETE", "/v3/apikey", passthrough_body=True),
+    "apikey_update": ActionSpec("PUT", "/v3/apikey", passthrough_body=True),
+    "apikey_create": ActionSpec("POST", "/v3/apikey", passthrough_body=True),
+    "apikey_list": ActionSpec("GET", "/v3/apikey/list"),
+    "apikey_secret": ActionSpec("GET", "/v3/apikey/secret", body_keys=["uniqueId"]),
+    # syslog auto-blacklist
+    "auto_blacklist_delete": ActionSpec(
+        "DELETE", "/v3/autoBlacklist", passthrough_body=True
+    ),
+    "auto_blacklist_check": ActionSpec(
+        "POST", "/v3/autoBlacklist/check", passthrough_body=True
+    ),
+    "auto_blacklist_create": ActionSpec(
+        "POST", "/v3/autoBlacklist", passthrough_body=True
+    ),
+    "auto_blacklist_update": ActionSpec(
+        "PUT", "/v3/autoBlacklist", passthrough_body=True
+    ),
+    "auto_blacklist_list": ActionSpec(
+        "POST", "/v3/autoBlacklist/list", passthrough_body=True
+    ),
+    "auto_blacklist_trend": ActionSpec(
+        "GET", "/v3/autoBlacklist/trend", body_keys=["startTime", "endTime"]
+    ),
+    "auto_blacklist_sample": ActionSpec(
+        "POST", "/v3/autoBlacklist/sample", passthrough_body=True
+    ),
+    # ftp/sftp linkage
+    "linkage_delete": ActionSpec("DELETE", "/v3/linkage", passthrough_body=True),
+    "linkage_create": ActionSpec("POST", "/v3/linkage", passthrough_body=True),
+    "linkage_update": ActionSpec("PUT", "/v3/linkage", passthrough_body=True),
+    "linkage_enable": ActionSpec("POST", "/v3/linkage/enable", passthrough_body=True),
+    "linkage_info": ActionSpec("GET", "/v3/linkage/info", body_keys=["uniqueId"]),
+    "linkage_list": ActionSpec("POST", "/v3/linkage/list", passthrough_body=True),
+    "linkage_template": ActionSpec("GET", "/v3/linkage/template", binary=True),
+    "linkage_test": ActionSpec("POST", "/v3/linkage/test", passthrough_body=True),
+    # IPS
+    "ips_rule_create": ActionSpec("POST", "/v3/ips/rule", passthrough_body=True),
+    "ips_rule_all": ActionSpec("POST", "/v3/ips/rule/all", passthrough_body=True),
+    "ips_rule_apply": ActionSpec("POST", "/v3/ips/rule/apply", passthrough_body=True),
+    "ips_rule_list": ActionSpec("POST", "/v3/ips/rule/list", passthrough_body=True),
+    "ips_ruleset_create": ActionSpec("POST", "/v3/ips/ruleset", passthrough_body=True),
+    "ips_ruleset_update": ActionSpec("PUT", "/v3/ips/ruleset", passthrough_body=True),
+    "ips_ruleset_delete": ActionSpec("DELETE", "/v3/ips/ruleset", passthrough_body=True),
+    "ips_ruleset_info": ActionSpec("POST", "/v3/ips/ruleset/info", passthrough_body=True),
+    "ips_ruleset_list": ActionSpec("POST", "/v3/ips/ruleset/list", passthrough_body=True),
+    "ips_ruleset_namelist": ActionSpec(
+        "POST", "/v3/ips/ruleset/namelist", passthrough_body=True
+    ),
+    "ips_threat_types": ActionSpec("POST", "/v3/ips/threatTypes", passthrough_body=True),
+    # HTTP protect (HTTP blacklist)
+    "http_blacklist_delete": ActionSpec(
+        "DELETE", "/v3/httpBlacklist", passthrough_body=True
+    ),
+    "http_blacklist_enable": ActionSpec(
+        "POST", "/v3/httpBlacklist/enable", passthrough_body=True
+    ),
+    "http_blacklist_export": ActionSpec(
+        "POST", "/v3/httpBlacklist/export", passthrough_body=True, binary=True
+    ),
+    "http_blacklist_list": ActionSpec(
+        "POST", "/v3/httpBlacklist/list", passthrough_body=True
+    ),
+    "http_blacklist_create": ActionSpec(
+        "POST", "/v3/httpBlacklist", passthrough_body=True
+    ),
+    "http_blacklist_update": ActionSpec(
+        "PUT", "/v3/httpBlacklist", passthrough_body=True
+    ),
+    "get_advanced_config": ActionSpec("GET", "/v3/setting/advancedConfig"),
+    "set_advanced_config": ActionSpec("PUT", "/v3/setting/advancedConfig", passthrough_body=True),
+    "get_xff_config": ActionSpec("GET", "/v3/setting/xffConfig"),
+    "set_xff_config": ActionSpec("PUT", "/v3/setting/xffConfig", passthrough_body=True),
+    # port protect groups
+    "port_protect_group_delete": ActionSpec(
+        "DELETE", "/v3/portProtectGroup", passthrough_body=True
+    ),
+    "port_protect_group_create": ActionSpec(
+        "POST", "/v3/portProtectGroup", passthrough_body=True
+    ),
+    "port_protect_group_update": ActionSpec(
+        "PUT", "/v3/portProtectGroup", passthrough_body=True
+    ),
+    "port_protect_group_clone": ActionSpec(
+        "POST", "/v3/portProtectGroup/clone", passthrough_body=True
+    ),
+    "port_protect_group_default_info": ActionSpec(
+        "GET", "/v3/portProtectGroup/defaultInfo"
+    ),
+    "port_protect_group_list_full": ActionSpec(
+        "POST", "/v3/portProtectGroup/list", passthrough_body=True
+    ),
+    "port_protect_port_delete": ActionSpec(
+        "DELETE", "/v3/portProtectGroup/port", passthrough_body=True
+    ),
+    "port_protect_port_create": ActionSpec(
+        "POST", "/v3/portProtectGroup/port", passthrough_body=True
+    ),
+    "port_protect_port_update": ActionSpec(
+        "PUT", "/v3/portProtectGroup/port", passthrough_body=True
+    ),
+    "port_protect_port_export": ActionSpec(
+        "POST", "/v3/portProtectGroup/port/export", passthrough_body=True, binary=True
+    ),
+    "port_protect_port_list": ActionSpec(
+        "POST", "/v3/portProtectGroup/port/list", passthrough_body=True
+    ),
+    "port_protect_port_onekey_import": ActionSpec(
+        "POST", "/v3/portProtectGroup/port/onekeyImport", passthrough_body=True
+    ),
+    "port_protect_port_onekey_status": ActionSpec(
+        "GET", "/v3/portProtectGroup/port/onekeyImport"
+    ),
+    "port_protect_portinfo": ActionSpec(
+        "POST", "/v3/portProtectGroup/portinfo", passthrough_body=True
+    ),
+    # strategy page (custom protection policy)
+    "device_onekey_bypass": ActionSpec(
+        "POST", "/v3/device/onekeyBypass", passthrough_body=True
+    ),
+    "protection_policy_delete": ActionSpec(
+        "DELETE", "/v3/protection/policy", passthrough_body=True
+    ),
+    "protection_policy_update": ActionSpec(
+        "PUT", "/v3/protection/policy", passthrough_body=True
+    ),
+    "protection_policy_get": ActionSpec(
+        "GET", "/v3/protection/policy", body_keys=["uniqueId"]
+    ),
+    "protection_policy_tree": ActionSpec("GET", "/v3/protection/policy/tree"),
+    "set_scan_config": ActionSpec("PUT", "/v3/setting/scanConfig", passthrough_body=True),
+}
+
+# Assets ------------------------------------------------------------------
+
+ASSETS_ACTION_SPECS: dict[str, ActionSpec] = {
+    "asset_delete": ActionSpec("DELETE", "/v3/asset", passthrough_body=True),
+    "asset_create": ActionSpec("POST", "/v3/asset", passthrough_body=True),
+    "asset_update": ActionSpec("PUT", "/v3/asset", passthrough_body=True),
+    "asset_export": ActionSpec("POST", "/v3/asset/export", passthrough_body=True, binary=True),
+    "asset_group_delete": ActionSpec("DELETE", "/v3/asset/group", passthrough_body=True),
+    "asset_group_get": ActionSpec("GET", "/v3/asset/group"),
+    "asset_group_create": ActionSpec("POST", "/v3/asset/group", passthrough_body=True),
+    "asset_group_update": ActionSpec("PUT", "/v3/asset/group", passthrough_body=True),
+    "asset_import": ActionSpec(
+        "POST", "/v3/asset/import", passthrough_body=True, multipart=True
+    ),
+    "asset_template": ActionSpec("GET", "/v3/asset/template", binary=True),
+    "asset_list": ActionSpec("POST", "/v3/asset/list", passthrough_body=True),
+    "asset_type_delete": ActionSpec("DELETE", "/v3/asset/type", passthrough_body=True),
+    "asset_type_get": ActionSpec("GET", "/v3/asset/type"),
+    "asset_type_create": ActionSpec("POST", "/v3/asset/type", passthrough_body=True),
+    "common_asset_group_tree": ActionSpec("GET", "/v3/common/assetGroupTree"),
+}
+
+# Device ------------------------------------------------------------------
+
+DEVICE_ACTION_SPECS: dict[str, ActionSpec] = {
+    # alert policy
+    "alert_policy_list": ActionSpec(
+        "POST", "/v3/alert/policy/list", passthrough_body=True
+    ),
+    "alert_policy_enable": ActionSpec(
+        "POST", "/v3/alert/policy/enable", passthrough_body=True
+    ),
+    "alert_policy_delete": ActionSpec(
+        "DELETE", "/v3/alert/policy", passthrough_body=True
+    ),
+    "alert_policy_create": ActionSpec(
+        "POST", "/v3/alert/policy", passthrough_body=True
+    ),
+    "alert_policy_update": ActionSpec(
+        "PUT", "/v3/alert/policy", passthrough_body=True
+    ),
+    "alert_policy_export": ActionSpec(
+        "POST", "/v3/alert/policy/export", passthrough_body=True, binary=True
+    ),
+    "alert_policy_find_by_config": ActionSpec(
+        "POST", "/v3/alert/policy/findByConfig", passthrough_body=True
+    ),
+    "alert_policy_object": ActionSpec(
+        "POST", "/v3/alert/policy/object", passthrough_body=True
+    ),
+    "get_notice_config": ActionSpec("GET", "/v3/setting/noticeConfig"),
+    "set_notice_config": ActionSpec("PUT", "/v3/setting/noticeConfig", passthrough_body=True),
+    "get_notice_send_key": ActionSpec("GET", "/v3/setting/noticeConfig/sendKey"),
+    "test_email": ActionSpec("POST", "/v3/test/email", passthrough_body=True),
+    "test_syslog": ActionSpec("POST", "/v3/test/syslog", passthrough_body=True),
+    "test_webhook": ActionSpec("POST", "/v3/test/webhook", passthrough_body=True),
+    # audit logs
+    "aclog_stat": ActionSpec("GET", "/v3/aclog/stat", body_keys=["startTime", "endTime"]),
+    "aclog_list": ActionSpec("POST", "/v3/aclog/list", passthrough_body=True),
+    "aclog_export": ActionSpec(
+        "POST", "/v3/aclog/export", passthrough_body=True, binary=True
+    ),
+    "aclog_delete": ActionSpec(
+        "DELETE",
+        "/v3/aclog",
+        passthrough_body=True,
+        encrypt_fields=("password",),
+    ),
+    "get_clean_config": ActionSpec("GET", "/v3/setting/cleanConfig"),
+    "set_clean_config": ActionSpec("PUT", "/v3/setting/cleanConfig", passthrough_body=True),
+    # users / login mgmt
+    "user_list": ActionSpec("POST", "/v3/user/list", passthrough_body=True),
+    "user_export": ActionSpec(
+        "POST", "/v3/user/export", passthrough_body=True, binary=True
+    ),
+    "user_delete": ActionSpec(
+        "DELETE",
+        "/v3/user",
+        passthrough_body=True,
+        encrypt_fields=("password",),
+    ),
+    "user_secret_reset": ActionSpec(
+        "PUT",
+        "/v3/user/secret/reset",
+        passthrough_body=True,
+        encrypt_fields=("password",),
+    ),
+    "user_create": ActionSpec(
+        "POST",
+        "/v3/user",
+        passthrough_body=True,
+        encrypt_fields=("password", "dupPassword"),
+    ),
+    "user_update": ActionSpec("PUT", "/v3/user", passthrough_body=True),
+    "get_login_config": ActionSpec("GET", "/v3/setting/loginConfig"),
+    "set_login_config": ActionSpec("PUT", "/v3/setting/loginConfig", passthrough_body=True),
+    # HTTPS decryption
+    "get_decrypt_config": ActionSpec("GET", "/v3/setting/decryptConfig"),
+    "set_decrypt_config": ActionSpec("PUT", "/v3/setting/decryptConfig", passthrough_body=True),
+    "get_detect_config": ActionSpec("GET", "/v3/setting/detectConfig"),
+    "set_detect_config": ActionSpec("PUT", "/v3/setting/detectConfig", passthrough_body=True),
+    "tls_decrypt_policy_list": ActionSpec(
+        "POST", "/v3/tls/decrypt/policy/list", passthrough_body=True
+    ),
+    "tls_decrypt_policy_create": ActionSpec(
+        "POST", "/v3/tls/decrypt/policy", passthrough_body=True
+    ),
+    "tls_decrypt_policy_update": ActionSpec(
+        "PUT", "/v3/tls/decrypt/policy", passthrough_body=True
+    ),
+    "tls_decrypt_policy_enable": ActionSpec(
+        "POST", "/v3/tls/decrypt/policy/enable", passthrough_body=True
+    ),
+    "tls_decrypt_policy_delete": ActionSpec(
+        "DELETE", "/v3/tls/decrypt/policy", passthrough_body=True
+    ),
+    "tls_decrypt_policy_batch": ActionSpec(
+        "POST", "/v3/tls/decrypt/policy/batch", passthrough_body=True
+    ),
+    "tls_cert_list": ActionSpec("POST", "/v3/tls/cert/list", passthrough_body=True),
+    "tls_cert_create": ActionSpec(
+        "POST", "/v3/tls/cert", passthrough_body=True, multipart=True,
+        multipart_file_field="certFile",
+    ),
+    "tls_cert_update": ActionSpec(
+        "PUT", "/v3/tls/cert", passthrough_body=True, multipart=True,
+        multipart_file_field="certFile",
+    ),
+    "tls_cert_delete": ActionSpec("DELETE", "/v3/tls/cert", passthrough_body=True),
+    "tls_cert_set_default": ActionSpec(
+        "POST", "/v3/tls/cert/set_default", passthrough_body=True
+    ),
+    "tls_detect_list": ActionSpec("POST", "/v3/tls/detect/list", passthrough_body=True),
+    "tls_detect_list_detail": ActionSpec(
+        "POST", "/v3/tls/detect/list/detail", passthrough_body=True
+    ),
+    "tls_detect_delete": ActionSpec("DELETE", "/v3/tls/detect", passthrough_body=True),
+    "tls_detect_group": ActionSpec("POST", "/v3/tls/detect/group", passthrough_body=True),
+    "tls_detect_group_export": ActionSpec(
+        "POST", "/v3/tls/detect/group/export", passthrough_body=True, binary=True
+    ),
+    "tls_detect_list_export": ActionSpec(
+        "POST", "/v3/tls/detect/list/export", passthrough_body=True, binary=True
+    ),
+    # deploy guide / interface
+    "interface_list": ActionSpec("GET", "/v3/interface/list"),
+    "interface_update": ActionSpec(
+        "PUT",
+        "/v3/interface",
+        passthrough_body=True,
+        encrypt_fields=("password",),
+    ),
+    "interface_check_loop": ActionSpec(
+        "POST", "/v3/interface/check/loop", passthrough_body=True
+    ),
+    "interface_relation_list": ActionSpec("GET", "/v3/interface/relation/list"),
+    "interface_select_list": ActionSpec("GET", "/v3/interface/select/list"),
+    "interface_virtual_line_create": ActionSpec(
+        "POST", "/v3/interface/virtualLine", passthrough_body=True
+    ),
+    "interface_virtual_line_update": ActionSpec(
+        "PUT", "/v3/interface/virtualLine", passthrough_body=True
+    ),
+    "interface_virtual_line_delete": ActionSpec(
+        "DELETE", "/v3/interface/virtualLine", passthrough_body=True
+    ),
+    "interface_listen_create": ActionSpec(
+        "POST", "/v3/interface/listen", passthrough_body=True
+    ),
+    "interface_listen_update": ActionSpec(
+        "PUT", "/v3/interface/listen", passthrough_body=True
+    ),
+    "interface_listen_delete": ActionSpec(
+        "DELETE", "/v3/interface/listen", passthrough_body=True
+    ),
+    "interface_bridge_create": ActionSpec(
+        "POST", "/v3/interface/bridge", passthrough_body=True
+    ),
+    "interface_bridge_update": ActionSpec(
+        "PUT", "/v3/interface/bridge", passthrough_body=True
+    ),
+    "interface_bridge_delete": ActionSpec(
+        "DELETE", "/v3/interface/bridge", passthrough_body=True
+    ),
+    # routes
+    "route_outif_list": ActionSpec("GET", "/v3/route/outIf/list"),
+    "route_static_list": ActionSpec("POST", "/v3/route/static/list", passthrough_body=True),
+    "route_static_create": ActionSpec("POST", "/v3/route/static", passthrough_body=True),
+    "route_static_update": ActionSpec("PUT", "/v3/route/static", passthrough_body=True),
+    "route_static_delete": ActionSpec(
+        "DELETE", "/v3/route/static", passthrough_body=True
+    ),
+    "route_table_list": ActionSpec("POST", "/v3/route/table/list", passthrough_body=True),
+    "ipv6_route_static_list": ActionSpec(
+        "POST", "/v3/ipv6Route/static/list", passthrough_body=True
+    ),
+    "ipv6_route_static_create": ActionSpec(
+        "POST", "/v3/ipv6Route/static", passthrough_body=True
+    ),
+    "ipv6_route_static_update": ActionSpec(
+        "PUT", "/v3/ipv6Route/static", passthrough_body=True
+    ),
+    "ipv6_route_static_delete": ActionSpec(
+        "DELETE", "/v3/ipv6Route/static", passthrough_body=True
+    ),
+    "ipv6_route_table_list": ActionSpec(
+        "POST", "/v3/ipv6Route/table/list", passthrough_body=True
+    ),
+    # DNS config
+    "get_dns_config": ActionSpec("GET", "/v3/setting/dnsConfig"),
+    "set_dns_config": ActionSpec("PUT", "/v3/setting/dnsConfig", passthrough_body=True),
+    "hosts_get": ActionSpec("GET", "/v3/setting/hosts"),
+    "hosts_create": ActionSpec("POST", "/v3/setting/hosts", passthrough_body=True),
+    "hosts_update": ActionSpec("PUT", "/v3/setting/hosts", passthrough_body=True),
+    "hosts_delete": ActionSpec("DELETE", "/v3/setting/hosts", passthrough_body=True),
+    "test_network": ActionSpec("GET", "/v3/test/network"),
+    # proxy / agent
+    "get_proxy_config": ActionSpec("GET", "/v3/setting/proxyConfig"),
+    "set_proxy_config": ActionSpec("PUT", "/v3/setting/proxyConfig", passthrough_body=True),
+    "test_proxy": ActionSpec("POST", "/v3/test/proxy", passthrough_body=True),
+    # HA
+    "ha_status": ActionSpec("GET", "/v3/ha/status"),
+    "get_ha_config": ActionSpec("GET", "/v3/setting/haConfig"),
+    "set_ha_config": ActionSpec("PUT", "/v3/setting/haConfig", passthrough_body=True),
+    "ha_module_list": ActionSpec("GET", "/v3/ha/moduleList"),
+    "ha_compare_config": ActionSpec("POST", "/v3/ha/compareConfig", passthrough_body=True),
+    "ha_switching": ActionSpec("PUT", "/v3/ha/switching", passthrough_body=True),
+    "ha_sync_config": ActionSpec("POST", "/v3/ha/syncConfig", passthrough_body=True),
+    "ha_sync_status": ActionSpec("GET", "/v3/ha/syncStatus"),
+    # centralized control (OneCC)
+    "onecc_status": ActionSpec("GET", "/v3/setting/oneccConfig/status"),
+    "get_onecc_config": ActionSpec("GET", "/v3/setting/oneccConfig"),
+    "set_onecc_config": ActionSpec("PUT", "/v3/setting/oneccConfig", passthrough_body=True),
+    "set_onecc_status": ActionSpec("PUT", "/v3/setting/oneccConfig/status", passthrough_body=True),
+    "test_onecc": ActionSpec("POST", "/v3/test/onecc", passthrough_body=True),
+    # device config
+    "device_quick_bypass": ActionSpec(
+        "POST", "/v3/device/quickBypass", passthrough_body=True
+    ),
+    "device_upgrade_record_list": ActionSpec(
+        "POST", "/v3/device/upgradeRecord/list", passthrough_body=True
+    ),
+    "get_upgrade_config": ActionSpec("GET", "/v3/setting/upgradeConfig"),
+    "set_upgrade_config": ActionSpec(
+        "PUT", "/v3/setting/upgradeConfig", passthrough_body=True
+    ),
+    "basic_version": ActionSpec("GET", "/v3/basic/version"),
+    "device_upgrade_info": ActionSpec("GET", "/v3/device/upgradeInfo"),
+    "device_download_package": ActionSpec(
+        "POST", "/v3/device/downloadPackage", passthrough_body=True
+    ),
+    # /v3/device/upgrade has two flavors:
+    #   * 已下载包升级: JSON body with `name` (Query) + `password` (RSA);
+    #   * 本地上传包: multipart with file + `password`.
+    # Default to JSON; supply `file_path` to use multipart.
+    "device_upgrade": ActionSpec(
+        "POST",
+        "/v3/device/upgrade",
+        passthrough_body=True,
+        encrypt_fields=("password",),
+    ),
+    "device_upgrade_upload": ActionSpec(
+        "POST",
+        "/v3/device/upgrade",
+        passthrough_body=True,
+        multipart=True,
+        encrypt_fields=("password",),
+    ),
+    "system_upgrade": ActionSpec(
+        "POST", "/v3/system/upgrade", passthrough_body=True, multipart=True
+    ),
+    "device_custom_get": ActionSpec("GET", "/v3/device/custom"),
+    "device_custom_set": ActionSpec("PUT", "/v3/device/custom", passthrough_body=True),
+    "device_reboot": ActionSpec("POST", "/v3/device/reboot", passthrough_body=True),
+    "device_shutdown": ActionSpec("POST", "/v3/device/shutdown", passthrough_body=True),
+    "device_reinit": ActionSpec("POST", "/v3/device/reinit", passthrough_body=True),
+    "device_system_timezone": ActionSpec("GET", "/v3/device/systemTimeZone"),
+    "device_system_time_get": ActionSpec("GET", "/v3/device/systemTime"),
+    "device_system_time_set": ActionSpec("PUT", "/v3/device/systemTime", passthrough_body=True),
+    "get_storage_config": ActionSpec("GET", "/v3/setting/storageConfig"),
+    "set_storage_config": ActionSpec("PUT", "/v3/setting/storageConfig", passthrough_body=True),
+    "backup_recover_progress": ActionSpec("GET", "/v3/backup/recover/progress"),
+    "backup_list": ActionSpec("POST", "/v3/backup/list", passthrough_body=True),
+    "backup_create": ActionSpec("POST", "/v3/backup", passthrough_body=True),
+    "backup_download": ActionSpec(
+        "GET", "/v3/backup/download", body_keys=["uniqueId"], binary=True
+    ),
+    "backup_recover": ActionSpec("POST", "/v3/backup/recover", passthrough_body=True),
+    "backup_delete": ActionSpec("DELETE", "/v3/backup", passthrough_body=True),
+    "backup_update": ActionSpec("PUT", "/v3/backup", passthrough_body=True),
+    "backup_import": ActionSpec(
+        "POST", "/v3/backup/import", passthrough_body=True, multipart=True
+    ),
+    "logaccess_list": ActionSpec("POST", "/v3/logAccess/list", passthrough_body=True),
+    "logaccess_delete": ActionSpec("DELETE", "/v3/logAccess", passthrough_body=True),
+    "logaccess_create": ActionSpec("POST", "/v3/logAccess", passthrough_body=True),
+    "logaccess_update": ActionSpec("PUT", "/v3/logAccess", passthrough_body=True),
+    "logaccess_sample": ActionSpec("POST", "/v3/logAccess/sample", passthrough_body=True),
+    "logaccess_test": ActionSpec("POST", "/v3/logAccess/test", passthrough_body=True),
+    "logaccess_check": ActionSpec("GET", "/v3/logAccess/check", body_keys=["name"]),
+    # system info
+    "basic_license_get": ActionSpec("GET", "/v3/basic/license"),
+    "basic_connect_status": ActionSpec("GET", "/v3/basic/connectStatus"),
+    "basic_information": ActionSpec("GET", "/v3/basic/information"),
+    "basic_information_enable": ActionSpec(
+        "POST", "/v3/basic/information/enable", passthrough_body=True
+    ),
+    "basic_information_import": ActionSpec(
+        "POST", "/v3/basic/information", passthrough_body=True, multipart=True
+    ),
+    "basic_license_upload": ActionSpec(
+        "POST", "/v3/basic/license", passthrough_body=True, multipart=True
+    ),
+    "mdr_service_status": ActionSpec("GET", "/v3/mdrService/status"),
+    "mdr_service_enable": ActionSpec(
+        "PUT", "/v3/mdrService/enable", passthrough_body=True
+    ),
+    # system diagnosis
+    "device_coredump_list": ActionSpec("GET", "/v3/device/coredump"),
+    "device_coredump_download": ActionSpec(
+        "POST", "/v3/device/coredumpDownload", passthrough_body=True, binary=True
+    ),
+    "device_coredump_delete": ActionSpec(
+        "DELETE", "/v3/device/coredump", passthrough_body=True
+    ),
+    "device_pcap_get": ActionSpec("GET", "/v3/device/pcap"),
+    "device_pcap_set": ActionSpec("PUT", "/v3/device/pcap", passthrough_body=True),
+    "device_pcap_file_list": ActionSpec("GET", "/v3/device/pcapFile"),
+    "device_pcap_download": ActionSpec(
+        "POST", "/v3/device/pcapDownload", passthrough_body=True, binary=True
+    ),
+    "device_pcap_file_delete": ActionSpec(
+        "DELETE", "/v3/device/pcapFile", passthrough_body=True
+    ),
+}
+
+# Helper ------------------------------------------------------------------
+
+HELPER_ACTION_SPECS: dict[str, ActionSpec] = {
+    "document_list": ActionSpec("POST", "/v3/document/list", passthrough_body=True),
+    "document_preview": ActionSpec(
+        "GET", "/v3/document/preview", body_keys=["fileName"]
+    ),
+    "product_news_get": ActionSpec("GET", "/v3/product/news"),
+    "product_news_mark_read": ActionSpec(
+        "PUT", "/v3/product/news", passthrough_body=True
+    ),
+    "product_version": ActionSpec("GET", "/v3/product/version"),
+    "product_issue": ActionSpec("POST", "/v3/product/issue", passthrough_body=True),
+}
+
+
+GROUP_SPECS: dict[str, dict[str, ActionSpec]] = {
+    "login": LOGIN_ACTION_SPECS,
+    "monitoring": MONITORING_ACTION_SPECS,
+    "strategy": STRATEGY_ACTION_SPECS,
+    "assets": ASSETS_ACTION_SPECS,
+    "device": DEVICE_ACTION_SPECS,
+    "helper": HELPER_ACTION_SPECS,
+}
+
+# Lightweight read-only actions used by `action="test"` for connectivity check.
+_CONNECTIVITY_TEST_ACTIONS: dict[str, str] = {
+    "login": "get_account",
+    "monitoring": "common_threat_type_list",
+    "strategy": "blacklist_location_options",
+    "assets": "common_asset_group_tree",
+    "device": "basic_version",
+    "helper": "product_version",
+}
+
+
+# ---------------------------------------------------------------------------
+# Output handling
+# ---------------------------------------------------------------------------
+
+
+def _outputs_dir() -> str:
+    """Resolve the daily outputs directory used to persist binary downloads."""
+    import datetime
+    from pathlib import Path
+
+    try:
+        from flocks.workspace.manager import WorkspaceManager
+
+        ws = WorkspaceManager.get_instance()
+        base = Path(ws.get_workspace_dir()) / "outputs" / datetime.date.today().isoformat()
+    except Exception:
+        base = Path.home() / ".flocks" / "workspace" / "outputs" / datetime.date.today().isoformat()
+    base.mkdir(parents=True, exist_ok=True)
+    return str(base)
+
+
+def _save_binary(path: str, body: bytes, content_type: str) -> str:
+    import datetime
+    from pathlib import Path
+
+    safe_name = path.strip("/").replace("/", "_") or "download"
+    ext = ""
+    ct = content_type.lower()
+    if "csv" in ct:
+        ext = ".csv"
+    elif "excel" in ct or "spreadsheet" in ct or "xlsx" in ct:
+        ext = ".xlsx"
+    elif "zip" in ct:
+        ext = ".zip"
+    elif "pdf" in ct:
+        ext = ".pdf"
+    elif "octet-stream" in ct:
+        ext = ".bin"
+    timestamp = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+    target = Path(_outputs_dir()) / f"onesig_{safe_name}_{timestamp}{ext}"
+    target.write_bytes(body)
+    return str(target)
+
+
+def _envelope_to_result(action: str, envelope: dict[str, Any]) -> ToolResult:
+    metadata = {"source": "OneSIG", "api": action}
+    response_code = envelope.get("responseCode")
+    if response_code is not None and response_code != _RESPONSE_CODE_OK:
+        msg = envelope.get("verboseMsg") or envelope.get("verbose_msg") or "Unknown error"
+        return ToolResult(
+            success=False,
+            error=f"OneSIG API error (responseCode={response_code}): {msg}",
+            output=envelope,
+            metadata=metadata,
+        )
+    if "data" in envelope:
+        return ToolResult(success=True, output=envelope.get("data"), metadata=metadata)
+    return ToolResult(success=True, output=envelope, metadata=metadata)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+async def _encrypt_body_fields(
+    session: "OneSIGSession",
+    spec: ActionSpec,
+    body: Optional[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
+    """Replace each plaintext field listed in ``spec.encrypt_fields`` with its
+    RSA-OAEP ciphertext (Base64). A fresh pubkey is fetched per call to match
+    the front-end's ``clearRSACache`` behavior. No-op if body is None."""
+    if not spec.encrypt_fields or body is None or not isinstance(body, dict):
+        return body
+    has_target = any(_has_value(body.get(f)) for f in spec.encrypt_fields)
+    if not has_target:
+        return body
+    pubkey_resp = await session._raw_request_json("GET", "/v3/pubkey")
+    pubkey = (pubkey_resp or {}).get("data", {}).get("pubkey")
+    if not pubkey:
+        raise ValueError(
+            f"无法从 /v3/pubkey 获取 RSA 公钥用于加密字段 {list(spec.encrypt_fields)}: {pubkey_resp!r}"
+        )
+    out = dict(body)
+    for field in spec.encrypt_fields:
+        plain = out.get(field)
+        if isinstance(plain, str) and plain:
+            out[field] = _rsa_oaep_encrypt(pubkey, plain, session.config.oaep_hash)
+    return out
+
+
+def _build_form_data(
+    spec: ActionSpec,
+    body: Optional[dict[str, Any]],
+    file_path: Optional[str],
+) -> "aiohttp.FormData":
+    """Assemble a multipart/form-data payload: the file under
+    ``spec.multipart_file_field`` plus any non-file fields from ``body``."""
+    if not file_path:
+        raise ValueError(
+            f"multipart 接口 {spec.path} 需要 `file_path` 参数指向待上传的本地文件"
+        )
+    from pathlib import Path as _Path
+
+    fp = _Path(file_path).expanduser()
+    if not fp.is_file():
+        raise ValueError(f"file_path 指向的文件不存在或不是常规文件：{fp}")
+
+    form = aiohttp.FormData()
+    fname = fp.name
+    # Stream the file via an open handle; aiohttp closes it on send completion.
+    form.add_field(
+        spec.multipart_file_field,
+        fp.open("rb"),
+        filename=fname,
+        content_type="application/octet-stream",
+    )
+    if isinstance(body, dict):
+        for k, v in body.items():
+            if v is None:
+                continue
+            if isinstance(v, (dict, list, tuple)):
+                import json as _json
+
+                form.add_field(k, _json.dumps(v, ensure_ascii=False))
+            elif isinstance(v, bool):
+                form.add_field(k, "true" if v else "false")
+            else:
+                form.add_field(k, str(v))
+    return form
+
+
+async def _execute_action(
+    group: str,
+    action: str,
+    params: dict[str, Any],
+) -> ToolResult:
+    spec_map = GROUP_SPECS[group]
+    spec = spec_map[action]
+
+    validation_error = _validate_required(spec, action, params)
+    if validation_error:
+        return ToolResult(success=False, error=validation_error)
+
+    try:
+        config = _resolve_runtime_config()
+    except ValueError as exc:
+        return ToolResult(success=False, error=str(exc))
+
+    captcha = params.get("captcha")
+    totp = params.get("totp")
+
+    session = await _get_session(config)
+    try:
+        query, body = spec.build_request(params)
+        body = await _encrypt_body_fields(session, spec, body)
+
+        if spec.multipart:
+            form = _build_form_data(spec, body, params.get("file_path"))
+            status, envelope, body_bytes, content_type = await session.request(
+                spec.method,
+                spec.path,
+                params=query,
+                form_data=form,
+                captcha=captcha,
+                totp=totp,
+            )
+        else:
+            status, envelope, body_bytes, content_type = await session.request(
+                spec.method,
+                spec.path,
+                params=query,
+                json_body=body,
+                captcha=captcha,
+                totp=totp,
+            )
+    except ValueError as exc:
+        return ToolResult(success=False, error=str(exc))
+    except aiohttp.ClientError as exc:
+        return ToolResult(success=False, error=f"Request failed: {exc}")
+    except Exception as exc:  # pragma: no cover - defensive
+        return ToolResult(success=False, error=f"Unexpected error: {exc}")
+
+    metadata: dict[str, Any] = {
+        "source": "OneSIG",
+        "api": action,
+        "method": spec.method,
+        "path": spec.path,
+        "http_status": status,
+    }
+    if isinstance(envelope, dict):
+        if "responseCode" in envelope:
+            metadata["response_code"] = envelope.get("responseCode")
+        verbose_msg = envelope.get("verboseMsg") or envelope.get("verbose_msg")
+        if verbose_msg:
+            metadata["verbose_msg"] = verbose_msg
+
+    if spec.binary or (body_bytes and not envelope):
+        if status >= 400:
+            return ToolResult(
+                success=False,
+                error=f"HTTP {status} from {spec.path}",
+                metadata=metadata,
+            )
+        saved_path = _save_binary(spec.path, body_bytes, content_type)
+        metadata["saved_path"] = saved_path
+        metadata["binary_size"] = len(body_bytes)
+        metadata["content_type"] = content_type
+        return ToolResult(
+            success=True,
+            output={
+                "saved_path": saved_path,
+                "size": len(body_bytes),
+                "content_type": content_type,
+            },
+            metadata=metadata,
+        )
+
+    if status >= 400 and not envelope:
+        return ToolResult(
+            success=False,
+            error=f"HTTP {status} from {spec.path}",
+            metadata=metadata,
+        )
+
+    result = _envelope_to_result(action, envelope or {})
+    merged_meta = dict(result.metadata or {})
+    merged_meta.update(metadata)
+    result.metadata = merged_meta
+    return result
+
+
+async def _dispatch_group(
+    ctx: ToolContext,
+    group: str,
+    action: str,
+    **params: Any,
+) -> ToolResult:
+    del ctx
+    if action == "test":
+        test_action = _CONNECTIVITY_TEST_ACTIONS.get(group)
+        if test_action:
+            return await _execute_action(group, test_action, params)
+    spec_map = GROUP_SPECS[group]
+    if action not in spec_map and action not in {"login", "logout", "change_password"}:
+        available = ", ".join(sorted(spec_map))
+        return ToolResult(
+            success=False,
+            error=f"Unsupported {group} action: {action}. Available actions: {available}",
+        )
+    if group == "login":
+        if action == "login":
+            return await _login_action(params)
+        if action == "logout":
+            return await _logout_action()
+        if action == "change_password":
+            return await _change_password_action(params)
+    return await _execute_action(group, action, params)
+
+
+async def _login_action(params: dict[str, Any]) -> ToolResult:
+    try:
+        config = _resolve_runtime_config()
+    except ValueError as exc:
+        return ToolResult(success=False, error=str(exc))
+    session = await _get_session(config)
+    try:
+        account = await session.login(
+            captcha=params.get("captcha"),
+            totp=params.get("totp"),
+            force=True,
+        )
+    except ValueError as exc:
+        return ToolResult(success=False, error=str(exc))
+    return ToolResult(
+        success=True,
+        output={"account": account, "message": "Logged in to OneSIG"},
+        metadata={"source": "OneSIG", "api": "login"},
+    )
+
+
+async def _logout_action() -> ToolResult:
+    try:
+        config = _resolve_runtime_config()
+    except ValueError as exc:
+        return ToolResult(success=False, error=str(exc))
+    session = await _get_session(config)
+    try:
+        envelope = await session.logout()
+    except ValueError as exc:
+        return ToolResult(success=False, error=str(exc))
+    finally:
+        await session.close()
+        async with _SESSIONS_LOCK:
+            _SESSIONS.pop(config.session_key, None)
+    return _envelope_to_result("logout", envelope or {})
+
+
+async def _change_password_action(params: dict[str, Any]) -> ToolResult:
+    """Change the current user's password (RSA-OAEP encrypts each field)."""
+    new_password = params.get("new_password") or params.get("newPassword")
+    old_password = params.get("old_password") or params.get("oldPassword")
+    dup_password = params.get("dup_password") or params.get("dupPassword") or new_password
+    if not new_password:
+        return ToolResult(
+            success=False,
+            error="change_password 缺少 new_password 参数",
+        )
+    try:
+        config = _resolve_runtime_config()
+    except ValueError as exc:
+        return ToolResult(success=False, error=str(exc))
+    session = await _get_session(config)
+    try:
+        if not session._logged_in:
+            await session.login(captcha=params.get("captcha"), totp=params.get("totp"))
+        pubkey_resp = await session._raw_request_json("GET", "/v3/pubkey")
+        pubkey = (pubkey_resp or {}).get("data", {}).get("pubkey")
+        if not pubkey:
+            return ToolResult(
+                success=False,
+                error=f"无法获取 RSA 公钥用于改密：{pubkey_resp!r}",
+            )
+        body: dict[str, Any] = {
+            "username": params.get("username") or config.username,
+            "newPassword": _rsa_oaep_encrypt(pubkey, new_password, config.oaep_hash),
+            "dupPassword": _rsa_oaep_encrypt(pubkey, dup_password, config.oaep_hash),
+        }
+        if old_password:
+            body["oldPassword"] = _rsa_oaep_encrypt(pubkey, old_password, config.oaep_hash)
+        status, envelope, _, _ = await session.request(
+            "PUT", "/v3/user/password", json_body=body
+        )
+    except ValueError as exc:
+        return ToolResult(success=False, error=str(exc))
+    if status >= 400 and not envelope:
+        return ToolResult(success=False, error=f"HTTP {status} from /v3/user/password")
+    return _envelope_to_result("change_password", envelope or {})
+
+
+# ---------------------------------------------------------------------------
+# Public group entry points (referenced from YAML handler stanzas)
+# ---------------------------------------------------------------------------
+
+
+async def login(ctx: ToolContext, action: str = "login", **params: Any) -> ToolResult:
+    return await _dispatch_group(ctx, "login", action, **params)
+
+
+async def monitoring(ctx: ToolContext, action: str, **params: Any) -> ToolResult:
+    return await _dispatch_group(ctx, "monitoring", action, **params)
+
+
+async def strategy(ctx: ToolContext, action: str, **params: Any) -> ToolResult:
+    return await _dispatch_group(ctx, "strategy", action, **params)
+
+
+async def assets(ctx: ToolContext, action: str, **params: Any) -> ToolResult:
+    return await _dispatch_group(ctx, "assets", action, **params)
+
+
+async def device(ctx: ToolContext, action: str, **params: Any) -> ToolResult:
+    return await _dispatch_group(ctx, "device", action, **params)
+
+
+async def helper(ctx: ToolContext, action: str, **params: Any) -> ToolResult:
+    return await _dispatch_group(ctx, "helper", action, **params)

--- a/.flocks/plugins/tools/api/onesig/onesig.handler.py
+++ b/.flocks/plugins/tools/api/onesig/onesig.handler.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
+import json
 import os
 import ssl
+import time
+from email.utils import parsedate_to_datetime
+from http.cookies import Morsel, SimpleCookie
 from typing import Any, Optional
 
 import aiohttp
+from yarl import URL
 
 from flocks.config.config_writer import ConfigWriter
 from flocks.tool.registry import ToolContext, ToolResult
@@ -14,10 +20,20 @@ from flocks.tool.registry import ToolContext, ToolResult
 
 SERVICE_ID = "onesig_api"
 
-DEFAULT_API_PREFIX = "/api"
+# OneSIG v2.5.x 设备直接监听 ``/v3/...``，没有任何额外前缀。早期对接时曾
+# 经默认 ``"/api"``，结果实际部署里 nginx 把 ``/v3/`` 直接路由到了后端，
+# ``/api/v3/...`` 全部 404。改成空字符串作为开盒即用值；个别需要前缀的
+# 部署仍可在 UI 上把 ``api_prefix`` 设成 ``"/api"`` 或其它值覆盖。
+DEFAULT_API_PREFIX = ""
 DEFAULT_OAEP_HASH = "sha1"
 DEFAULT_TIMEOUT = 60
-DEFAULT_VERIFY_SSL = True
+DEFAULT_VERIFY_SSL = False
+DEFAULT_PERSIST_COOKIES = True
+
+# Bumped whenever the on-disk shape under ``onesig_session_cookie__*`` changes
+# in an incompatible way; older snapshots are silently discarded.
+_COOKIE_SNAPSHOT_VERSION = 1
+_COOKIE_SECRET_PREFIX = "onesig_session_cookie__"
 
 _RESPONSE_CODE_OK = 0
 _RESPONSE_CODE_TOTP_REQUIRED = 1012
@@ -66,6 +82,84 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return default
 
 
+def _resolve_verify_ssl(raw: dict[str, Any]) -> bool:
+    """Resolve the SSL verification toggle from a service-config dict.
+
+    Mirrors the PR #193 cross-handler convention so that the WebUI's
+    "SSL verify" switch (which writes to ``custom_settings.verify_ssl``)
+    drives onesec / ngtip / qingteng / onesig **uniformly**. Lookup order:
+
+      1. ``raw["verify_ssl"]``                    - canonical
+      2. ``raw["ssl_verify"]``                    - snake_case alias (PR #193)
+      3. ``raw["verifySsl"]``                     - camelCase alias (onesig legacy)
+      4. ``raw["custom_settings"]["verify_ssl"]`` - WebUI generic toggle
+      5. ``ONESIG_VERIFY_SSL`` env var            - onesig-specific override
+      6. fallback to ``DEFAULT_VERIFY_SSL``       - default ``False`` (parity
+                                                    with onesec / ngtip / qingteng
+                                                    after PR #193): OneSIG is
+                                                    almost always deployed as a
+                                                    private gateway with self-
+                                                    signed certs, so the open-
+                                                    box behaviour is to skip
+                                                    validation. Flip the toggle
+                                                    on to enforce certificate
+                                                    checks for public / signed
+                                                    deployments.
+
+    String values are normalised through ``_coerce_bool`` so that any of
+    ``"true"/"false"/"1"/"0"/"yes"/"no"/"on"/"off"`` work consistently with
+    the rest of the codebase.
+    """
+    candidates: list[Any] = [
+        raw.get("verify_ssl"),
+        raw.get("ssl_verify"),
+        raw.get("verifySsl"),
+    ]
+    custom = raw.get("custom_settings")
+    if isinstance(custom, dict):
+        candidates.append(custom.get("verify_ssl"))
+    candidates.append(os.getenv("ONESIG_VERIFY_SSL"))
+
+    for value in candidates:
+        if value is None:
+            continue
+        return _coerce_bool(value, default=DEFAULT_VERIFY_SSL)
+    return DEFAULT_VERIFY_SSL
+
+
+def _resolve_persist_cookies(raw: dict[str, Any]) -> bool:
+    """Resolve the cookie-persistence toggle.
+
+    OneSIG sessions are cookie-based; persisting the jar to ``.secret.json``
+    lets a flocks restart skip the captcha → pubkey → /v3/login → /v3/account
+    chain (~4 RTT) and reuse the still-valid cookie until the device returns
+    401 / responseCode 1019..1022, at which point the existing auto-relogin
+    path takes over.
+
+    Same shape as :func:`_resolve_verify_ssl`:
+
+      1. ``raw["persist_cookies"]``                    - canonical
+      2. ``raw["persistCookies"]``                     - camelCase alias
+      3. ``raw["custom_settings"]["persist_cookies"]`` - WebUI generic toggle
+      4. ``ONESIG_PERSIST_COOKIES`` env var            - CLI / container
+      5. fallback to ``DEFAULT_PERSIST_COOKIES``       - ``True``
+    """
+    candidates: list[Any] = [
+        raw.get("persist_cookies"),
+        raw.get("persistCookies"),
+    ]
+    custom = raw.get("custom_settings")
+    if isinstance(custom, dict):
+        candidates.append(custom.get("persist_cookies"))
+    candidates.append(os.getenv("ONESIG_PERSIST_COOKIES"))
+
+    for value in candidates:
+        if value is None:
+            continue
+        return _coerce_bool(value, default=DEFAULT_PERSIST_COOKIES)
+    return DEFAULT_PERSIST_COOKIES
+
+
 class OneSIGRuntimeConfig:
     """Resolved runtime configuration for a single OneSIG service entry."""
 
@@ -79,6 +173,7 @@ class OneSIGRuntimeConfig:
         oaep_hash: str,
         verify_ssl: bool,
         timeout: int,
+        persist_cookies: bool = DEFAULT_PERSIST_COOKIES,
     ) -> None:
         self.base_url = base_url
         self.api_prefix = api_prefix
@@ -87,6 +182,7 @@ class OneSIGRuntimeConfig:
         self.oaep_hash = oaep_hash
         self.verify_ssl = verify_ssl
         self.timeout = timeout
+        self.persist_cookies = persist_cookies
 
     @property
     def session_key(self) -> str:
@@ -152,10 +248,8 @@ def _resolve_runtime_config() -> OneSIGRuntimeConfig:
     if oaep_hash not in {"sha1", "sha256"}:
         oaep_hash = DEFAULT_OAEP_HASH
 
-    verify_ssl = _coerce_bool(
-        raw.get("verify_ssl", raw.get("verifySsl", os.getenv("ONESIG_VERIFY_SSL"))),
-        default=DEFAULT_VERIFY_SSL,
-    )
+    verify_ssl = _resolve_verify_ssl(raw)
+    persist_cookies = _resolve_persist_cookies(raw)
 
     timeout_raw = raw.get("timeout", DEFAULT_TIMEOUT)
     try:
@@ -171,6 +265,7 @@ def _resolve_runtime_config() -> OneSIGRuntimeConfig:
         oaep_hash=oaep_hash,
         verify_ssl=verify_ssl,
         timeout=timeout,
+        persist_cookies=persist_cookies,
     )
 
 
@@ -204,6 +299,168 @@ def _ssl_context(verify_ssl: bool) -> Any:
     return ctx
 
 
+# ---------------------------------------------------------------------------
+# Cookie persistence (.secret.json round-trip)
+# ---------------------------------------------------------------------------
+# OneSIG sessions are cookie-based and the device hands out a session cookie
+# only after the captcha → pubkey → /v3/login dance. To avoid re-running that
+# 4-RTT dance after every flocks restart we serialise the cookie jar to the
+# existing ``~/.flocks/config/.secret.json`` (mode 0600) under a per-device
+# secret_id, then re-hydrate it when a fresh ``OneSIGSession`` is constructed.
+#
+# Format choices intentionally avoid ``aiohttp.CookieJar.save/load`` (pickle):
+#   - JSON keeps the file human-readable for ops debugging.
+#   - JSON is immune to deserialisation-as-RCE if .secret.json ever leaks
+#     write privileges.
+#   - The shape is versioned so future changes can simply bump
+#     ``_COOKIE_SNAPSHOT_VERSION`` and discard older snapshots.
+
+
+def _cookie_secret_id(base_url: str, username: str) -> str:
+    """Stable, filesystem-/JSON-safe secret id for a (device, account) pair.
+
+    The pair is hashed (sha1, truncated) so URL/IP/port special chars never
+    leak into the secret_id namespace, and so the same secret slot is reused
+    across reconfigurations of the same logical session.
+    """
+    digest = hashlib.sha1(
+        f"{base_url}|{username}".encode("utf-8")
+    ).hexdigest()[:12]
+    return f"{_COOKIE_SECRET_PREFIX}{digest}"
+
+
+def _cookies_to_snapshot(jar: aiohttp.CookieJar) -> list[dict[str, Any]]:
+    """Snapshot every Morsel in ``jar`` into a list of plain JSON-able dicts."""
+    rows: list[dict[str, Any]] = []
+    for morsel in jar:  # iterates over http.cookies.Morsel
+        rows.append(
+            {
+                "name": morsel.key,
+                "value": morsel.value,
+                "domain": morsel["domain"] or "",
+                "path": morsel["path"] or "/",
+                "expires": morsel["expires"] or "",
+                "secure": bool(morsel["secure"]),
+                "httponly": bool(morsel["httponly"]),
+            }
+        )
+    return rows
+
+
+def _is_cookie_expired(expires: str, *, now: Optional[float] = None) -> bool:
+    """Best-effort check on RFC 1123 ``Expires`` string. Unparseable → False
+    (defer to aiohttp's own jar logic; we don't want to silently drop cookies
+    just because the device returned a non-standard expires format)."""
+    if not expires:
+        return False
+    try:
+        exp_dt = parsedate_to_datetime(expires)
+    except (TypeError, ValueError):
+        return False
+    if exp_dt is None:
+        return False
+    ts = exp_dt.timestamp()
+    return ts <= (now if now is not None else time.time())
+
+
+def _snapshot_into_jar(
+    jar: aiohttp.CookieJar,
+    rows: list[dict[str, Any]],
+    base_url: str,
+) -> int:
+    """Inflate ``rows`` (output of :func:`_cookies_to_snapshot`) back into
+    an aiohttp jar. Already-expired cookies are silently dropped. Returns
+    the number of cookies actually injected."""
+    if not rows:
+        return 0
+    sc: SimpleCookie = SimpleCookie()
+    injected = 0
+    for row in rows:
+        name = row.get("name") or ""
+        if not name:
+            continue
+        if _is_cookie_expired(row.get("expires") or ""):
+            continue
+        value = row.get("value") or ""
+        sc[name] = value
+        m: Morsel = sc[name]
+        if row.get("domain"):
+            m["domain"] = row["domain"]
+        if row.get("path"):
+            m["path"] = row["path"]
+        if row.get("expires"):
+            m["expires"] = row["expires"]
+        if row.get("secure"):
+            m["secure"] = True
+        if row.get("httponly"):
+            m["httponly"] = True
+        injected += 1
+    if injected == 0:
+        return 0
+    # response_url seeds the jar's domain/path bookkeeping for any cookie
+    # that didn't carry an explicit Domain attribute (typical for OneSIG,
+    # which scopes cookies to the device host).
+    try:
+        response_url = URL(base_url)
+    except Exception:
+        response_url = URL("http://localhost")
+    jar.update_cookies(sc, response_url=response_url)
+    return injected
+
+
+def _load_cookie_snapshot(secret_id: str) -> Optional[dict[str, Any]]:
+    """Pull a previously persisted snapshot dict, dropping malformed or
+    fully-expired payloads. Returns ``None`` when there is nothing usable.
+
+    Failure modes (corrupt JSON, version mismatch, all cookies expired) are
+    swallowed so a poisoned secret never breaks the calling tool — the
+    handler will simply fall through to a fresh login."""
+    raw = _get_secret_manager().get(secret_id)
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("version") != _COOKIE_SNAPSHOT_VERSION:
+        return None
+    cookies = data.get("cookies")
+    if not isinstance(cookies, list):
+        return None
+    fresh = [
+        c for c in cookies
+        if isinstance(c, dict)
+        and c.get("name")
+        and not _is_cookie_expired(c.get("expires") or "")
+    ]
+    if not fresh:
+        return None
+    data["cookies"] = fresh
+    return data
+
+
+def _save_cookie_snapshot(secret_id: str, snapshot: dict[str, Any]) -> bool:
+    """Persist a snapshot. Best-effort: returns False on I/O failure but
+    never raises — cookie persistence is an optimisation, not a hard
+    requirement of the request path."""
+    try:
+        _get_secret_manager().set(
+            secret_id, json.dumps(snapshot, separators=(",", ":"))
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _delete_cookie_snapshot(secret_id: str) -> bool:
+    try:
+        return _get_secret_manager().delete(secret_id)
+    except Exception:
+        return False
+
+
 class OneSIGSession:
     """Cookie-based session for a OneSIG device.
 
@@ -217,14 +474,82 @@ class OneSIGSession:
         self._session: Optional[aiohttp.ClientSession] = None
         self._logged_in = False
         self._login_lock = asyncio.Lock()
+        # Cookies waiting to be injected into the jar at the next
+        # ``_ensure_session`` call. Populated synchronously from
+        # ``.secret.json`` here so that tests / dispatchers can observe
+        # ``_logged_in`` immediately after construction.
+        self._pending_cookies: Optional[list[dict[str, Any]]] = None
+        self._cookies_loaded = False
+
+        if self.config.persist_cookies:
+            snapshot = _load_cookie_snapshot(self._cookie_secret_id)
+            cookies = (snapshot or {}).get("cookies") if snapshot else None
+            if cookies:
+                self._pending_cookies = cookies
+                # Trust the persisted cookie. If the device has rotated /
+                # invalidated it the existing 401-or-1019..1022 auto-relogin
+                # path in ``request()`` will repair the session on first
+                # business call. No extra RTT lost vs. unconditional login.
+                self._logged_in = True
+
+    @property
+    def _cookie_secret_id(self) -> str:
+        return _cookie_secret_id(self.config.base_url, self.config.username)
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
             jar = aiohttp.CookieJar(unsafe=True)
+            if self._pending_cookies and not self._cookies_loaded:
+                try:
+                    _snapshot_into_jar(
+                        jar, self._pending_cookies, self.config.base_url
+                    )
+                except Exception:
+                    # Bad on-disk snapshot must not block the request path:
+                    # forget the persisted cookies and force a clean login.
+                    self._logged_in = False
+                self._cookies_loaded = True
+                self._pending_cookies = None
             self._session = aiohttp.ClientSession(cookie_jar=jar)
         return self._session
 
+    def _persist_cookies(self) -> None:
+        """Snapshot the current jar to ``.secret.json``. Called after every
+        successful login / re-login. No-op when persistence is disabled or
+        the jar is empty.
+
+        Best-effort: any exception (missing ``cookie_jar`` on a swapped-in
+        test double, FS error, JSON encode bug, …) is swallowed so the
+        request path is never blocked by a persistence side-effect."""
+        if not self.config.persist_cookies:
+            return
+        if self._session is None or self._session.closed:
+            return
+        try:
+            jar = getattr(self._session, "cookie_jar", None)
+            if jar is None:
+                return
+            rows = _cookies_to_snapshot(jar)
+            if not rows:
+                return
+            snapshot = {
+                "version": _COOKIE_SNAPSHOT_VERSION,
+                "session_key": self.config.session_key,
+                "saved_at": int(time.time()),
+                "cookies": rows,
+            }
+            _save_cookie_snapshot(self._cookie_secret_id, snapshot)
+        except Exception:
+            return
+
+    def _drop_persisted_cookies(self) -> None:
+        if self.config.persist_cookies:
+            _delete_cookie_snapshot(self._cookie_secret_id)
+
     async def close(self) -> None:
+        # ``close`` is for graceful shutdown (e.g. process exit). It does NOT
+        # drop the persisted cookie — that's the whole point of persistence.
+        # Use ``logout()`` for an explicit invalidation instead.
         if self._session is not None and not self._session.closed:
             await self._session.close()
         self._session = None
@@ -276,8 +601,24 @@ class OneSIGSession:
             )
             pubkey = pubkey_data.get("pubkey")
             if not pubkey:
+                # 把 status / URL / body 摘要都拼进错误里：拿到 404 一般就是
+                # ``api_prefix`` 配错（v2.5.x 大部分部署不带 ``/api``）；拿到
+                # 5xx / connection error 才是真的 device 不通。
+                hint = ""
+                if isinstance(pubkey_info, dict) and pubkey_info.get("_status"):
+                    status = pubkey_info["_status"]
+                    if status == 404:
+                        hint = (
+                            "（HTTP 404，通常意味着 `api_prefix` 配置不对 —— "
+                            "OneSIG v2.5.x 大多数部署需要把 `api_prefix` 留空"
+                            "或显式设成 `\"\"`，少数 reverse-proxy 部署才需要 "
+                            "`\"/api\"`。）"
+                        )
+                    else:
+                        hint = f"（HTTP {status}）"
                 raise ValueError(
-                    f"无法从 /v3/pubkey 获取 RSA 公钥：{pubkey_info!r}"
+                    f"无法从 {self.config.build_url('/v3/pubkey')} 获取 RSA 公钥{hint}："
+                    f"{pubkey_info!r}"
                 )
 
             try:
@@ -333,6 +674,10 @@ class OneSIGSession:
                 )
 
             self._logged_in = True
+            # Persist immediately on successful login (before /v3/account so
+            # cookie survives even if the verification call fails). Best-
+            # effort: failures here never break the calling tool.
+            self._persist_cookies()
             account_resp = await self._raw_request_json("GET", "/v3/account")
             if (
                 isinstance(account_resp, dict)
@@ -346,6 +691,10 @@ class OneSIGSession:
             resp = await self._raw_request_json("POST", "/v3/logout", json_body={})
         finally:
             self._logged_in = False
+            # Logout invalidates the cookie server-side; remove the local
+            # snapshot too so the next process doesn't try to reuse a dead
+            # session and pay an extra round-trip discovering it.
+            self._drop_persisted_cookies()
         if isinstance(resp, dict):
             return resp
         return {}
@@ -375,9 +724,23 @@ class OneSIGSession:
         async with session.request(method.upper(), url, **kwargs) as resp:
             text = await resp.text()
             try:
-                return await resp.json(content_type=None)
+                parsed = await resp.json(content_type=None)
             except Exception:
-                return {"_status": resp.status, "_text": text[:500]}
+                parsed = None
+            # ``aiohttp.ClientResponse.json(content_type=None)`` returns
+            # ``None`` for empty / whitespace-only bodies *without raising*,
+            # which used to surface as the very confusing
+            #   ``无法从 /v3/pubkey 获取 RSA 公钥：None``
+            # 在错误日志里 — 看不到 status / URL，根本没法定位到「``/api`` 前
+            # 缀错了导致 404」之类的根因。这里把 ``None`` 也统一塞进 fallback
+            # 字典，让上层的报错带上 status 和 body 摘要。
+            if parsed is None or not isinstance(parsed, (dict, list)):
+                return {
+                    "_status": resp.status,
+                    "_url": str(resp.url),
+                    "_text": text[:500],
+                }
+            return parsed
 
     async def encrypt_with_pubkey(self, plain: str) -> str:
         """Fetch the latest /v3/pubkey and RSA-OAEP encrypt the given plaintext.
@@ -539,9 +902,22 @@ class ActionSpec:
 
         body: Optional[Any] = None
         if self.method == "GET" and not self.multipart:
+            # OneSIG 的 GET list 接口对 query 里的分页/过滤参数要求很严
+            # （e.g. /v3/apikey/list 不带 pageNo/pageSize 直接回 1004）。
+            # body_keys 里声明过的字段先入 query；剩余非保留、非已声明的字段
+            # 也透传进 query，避免调用方传了 pageNo/severity 这类常见过滤
+            # 项被 handler 静默丢掉。
             for key in self.body_keys:
                 if params.get(key) is not None:
                     query[key] = params[key]
+            for k, v in params.items():
+                if v is None:
+                    continue
+                if k in _RESERVED_PARAM_KEYS:
+                    continue
+                if k in self.query_keys or k in self.body_keys:
+                    continue
+                query[k] = v
         else:
             if self.passthrough_body:
                 body = {
@@ -608,9 +984,23 @@ MONITORING_ACTION_SPECS: dict[str, ActionSpec] = {
     "overview_export_event_outbound": ActionSpec(
         "POST", "/v3/overview/exportEventOutbound", passthrough_body=True, binary=True
     ),
-    "overview_asset_brief": ActionSpec("POST", "/v3/overview/assetBrief", passthrough_body=True),
+    # OneSIG v2.5.3 实测：文档标 `incIntervalSec` 选填，但服务端实际必填，
+    # 不带直接回 1004 "请求数据非法"。前端总是从页面 ref 取轮询间隔传入。
+    "overview_asset_brief": ActionSpec(
+        "POST",
+        "/v3/overview/assetBrief",
+        passthrough_body=True,
+        required=["startTime", "endTime", "incIntervalSec"],
+    ),
     "overview_asset_top": ActionSpec("POST", "/v3/overview/assetTop", passthrough_body=True),
-    "overview_event_inbound_agg": ActionSpec("POST", "/v3/overview/eventInboundAgg", passthrough_body=True),
+    # OneSIG v2.5.3 实测：除文档明示的 startTime/endTime 外，`type` 与
+    # `pageNo`/`pageSize` 也是必填，不带任何一个均回 1004。
+    "overview_event_inbound_agg": ActionSpec(
+        "POST",
+        "/v3/overview/eventInboundAgg",
+        passthrough_body=True,
+        required=["startTime", "endTime", "type", "pageNo", "pageSize"],
+    ),
     "overview_export_event_inbound_agg": ActionSpec(
         "POST", "/v3/overview/exportEventInboundAgg", passthrough_body=True, binary=True
     ),
@@ -619,9 +1009,22 @@ MONITORING_ACTION_SPECS: dict[str, ActionSpec] = {
         "POST", "/v3/overview/exportEventOutboundAgg", passthrough_body=True, binary=True
     ),
     "overview_event_recent_agg": ActionSpec("POST", "/v3/overview/eventRecentAgg", passthrough_body=True),
-    "overview_event_trend": ActionSpec("POST", "/v3/overview/eventTrend", passthrough_body=True),
+    # OneSIG v2.5.3 实测：`interval` 文档标选填，实际必填（"1 DAY" / "1 HOUR"），
+    # 否则回 1004。前端按时间窗自动派发 "1 DAY" 或 "1 HOUR"。
+    "overview_event_trend": ActionSpec(
+        "POST",
+        "/v3/overview/eventTrend",
+        passthrough_body=True,
+        required=["startTime", "endTime", "interval"],
+    ),
     "overview_traffic_trend": ActionSpec("POST", "/v3/overview/trafficTrend", passthrough_body=True),
-    "overview_stat": ActionSpec("POST", "/v3/overview/stat", passthrough_body=True),
+    # OneSIG v2.5.3 实测：`incIntervalSec` 文档标选填，实际必填。
+    "overview_stat": ActionSpec(
+        "POST",
+        "/v3/overview/stat",
+        passthrough_body=True,
+        required=["startTime", "endTime", "incIntervalSec"],
+    ),
     "overview_threat_type_proportion": ActionSpec(
         "POST", "/v3/overview/threatTypeProportion", passthrough_body=True
     ),
@@ -638,7 +1041,15 @@ MONITORING_ACTION_SPECS: dict[str, ActionSpec] = {
     "set_overview_config": ActionSpec("PUT", "/v3/setting/overviewConfig", passthrough_body=True),
     # status
     "device_platform_status": ActionSpec("GET", "/v3/device/platformStatus"),
-    "device_system_status": ActionSpec("GET", "/v3/device/systemStatus"),
+    # OneSIG v2.5.3 文档：模式 A 用 (time, module)；模式 B 用 (startTime, endTime,
+    # module, ifName)。`module` 必传但前端在 index.jsx 初次批拉时传空串即可，
+    # 因此这里把 `time` 列为强制必填，调用方至少要给一个时间锚。
+    "device_system_status": ActionSpec(
+        "GET",
+        "/v3/device/systemStatus",
+        body_keys=["time", "module", "startTime", "endTime", "ifName"],
+        required=["time"],
+    ),
     "device_network_status": ActionSpec("GET", "/v3/device/networkStatus"),
     "common_interface_list": ActionSpec("GET", "/v3/common/interfaceList"),
     "basic_cpu_attr": ActionSpec("GET", "/v3/basic/cpuAttr"),
@@ -656,9 +1067,19 @@ MONITORING_ACTION_SPECS: dict[str, ActionSpec] = {
     "alert_host_export": ActionSpec(
         "POST", "/v3/alertHost/export", passthrough_body=True, binary=True
     ),
-    "alert_host_detail": ActionSpec("POST", "/v3/alertHost/detail", passthrough_body=True),
+    # OneSIG 文档 monitoringHostdetail.md：必填 startTime + endTime + source
+    # （source = 当前告警主机 IP，由列表行 `detailData.source` 带入）。
+    "alert_host_detail": ActionSpec(
+        "POST",
+        "/v3/alertHost/detail",
+        passthrough_body=True,
+        required=["startTime", "endTime", "source"],
+    ),
     "alert_host_detail_list": ActionSpec(
-        "POST", "/v3/alertHost/detail/list", passthrough_body=True
+        "POST",
+        "/v3/alertHost/detail/list",
+        passthrough_body=True,
+        required=["startTime", "endTime", "source"],
     ),
     "alert_host_detail_export": ActionSpec(
         "POST", "/v3/alertHost/detail/export", passthrough_body=True, binary=True
@@ -677,12 +1098,27 @@ MONITORING_ACTION_SPECS: dict[str, ActionSpec] = {
     "event_inbound_export": ActionSpec(
         "POST", "/v3/event/inbound/export", passthrough_body=True, binary=True
     ),
-    "event_inbound_detail": ActionSpec("POST", "/v3/event/inbound/detail", passthrough_body=True),
+    # OneSIG 文档 monitoringInboundThreat.md：必填 startTime + endTime；
+    # 实测仅传时间窗仍可能 1004，因为入站详情弹窗在生产路径上始终带 `threatTag`
+    # 等行级威胁元数据，建议调用方一并传入 (`threatName` / `threatTag` /
+    # `threatType` 三选一非空)。
+    "event_inbound_detail": ActionSpec(
+        "POST",
+        "/v3/event/inbound/detail",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
+    ),
     "event_inbound_detail_trend": ActionSpec(
-        "POST", "/v3/event/inbound/detail/trend", passthrough_body=True
+        "POST",
+        "/v3/event/inbound/detail/trend",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
     ),
     "event_inbound_detail_list": ActionSpec(
-        "POST", "/v3/event/inbound/detail/list", passthrough_body=True
+        "POST",
+        "/v3/event/inbound/detail/list",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
     ),
     "event_inbound_detail_export": ActionSpec(
         "POST", "/v3/event/inbound/detail/export", passthrough_body=True, binary=True
@@ -705,12 +1141,25 @@ MONITORING_ACTION_SPECS: dict[str, ActionSpec] = {
     "event_outbound_export": ActionSpec(
         "POST", "/v3/event/outbound/export", passthrough_body=True, binary=True
     ),
-    "event_outbound_detail": ActionSpec("POST", "/v3/event/outbound/detail", passthrough_body=True),
+    # OneSIG 文档 monitoringOutboundThreat.md：必填 startTime + endTime；
+    # 与入站系列同理，弹窗内联动行上下文（`threatName` 等）后才能稳定返回数据。
+    "event_outbound_detail": ActionSpec(
+        "POST",
+        "/v3/event/outbound/detail",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
+    ),
     "event_outbound_detail_trend": ActionSpec(
-        "POST", "/v3/event/outbound/detail/trend", passthrough_body=True
+        "POST",
+        "/v3/event/outbound/detail/trend",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
     ),
     "event_outbound_detail_list": ActionSpec(
-        "POST", "/v3/event/outbound/detail/list", passthrough_body=True
+        "POST",
+        "/v3/event/outbound/detail/list",
+        passthrough_body=True,
+        required=["startTime", "endTime"],
     ),
     "event_outbound_detail_export": ActionSpec(
         "POST", "/v3/event/outbound/detail/export", passthrough_body=True, binary=True
@@ -743,7 +1192,13 @@ MONITORING_ACTION_SPECS: dict[str, ActionSpec] = {
     "ips_rule_create": ActionSpec("POST", "/v3/ips/rule", passthrough_body=True),
     "ips_rule_apply": ActionSpec("POST", "/v3/ips/rule/apply", passthrough_body=True),
     "ips_ruleset_namelist": ActionSpec("POST", "/v3/ips/ruleset/namelist", passthrough_body=True),
-    "ips_ruleset_referred": ActionSpec("POST", "/v3/ips/ruleset/referred", passthrough_body=True),
+    # OneSIG 文档：必填 ruleId + assetIp（用于查询「当前」生效的规则集名称）。
+    "ips_ruleset_referred": ActionSpec(
+        "POST",
+        "/v3/ips/ruleset/referred",
+        passthrough_body=True,
+        required=["ruleId", "assetIp"],
+    ),
     "logaccess_stat": ActionSpec("GET", "/v3/logAccess/stat"),
     "get_dnslog_config": ActionSpec("GET", "/v3/setting/dnslogConfig"),
 }
@@ -773,7 +1228,13 @@ STRATEGY_ACTION_SPECS: dict[str, ActionSpec] = {
     "blacklist_add": ActionSpec("POST", "/v3/globalBlacklist", passthrough_body=True),
     "blacklist_update": ActionSpec("PUT", "/v3/globalBlacklist", passthrough_body=True),
     "blacklist_delete": ActionSpec("DELETE", "/v3/globalBlacklist", passthrough_body=True),
-    "blacklist_check": ActionSpec("POST", "/v3/globalBlacklist/check", passthrough_body=True),
+    # OneSIG 文档：必填 blackList（待校验的黑名单对象数组）。
+    "blacklist_check": ActionSpec(
+        "POST",
+        "/v3/globalBlacklist/check",
+        passthrough_body=True,
+        required=["blackList"],
+    ),
     "blacklist_export": ActionSpec(
         "POST", "/v3/globalBlacklist/export", passthrough_body=True, binary=True
     ),
@@ -784,8 +1245,13 @@ STRATEGY_ACTION_SPECS: dict[str, ActionSpec] = {
         "DELETE", "/v3/globalBlacklist/remove", passthrough_body=True
     ),
     # multi-block
+    # OneSIG 文档：必填 name + startTime + endTime + pageNo + pageSize；
+    # `name` 缺失时直接 1004。
     "multiblock_executelog_list": ActionSpec(
-        "POST", "/v3/multiblock/executelog", passthrough_body=True
+        "POST",
+        "/v3/multiblock/executelog",
+        passthrough_body=True,
+        required=["name", "startTime", "endTime", "pageNo", "pageSize"],
     ),
     "multiblock_executelog_export": ActionSpec(
         "POST", "/v3/multiblock/executelog/export", passthrough_body=True, binary=True
@@ -802,11 +1268,27 @@ STRATEGY_ACTION_SPECS: dict[str, ActionSpec] = {
     "multiblock_rule_list": ActionSpec(
         "POST", "/v3/multiblock/rule/list", passthrough_body=True
     ),
+    # OneSIG 文档：必填 name（多维封锁规则名称）。
     "multiblock_rule_get": ActionSpec(
-        "POST", "/v3/multiblock/rule/get", passthrough_body=True
+        "POST",
+        "/v3/multiblock/rule/get",
+        passthrough_body=True,
+        required=["name"],
     ),
+    # OneSIG 文档：预运行需带规则核心字段；前端在发起前会移除 blockTime/
+    # blockDirection/showCommit。
     "multiblock_rule_preview": ActionSpec(
-        "POST", "/v3/multiblock/rule/preview", passthrough_body=True
+        "POST",
+        "/v3/multiblock/rule/preview",
+        passthrough_body=True,
+        required=[
+            "name",
+            "detectTimeNum",
+            "detectTimeUnit",
+            "detectDirection",
+            "detectGroups",
+            "blockType",
+        ],
     ),
     "multiblock_rule_create": ActionSpec(
         "POST", "/v3/multiblock/rule", passthrough_body=True
@@ -818,14 +1300,30 @@ STRATEGY_ACTION_SPECS: dict[str, ActionSpec] = {
     "apikey_delete": ActionSpec("DELETE", "/v3/apikey", passthrough_body=True),
     "apikey_update": ActionSpec("PUT", "/v3/apikey", passthrough_body=True),
     "apikey_create": ActionSpec("POST", "/v3/apikey", passthrough_body=True),
-    "apikey_list": ActionSpec("GET", "/v3/apikey/list"),
-    "apikey_secret": ActionSpec("GET", "/v3/apikey/secret", body_keys=["uniqueId"]),
+    # OneSIG 服务端 GET list 接口要求 query 里至少带 pageNo/pageSize，
+    # 否则统一回 responseCode=1004 "请求数据非法"。
+    "apikey_list": ActionSpec(
+        "GET", "/v3/apikey/list", body_keys=["pageNo", "pageSize"]
+    ),
+    # OneSIG 文档 strategyApi.md：query 必填 key + password
+    # （二次校验登录密码用于查看 secret，敏感字段勿入日志）。
+    "apikey_secret": ActionSpec(
+        "GET",
+        "/v3/apikey/secret",
+        body_keys=["key", "password"],
+        required=["key", "password"],
+    ),
     # syslog auto-blacklist
     "auto_blacklist_delete": ActionSpec(
         "DELETE", "/v3/autoBlacklist", passthrough_body=True
     ),
+    # OneSIG 文档：必填 name + port + srcIp + protocol + direction
+    # （步骤 1 → 步骤 2 之间的接入配置重复性校验）。
     "auto_blacklist_check": ActionSpec(
-        "POST", "/v3/autoBlacklist/check", passthrough_body=True
+        "POST",
+        "/v3/autoBlacklist/check",
+        passthrough_body=True,
+        required=["name", "port", "srcIp", "protocol", "direction"],
     ),
     "auto_blacklist_create": ActionSpec(
         "POST", "/v3/autoBlacklist", passthrough_body=True
@@ -836,18 +1334,40 @@ STRATEGY_ACTION_SPECS: dict[str, ActionSpec] = {
     "auto_blacklist_list": ActionSpec(
         "POST", "/v3/autoBlacklist/list", passthrough_body=True
     ),
+    # OneSIG 文档：query 仅 `srcIp` 必填（来自 syslog 接入配置的源 IP）。
     "auto_blacklist_trend": ActionSpec(
-        "GET", "/v3/autoBlacklist/trend", body_keys=["startTime", "endTime"]
+        "GET",
+        "/v3/autoBlacklist/trend",
+        body_keys=["srcIp", "startTime", "endTime"],
+        required=["srcIp"],
     ),
+    # OneSIG 文档：必填 srcIp + protocol + direction（入站/出站）。
     "auto_blacklist_sample": ActionSpec(
-        "POST", "/v3/autoBlacklist/sample", passthrough_body=True
+        "POST",
+        "/v3/autoBlacklist/sample",
+        passthrough_body=True,
+        required=["srcIp", "protocol", "direction"],
     ),
     # ftp/sftp linkage
     "linkage_delete": ActionSpec("DELETE", "/v3/linkage", passthrough_body=True),
     "linkage_create": ActionSpec("POST", "/v3/linkage", passthrough_body=True),
     "linkage_update": ActionSpec("PUT", "/v3/linkage", passthrough_body=True),
     "linkage_enable": ActionSpec("POST", "/v3/linkage/enable", passthrough_body=True),
-    "linkage_info": ActionSpec("GET", "/v3/linkage/info", body_keys=["uniqueId"]),
+    # 注意：尽管命名是 "info"，OneSIG 服务端在响应前会触发一次 FTP/SFTP
+    # 连通性测试（v2.5.3 实测：传 uniqueId=dummy 直接返回 1309
+    # "FTP联通测试失败[dummy]"）。换言之这是个有副作用的接口，仅在确
+    # 实需要重新探活时再调用，普通"读配置"用 linkage_list 即可。
+    # OneSIG 文档：query 必填 uniqueId（联动配置 ID）；password 选填，
+    # 仅在 FTPAccount 查看密钥时拼接。
+    # 注意：尽管命名是 "info"，OneSIG 服务端在响应前会触发一次 FTP/SFTP
+    # 连通性测试（v2.5.3 实测：传 uniqueId=dummy 直接返回 1309
+    # "FTP联通测试失败[dummy]"）。换言之这是个有副作用的接口。
+    "linkage_info": ActionSpec(
+        "GET",
+        "/v3/linkage/info",
+        body_keys=["uniqueId", "password"],
+        required=["uniqueId"],
+    ),
     "linkage_list": ActionSpec("POST", "/v3/linkage/list", passthrough_body=True),
     "linkage_template": ActionSpec("GET", "/v3/linkage/template", binary=True),
     "linkage_test": ActionSpec("POST", "/v3/linkage/test", passthrough_body=True),
@@ -859,7 +1379,13 @@ STRATEGY_ACTION_SPECS: dict[str, ActionSpec] = {
     "ips_ruleset_create": ActionSpec("POST", "/v3/ips/ruleset", passthrough_body=True),
     "ips_ruleset_update": ActionSpec("PUT", "/v3/ips/ruleset", passthrough_body=True),
     "ips_ruleset_delete": ActionSpec("DELETE", "/v3/ips/ruleset", passthrough_body=True),
-    "ips_ruleset_info": ActionSpec("POST", "/v3/ips/ruleset/info", passthrough_body=True),
+    # OneSIG 文档：必填 name（IPS 规则集名称）。
+    "ips_ruleset_info": ActionSpec(
+        "POST",
+        "/v3/ips/ruleset/info",
+        passthrough_body=True,
+        required=["name"],
+    ),
     "ips_ruleset_list": ActionSpec("POST", "/v3/ips/ruleset/list", passthrough_body=True),
     "ips_ruleset_namelist": ActionSpec(
         "POST", "/v3/ips/ruleset/namelist", passthrough_body=True
@@ -919,8 +1445,13 @@ STRATEGY_ACTION_SPECS: dict[str, ActionSpec] = {
     "port_protect_port_export": ActionSpec(
         "POST", "/v3/portProtectGroup/port/export", passthrough_body=True, binary=True
     ),
+    # OneSIG 文档：必填 groupName + pageNo + pageSize；search 超过 32 字符
+    # 前端拦截。
     "port_protect_port_list": ActionSpec(
-        "POST", "/v3/portProtectGroup/port/list", passthrough_body=True
+        "POST",
+        "/v3/portProtectGroup/port/list",
+        passthrough_body=True,
+        required=["groupName", "pageNo", "pageSize"],
     ),
     "port_protect_port_onekey_import": ActionSpec(
         "POST", "/v3/portProtectGroup/port/onekeyImport", passthrough_body=True
@@ -992,8 +1523,14 @@ DEVICE_ACTION_SPECS: dict[str, ActionSpec] = {
     "alert_policy_export": ActionSpec(
         "POST", "/v3/alert/policy/export", passthrough_body=True, binary=True
     ),
+    # OneSIG 文档：必填 search + type；
+    #   - syslog: search 形如 "UDP:192.168.0.1:514"
+    #   - webhook: search 形如 "type:url"
     "alert_policy_find_by_config": ActionSpec(
-        "POST", "/v3/alert/policy/findByConfig", passthrough_body=True
+        "POST",
+        "/v3/alert/policy/findByConfig",
+        passthrough_body=True,
+        required=["search", "type"],
     ),
     "alert_policy_object": ActionSpec(
         "POST", "/v3/alert/policy/object", passthrough_body=True
@@ -1081,8 +1618,13 @@ DEVICE_ACTION_SPECS: dict[str, ActionSpec] = {
         "POST", "/v3/tls/cert/set_default", passthrough_body=True
     ),
     "tls_detect_list": ActionSpec("POST", "/v3/tls/detect/list", passthrough_body=True),
+    # OneSIG 文档：必填 server + port + orderBy + sortBy
+    # （父行 serverAddress/serverPort，固定 desc / updateTime）。
     "tls_detect_list_detail": ActionSpec(
-        "POST", "/v3/tls/detect/list/detail", passthrough_body=True
+        "POST",
+        "/v3/tls/detect/list/detail",
+        passthrough_body=True,
+        required=["server", "port", "orderBy", "sortBy"],
     ),
     "tls_detect_delete": ActionSpec("DELETE", "/v3/tls/detect", passthrough_body=True),
     "tls_detect_group": ActionSpec("POST", "/v3/tls/detect/group", passthrough_body=True),
@@ -1104,7 +1646,13 @@ DEVICE_ACTION_SPECS: dict[str, ActionSpec] = {
         "POST", "/v3/interface/check/loop", passthrough_body=True
     ),
     "interface_relation_list": ActionSpec("GET", "/v3/interface/relation/list"),
-    "interface_select_list": ActionSpec("GET", "/v3/interface/select/list"),
+    # OneSIG 文档：必填 workMode（listen/bridge/vline）；不传直接 1004。
+    "interface_select_list": ActionSpec(
+        "GET",
+        "/v3/interface/select/list",
+        body_keys=["workMode", "name", "itemName"],
+        required=["workMode"],
+    ),
     "interface_virtual_line_create": ActionSpec(
         "POST", "/v3/interface/virtualLine", passthrough_body=True
     ),
@@ -1176,7 +1724,10 @@ DEVICE_ACTION_SPECS: dict[str, ActionSpec] = {
     "ha_compare_config": ActionSpec("POST", "/v3/ha/compareConfig", passthrough_body=True),
     "ha_switching": ActionSpec("PUT", "/v3/ha/switching", passthrough_body=True),
     "ha_sync_config": ActionSpec("POST", "/v3/ha/syncConfig", passthrough_body=True),
-    "ha_sync_status": ActionSpec("GET", "/v3/ha/syncStatus"),
+    # OneSIG 文档：必填 syncId（由 ha_sync_config 返回的任务 ID）。
+    "ha_sync_status": ActionSpec(
+        "GET", "/v3/ha/syncStatus", body_keys=["syncId"], required=["syncId"]
+    ),
     # centralized control (OneCC)
     "onecc_status": ActionSpec("GET", "/v3/setting/oneccConfig/status"),
     "get_onecc_config": ActionSpec("GET", "/v3/setting/oneccConfig"),
@@ -1241,11 +1792,23 @@ DEVICE_ACTION_SPECS: dict[str, ActionSpec] = {
     "backup_import": ActionSpec(
         "POST", "/v3/backup/import", passthrough_body=True, multipart=True
     ),
-    "logaccess_list": ActionSpec("POST", "/v3/logAccess/list", passthrough_body=True),
+    # OneSIG 文档：必填 pageNo + pageSize + type（"DNS" 或 "DHCP"）。
+    "logaccess_list": ActionSpec(
+        "POST",
+        "/v3/logAccess/list",
+        passthrough_body=True,
+        required=["pageNo", "pageSize", "type"],
+    ),
     "logaccess_delete": ActionSpec("DELETE", "/v3/logAccess", passthrough_body=True),
     "logaccess_create": ActionSpec("POST", "/v3/logAccess", passthrough_body=True),
     "logaccess_update": ActionSpec("PUT", "/v3/logAccess", passthrough_body=True),
-    "logaccess_sample": ActionSpec("POST", "/v3/logAccess/sample", passthrough_body=True),
+    # OneSIG 文档：必填 srcIp + protocol + type（"DNS" 或 "DHCP"）。
+    "logaccess_sample": ActionSpec(
+        "POST",
+        "/v3/logAccess/sample",
+        passthrough_body=True,
+        required=["srcIp", "protocol", "type"],
+    ),
     "logaccess_test": ActionSpec("POST", "/v3/logAccess/test", passthrough_body=True),
     "logaccess_check": ActionSpec("GET", "/v3/logAccess/check", body_keys=["name"]),
     # system info
@@ -1288,8 +1851,13 @@ DEVICE_ACTION_SPECS: dict[str, ActionSpec] = {
 
 HELPER_ACTION_SPECS: dict[str, ActionSpec] = {
     "document_list": ActionSpec("POST", "/v3/document/list", passthrough_body=True),
+    # OneSIG 文档 helperDocs.md：query 必填 `id`（来自文档列表项），
+    # 而非 `fileName`。返回值是路径字符串（非对象），前端拼接 baseUrl 后 open。
     "document_preview": ActionSpec(
-        "GET", "/v3/document/preview", body_keys=["fileName"]
+        "GET",
+        "/v3/document/preview",
+        body_keys=["id"],
+        required=["id"],
     ),
     "product_news_get": ActionSpec("GET", "/v3/product/news"),
     "product_news_mark_read": ActionSpec(

--- a/.flocks/plugins/tools/api/onesig/onesig_assets.yaml
+++ b/.flocks/plugins/tools/api/onesig/onesig_assets.yaml
@@ -1,0 +1,90 @@
+name: onesig_assets
+description: >
+  OneSIG asset management grouped tool. Use the `action` parameter to manage
+  assets, asset groups, asset types, and import / export workflows under
+  `/assets/segment`.
+description_cn: >
+  OneSIG 资产管理分组工具。通过 `action` 调用资产、资产组、资产类型以及导入/导出
+  相关接口，对应 Web 控制台 `/assets/segment` 资产配置页。
+category: custom
+enabled: true
+requires_confirmation: true
+provider: onesig_api
+inputSchema:
+  type: object
+  properties:
+    action:
+      type: string
+      description: |
+        Assets 分组动作名：
+        - asset_delete           DELETE /v3/asset                      删除资产
+        - asset_create           POST   /v3/asset                      新增资产
+        - asset_update           PUT    /v3/asset                      更新资产
+        - asset_export           POST   /v3/asset/export               导出资产（文件）
+        - asset_group_delete     DELETE /v3/asset/group                删除资产组
+        - asset_group_get        GET    /v3/asset/group                查询资产组
+        - asset_group_create     POST   /v3/asset/group                新增资产组
+        - asset_group_update     PUT    /v3/asset/group                更新资产组
+        - asset_import           POST   /v3/asset/import               导入资产（multipart：传 file_path）
+        - asset_template         GET    /v3/asset/template             导入模板（文件）
+        - asset_list             POST   /v3/asset/list                 分页查询资产列表
+        - asset_type_delete      DELETE /v3/asset/type                 删除资产类型
+        - asset_type_get         GET    /v3/asset/type                 查询资产类型
+        - asset_type_create      POST   /v3/asset/type                 新增资产类型
+        - common_asset_group_tree GET   /v3/common/assetGroupTree      资产组树
+      enum:
+        - asset_delete
+        - asset_create
+        - asset_update
+        - asset_export
+        - asset_group_delete
+        - asset_group_get
+        - asset_group_create
+        - asset_group_update
+        - asset_import
+        - asset_template
+        - asset_list
+        - asset_type_delete
+        - asset_type_get
+        - asset_type_create
+        - common_asset_group_tree
+    uniqueId:
+      type: string
+      description: 资产/资产组/资产类型 ID
+    uniqueIds:
+      type: array
+      items:
+        type: string
+      description: 批量删除使用的 ID 列表
+    name:
+      type: string
+      description: 名称
+    ip:
+      type: string
+      description: IP / CIDR / 网段
+    assetGroup:
+      type: string
+      description: 资产组路径
+    assetType:
+      type: string
+      description: 资产类型
+    pageNo:
+      type: integer
+      default: 1
+    pageSize:
+      type: integer
+      default: 20
+    search:
+      type: string
+      description: 模糊查询关键字
+    file_path:
+      type: string
+      description: |
+        本地待上传文件的绝对路径；仅 multipart 上传类动作使用：
+          - asset_import      .csv 资产导入文件（字段名 `file`）
+  required:
+    - action
+handler:
+  type: script
+  script_file: onesig.handler.py
+  function: assets

--- a/.flocks/plugins/tools/api/onesig/onesig_device.yaml
+++ b/.flocks/plugins/tools/api/onesig/onesig_device.yaml
@@ -1,0 +1,400 @@
+name: onesig_device
+description: >
+  OneSIG device management grouped tool. Use the `action` parameter to access
+  alert / notification policies, audit logs, user / login management, HTTPS
+  decryption, deployment guide, network interfaces, routes, DNS, HA, OneCC
+  (centralized control), system info, license, MDR service, system diagnosis,
+  and the device configuration / backup / upgrade flows under `/device/*`.
+description_cn: >
+  OneSIG 平台管理分组工具。通过 `action` 调用告警/通知策略、管理日志、用户/登录安全
+  策略、HTTPS 解密、部署引导、接口、路由、DNS、HA 高可用、一体化管控、系统信息、
+  许可证、MDR 服务、设备诊断以及备份/升级等接口（覆盖 Web 控制台 `/device/*` 子页）。
+category: custom
+enabled: true
+requires_confirmation: true
+provider: onesig_api
+inputSchema:
+  type: object
+  properties:
+    action:
+      type: string
+      description: |
+        Device 分组动作名（按 UI 子页归类）：
+
+        # 通知配置 (/device/alert)
+        - alert_policy_list                POST   /v3/alert/policy/list
+        - alert_policy_enable              POST   /v3/alert/policy/enable
+        - alert_policy_delete              DELETE /v3/alert/policy
+        - alert_policy_create              POST   /v3/alert/policy
+        - alert_policy_update              PUT    /v3/alert/policy
+        - alert_policy_export              POST   /v3/alert/policy/export       （文件）
+        - alert_policy_find_by_config      POST   /v3/alert/policy/findByConfig
+        - alert_policy_object              POST   /v3/alert/policy/object
+        - get_notice_config                GET    /v3/setting/noticeConfig
+        - set_notice_config                PUT    /v3/setting/noticeConfig
+        - get_notice_send_key              GET    /v3/setting/noticeConfig/sendKey
+        - test_email                       POST   /v3/test/email
+        - test_syslog                      POST   /v3/test/syslog
+        - test_webhook                     POST   /v3/test/webhook
+
+        # 审计日志 (/device/audit)
+        - aclog_stat                       GET    /v3/aclog/stat
+        - aclog_list                       POST   /v3/aclog/list
+        - aclog_export                     POST   /v3/aclog/export             （文件）
+        - aclog_delete                     DELETE /v3/aclog                         （password 自动 RSA 加密）
+        - get_clean_config                 GET    /v3/setting/cleanConfig
+        - set_clean_config                 PUT    /v3/setting/cleanConfig
+
+        # 登录管理 (/device/loginManagement)
+        - user_list                        POST   /v3/user/list
+        - user_export                      POST   /v3/user/export              （文件）
+        - user_delete                      DELETE /v3/user                          （password 自动 RSA 加密）
+        - user_secret_reset                PUT    /v3/user/secret/reset            （password 自动 RSA 加密）
+        - user_create                      POST   /v3/user                          （password / dupPassword 自动 RSA 加密）
+        - user_update                      PUT    /v3/user
+        - get_login_config                 GET    /v3/setting/loginConfig
+        - set_login_config                 PUT    /v3/setting/loginConfig
+
+        # HTTPS 解密 (/device/httpsDecryption)
+        - get_decrypt_config               GET    /v3/setting/decryptConfig
+        - set_decrypt_config               PUT    /v3/setting/decryptConfig
+        - get_detect_config                GET    /v3/setting/detectConfig
+        - set_detect_config                PUT    /v3/setting/detectConfig
+        - tls_decrypt_policy_list          POST   /v3/tls/decrypt/policy/list
+        - tls_decrypt_policy_create        POST   /v3/tls/decrypt/policy
+        - tls_decrypt_policy_update        PUT    /v3/tls/decrypt/policy
+        - tls_decrypt_policy_enable        POST   /v3/tls/decrypt/policy/enable
+        - tls_decrypt_policy_delete        DELETE /v3/tls/decrypt/policy
+        - tls_decrypt_policy_batch         POST   /v3/tls/decrypt/policy/batch
+        - tls_cert_list                    POST   /v3/tls/cert/list
+        - tls_cert_create                  POST   /v3/tls/cert                     （multipart：file_path 指向 .crt/.pem，字段名 certFile）
+        - tls_cert_update                  PUT    /v3/tls/cert                     （multipart：同 tls_cert_create，body 需带 uniqueId）
+        - tls_cert_delete                  DELETE /v3/tls/cert
+        - tls_cert_set_default             POST   /v3/tls/cert/set_default
+        - tls_detect_list                  POST   /v3/tls/detect/list
+        - tls_detect_list_detail           POST   /v3/tls/detect/list/detail
+        - tls_detect_delete                DELETE /v3/tls/detect
+        - tls_detect_group                 POST   /v3/tls/detect/group
+        - tls_detect_group_export          POST   /v3/tls/detect/group/export   （文件）
+        - tls_detect_list_export           POST   /v3/tls/detect/list/export    （文件）
+
+        # 接口 / 部署引导 (/device/interface, /device/deployguide)
+        - interface_list                   GET    /v3/interface/list
+        - interface_update                 PUT    /v3/interface                    （启停场景 password 自动 RSA 加密）
+        - interface_check_loop             POST   /v3/interface/check/loop
+        - interface_relation_list          GET    /v3/interface/relation/list
+        - interface_select_list            GET    /v3/interface/select/list
+        - interface_virtual_line_create    POST   /v3/interface/virtualLine
+        - interface_virtual_line_update    PUT    /v3/interface/virtualLine
+        - interface_virtual_line_delete    DELETE /v3/interface/virtualLine
+        - interface_listen_create          POST   /v3/interface/listen
+        - interface_listen_update          PUT    /v3/interface/listen
+        - interface_listen_delete          DELETE /v3/interface/listen
+        - interface_bridge_create          POST   /v3/interface/bridge
+        - interface_bridge_update          PUT    /v3/interface/bridge
+        - interface_bridge_delete          DELETE /v3/interface/bridge
+
+        # 路由 (/device/route)
+        - route_outif_list                 GET    /v3/route/outIf/list
+        - route_static_list                POST   /v3/route/static/list
+        - route_static_create              POST   /v3/route/static
+        - route_static_update              PUT    /v3/route/static
+        - route_static_delete              DELETE /v3/route/static
+        - route_table_list                 POST   /v3/route/table/list
+        - ipv6_route_static_list           POST   /v3/ipv6Route/static/list
+        - ipv6_route_static_create         POST   /v3/ipv6Route/static
+        - ipv6_route_static_update         PUT    /v3/ipv6Route/static
+        - ipv6_route_static_delete         DELETE /v3/ipv6Route/static
+        - ipv6_route_table_list            POST   /v3/ipv6Route/table/list
+
+        # DNS 配置 (/device/system_dns)
+        - get_dns_config                   GET    /v3/setting/dnsConfig
+        - set_dns_config                   PUT    /v3/setting/dnsConfig
+        - hosts_get                        GET    /v3/setting/hosts
+        - hosts_create                     POST   /v3/setting/hosts
+        - hosts_update                     PUT    /v3/setting/hosts
+        - hosts_delete                     DELETE /v3/setting/hosts
+        - test_network                     GET    /v3/test/network
+
+        # 代理 (/device/agent)
+        - get_proxy_config                 GET    /v3/setting/proxyConfig
+        - set_proxy_config                 PUT    /v3/setting/proxyConfig
+        - test_proxy                       POST   /v3/test/proxy
+
+        # 高可用 (/device/high_availability)
+        - ha_status                        GET    /v3/ha/status
+        - get_ha_config                    GET    /v3/setting/haConfig
+        - set_ha_config                    PUT    /v3/setting/haConfig
+        - ha_module_list                   GET    /v3/ha/moduleList
+        - ha_compare_config                POST   /v3/ha/compareConfig
+        - ha_switching                     PUT    /v3/ha/switching
+        - ha_sync_config                   POST   /v3/ha/syncConfig
+        - ha_sync_status                   GET    /v3/ha/syncStatus
+
+        # 集中管控 (/device/centralized_control)
+        - onecc_status                     GET    /v3/setting/oneccConfig/status
+        - get_onecc_config                 GET    /v3/setting/oneccConfig
+        - set_onecc_config                 PUT    /v3/setting/oneccConfig
+        - set_onecc_status                 PUT    /v3/setting/oneccConfig/status
+        - test_onecc                       POST   /v3/test/onecc
+
+        # 设备配置 / 升级 / 备份 / 日志外发 (/device/deviceConfig)
+        - device_quick_bypass              POST   /v3/device/quickBypass
+        - device_upgrade_record_list       POST   /v3/device/upgradeRecord/list
+        - get_upgrade_config               GET    /v3/setting/upgradeConfig
+        - set_upgrade_config               PUT    /v3/setting/upgradeConfig
+        - basic_version                    GET    /v3/basic/version
+        - device_upgrade_info              GET    /v3/device/upgradeInfo
+        - device_download_package          POST   /v3/device/downloadPackage
+        - device_upgrade                   POST   /v3/device/upgrade               （已下载包升级；password 自动 RSA 加密）
+        - device_upgrade_upload            POST   /v3/device/upgrade               （本地上传包升级；multipart + password 自动 RSA 加密）
+        - system_upgrade                   POST   /v3/system/upgrade               （multipart：file_path 指向系统升级包）
+        - device_custom_get                GET    /v3/device/custom
+        - device_custom_set                PUT    /v3/device/custom
+        - device_reboot                    POST   /v3/device/reboot
+        - device_shutdown                  POST   /v3/device/shutdown
+        - device_reinit                    POST   /v3/device/reinit
+        - device_system_timezone           GET    /v3/device/systemTimeZone
+        - device_system_time_get           GET    /v3/device/systemTime
+        - device_system_time_set           PUT    /v3/device/systemTime
+        - get_storage_config               GET    /v3/setting/storageConfig
+        - set_storage_config               PUT    /v3/setting/storageConfig
+        - backup_recover_progress          GET    /v3/backup/recover/progress
+        - backup_list                      POST   /v3/backup/list
+        - backup_create                    POST   /v3/backup
+        - backup_download                  GET    /v3/backup/download           （文件）
+        - backup_recover                   POST   /v3/backup/recover
+        - backup_delete                    DELETE /v3/backup
+        - backup_update                    PUT    /v3/backup
+        - backup_import                    POST   /v3/backup/import                （multipart：file_path 指向备份包）
+        - logaccess_list                   POST   /v3/logAccess/list
+        - logaccess_delete                 DELETE /v3/logAccess
+        - logaccess_create                 POST   /v3/logAccess
+        - logaccess_update                 PUT    /v3/logAccess
+        - logaccess_sample                 POST   /v3/logAccess/sample
+        - logaccess_test                   POST   /v3/logAccess/test
+        - logaccess_check                  GET    /v3/logAccess/check
+
+        # 基本信息 (/device/system_info)
+        - basic_license_get                GET    /v3/basic/license
+        - basic_connect_status             GET    /v3/basic/connectStatus
+        - basic_information                GET    /v3/basic/information
+        - basic_information_enable         POST   /v3/basic/information/enable
+        - basic_information_import         POST   /v3/basic/information            （multipart：file_path 指向离线情报库更新包，Query 需 name=...）
+        - basic_license_upload             POST   /v3/basic/license                （multipart：file_path 指向授权文件）
+        - mdr_service_status               GET    /v3/mdrService/status
+        - mdr_service_enable               PUT    /v3/mdrService/enable
+
+        # 设备诊断 (/device/system_diagnosis)
+        - device_coredump_list             GET    /v3/device/coredump
+        - device_coredump_download         POST   /v3/device/coredumpDownload   （文件）
+        - device_coredump_delete           DELETE /v3/device/coredump
+        - device_pcap_get                  GET    /v3/device/pcap
+        - device_pcap_set                  PUT    /v3/device/pcap
+        - device_pcap_file_list            GET    /v3/device/pcapFile
+        - device_pcap_download             POST   /v3/device/pcapDownload       （文件）
+        - device_pcap_file_delete          DELETE /v3/device/pcapFile
+      enum:
+        - alert_policy_list
+        - alert_policy_enable
+        - alert_policy_delete
+        - alert_policy_create
+        - alert_policy_update
+        - alert_policy_export
+        - alert_policy_find_by_config
+        - alert_policy_object
+        - get_notice_config
+        - set_notice_config
+        - get_notice_send_key
+        - test_email
+        - test_syslog
+        - test_webhook
+        - aclog_stat
+        - aclog_list
+        - aclog_export
+        - aclog_delete
+        - get_clean_config
+        - set_clean_config
+        - user_list
+        - user_export
+        - user_delete
+        - user_secret_reset
+        - user_create
+        - user_update
+        - get_login_config
+        - set_login_config
+        - get_decrypt_config
+        - set_decrypt_config
+        - get_detect_config
+        - set_detect_config
+        - tls_decrypt_policy_list
+        - tls_decrypt_policy_create
+        - tls_decrypt_policy_update
+        - tls_decrypt_policy_enable
+        - tls_decrypt_policy_delete
+        - tls_decrypt_policy_batch
+        - tls_cert_list
+        - tls_cert_create
+        - tls_cert_update
+        - tls_cert_delete
+        - tls_cert_set_default
+        - tls_detect_list
+        - tls_detect_list_detail
+        - tls_detect_delete
+        - tls_detect_group
+        - tls_detect_group_export
+        - tls_detect_list_export
+        - interface_list
+        - interface_update
+        - interface_check_loop
+        - interface_relation_list
+        - interface_select_list
+        - interface_virtual_line_create
+        - interface_virtual_line_update
+        - interface_virtual_line_delete
+        - interface_listen_create
+        - interface_listen_update
+        - interface_listen_delete
+        - interface_bridge_create
+        - interface_bridge_update
+        - interface_bridge_delete
+        - route_outif_list
+        - route_static_list
+        - route_static_create
+        - route_static_update
+        - route_static_delete
+        - route_table_list
+        - ipv6_route_static_list
+        - ipv6_route_static_create
+        - ipv6_route_static_update
+        - ipv6_route_static_delete
+        - ipv6_route_table_list
+        - get_dns_config
+        - set_dns_config
+        - hosts_get
+        - hosts_create
+        - hosts_update
+        - hosts_delete
+        - test_network
+        - get_proxy_config
+        - set_proxy_config
+        - test_proxy
+        - ha_status
+        - get_ha_config
+        - set_ha_config
+        - ha_module_list
+        - ha_compare_config
+        - ha_switching
+        - ha_sync_config
+        - ha_sync_status
+        - onecc_status
+        - get_onecc_config
+        - set_onecc_config
+        - set_onecc_status
+        - test_onecc
+        - device_quick_bypass
+        - device_upgrade_record_list
+        - get_upgrade_config
+        - set_upgrade_config
+        - basic_version
+        - device_upgrade_info
+        - device_download_package
+        - device_upgrade
+        - device_upgrade_upload
+        - system_upgrade
+        - device_custom_get
+        - device_custom_set
+        - device_reboot
+        - device_shutdown
+        - device_reinit
+        - device_system_timezone
+        - device_system_time_get
+        - device_system_time_set
+        - get_storage_config
+        - set_storage_config
+        - backup_recover_progress
+        - backup_list
+        - backup_create
+        - backup_download
+        - backup_recover
+        - backup_delete
+        - backup_update
+        - backup_import
+        - logaccess_list
+        - logaccess_delete
+        - logaccess_create
+        - logaccess_update
+        - logaccess_sample
+        - logaccess_test
+        - logaccess_check
+        - basic_license_get
+        - basic_connect_status
+        - basic_information
+        - basic_information_enable
+        - basic_information_import
+        - basic_license_upload
+        - mdr_service_status
+        - mdr_service_enable
+        - device_coredump_list
+        - device_coredump_download
+        - device_coredump_delete
+        - device_pcap_get
+        - device_pcap_set
+        - device_pcap_file_list
+        - device_pcap_download
+        - device_pcap_file_delete
+    uniqueId:
+      type: string
+      description: 资源唯一 ID（删除/下载等场景）
+    uniqueIds:
+      type: array
+      items:
+        type: string
+      description: 批量删除使用的 ID 列表
+    pageNo:
+      type: integer
+      default: 1
+    pageSize:
+      type: integer
+      default: 20
+    startTime:
+      type: integer
+      description: 起始时间戳（管理日志统计 / 列表 / 导出场景使用）
+    endTime:
+      type: integer
+      description: 结束时间戳
+    name:
+      type: string
+      description: 名称（用户名、配置项名称等）
+    enable:
+      type: boolean
+      description: 启停标识
+    password:
+      type: string
+      description: |
+        敏感写操作所需的当前用户登录密码（明文）。处理器会自动用 `/v3/pubkey`
+        最新公钥做 RSA-OAEP 加密后再发送，无需调用方手动加密。
+        适用：aclog_delete、user_delete、user_secret_reset、user_create
+        （同时配合 dupPassword）、interface_update（接口启停）、
+        device_upgrade、device_upgrade_upload。
+    dupPassword:
+      type: string
+      description: |
+        新增用户（user_create）使用的二次确认密码（明文）。处理器会与
+        `password` 一起用同一公钥 RSA-OAEP 加密。
+    file_path:
+      type: string
+      description: |
+        本地待上传文件的绝对路径；仅 multipart 上传类动作使用：
+          - tls_cert_create / tls_cert_update    .crt/.pem 证书文件（字段名 `certFile`）
+          - basic_information_import             离线情报库更新包（字段名 `file`，Query 需 `name`）
+          - basic_license_upload                 授权 license 文件（字段名 `file`）
+          - system_upgrade                       系统升级包（字段名 `file`）
+          - device_upgrade_upload                设备升级包（字段名 `file`，body 同时要求 password）
+          - backup_import                        配置备份包（字段名 `file`）
+  required:
+    - action
+handler:
+  type: script
+  script_file: onesig.handler.py
+  function: device

--- a/.flocks/plugins/tools/api/onesig/onesig_helper.yaml
+++ b/.flocks/plugins/tools/api/onesig/onesig_helper.yaml
@@ -1,0 +1,56 @@
+name: onesig_helper
+description: >
+  OneSIG help center grouped tool. Use the `action` parameter to access help
+  documentation, product news red dots, version information and feedback
+  endpoints under the `/helper/*` routes.
+description_cn: >
+  OneSIG 帮助中心分组工具。通过 `action` 调用帮助文档、产品动态红点、版本信息以及
+  问题反馈接口，对应 Web 控制台 `/helper/*` 子页。
+category: custom
+enabled: true
+requires_confirmation: false
+provider: onesig_api
+inputSchema:
+  type: object
+  properties:
+    action:
+      type: string
+      description: |
+        Helper 分组动作名：
+        - document_list           POST /v3/document/list                分页查询帮助文档
+        - document_preview        GET  /v3/document/preview             预览帮助文档（需 fileName）
+        - product_news_get        GET  /v3/product/news                 产品动态红点
+        - product_news_mark_read  PUT  /v3/product/news                 标记产品动态已读
+        - product_version         GET  /v3/product/version              产品版本信息
+        - product_issue           POST /v3/product/issue                提交产品问题反馈
+      enum:
+        - document_list
+        - document_preview
+        - product_news_get
+        - product_news_mark_read
+        - product_version
+        - product_issue
+    fileName:
+      type: string
+      description: 帮助文档文件名（document_preview 必填）
+    pageNo:
+      type: integer
+      default: 1
+    pageSize:
+      type: integer
+      default: 20
+    search:
+      type: string
+      description: 文档列表模糊搜索关键字
+    documentUpdate:
+      type: boolean
+      description: 标记帮助文档红点已读
+    versionUpdate:
+      type: boolean
+      description: 标记版本更新红点已读
+  required:
+    - action
+handler:
+  type: script
+  script_file: onesig.handler.py
+  function: helper

--- a/.flocks/plugins/tools/api/onesig/onesig_login.yaml
+++ b/.flocks/plugins/tools/api/onesig/onesig_login.yaml
@@ -1,0 +1,124 @@
+name: onesig_login
+description: >
+  OneSIG login / session management grouped tool. Use the `action` parameter to
+  log in (build a cookie session), log out, change the current user's password,
+  pull captcha / pubkey / account info, and manage product news / TOTP recovery
+  codes. Most other OneSIG tools auto-login on demand so explicit `login` calls
+  are only needed when captcha or TOTP is required.
+
+  Auth-flow endpoints handled internally (NOT registered as ActionSpecs):
+    - GET  /v3/captcha       fetched implicitly during login
+    - GET  /v3/pubkey        fetched before each login + before any
+                             RSA-encrypted body field is sent
+    - POST /v3/login         driven by `login` action
+    - POST /v3/login/totp    driven by `login` action when responseCode 1012
+                             or when the device requires inline TOTP
+    - POST /v3/logout        driven by `logout` action
+    - PUT  /v3/user/password driven by `change_password` action (each of
+                             oldPassword / newPassword / dupPassword is
+                             auto RSA-OAEP encrypted with the latest pubkey)
+description_cn: >
+  OneSIG 登录/会话管理工具。通过 `action` 调用登录、登出、改密、拉取验证码 / 公钥 /
+  账户信息，以及产品动态、TOTP 恢复码等接口。其他 OneSIG 工具会按需自动登录，
+  仅在设备启用图形验证码或 TOTP 时需要显式调用 `login` 并传入 `captcha`/`totp`。
+
+  专用鉴权流程（已在处理器内部封装，不以 ActionSpec 形式开放）：
+    - GET  /v3/captcha       登录时自动拉取，判断是否需 captcha / inline TOTP
+    - GET  /v3/pubkey        登录前与所有需 RSA 加密字段的接口前自动拉取
+    - POST /v3/login         由 `login` 动作驱动
+    - POST /v3/login/totp    `login` 动作在 responseCode 1012 或 inline-TOTP
+                             场景下自动续走
+    - POST /v3/logout        由 `logout` 动作驱动
+    - PUT  /v3/user/password 由 `change_password` 驱动；oldPassword /
+                             newPassword / dupPassword 三个字段会用最新公钥
+                             分别做 RSA-OAEP 加密（无需调用方手动加密）
+category: custom
+enabled: true
+requires_confirmation: true
+provider: onesig_api
+inputSchema:
+  type: object
+  properties:
+    action:
+      type: string
+      description: |
+        Login 分组动作名，可选值：
+        - login
+          用途: 显式触发登录流程（拉取 captcha+pubkey、RSA-OAEP 加密密码、POST /v3/login，必要时再走 /v3/login/totp）
+          必填: 无（用户名密码取自服务凭据）
+          常用: `captcha`、`totp`
+          风险提示: 大多数业务调用会按需自动登录，仅在启用验证码 / TOTP 时需手动登录
+        - logout
+          用途: 退出当前会话（POST /v3/logout）并清空本地 Cookie
+          必填: 无
+          常用: 无
+          风险提示: 后续调用会重新登录
+        - change_password
+          用途: 修改当前用户密码（PUT /v3/user/password，三个密码字段会自动 RSA-OAEP 加密）
+          必填: `new_password`
+          常用: `old_password`、`dup_password`、`username`
+          风险提示: 写操作；密码长度需 8~20 且含字母+数字+特殊字符
+        - get_captcha
+          用途: 获取图形验证码状态（GET /v3/captcha）
+          必填: 无
+        - get_pubkey
+          用途: 获取登录 RSA 公钥（GET /v3/pubkey）
+          必填: 无
+        - get_account
+          用途: 获取当前账户信息（GET /v3/account）
+          必填: 无
+        - get_recovery_code
+          用途: 查看 TOTP 恢复码（GET /v3/user/recoveryCode）
+          必填: 无
+        - regenerate_recovery_code
+          用途: 重新生成 TOTP 恢复码（PUT /v3/user/recoveryCode）
+          必填: 无
+          风险提示: 旧恢复码立即失效
+        - get_product_news
+          用途: 获取产品动态红点状态（GET /v3/product/news）
+          必填: 无
+        - mark_product_news_read
+          用途: 标记产品动态已读（PUT /v3/product/news）
+          必填: 至少一个布尔字段（如 `documentUpdate=false`）
+          风险提示: 写操作
+      enum:
+        - login
+        - logout
+        - change_password
+        - get_captcha
+        - get_pubkey
+        - get_account
+        - get_recovery_code
+        - regenerate_recovery_code
+        - get_product_news
+        - mark_product_news_read
+    captcha:
+      type: string
+      description: 当设备启用图形验证码时填写（4 位）。仅在 `login` 动作有效。
+    totp:
+      type: string
+      description: 当设备启用 TOTP（双因素）时填写动态口令或恢复码。仅在 `login` 动作有效。
+    username:
+      type: string
+      description: 改密时使用的用户名，默认取服务凭据中的 `username`。
+    new_password:
+      type: string
+      description: 新密码明文，长度 8~20，需包含字母、数字与特殊字符。仅在 `change_password` 动作必填。
+    old_password:
+      type: string
+      description: 当前密码明文。强制改密分支可省略；常规改密必填。
+    dup_password:
+      type: string
+      description: 新密码确认明文，留空时与 `new_password` 相同。
+    documentUpdate:
+      type: boolean
+      description: 标记帮助文档红点是否已读（mark_product_news_read 使用）。
+    versionUpdate:
+      type: boolean
+      description: 标记版本更新红点是否已读（mark_product_news_read 使用）。
+  required:
+    - action
+handler:
+  type: script
+  script_file: onesig.handler.py
+  function: login

--- a/.flocks/plugins/tools/api/onesig/onesig_monitoring.yaml
+++ b/.flocks/plugins/tools/api/onesig/onesig_monitoring.yaml
@@ -1,0 +1,256 @@
+name: onesig_monitoring
+description: >
+  OneSIG monitoring grouped tool. Use the `action` parameter to access
+  dashboard, threat overview, device status, alert host, inbound / outbound
+  threat events, and report management APIs. The handler accepts arbitrary
+  filter / pagination keys and forwards them to the JSON body, matching the
+  Web console behaviour.
+description_cn: >
+  OneSIG 监控分组工具。通过 `action` 调用仪表盘、威胁防护大屏、设备状态、失陷主机、
+  入站 / 出站威胁事件、报告管理等接口。处理器会把所有过滤 / 分页字段透传到 JSON
+  请求体，与 Web 控制台调用方式保持一致。
+category: custom
+enabled: true
+requires_confirmation: true
+provider: onesig_api
+inputSchema:
+  type: object
+  properties:
+    action:
+      type: string
+      description: |
+        Monitoring 分组动作名，按页面分类：
+
+        # 仪表盘 (/monitoring/dashboard)
+        - dashboard_overview            POST /v3/dashboard/overview         仪表盘总览数据
+        - dashboard_outbound            POST /v3/dashboard/outbound         仪表盘出站数据
+        - dashboard_inbound             POST /v3/dashboard/inbound          仪表盘入站数据
+        - dashboard_zeroday             POST /v3/dashboard/zeroday          仪表盘零日数据
+        - dashboard_status              GET  /v3/dashboard/status           仪表盘服务状态
+        - dashboard_ioc_type_sum        GET  /v3/dashboard/ioctypesum       IOC 类型汇总
+        - set_custom_config             PUT  /v3/setting/customConfig       更新仪表盘自定义配置（写）
+
+        # 威胁防护大屏 (/monitoring/overview)
+        - common_threat_type_list       GET  /v3/common/threatTypeList      威胁类型列表
+        - overview_event_inbound        POST /v3/overview/eventInbound      入站事件
+        - overview_event_outbound       POST /v3/overview/eventOutbound     出站事件
+        - overview_export_event_inbound POST /v3/overview/exportEventInbound      导出入站事件（文件）
+        - overview_export_event_outbound POST /v3/overview/exportEventOutbound    导出出站事件（文件）
+        - overview_asset_brief          POST /v3/overview/assetBrief        资产简报
+        - overview_asset_top            POST /v3/overview/assetTop          资产 TOP
+        - overview_event_inbound_agg    POST /v3/overview/eventInboundAgg   入站聚合
+        - overview_export_event_inbound_agg  POST /v3/overview/exportEventInboundAgg   导出入站聚合（文件）
+        - overview_event_outbound_agg   POST /v3/overview/eventOutboundAgg  出站聚合
+        - overview_export_event_outbound_agg POST /v3/overview/exportEventOutboundAgg  导出出站聚合（文件）
+        - overview_event_recent_agg     POST /v3/overview/eventRecentAgg    近期事件聚合
+        - overview_event_trend          POST /v3/overview/eventTrend        事件趋势
+        - overview_traffic_trend        POST /v3/overview/trafficTrend      流量趋势
+        - overview_stat                 POST /v3/overview/stat              总览统计卡片
+        - overview_threat_type_proportion POST /v3/overview/threatTypeProportion  威胁类型占比
+        - overview_ioc_type_proportion  POST /v3/overview/iocTypeProportion       IOC 类型占比
+        - overview_export_threat_type_proportion POST /v3/overview/exportThreatTypeProportion 导出威胁类型占比（文件）
+        - overview_export_ioc_type_proportion    POST /v3/overview/exportIocTypeProportion    导出 IOC 类型占比（文件）
+        - get_overview_config           GET  /v3/setting/overviewConfig     总览展示配置
+        - set_overview_config           PUT  /v3/setting/overviewConfig     更新总览展示配置（写）
+
+        # 设备状态 (/monitoring/status)
+        - device_platform_status        GET  /v3/device/platformStatus      平台运行状态
+        - device_system_status          GET  /v3/device/systemStatus        系统资源状态
+        - device_network_status         GET  /v3/device/networkStatus       网络状态
+        - common_interface_list         GET  /v3/common/interfaceList       网口列表
+        - basic_cpu_attr                GET  /v3/basic/cpuAttr              CPU 属性
+
+        # 失陷主机 (/monitoring/hosts, /monitoring/hostdetail)
+        - alert_host_stat               GET  /v3/alertHost/stat             失陷主机统计
+        - alert_host_tree               POST /v3/alertHost/tree             失陷主机资产树
+        - alert_host_list               POST /v3/alertHost/list             分页查询失陷主机（必填 startTime/endTime）
+        - alert_host_export             POST /v3/alertHost/export           导出失陷主机（文件）
+        - alert_host_detail             POST /v3/alertHost/detail           失陷主机详情概览
+        - alert_host_detail_list        POST /v3/alertHost/detail/list      失陷主机详情关联列表
+        - alert_host_detail_export      POST /v3/alertHost/detail/export    导出失陷主机详情（文件）
+        - common_asset_type_list        GET  /v3/common/assetTypeList       资产类型列表
+
+        # 入站威胁 (/monitoring/inbound_threat)
+        - event_inbound_stat            GET  /v3/event/inbound/stat         入站威胁统计
+        - event_inbound_list            POST /v3/event/inbound/list         分页查询入站威胁（必填 startTime/endTime）
+        - event_inbound_export          POST /v3/event/inbound/export       导出入站威胁（文件）
+        - event_inbound_detail          POST /v3/event/inbound/detail       入站威胁详情
+        - event_inbound_detail_trend    POST /v3/event/inbound/detail/trend 入站威胁详情趋势
+        - event_inbound_detail_list     POST /v3/event/inbound/detail/list  入站威胁详情列表
+        - event_inbound_detail_export   POST /v3/event/inbound/detail/export 导出入站威胁详情（文件）
+        - port_protect_group_list       POST /v3/portProtectGroup/list      端口防护组列表（共享）
+        - web_custom_column_set         PUT  /v3/webCustomColumn/set        保存自定义列配置（写）
+
+        # 出站威胁 (/monitoring/outbound_threat)
+        - event_outbound_stat           GET  /v3/event/outbound/stat        出站威胁统计
+        - event_outbound_list           POST /v3/event/outbound/list        分页查询出站威胁（必填 startTime/endTime）
+        - event_outbound_export         POST /v3/event/outbound/export      导出出站威胁（文件）
+        - event_outbound_detail         POST /v3/event/outbound/detail      出站威胁详情
+        - event_outbound_detail_trend   POST /v3/event/outbound/detail/trend 出站威胁详情趋势
+        - event_outbound_detail_list    POST /v3/event/outbound/detail/list 出站威胁详情列表
+        - event_outbound_detail_export  POST /v3/event/outbound/detail/export 导出出站威胁详情（文件）
+        - set_dnslog_config             PUT  /v3/setting/dnslogConfig       更新 DNS 日志接入配置（写）
+
+        # 报告管理 (/monitoring/report)
+        - get_notice_config             GET  /v3/setting/noticeConfig       通知配置
+        - report_form_create            POST /v3/report/form                新增报表表单
+        - report_form_list              POST /v3/report/form/list           分页查询报表表单
+        - report_form_download          GET  /v3/report/form/download       下载报表（文件，需 uniqueId）
+        - report_form_delete            DELETE /v3/report/form              删除报表表单
+        - report_task_list              POST /v3/report/task/list           分页查询报表任务
+        - report_task_create            POST /v3/report/task                新增报表任务
+        - report_task_update            PUT  /v3/report/task                更新报表任务
+        - report_task_delete            DELETE /v3/report/task              删除报表任务
+        - report_task_test              POST /v3/report/task/test           测试报表任务
+
+        # 共享 (monitoring layout)
+        - common_asset_group_tree       GET  /v3/common/assetGroupTree      资产组树
+        - ips_rule_create               POST /v3/ips/rule                   新增 IPS 自定义规则
+        - ips_rule_apply                POST /v3/ips/rule/apply             应用 IPS 规则变更
+        - ips_ruleset_namelist          POST /v3/ips/ruleset/namelist       规则集名称列表
+        - ips_ruleset_referred          POST /v3/ips/ruleset/referred       规则集引用关系
+        - logaccess_stat                GET  /v3/logAccess/stat             日志接入统计
+        - get_dnslog_config             GET  /v3/setting/dnslogConfig       DNS 日志接入配置
+      enum:
+        - dashboard_overview
+        - dashboard_outbound
+        - dashboard_inbound
+        - dashboard_zeroday
+        - dashboard_status
+        - dashboard_ioc_type_sum
+        - set_custom_config
+        - common_threat_type_list
+        - overview_event_inbound
+        - overview_event_outbound
+        - overview_export_event_inbound
+        - overview_export_event_outbound
+        - overview_asset_brief
+        - overview_asset_top
+        - overview_event_inbound_agg
+        - overview_export_event_inbound_agg
+        - overview_event_outbound_agg
+        - overview_export_event_outbound_agg
+        - overview_event_recent_agg
+        - overview_event_trend
+        - overview_traffic_trend
+        - overview_stat
+        - overview_threat_type_proportion
+        - overview_ioc_type_proportion
+        - overview_export_threat_type_proportion
+        - overview_export_ioc_type_proportion
+        - get_overview_config
+        - set_overview_config
+        - device_platform_status
+        - device_system_status
+        - device_network_status
+        - common_interface_list
+        - basic_cpu_attr
+        - alert_host_stat
+        - alert_host_tree
+        - alert_host_list
+        - alert_host_export
+        - alert_host_detail
+        - alert_host_detail_list
+        - alert_host_detail_export
+        - common_asset_type_list
+        - event_inbound_stat
+        - event_inbound_list
+        - event_inbound_export
+        - event_inbound_detail
+        - event_inbound_detail_trend
+        - event_inbound_detail_list
+        - event_inbound_detail_export
+        - port_protect_group_list
+        - web_custom_column_set
+        - event_outbound_stat
+        - event_outbound_list
+        - event_outbound_export
+        - event_outbound_detail
+        - event_outbound_detail_trend
+        - event_outbound_detail_list
+        - event_outbound_detail_export
+        - set_dnslog_config
+        - get_notice_config
+        - report_form_create
+        - report_form_list
+        - report_form_download
+        - report_form_delete
+        - report_task_list
+        - report_task_create
+        - report_task_update
+        - report_task_delete
+        - report_task_test
+        - common_asset_group_tree
+        - ips_rule_create
+        - ips_rule_apply
+        - ips_ruleset_namelist
+        - ips_ruleset_referred
+        - logaccess_stat
+        - get_dnslog_config
+    startTime:
+      type: integer
+      description: 起始时间戳（Unix 秒）
+    endTime:
+      type: integer
+      description: 结束时间戳（Unix 秒）
+    pageNo:
+      type: integer
+      default: 1
+      description: 分页页码
+    pageSize:
+      type: integer
+      default: 20
+      description: 分页大小
+    sortBy:
+      type: string
+      description: 排序字段
+    orderBy:
+      type: string
+      description: 排序方向，`asc` / `desc`
+    search:
+      type: string
+      description: 模糊搜索关键字
+    severity:
+      type: array
+      items:
+        type: integer
+      description: 威胁等级过滤
+    threatType:
+      type: array
+      items:
+        type: string
+      description: 威胁类型过滤
+    assetType:
+      type: array
+      items:
+        type: string
+      description: 资产类型过滤
+    threatLabel:
+      type: array
+      items:
+        type: string
+      description: 特定威胁标签过滤
+    threatState:
+      type: string
+      description: 失陷主机状态过滤
+    assetGroup:
+      type: string
+      description: 资产组路径，`全部` 转为空串
+    direction:
+      type: string
+      description: 威胁方向（inbound/outbound）
+    isTls:
+      type: boolean
+      description: 是否仅 TLS 加密流量
+    uniqueId:
+      type: string
+      description: 资源唯一 ID（删除/下载/详情等）
+    fileName:
+      type: string
+      description: 文件名（下载报表表单）
+  required:
+    - action
+handler:
+  type: script
+  script_file: onesig.handler.py
+  function: monitoring

--- a/.flocks/plugins/tools/api/onesig/onesig_strategy.yaml
+++ b/.flocks/plugins/tools/api/onesig/onesig_strategy.yaml
@@ -1,0 +1,268 @@
+name: onesig_strategy
+description: >
+  OneSIG strategy grouped tool. Use the `action` parameter to manage protection
+  policies including global whitelist / blacklist, multi-dimensional blocking,
+  API keys, syslog auto-blacklist, FTP / SFTP linkage, IPS rules and rule sets,
+  HTTP blacklist, port protection groups, and the strategy landing page itself.
+description_cn: >
+  OneSIG 防护策略分组工具。通过 `action` 调用全局白/黑名单、多维封锁、API 联动密钥、
+  Syslog 自动封禁、FTP/SFTP 联动、IPS 规则和规则集、HTTP 黑名单、端口防护组以及策略
+  首页相关接口。多数写操作具有破坏性，请谨慎调用。
+category: custom
+enabled: true
+requires_confirmation: true
+provider: onesig_api
+inputSchema:
+  type: object
+  properties:
+    action:
+      type: string
+      description: |
+        Strategy 分组动作名（按 UI 子页归类）：
+
+        # 白名单 (/strategy/whitelist)
+        - whitelist_add               POST   /v3/globalWhitelist             新增（多方向）
+        - whitelist_update            PUT    /v3/globalWhitelist             更新（编辑单方向）
+        - whitelist_delete            DELETE /v3/globalWhitelist             删除（uniqueIds 数组）
+        - whitelist_export            POST   /v3/globalWhitelist/export      导出（文件）
+        - whitelist_import            POST   /v3/globalWhitelist/import      导入
+        - whitelist_template          GET    /v3/globalWhitelist/template    导入模板（文件）
+        - whitelist_list              POST   /v3/globalWhitelist/list        分页查询
+        - whitelist_remove_batch      DELETE /v3/globalWhitelist/remove      批量移除
+
+        # 黑名单 (/strategy/blacklist)
+        - blacklist_location_options  GET    /v3/blacklist/location          地理位置选项
+        - blacklist_add               POST   /v3/globalBlacklist             新增
+        - blacklist_update            PUT    /v3/globalBlacklist             更新
+        - blacklist_delete            DELETE /v3/globalBlacklist             删除
+        - blacklist_check             POST   /v3/globalBlacklist/check       冲突校验
+        - blacklist_export            POST   /v3/globalBlacklist/export      导出（文件）
+        - blacklist_import            POST   /v3/globalBlacklist/import      导入
+        - blacklist_template          GET    /v3/globalBlacklist/template    导入模板（文件）
+        - blacklist_list              POST   /v3/globalBlacklist/list        分页查询
+        - blacklist_remove_batch      DELETE /v3/globalBlacklist/remove      批量移除
+
+        # 多维封锁 (/strategy/multi_block, /strategy/add_multi_block)
+        - multiblock_executelog_list   POST   /v3/multiblock/executelog
+        - multiblock_executelog_export POST   /v3/multiblock/executelog/export   （文件）
+        - multiblock_rule_delete       DELETE /v3/multiblock/rule
+        - multiblock_rule_active       POST   /v3/multiblock/rule/active
+        - multiblock_rule_dict         POST   /v3/multiblock/rule/dict
+        - multiblock_rule_list         POST   /v3/multiblock/rule/list
+        - multiblock_rule_get          POST   /v3/multiblock/rule/get
+        - multiblock_rule_preview      POST   /v3/multiblock/rule/preview
+        - multiblock_rule_create       POST   /v3/multiblock/rule
+        - multiblock_rule_update       PUT    /v3/multiblock/rule
+
+        # API 联动 (/strategy/api)
+        - apikey_delete               DELETE /v3/apikey
+        - apikey_update               PUT    /v3/apikey
+        - apikey_create               POST   /v3/apikey
+        - apikey_list                 GET    /v3/apikey/list
+        - apikey_secret               GET    /v3/apikey/secret               需 uniqueId
+
+        # Syslog 自动封禁 (/strategy/syslog)
+        - auto_blacklist_delete       DELETE /v3/autoBlacklist
+        - auto_blacklist_check        POST   /v3/autoBlacklist/check
+        - auto_blacklist_create       POST   /v3/autoBlacklist
+        - auto_blacklist_update       PUT    /v3/autoBlacklist
+        - auto_blacklist_list         POST   /v3/autoBlacklist/list
+        - auto_blacklist_trend        GET    /v3/autoBlacklist/trend         需 startTime/endTime
+        - auto_blacklist_sample       POST   /v3/autoBlacklist/sample
+
+        # FTP/SFTP 联动 (/strategy/ftp)
+        - linkage_delete              DELETE /v3/linkage
+        - linkage_create              POST   /v3/linkage
+        - linkage_update              PUT    /v3/linkage
+        - linkage_enable              POST   /v3/linkage/enable
+        - linkage_info                GET    /v3/linkage/info                需 uniqueId
+        - linkage_list                POST   /v3/linkage/list
+        - linkage_template            GET    /v3/linkage/template            （文件）
+        - linkage_test                POST   /v3/linkage/test
+
+        # 入侵防护 (/strategy/intrusion_prevention)
+        - ips_rule_create             POST   /v3/ips/rule
+        - ips_rule_all                POST   /v3/ips/rule/all                全量操作
+        - ips_rule_apply              POST   /v3/ips/rule/apply              应用变更
+        - ips_rule_list               POST   /v3/ips/rule/list
+        - ips_ruleset_create          POST   /v3/ips/ruleset
+        - ips_ruleset_update          PUT    /v3/ips/ruleset
+        - ips_ruleset_delete          DELETE /v3/ips/ruleset
+        - ips_ruleset_info            POST   /v3/ips/ruleset/info
+        - ips_ruleset_list            POST   /v3/ips/ruleset/list
+        - ips_ruleset_namelist        POST   /v3/ips/ruleset/namelist
+        - ips_threat_types            POST   /v3/ips/threatTypes
+
+        # HTTP 防护 (/strategy/httpProtect)
+        - http_blacklist_delete       DELETE /v3/httpBlacklist
+        - http_blacklist_enable       POST   /v3/httpBlacklist/enable
+        - http_blacklist_export       POST   /v3/httpBlacklist/export        （文件）
+        - http_blacklist_list         POST   /v3/httpBlacklist/list
+        - http_blacklist_create       POST   /v3/httpBlacklist
+        - http_blacklist_update       PUT    /v3/httpBlacklist
+        - get_advanced_config         GET    /v3/setting/advancedConfig      共享高级配置
+        - set_advanced_config         PUT    /v3/setting/advancedConfig      共享高级配置（写）
+        - get_xff_config              GET    /v3/setting/xffConfig
+        - set_xff_config              PUT    /v3/setting/xffConfig
+
+        # 高危端口防护 (/strategy/portProtect)
+        - port_protect_group_delete       DELETE /v3/portProtectGroup
+        - port_protect_group_create       POST   /v3/portProtectGroup
+        - port_protect_group_update       PUT    /v3/portProtectGroup
+        - port_protect_group_clone        POST   /v3/portProtectGroup/clone
+        - port_protect_group_default_info GET    /v3/portProtectGroup/defaultInfo
+        - port_protect_group_list_full    POST   /v3/portProtectGroup/list
+        - port_protect_port_delete        DELETE /v3/portProtectGroup/port
+        - port_protect_port_create        POST   /v3/portProtectGroup/port
+        - port_protect_port_update        PUT    /v3/portProtectGroup/port
+        - port_protect_port_export        POST   /v3/portProtectGroup/port/export       （文件）
+        - port_protect_port_list          POST   /v3/portProtectGroup/port/list
+        - port_protect_port_onekey_import POST   /v3/portProtectGroup/port/onekeyImport
+        - port_protect_port_onekey_status GET    /v3/portProtectGroup/port/onekeyImport
+        - port_protect_portinfo           POST   /v3/portProtectGroup/portinfo
+
+        # 策略首页 (/strategy/strategy)
+        - device_onekey_bypass        POST   /v3/device/onekeyBypass
+        - protection_policy_delete    DELETE /v3/protection/policy
+        - protection_policy_update    PUT    /v3/protection/policy
+        - protection_policy_get       GET    /v3/protection/policy           需 uniqueId
+        - protection_policy_tree      GET    /v3/protection/policy/tree
+        - set_scan_config             PUT    /v3/setting/scanConfig
+      enum:
+        - whitelist_add
+        - whitelist_update
+        - whitelist_delete
+        - whitelist_export
+        - whitelist_import
+        - whitelist_template
+        - whitelist_list
+        - whitelist_remove_batch
+        - blacklist_location_options
+        - blacklist_add
+        - blacklist_update
+        - blacklist_delete
+        - blacklist_check
+        - blacklist_export
+        - blacklist_import
+        - blacklist_template
+        - blacklist_list
+        - blacklist_remove_batch
+        - multiblock_executelog_list
+        - multiblock_executelog_export
+        - multiblock_rule_delete
+        - multiblock_rule_active
+        - multiblock_rule_dict
+        - multiblock_rule_list
+        - multiblock_rule_get
+        - multiblock_rule_preview
+        - multiblock_rule_create
+        - multiblock_rule_update
+        - apikey_delete
+        - apikey_update
+        - apikey_create
+        - apikey_list
+        - apikey_secret
+        - auto_blacklist_delete
+        - auto_blacklist_check
+        - auto_blacklist_create
+        - auto_blacklist_update
+        - auto_blacklist_list
+        - auto_blacklist_trend
+        - auto_blacklist_sample
+        - linkage_delete
+        - linkage_create
+        - linkage_update
+        - linkage_enable
+        - linkage_info
+        - linkage_list
+        - linkage_template
+        - linkage_test
+        - ips_rule_create
+        - ips_rule_all
+        - ips_rule_apply
+        - ips_rule_list
+        - ips_ruleset_create
+        - ips_ruleset_update
+        - ips_ruleset_delete
+        - ips_ruleset_info
+        - ips_ruleset_list
+        - ips_ruleset_namelist
+        - ips_threat_types
+        - http_blacklist_delete
+        - http_blacklist_enable
+        - http_blacklist_export
+        - http_blacklist_list
+        - http_blacklist_create
+        - http_blacklist_update
+        - get_advanced_config
+        - set_advanced_config
+        - get_xff_config
+        - set_xff_config
+        - port_protect_group_delete
+        - port_protect_group_create
+        - port_protect_group_update
+        - port_protect_group_clone
+        - port_protect_group_default_info
+        - port_protect_group_list_full
+        - port_protect_port_delete
+        - port_protect_port_create
+        - port_protect_port_update
+        - port_protect_port_export
+        - port_protect_port_list
+        - port_protect_port_onekey_import
+        - port_protect_port_onekey_status
+        - port_protect_portinfo
+        - device_onekey_bypass
+        - protection_policy_delete
+        - protection_policy_update
+        - protection_policy_get
+        - protection_policy_tree
+        - set_scan_config
+    uniqueId:
+      type: string
+      description: 资源唯一 ID（GET / DELETE 单条目时使用）
+    uniqueIds:
+      type: array
+      items:
+        type: string
+      description: 批量删除使用的 ID 列表
+    whiteList:
+      type: array
+      items:
+        type: object
+      description: 白名单方向数组（whitelist_add 必填，元素含 `direction`）
+    direction:
+      type: string
+      description: 白名单方向（whitelist_update 必填，可选 inbound/outbound/both）
+    condition:
+      type: array
+      items:
+        type: object
+      description: 白/黑名单条件列表
+    comments:
+      type: string
+      description: 备注
+    pageNo:
+      type: integer
+      default: 1
+    pageSize:
+      type: integer
+      default: 20
+    startTime:
+      type: integer
+      description: 起始时间戳（auto_blacklist_trend 等使用）
+    endTime:
+      type: integer
+      description: 结束时间戳
+    name:
+      type: string
+      description: 名称（如 API 联动密钥名 / 端口防护组名）
+    enable:
+      type: boolean
+      description: 启停标识
+  required:
+    - action
+handler:
+  type: script
+  script_file: onesig.handler.py
+  function: strategy

--- a/tests/tool/test_onesig_api_tool.py
+++ b/tests/tool/test_onesig_api_tool.py
@@ -1,0 +1,697 @@
+"""Regression tests for the OneSIG handler.
+
+Two thematically distinct surfaces are covered here:
+
+1. **SSL verify resolution** (PR #193 follow-up). Confirms that the WebUI's
+   ``custom_settings.verify_ssl`` toggle, the ``ssl_verify`` snake-case alias,
+   and the ``verifySsl`` legacy camelCase alias all reach
+   ``aiohttp.session.request(..., ssl=...)`` with the right shape.
+
+2. **Cookie persistence to ``.secret.json``**. OneSIG sessions are cookie-
+   based, so the handler now serialises the jar after every successful
+   login under ``onesig_session_cookie__<sha1[:12]>`` and re-hydrates it on
+   construction. The tests cover the helper purity (snapshot round-trip,
+   expired filtering), the precedence of the ``persist_cookies`` toggle,
+   and the integration points: ``__init__`` loads + trusts, ``login()``
+   saves, ``logout()`` deletes, and the persisted-cookie path skips the
+   captcha → pubkey → /v3/login → /v3/account chain entirely.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+import time
+import types
+from email.utils import formatdate
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import aiohttp
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loading
+# ---------------------------------------------------------------------------
+# The OneSIG handler lives outside the ``flocks`` package, so we load it
+# directly via importlib (the same trick the YAML tool loader uses).
+_HANDLER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".flocks"
+    / "plugins"
+    / "tools"
+    / "api"
+    / "onesig"
+    / "onesig.handler.py"
+)
+
+
+def _load_handler():
+    spec = importlib.util.spec_from_file_location(
+        "onesig_handler_under_test", _HANDLER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def handler():
+    return _load_handler()
+
+
+# ---------------------------------------------------------------------------
+# _resolve_verify_ssl: precedence
+# ---------------------------------------------------------------------------
+# Each row is `(env, raw_dict, expected)`. The env key is unset for rows that
+# do not set it explicitly so we don't leak across tests.
+@pytest.mark.parametrize(
+    "raw, env, expected, why",
+    [
+        # 1. canonical key wins over everything below it
+        ({"verify_ssl": False, "ssl_verify": True, "custom_settings": {"verify_ssl": True}},
+         None, False, "verify_ssl=False overrides ssl_verify=True and custom_settings"),
+        # 2. ssl_verify is honoured when verify_ssl missing (PR #193 alias)
+        ({"ssl_verify": False}, None, False, "ssl_verify alias respected"),
+        # 3. legacy camelCase verifySsl still works after canonical/ssl_verify both missing
+        ({"verifySsl": False}, None, False, "verifySsl legacy alias respected"),
+        # 4. WebUI's custom_settings.verify_ssl drives the default UI switch
+        ({"custom_settings": {"verify_ssl": False}}, None, False,
+         "custom_settings.verify_ssl honoured (UI toggle path)"),
+        # 5. env var fallback for CLI / containerised deployments
+        ({}, "false", False, "ONESIG_VERIFY_SSL env var honoured"),
+        # 6. nothing set → default False (parity with onesec/ngtip/qingteng).
+        # OneSIG is overwhelmingly deployed as a private gateway with self-
+        # signed certs, so the open-box default is to *not* validate. Users
+        # opt in to strict validation by toggling the UI switch.
+        ({}, None, False, "default DEFAULT_VERIFY_SSL=False when unset"),
+        # 7. string coercion through _coerce_bool
+        ({"verify_ssl": "off"}, None, False, "off → False"),
+        ({"verify_ssl": "1"}, None, True, "'1' → True"),
+        ({"verify_ssl": 0}, None, False, "numeric 0 → False"),
+        # 8. precedence regression: custom_settings ignored once ssl_verify present
+        ({"ssl_verify": True, "custom_settings": {"verify_ssl": False}},
+         None, True, "ssl_verify (closer to canonical) wins over custom_settings"),
+    ],
+)
+def test_resolve_verify_ssl_precedence(handler, raw, env, expected, why, monkeypatch):
+    if env is None:
+        monkeypatch.delenv("ONESIG_VERIFY_SSL", raising=False)
+    else:
+        monkeypatch.setenv("ONESIG_VERIFY_SSL", env)
+    assert handler._resolve_verify_ssl(raw) is expected, why
+
+
+def test_default_verify_ssl_is_off_for_private_deployments(handler):
+    # OneSIG defaults to *not* validating certificates so private-deployment
+    # users (the overwhelmingly common case) work out of the box. This is the
+    # same default onesec / ngtip / qingteng adopted in PR #193. Flipping the
+    # constant back to True would silently break every self-signed deployment,
+    # so guard it explicitly.
+    assert handler.DEFAULT_VERIFY_SSL is False
+
+
+# ---------------------------------------------------------------------------
+# _ssl_context: bool -> aiohttp ssl arg shape
+# ---------------------------------------------------------------------------
+def test_ssl_context_returns_none_when_verify_enabled(handler):
+    # When verification is on, returning None lets aiohttp use its default
+    # certifi-backed context (i.e. real validation).
+    assert handler._ssl_context(True) is None
+
+
+def test_ssl_context_disables_validation_when_disabled(handler):
+    import ssl as _ssl
+
+    ctx = handler._ssl_context(False)
+    assert isinstance(ctx, _ssl.SSLContext)
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == _ssl.CERT_NONE
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: WebUI toggle (custom_settings.verify_ssl=False) propagates all
+# the way to aiohttp.session.request(..., ssl=<SSLContext with CERT_NONE>).
+# ---------------------------------------------------------------------------
+class _FakeResponse:
+    def __init__(self, *, status: int = 200, json_payload: Any = None,
+                 text_payload: str = "", content_type: str = "application/json"):
+        self.status = status
+        self._json_payload = json_payload
+        self._text_payload = text_payload
+        self.headers = {"Content-Type": content_type}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def json(self, content_type=None):  # noqa: ARG002 - signature parity
+        return self._json_payload
+
+    async def text(self):
+        return self._text_payload
+
+    async def read(self):
+        return self._text_payload.encode("utf-8") if self._text_payload else b""
+
+
+class _FakeSession:
+    """Stand-in for ``aiohttp.ClientSession`` with a scripted response queue."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return self._responses.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+def _captcha_then_pubkey_then_login_then_business():
+    return [
+        # GET /v3/captcha
+        _FakeResponse(json_payload={
+            "responseCode": 0,
+            "verboseMsg": "成功",
+            "data": {"enableCaptcha": False, "enableTotp": False},
+        }),
+        # GET /v3/pubkey
+        _FakeResponse(json_payload={
+            "responseCode": 0,
+            "verboseMsg": "成功",
+            "data": {"pubkey": "FAKE-PUBKEY-PEM"},
+        }),
+        # POST /v3/login
+        _FakeResponse(json_payload={"responseCode": 0, "verboseMsg": "成功"}),
+        # GET /v3/account (post-login probe)
+        _FakeResponse(json_payload={
+            "responseCode": 0,
+            "verboseMsg": "成功",
+            "data": {"username": "admin"},
+        }),
+        # business request (basic_version → GET /v3/basic/version)
+        _FakeResponse(json_payload={
+            "responseCode": 0,
+            "verboseMsg": "成功",
+            "data": {"version": "v2.5.3"},
+        }),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "service_config, expect_ssl_validation",
+    [
+        # WebUI "SSL verify" switch OFF → custom_settings.verify_ssl=False.
+        # Before this fix the OneSIG handler ignored that field entirely and
+        # kept verify_ssl at its default (True), so private-deployment users
+        # who toggled the UI saw no behaviour change. The fix makes the
+        # toggle drive aiohttp's ssl= argument.
+        ({"custom_settings": {"verify_ssl": False}}, False),
+        # Canonical verify_ssl still wins.
+        ({"verify_ssl": True, "custom_settings": {"verify_ssl": False}}, True),
+        # ssl_verify alias also honoured (parity with PR #193).
+        ({"ssl_verify": False}, False),
+    ],
+    ids=["custom_settings_off", "canonical_overrides_ui", "ssl_verify_alias_off"],
+)
+async def test_onesig_request_honours_verify_ssl_from_config(
+    handler, service_config, expect_ssl_validation
+):
+    fake_session = _FakeSession(_captcha_then_pubkey_then_login_then_business())
+
+    raw_service: dict[str, Any] = {
+        "base_url": f"https://onesig-{id(service_config)}.example.local",
+        "username": "admin",
+        "password": "{secret:onesig_password}",
+        "oaep_hash": "sha1",
+    }
+    raw_service.update(service_config)
+
+    secret_manager = MagicMock()
+    secret_manager.get.side_effect = lambda key: {
+        "onesig_password": "supersecret",
+    }.get(key)
+
+    fake_flocks_security = types.ModuleType("flocks.security")
+    fake_flocks_security.get_secret_manager = lambda: secret_manager
+    sys.modules["flocks.security"] = fake_flocks_security
+
+    with (
+        patch.object(
+            handler.ConfigWriter, "get_api_service_raw", return_value=raw_service
+        ),
+        patch.object(
+            handler, "_rsa_oaep_encrypt", return_value="ENCRYPTED-PASSWORD"
+        ),
+        patch.object(
+            handler.aiohttp, "ClientSession", return_value=fake_session
+        ),
+    ):
+        # Flush the per-base-url session pool so each parametrised case gets a
+        # fresh OneSIGSession instance bound to the parametrised config.
+        handler._SESSIONS.clear()
+
+        config = handler._resolve_runtime_config()
+        session = handler.OneSIGSession(config)
+        status, envelope, _body, _ct = await session.request(
+            "GET", "/v3/basic/version"
+        )
+
+    # All five recorded requests (4 auth + 1 business) must use the resolved
+    # ssl context. We assert on the business request (last call) which is the
+    # one users actually care about.
+    assert envelope.get("responseCode") == 0
+    assert status == 200
+    assert len(fake_session.calls) == 5
+
+    business_method, business_url, business_kwargs = fake_session.calls[-1]
+    assert business_method == "GET"
+    assert business_url.endswith("/v3/basic/version")
+
+    ssl_arg = business_kwargs["ssl"]
+    if expect_ssl_validation:
+        # When validation is on, the handler passes ``ssl=None`` so aiohttp
+        # falls back to its default certifi context.
+        assert ssl_arg is None
+    else:
+        # When validation is off, the handler passes a permissive SSLContext
+        # so private deployments with self-signed certs work.
+        import ssl as _ssl
+        assert isinstance(ssl_arg, _ssl.SSLContext)
+        assert ssl_arg.check_hostname is False
+        assert ssl_arg.verify_mode == _ssl.CERT_NONE
+
+    # All other requests in the auth chain should use the same ssl arg.
+    for _method, _url, kwargs in fake_session.calls:
+        if expect_ssl_validation:
+            assert kwargs["ssl"] is None
+        else:
+            assert kwargs["ssl"] is not None
+
+
+# ===========================================================================
+# Cookie persistence: snapshot helpers (pure functions)
+# ===========================================================================
+def _future_rfc1123(seconds_from_now: int = 3600) -> str:
+    """Return an RFC 1123 string ``seconds_from_now`` seconds in the future."""
+    return formatdate(time.time() + seconds_from_now, usegmt=True)
+
+
+def _past_rfc1123(seconds_ago: int = 3600) -> str:
+    return formatdate(time.time() - seconds_ago, usegmt=True)
+
+
+def test_cookie_secret_id_is_stable_and_unique(handler):
+    a1 = handler._cookie_secret_id("https://1.2.3.4", "admin")
+    a2 = handler._cookie_secret_id("https://1.2.3.4", "admin")
+    b = handler._cookie_secret_id("https://1.2.3.4", "audit")
+    c = handler._cookie_secret_id("https://1.2.3.5", "admin")
+
+    assert a1 == a2, "stable across calls (same input → same secret_id)"
+    assert a1 != b, "different username → different secret_id"
+    assert a1 != c, "different base_url → different secret_id"
+    # Filesystem-/JSON-safe characters only (avoids leaking IP / port / scheme).
+    assert re.fullmatch(r"onesig_session_cookie__[0-9a-f]{12}", a1)
+
+
+@pytest.mark.asyncio
+async def test_cookies_to_snapshot_round_trip(handler):
+    # Seed a real CookieJar with two cookies so we exercise the actual
+    # aiohttp ↔ http.cookies.Morsel pathway (not a hand-rolled fake).
+    # ``aiohttp.CookieJar.__init__`` calls ``asyncio.get_running_loop()``
+    # so this needs to run inside an event loop.
+    jar = aiohttp.CookieJar(unsafe=True)
+    from http.cookies import SimpleCookie
+    from yarl import URL
+
+    sc: SimpleCookie = SimpleCookie()
+    sc["onesig_session"] = "abc123"
+    sc["onesig_session"]["domain"] = "1.2.3.4"
+    sc["onesig_session"]["path"] = "/"
+    sc["onesig_session"]["expires"] = _future_rfc1123(3600)
+    sc["onesig_session"]["httponly"] = True
+    sc["onesig_session"]["secure"] = True
+    sc["lang"] = "zh"
+    sc["lang"]["domain"] = "1.2.3.4"
+    sc["lang"]["path"] = "/"
+    jar.update_cookies(sc, response_url=URL("https://1.2.3.4/api"))
+
+    rows = handler._cookies_to_snapshot(jar)
+    assert {r["name"] for r in rows} == {"onesig_session", "lang"}
+
+    session_row = next(r for r in rows if r["name"] == "onesig_session")
+    assert session_row["value"] == "abc123"
+    assert session_row["domain"] == "1.2.3.4"
+    assert session_row["path"] == "/"
+    assert session_row["secure"] is True
+    assert session_row["httponly"] is True
+
+    # Round-trip back into a fresh jar.
+    fresh_jar = aiohttp.CookieJar(unsafe=True)
+    injected = handler._snapshot_into_jar(fresh_jar, rows, "https://1.2.3.4/api")
+    assert injected == 2
+    rehydrated = {r["name"]: r for r in handler._cookies_to_snapshot(fresh_jar)}
+    assert rehydrated["onesig_session"]["value"] == "abc123"
+    assert rehydrated["onesig_session"]["secure"] is True
+    assert rehydrated["lang"]["value"] == "zh"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_into_jar_drops_already_expired_cookies(handler):
+    rows = [
+        {
+            "name": "stale",
+            "value": "x",
+            "domain": "1.2.3.4",
+            "path": "/",
+            "expires": _past_rfc1123(60),
+            "secure": False,
+            "httponly": False,
+        },
+        {
+            "name": "fresh",
+            "value": "y",
+            "domain": "1.2.3.4",
+            "path": "/",
+            "expires": _future_rfc1123(3600),
+            "secure": False,
+            "httponly": False,
+        },
+    ]
+    jar = aiohttp.CookieJar(unsafe=True)
+    injected = handler._snapshot_into_jar(jar, rows, "https://1.2.3.4")
+    assert injected == 1
+    names = {m.key for m in jar}
+    assert names == {"fresh"}, "expired cookie must not poison the jar"
+
+
+def test_load_cookie_snapshot_rejects_corrupt_payloads(handler):
+    sm = MagicMock()
+    cases = [
+        None,                              # secret missing
+        "",                                # empty string
+        "{not json",                       # malformed
+        '{"version": 999, "cookies": []}', # version mismatch
+        '{"version": 1, "cookies": "nope"}',  # cookies field wrong type
+        '{"version": 1, "cookies": []}',   # empty cookies
+        json.dumps({                        # all entries already expired
+            "version": handler._COOKIE_SNAPSHOT_VERSION,
+            "cookies": [{"name": "x", "value": "y",
+                         "expires": _past_rfc1123(60)}],
+        }),
+    ]
+    for raw in cases:
+        sm.get.return_value = raw
+        with patch.object(handler, "_get_secret_manager", return_value=sm):
+            assert handler._load_cookie_snapshot("any-id") is None, raw
+
+
+def test_load_cookie_snapshot_keeps_unexpired_cookies(handler):
+    sm = MagicMock()
+    payload = json.dumps({
+        "version": handler._COOKIE_SNAPSHOT_VERSION,
+        "session_key": "https://1.2.3.4|admin",
+        "saved_at": int(time.time()),
+        "cookies": [
+            {"name": "a", "value": "1",
+             "expires": _future_rfc1123(3600)},
+            {"name": "b", "value": "2",
+             "expires": _past_rfc1123(60)},   # filtered out
+            {"name": "c", "value": "3", "expires": ""},  # no expiry → kept
+        ],
+    })
+    sm.get.return_value = payload
+    with patch.object(handler, "_get_secret_manager", return_value=sm):
+        snap = handler._load_cookie_snapshot("any-id")
+    assert snap is not None
+    names = {c["name"] for c in snap["cookies"]}
+    assert names == {"a", "c"}
+
+
+# ===========================================================================
+# Cookie persistence: persist_cookies precedence
+# ===========================================================================
+@pytest.mark.parametrize(
+    "raw, env, expected, why",
+    [
+        ({"persist_cookies": False}, None, False, "canonical key honoured"),
+        ({"persistCookies": False}, None, False, "camelCase alias honoured"),
+        ({"custom_settings": {"persist_cookies": False}}, None, False,
+         "WebUI custom_settings path honoured"),
+        ({}, "false", False, "ONESIG_PERSIST_COOKIES env var honoured"),
+        ({}, None, True, "default DEFAULT_PERSIST_COOKIES=True when unset"),
+        ({"persist_cookies": True,
+          "custom_settings": {"persist_cookies": False}},
+         None, True, "canonical wins over custom_settings"),
+        ({"persist_cookies": "off"}, None, False, "string 'off' coerced"),
+        ({"persist_cookies": 1}, None, True, "integer 1 coerced"),
+    ],
+)
+def test_resolve_persist_cookies_precedence(handler, raw, env, expected, why,
+                                            monkeypatch):
+    if env is None:
+        monkeypatch.delenv("ONESIG_PERSIST_COOKIES", raising=False)
+    else:
+        monkeypatch.setenv("ONESIG_PERSIST_COOKIES", env)
+    assert handler._resolve_persist_cookies(raw) is expected, why
+
+
+def test_default_persist_cookies_is_on(handler):
+    # Persistence is the open-box default. Flipping this back to False would
+    # silently make every flocks restart cost an extra 4-RTT login dance.
+    assert handler.DEFAULT_PERSIST_COOKIES is True
+
+
+# ===========================================================================
+# Cookie persistence: OneSIGSession integration
+# ===========================================================================
+def _build_config(handler, *, persist_cookies: bool = True,
+                  base_url: str = "https://1.2.3.4",
+                  username: str = "admin") -> Any:
+    return handler.OneSIGRuntimeConfig(
+        base_url=base_url,
+        api_prefix="/api",
+        username=username,
+        password="supersecret",
+        oaep_hash="sha1",
+        verify_ssl=False,
+        timeout=30,
+        persist_cookies=persist_cookies,
+    )
+
+
+def _persisted_payload(name: str = "onesig_session", value: str = "live") -> str:
+    return json.dumps({
+        "version": 1,
+        "session_key": "https://1.2.3.4|admin",
+        "saved_at": int(time.time()),
+        "cookies": [
+            {"name": name, "value": value,
+             "domain": "1.2.3.4", "path": "/",
+             "expires": _future_rfc1123(3600),
+             "secure": False, "httponly": True},
+        ],
+    })
+
+
+def test_session_init_loads_persisted_cookie_and_marks_logged_in(handler):
+    sm = MagicMock()
+    sm.get.return_value = _persisted_payload()
+    with patch.object(handler, "_get_secret_manager", return_value=sm):
+        session = handler.OneSIGSession(_build_config(handler))
+
+    assert session._logged_in is True, (
+        "persisted cookie present + non-expired → trust it; let request() "
+        "fall back to auto-relogin if device has rotated it"
+    )
+    assert session._pending_cookies and \
+           session._pending_cookies[0]["name"] == "onesig_session"
+    sm.get.assert_called_once()
+    assert sm.get.call_args[0][0].startswith("onesig_session_cookie__")
+
+
+def test_session_init_skips_load_when_persist_cookies_disabled(handler):
+    sm = MagicMock()
+    with patch.object(handler, "_get_secret_manager", return_value=sm):
+        session = handler.OneSIGSession(
+            _build_config(handler, persist_cookies=False)
+        )
+    assert session._logged_in is False
+    assert session._pending_cookies is None
+    sm.get.assert_not_called(), "no .secret.json read when toggle off"
+
+
+def test_session_init_does_not_trust_only_expired_cookie(handler):
+    sm = MagicMock()
+    sm.get.return_value = json.dumps({
+        "version": 1,
+        "cookies": [{"name": "stale", "value": "x",
+                     "expires": _past_rfc1123(60)}],
+    })
+    with patch.object(handler, "_get_secret_manager", return_value=sm):
+        session = handler.OneSIGSession(_build_config(handler))
+    assert session._logged_in is False
+    assert session._pending_cookies is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_injects_pending_cookies_into_jar(handler):
+    sm = MagicMock()
+    sm.get.return_value = _persisted_payload(name="JSESSIONID", value="hot")
+    with patch.object(handler, "_get_secret_manager", return_value=sm):
+        session = handler.OneSIGSession(_build_config(handler))
+        client = await session._ensure_session()
+        try:
+            cookies_in_jar = {m.key: m.value for m in client.cookie_jar}
+            assert cookies_in_jar.get("JSESSIONID") == "hot"
+            assert session._cookies_loaded is True
+            assert session._pending_cookies is None, (
+                "pending list cleared once installed into the live jar"
+            )
+        finally:
+            await client.close()
+
+
+@pytest.mark.asyncio
+async def test_login_persists_cookie_snapshot(handler):
+    sm = MagicMock()
+    sm.get.return_value = None  # no prior snapshot
+    captured: dict[str, Any] = {}
+
+    def _set(secret_id, payload):
+        captured["secret_id"] = secret_id
+        captured["payload"] = payload
+
+    sm.set.side_effect = _set
+
+    # Real CookieJar so _persist_cookies has actual content to serialise.
+    jar = aiohttp.CookieJar(unsafe=True)
+    from http.cookies import SimpleCookie
+    from yarl import URL
+    sc: SimpleCookie = SimpleCookie()
+    sc["onesig_session"] = "freshly-issued"
+    sc["onesig_session"]["domain"] = "1.2.3.4"
+    sc["onesig_session"]["path"] = "/"
+    sc["onesig_session"]["expires"] = _future_rfc1123(3600)
+    jar.update_cookies(sc, response_url=URL("https://1.2.3.4/api"))
+
+    fake_session = MagicMock()
+    fake_session.closed = False
+    fake_session.cookie_jar = jar
+
+    with patch.object(handler, "_get_secret_manager", return_value=sm):
+        session = handler.OneSIGSession(_build_config(handler))
+        session._session = fake_session  # bypass _ensure_session
+        session._persist_cookies()
+
+    assert captured["secret_id"].startswith("onesig_session_cookie__")
+    body = json.loads(captured["payload"])
+    assert body["version"] == 1
+    names = {c["name"] for c in body["cookies"]}
+    assert "onesig_session" in names
+
+
+@pytest.mark.asyncio
+async def test_logout_drops_persisted_cookie(handler):
+    sm = MagicMock()
+    sm.get.return_value = None  # no prior snapshot for __init__
+    deleted: list[str] = []
+    sm.delete.side_effect = lambda sid: deleted.append(sid) or True
+
+    with patch.object(handler, "_get_secret_manager", return_value=sm):
+        session = handler.OneSIGSession(_build_config(handler))
+        session._drop_persisted_cookies()
+
+    assert deleted, "_drop_persisted_cookies must call SecretManager.delete"
+    assert deleted[0].startswith("onesig_session_cookie__")
+
+
+@pytest.mark.asyncio
+async def test_persist_cookies_is_noop_when_toggle_off(handler):
+    sm = MagicMock()
+    sm.get.return_value = None
+    with patch.object(handler, "_get_secret_manager", return_value=sm):
+        session = handler.OneSIGSession(
+            _build_config(handler, persist_cookies=False)
+        )
+        # Even with a populated jar, set() must not be called.
+        session._session = MagicMock(closed=False,
+                                     cookie_jar=aiohttp.CookieJar(unsafe=True))
+        session._persist_cookies()
+        session._drop_persisted_cookies()
+    sm.set.assert_not_called()
+    sm.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_request_with_persisted_cookie_skips_full_login_chain(handler):
+    """End-to-end: a fresh process whose ``.secret.json`` already has a
+    cookie should fire **only** the business request — no captcha, no
+    pubkey, no /v3/login, no /v3/account."""
+    fake_session = _FakeSession([
+        # Just the business call. If the handler accidentally triggers the
+        # login chain there will be missing responses and the test fails.
+        _FakeResponse(json_payload={
+            "responseCode": 0, "verboseMsg": "成功",
+            "data": {"version": "v2.5.3"},
+        }),
+    ])
+
+    sm = MagicMock()
+    sm.get.return_value = _persisted_payload()
+    sm.set.return_value = None
+    sm.delete.return_value = None
+
+    fake_flocks_security = types.ModuleType("flocks.security")
+    fake_flocks_security.get_secret_manager = lambda: sm
+    sys.modules["flocks.security"] = fake_flocks_security
+
+    raw_service = {
+        "base_url": "https://1.2.3.4",
+        "username": "admin",
+        "password": "{secret:onesig_password}",
+        "oaep_hash": "sha1",
+        "verify_ssl": False,
+    }
+
+    with (
+        patch.object(handler.ConfigWriter, "get_api_service_raw",
+                     return_value=raw_service),
+        patch.object(handler.aiohttp, "ClientSession",
+                     return_value=fake_session),
+    ):
+        handler._SESSIONS.clear()
+        config = handler._resolve_runtime_config()
+        session = handler.OneSIGSession(config)
+        assert session._logged_in is True, (
+            "persisted cookie should make the session believe it's already in"
+        )
+        status, envelope, _, _ = await session.request(
+            "GET", "/v3/basic/version"
+        )
+
+    assert status == 200
+    assert envelope.get("responseCode") == 0
+    assert len(fake_session.calls) == 1, (
+        "exactly one HTTP call (the business request) — login chain skipped"
+    )
+    method, url, _kwargs = fake_session.calls[0]
+    assert method == "GET"
+    assert url.endswith("/v3/basic/version")

--- a/webui/src/pages/Tool/components/ServiceDetailPanel.tsx
+++ b/webui/src/pages/Tool/components/ServiceDetailPanel.tsx
@@ -662,11 +662,14 @@ export function APIServiceDetailPanel({
     const schema = buildFallbackCredentialSchema(nextMetadata);
     const nextValues: Record<string, string> = {};
 
+    // Always show whatever the backend reports in `fields`. Do NOT compare with
+    // schema.default_value to decide visibility: the metadata endpoint reuses
+    // the persisted base_url as default_value for some providers (e.g. onesig),
+    // and that previously caused the saved URL to be cleared from the form.
     schema.forEach((field) => {
       const dynamicValue = nextCredentials?.fields?.[field.key];
-      const value = dynamicValue ?? getLegacyCredentialValue(nextCredentials, field.key) ?? '';
-      const effectiveDefault = field.default_value || (field.key === 'base_url' ? nextMetadata?.base_url : undefined);
-      nextValues[field.key] = (effectiveDefault && value === effectiveDefault) ? '' : (value || '');
+      const legacyValue = getLegacyCredentialValue(nextCredentials, field.key);
+      nextValues[field.key] = dynamicValue ?? legacyValue ?? '';
     });
 
     setFormValues(nextValues);

--- a/webui/src/pages/Tool/components/ServiceDetailPanelApi.test.tsx
+++ b/webui/src/pages/Tool/components/ServiceDetailPanelApi.test.tsx
@@ -454,6 +454,63 @@ describe('APIServiceDetailPanel', () => {
     });
   });
 
+  it('renders saved base_url even when the metadata schema reports it as default_value (onesig regression)', async () => {
+    // The metadata endpoint backfills `default_value` for `base_url` from the
+    // currently-saved config (so a fresh form can preview the URL). The form
+    // must NOT treat "value === default_value" as "user has not filled in a
+    // value" — otherwise the saved Base URL silently disappears after save.
+    const savedBaseUrl = 'https://onesig-test-131.threatbook-inc.cn';
+    providerAPI.getMetadata.mockResolvedValueOnce({
+      data: {
+        name: 'onesig',
+        description: 'OneSIG API service',
+        base_url: savedBaseUrl,
+        credential_schema: [
+          { key: 'base_url', label: 'Base URL', storage: 'config', sensitive: false, required: true, input_type: 'url', config_key: 'base_url', default_value: savedBaseUrl },
+          { key: 'api_prefix', label: 'API Prefix', storage: 'config', sensitive: false, required: false, input_type: 'text', config_key: 'api_prefix', default_value: '/api' },
+          { key: 'username', label: 'Username', storage: 'config', sensitive: false, required: true, input_type: 'text', config_key: 'username' },
+          { key: 'password', label: 'Password', storage: 'secret', sensitive: true, required: true, input_type: 'password', config_key: 'password', secret_id: 'onesig_password' },
+          { key: 'oaep_hash', label: 'RSA-OAEP Hash', storage: 'config', sensitive: false, required: false, input_type: 'text', config_key: 'oaep_hash', default_value: 'sha1' },
+        ],
+      },
+    });
+    providerAPI.getServiceCredentials.mockResolvedValueOnce({
+      data: {
+        base_url: savedBaseUrl,
+        username: 'admin',
+        fields: {
+          base_url: savedBaseUrl,
+          username: 'admin',
+          password: 'Threatbook@506',
+          oaep_hash: 'sha256',
+        },
+        secret_ids: { password: 'onesig_password' },
+        has_credential: true,
+      },
+    });
+
+    render(
+      <APIServiceDetailPanel
+        serviceName="onesig_api"
+        serviceTools={[]}
+        onSelectTool={vi.fn()}
+        enabled
+        onToggleEnabled={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const baseUrlInput = await screen.findByPlaceholderText('输入 API 地址') as HTMLInputElement;
+    expect(baseUrlInput.value).toBe(savedBaseUrl);
+
+    const usernameInput = screen.getByPlaceholderText('输入用户名') as HTMLInputElement;
+    expect(usernameInput.value).toBe('admin');
+
+    // value matches default_value but is also the actually-saved value, so the
+    // form should be considered "unchanged" — no Save button.
+    expect(screen.queryByRole('button', { name: '保存' })).toBeNull();
+  });
+
   it('keeps service tool descriptions compact in the tools tab', async () => {
     const user = userEvent.setup();
     const longDescription = 'OneSEC DNS grouped tool. dns_search_blocked_queries_by_super_long_keyword_with_no_breaks_and_more_details_to_force_wrapping';


### PR DESCRIPTION
feat(onesig): persist cookie session, default-off SSL verify, blank api_prefix

Three interlocking changes that make OneSIG v2.5.x easier to bring online
out of the box and align SSL / cookie behaviour with the other built-in
providers (onesec / ngtip / qingteng).

- Persistent login session: after a successful login the aiohttp
  CookieJar is serialised into `~/.flocks/config/.secret.json` under a
  key shaped like `onesig_session_cookie__<sha1[:12]>`. On process
  restart, if at least one cookie is still alive the jar is rehydrated
  in-place and the captcha -> pubkey -> /v3/login -> /v3/account chain
  is skipped entirely; the very first business request that returns
  401 / responseCode 1019..1022 still triggers exactly one auto re-login
  to preserve previous behaviour. `logout()` wipes the on-disk entry,
  `close()` does not. The `persist_cookies` toggle defaults to True and
  honours camelCase / `custom_settings` / `ONESIG_PERSIST_COOKIES`
  fallbacks.
- SSL verification defaults to OFF, matching onesec / ngtip / qingteng.
  Five sources are recognised in priority order: `verify_ssl`,
  `ssl_verify`, `verifySsl`, `custom_settings.verify_ssl`, and the
  `ONESIG_VERIFY_SSL` env var, falling back to False. The
  `verify_ssl` field is removed from `provider.credential_fields` so
  the global "SSL verify" switch on `ServiceDetailPanel` becomes the
  single source of truth.
- `api_prefix` default changes from `"/api"` to `""`, matching the
  common v2.5.x deployments where nginx already routes `/v3/...` to
  the backend. Reverse-proxy deployments can set it back to `"/api"`.
  `_provider.yaml` notes are updated with the 404 -> flip-prefix
  troubleshooting tip.

`tests/tool/test_onesig_api_tool.py` covers: the three `verify_ssl`
aliases ending up as the right `ssl=` argument on
`aiohttp.session.request`, cookie snapshot purity (round-trip and
expired-cookie filtering), `__init__` load / `login()` save /
`logout()` delete, and the persisted-cookie path bypassing the full
captcha -> pubkey -> login -> account chain.