### PR TITLE
fix(webui): tighten delegate task card detection

### DIFF
--- a/webui/src/components/common/DelegateTaskCard.test.tsx
+++ b/webui/src/components/common/DelegateTaskCard.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldRenderDelegateTaskCard } from './DelegateTaskCard';
+import type { MessagePart } from '../../types';
+
+describe('shouldRenderDelegateTaskCard', () => {
+  it('does not treat generic tool category fields as delegate tasks', () => {
+    const part = {
+      id: 'part-wecom',
+      type: 'tool',
+      tool: 'wecom_mcp',
+      state: {
+        status: 'completed',
+        input: {
+          action: 'call',
+          category: 'doc',
+          method: 'create_doc',
+        },
+        output: 'ok',
+        metadata: {},
+      },
+    } as MessagePart;
+
+    expect(shouldRenderDelegateTaskCard(part)).toBe(false);
+  });
+
+  it('renders known delegate tools as delegate tasks', () => {
+    const part = {
+      id: 'part-task',
+      type: 'tool',
+      tool: 'task',
+      state: {
+        status: 'running',
+        input: {
+          description: 'Explore issue',
+          prompt: 'Find the issue',
+          subagent_type: 'explore',
+        },
+      },
+    } as MessagePart;
+
+    expect(shouldRenderDelegateTaskCard(part)).toBe(true);
+  });
+
+  it('uses persisted child session metadata as a delegate fallback', () => {
+    const part = {
+      id: 'part-legacy',
+      type: 'tool',
+      tool: 'unknown',
+      state: {
+        status: 'completed',
+        input: {
+          category: 'task',
+          description: 'Legacy task',
+        },
+        output: 'done',
+        metadata: {
+          sessionId: 'ses_child',
+        },
+      },
+    } as MessagePart;
+
+    expect(shouldRenderDelegateTaskCard(part)).toBe(true);
+  });
+});

--- a/webui/src/components/common/DelegateTaskCard.tsx
+++ b/webui/src/components/common/DelegateTaskCard.tsx
@@ -21,6 +21,21 @@ export function isDelegateTool(toolName: string): boolean {
   return DELEGATE_TOOLS.has(toolName);
 }
 
+export function shouldRenderDelegateTaskCard(part: MessagePart): boolean {
+  if (part.tool && isDelegateTool(part.tool)) {
+    return true;
+  }
+
+  const state: Partial<ToolState> = part.state || {};
+  const input = state.input || {};
+  if (typeof input.subagent_type === 'string' && input.subagent_type.trim()) {
+    return true;
+  }
+
+  const output = typeof state.output === 'string' ? state.output : undefined;
+  return !!extractSessionId(state.metadata, output);
+}
+
 interface ActivityStep {
   tool: string;
   title: string;
@@ -40,6 +55,28 @@ interface DelegateInfo {
   stepCount: number;
   currentText: string;
   elapsed: number;
+}
+
+function extractSessionId(
+  meta: Record<string, any> | undefined,
+  output: string | undefined,
+): string | undefined {
+  const innerMeta = meta?.metadata as Record<string, any> | undefined;
+  const sessionId =
+    meta?.sessionId ??
+    meta?.sessionID ??
+    meta?.session_id ??
+    innerMeta?.sessionId ??
+    innerMeta?.sessionID ??
+    innerMeta?.session_id;
+
+  if (typeof sessionId === 'string' && sessionId.trim()) {
+    return sessionId.trim();
+  }
+
+  if (!output) return undefined;
+  const match = output.match(/<task_metadata>[\s\S]*?session_id:\s*([^\n<]+)[\s\S]*?<\/task_metadata>/i);
+  return match?.[1]?.trim() || undefined;
 }
 
 function extractDelegateInfo(state: Partial<ToolState>, subTaskLabel: string): DelegateInfo {
@@ -67,8 +104,7 @@ function extractDelegateInfo(state: Partial<ToolState>, subTaskLabel: string): D
   const meta = state.metadata as Record<string, any> | undefined;
   const innerMeta = meta?.metadata as Record<string, any> | undefined;
 
-  const childSessionId: string | undefined =
-    meta?.sessionId ?? innerMeta?.sessionId ?? undefined;
+  const childSessionId = extractSessionId(meta, typeof state.output === 'string' ? state.output : undefined);
   const steps = (meta?.steps ?? innerMeta?.steps ?? []) as ActivityStep[];
   const stepCount = (meta?.stepCount ?? innerMeta?.stepCount ?? 0) as number;
   const currentText = (meta?.currentText ?? innerMeta?.currentText ?? '') as string;

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -23,7 +23,7 @@ import { useTranslation } from 'react-i18next';
 import LoadingSpinner from './LoadingSpinner';
 import { useToast } from './Toast';
 import { QuestionTool } from './QuestionTool';
-import DelegateTaskCard, { isDelegateTool } from './DelegateTaskCard';
+import DelegateTaskCard, { isDelegateTool, shouldRenderDelegateTaskCard } from './DelegateTaskCard';
 import CommandDropdown, { parseSlashCommand } from './CommandDropdown';
 import { useSessionMessages } from '@/hooks/useSessions';
 import { useSSE, type SSEConnectionStatus } from '@/hooks/useSSE';
@@ -2004,14 +2004,9 @@ export function ChatToolPart({ part, pendingQuestion, onAnswer, onReject }: Chat
   const { t } = useTranslation('session');
   const toolName = part.tool || 'unknown';
 
-  // Primary check: tool name is a known delegate tool.
-  // Fallback: state.input contains delegate-specific fields (handles cases where
-  // part.tool may be missing or unrecognized after reload).
-  const stateInput = part.state?.input as Record<string, any> | undefined;
-  if (
-    isDelegateTool(toolName) ||
-    (stateInput && ('subagent_type' in stateInput || 'category' in stateInput))
-  ) {
+  // Keep the delegate fallback narrow: many MCP tools also carry a generic
+  // `category` field (for example wecom_mcp category="doc").
+  if (shouldRenderDelegateTaskCard(part)) {
     return <DelegateTaskCard part={part} />;
   }
 

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 import SessionPage from './index';
 
 const {
@@ -59,7 +59,9 @@ vi.mock('@/components/common/LoadingSpinner', () => ({
 
 vi.mock('@/components/common/SessionChat', () => ({
   __esModule: true,
-  default: () => <div data-testid="session-chat">session-chat</div>,
+  default: ({ sessionId }: { sessionId?: string | null }) => (
+    <div data-testid="session-chat">{sessionId ?? 'no-session'}</div>
+  ),
 }));
 
 vi.mock('@/utils/agentDisplay', () => ({
@@ -89,6 +91,13 @@ const session = {
     updated: 1710000001000,
   },
   category: 'user',
+};
+
+const secondSession = {
+  ...session,
+  id: 'session-2',
+  slug: 'session-2',
+  title: 'Second Session',
 };
 
 function renderSessionPage() {
@@ -253,5 +262,46 @@ describe('SessionPage session actions menu', () => {
     });
     expect(removeSession).toHaveBeenCalledWith('session-1');
     expect(global.confirm).toHaveBeenCalledWith('confirmDelete');
+  });
+
+  it('syncs selected session when query param changes after mount', async () => {
+    const user = userEvent.setup();
+
+    useSessions.mockReturnValue({
+      sessions: [session, secondSession],
+      loading: false,
+      error: null,
+      refetch: refetchSessions,
+      updateSessionTitle,
+      removeSession,
+      removeSessions,
+      addSession,
+    });
+
+    function NavigateButton() {
+      const navigate = useNavigate();
+      return (
+        <button type="button" onClick={() => navigate('/sessions?session=session-2')}>
+          go-session-2
+        </button>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/sessions']}>
+        <NavigateButton />
+        <SessionPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-chat')).toHaveTextContent('session-1');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'go-session-2' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-chat')).toHaveTextContent('session-2');
+    });
   });
 });

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -31,8 +31,6 @@ function sanitizeSessionExportName(value: string) {
 export default function SessionPage() {
   const { t, i18n } = useTranslation('session');
   const [searchParams, setSearchParams] = useSearchParams();
-  // Capture params on mount only — avoids re-running when setSearchParams clears the URL.
-  const initialSearchParamsRef = useRef(searchParams);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState('rex');
@@ -79,21 +77,24 @@ export default function SessionPage() {
     }
   }, [updateSessionTitle, refetchSessions]);
 
-  // Handle ?session=<id>&message=<text> query params (e.g. from onboarding).
-  // We read from the ref captured at mount time so the effect only runs once
-  // and doesn't re-trigger when setSearchParams clears the URL.
+  // Keep the selected session in sync with URL query params (e.g. onboarding
+  // or other in-app navigation to `/sessions?session=...`). Clear the params
+  // after consuming them so refreshes don't re-send the initial message.
   useEffect(() => {
-    const params = initialSearchParamsRef.current;
-    const sessionParam = params.get('session');
-    const messageParam = params.get('message');
-    if (sessionParam) {
+    const sessionParam = searchParams.get('session');
+    const messageParam = searchParams.get('message');
+    if (!sessionParam) return;
+
+    if (sessionParam !== selectedSessionId) {
       setSelectedSessionId(sessionParam);
+    }
+    if (sessionParam) {
       if (messageParam) {
         setPendingInitialMessage(messageParam);
       }
       setSearchParams({}, { replace: true });
     }
-  }, []);
+  }, [searchParams, selectedSessionId, setSearchParams]);
 
   // Auto select first session
   useEffect(() => {
@@ -606,6 +607,7 @@ export default function SessionPage() {
 
         {/* Chat — powered by unified SessionChat */}
         <SessionChat
+          key={selectedSessionId ?? 'empty-session'}
           sessionId={selectedSessionId}
           live
           display={{ compact: false, showActions: true, showTimestamp: false }}


### PR DESCRIPTION
## Summary
- Avoid misclassifying generic MCP tools with `category` fields as delegate task cards, while keeping delegate cards available when a child session is present.
- Preserve child session ID extraction from metadata and task output for reloaded or legacy delegate parts.
- Keep Session page selection synchronized with URL query changes after mount and cover it with regression tests.

## Test plan
- `cd webui && npm run test:run -- DelegateTaskCard.test.tsx SessionChat.test.ts src/pages/Session/index.test.tsx`

Made with [Cursor](https://cursor.com)