### PR TITLE
fix(langfuse): restore trace capture for SDK v4

### DIFF
--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -1046,6 +1046,66 @@ Please address this message and continue with your tasks.
             },
         }
 
+    @staticmethod
+    def _serialize_chat_message_for_langfuse(message: ChatMessage) -> Dict[str, Any]:
+        """Serialize the exact provider-bound message payload for Langfuse."""
+        if hasattr(message, "model_dump"):
+            return message.model_dump(exclude_none=True)
+        return {
+            "role": message.role,
+            "content": message.content,
+            "reasoning": getattr(message, "reasoning", None),
+            "tool_calls": getattr(message, "tool_calls", None),
+            "tool_call_id": getattr(message, "tool_call_id", None),
+            "name": getattr(message, "name", None),
+            "custom_settings": getattr(message, "custom_settings", {}),
+        }
+
+    @classmethod
+    def _build_langfuse_request_payload(
+        cls,
+        *,
+        step: int,
+        messages: List[ChatMessage],
+        request_tools: Optional[List[Dict[str, Any]]],
+        available_tools: List[Dict[str, Any]],
+        provider_options: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "step": step,
+            "messages": [cls._serialize_chat_message_for_langfuse(message) for message in messages],
+            "provider_options": provider_options,
+        }
+        if request_tools is not None:
+            payload["request_tools"] = request_tools
+        if available_tools:
+            payload["available_tools"] = available_tools
+        return payload
+
+    @staticmethod
+    def _build_langfuse_response_payload(
+        *,
+        action: str,
+        content: str,
+        reasoning: str,
+        finish_reason: Optional[str],
+        tool_calls: List[ToolCall],
+    ) -> Dict[str, Any]:
+        return {
+            "action": action,
+            "content": content,
+            "reasoning": reasoning,
+            "finish_reason": finish_reason,
+            "tool_calls": [
+                {
+                    "id": tool_call.id,
+                    "name": tool_call.name,
+                    "arguments": tool_call.arguments,
+                }
+                for tool_call in tool_calls
+            ],
+        }
+
     def _resolve_usage_pricing(self) -> Optional[Any]:
         """Resolve pricing config for the current provider/model pair."""
         from flocks.provider.usage_service import resolve_usage_pricing
@@ -1829,6 +1889,7 @@ Please address this message and continue with your tasks.
         # Build provider options (thinking / reasoning / max_tokens)
         from flocks.provider.options import build_provider_options
         provider_options = build_provider_options(self.provider_id, self.model_id)
+        provider_tools = None if self._should_use_text_tool_call_mode() else (tools if tools else None)
 
         # Clean up any leftover reasoning state from a previous (failed) call
         if hasattr(self, '_current_reasoning_id'):
@@ -1847,13 +1908,6 @@ Please address this message and continue with your tasks.
         trace_ctx = None
         generation_ctx = None
         try:
-            input_preview = []
-            for _msg in messages[-12:]:
-                _mc = _msg.content or ""
-                input_preview.append(
-                    {"role": _msg.role, "chars": len(_mc), "preview": _mc[:240]}
-                )
-
             trace_tags = [
                 f"session:{self.session.id}",
                 f"step:{self._step}",
@@ -1861,36 +1915,43 @@ Please address this message and continue with your tasks.
                 f"agent:{agent.name}",
                 f"provider:{self.provider_id}",
             ]
+            request_payload = self._build_langfuse_request_payload(
+                step=self._step,
+                messages=messages,
+                request_tools=provider_tools,
+                available_tools=tools,
+                provider_options=provider_options,
+            )
             trace_ctx = trace_scope(
                 name="SessionRunner.step",
                 session_id=self.session.id,
                 tags=trace_tags,
-                input={
-                    "step": self._step,
-                    "message_count": len(messages),
-                    "tool_count": len(tools),
-                    "last_user_preview": next(
-                        ((m.content or "")[:280] for m in reversed(messages) if m.role == "user"),
-                        "",
-                    ),
-                },
+                input=request_payload,
                 metadata={
                     "provider_id": self.provider_id,
                     "model_id": self.model_id,
                     "agent": agent.name,
                     "workspace": self.session.directory,
+                    "message_count": len(messages),
+                    "available_tool_count": len(tools),
+                    "request_tool_count": len(provider_tools or []),
+                    "tool_transport": "provider_param" if provider_tools is not None else "text_prompt",
                 },
             )
             generation_ctx = generation_scope(
                 parent=trace_ctx.observation,
                 name="LLM.generate",
                 model=self.model_id,
-                input=input_preview,
+                input=request_payload,
                 metadata={
                     "provider_id": self.provider_id,
                     "session_id": self.session.id,
                     "step": self._step,
-                    "tool_names": [t.get("function", {}).get("name", "") for t in tools][:50],
+                    "agent": agent.name,
+                    "workspace": self.session.directory,
+                    "available_tool_count": len(tools),
+                    "request_tool_count": len(provider_tools or []),
+                    "tool_transport": "provider_param" if provider_tools is not None else "text_prompt",
                 },
             )
             processor._langfuse_generation = generation_ctx.observation
@@ -1923,7 +1984,6 @@ Please address this message and continue with your tasks.
         stream_usage: Optional[Dict[str, int]] = None
         
         # Stream response and convert chunks to events
-        provider_tools = None if self._should_use_text_tool_call_mode() else (tools if tools else None)
         if provider_tools is None and tools:
             log.info("runner.text_tool_call_mode.enabled", {
                 "session_id": self.session.id,
@@ -2103,28 +2163,26 @@ Please address this message and continue with your tasks.
             )
             for tc_state in processor.tool_calls.values()
         ]
+        finish_reason = processor.get_finish_reason()
         
         if tool_calls_for_result:
+            response_payload = self._build_langfuse_response_payload(
+                action="continue",
+                content=content,
+                reasoning=reasoning,
+                finish_reason=finish_reason,
+                tool_calls=tool_calls_for_result,
+            )
             self._end_observability(
                 generation_ctx, trace_ctx,
-                output={
-                    "content_preview": content[:600],
-                    "content_chars": len(content),
-                    "reasoning_chars": len(reasoning),
-                    "tool_calls": [{"id": tc.id, "name": tc.name} for tc in tool_calls_for_result[:30]],
-                },
+                output=response_payload,
                 usage=stream_usage,
                 metadata={
-                    "finish_reason": processor.get_finish_reason(),
+                    "finish_reason": finish_reason,
                     "status": "continue_with_tools",
                     "tool_call_count": len(tool_calls_for_result),
                 },
-                trace_output={
-                    "status": "ok",
-                    "next_action": "continue",
-                    "finish_reason": processor.get_finish_reason(),
-                    "tool_call_count": len(tool_calls_for_result),
-                },
+                trace_output=response_payload,
             )
             return StepResult(
                 action="continue",
@@ -2133,24 +2191,23 @@ Please address this message and continue with your tasks.
                 usage=stream_usage,
             )
         
+        response_payload = self._build_langfuse_response_payload(
+            action="stop",
+            content=content,
+            reasoning=reasoning,
+            finish_reason=finish_reason,
+            tool_calls=tool_calls_for_result,
+        )
         self._end_observability(
             generation_ctx, trace_ctx,
-            output={
-                "content_preview": content[:600],
-                "content_chars": len(content),
-                "reasoning_chars": len(reasoning),
-            },
+            output=response_payload,
             usage=stream_usage,
             metadata={
-                "finish_reason": processor.get_finish_reason(),
+                "finish_reason": finish_reason,
                 "status": "stop",
                 "tool_call_count": 0,
             },
-            trace_output={
-                "status": "ok",
-                "next_action": "stop",
-                "finish_reason": processor.get_finish_reason(),
-            },
+            trace_output=response_payload,
         )
         return StepResult(action="stop", content=content, usage=stream_usage)
     

--- a/flocks/session/streaming/stream_processor.py
+++ b/flocks/session/streaming/stream_processor.py
@@ -743,14 +743,10 @@ class StreamProcessor:
                 "tool_name": tool_name,
                 "success": result.success,
             })
-            output_preview = result.output if result.success else result.error
-            if isinstance(output_preview, str):
-                output_preview = output_preview[:600]
-
             try:
                 if tool_span_ctx is not None:
                     end_kwargs: Dict[str, Any] = {
-                        "output": output_preview,
+                        "output": result.output if result.success else result.error,
                         "metadata": {
                             "success": result.success,
                             "title": result.title,

--- a/flocks/utils/langfuse.py
+++ b/flocks/utils/langfuse.py
@@ -42,17 +42,47 @@ _current_observation: contextvars.ContextVar[Any] = contextvars.ContextVar(
     "langfuse_current_observation",
     default=None,
 )
+_CAPTURE_MODE_ENV = "FLOCKS_LANGFUSE_CAPTURE_MODE"
+_MAX_CHARS_ENV = "FLOCKS_LANGFUSE_MAX_CHARS"
+_DEFAULT_CAPTURE_MODE = "full"
+_DEFAULT_MAX_CHARS = 8000
+_VALID_CAPTURE_MODES = {"full", "truncated"}
+_TRACE_NAME_ATTR = "langfuse.trace.name"
+_TRACE_USER_ID_ATTR = "user.id"
+_TRACE_SESSION_ID_ATTR = "session.id"
+_TRACE_TAGS_ATTR = "langfuse.trace.tags"
 
 
 def _filter_none(values: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in values.items() if v is not None}
 
 
-def _truncate_value(value: Any, max_chars: int = 8000) -> Any:
+def _get_capture_mode() -> str:
+    mode = os.getenv(_CAPTURE_MODE_ENV, _DEFAULT_CAPTURE_MODE).strip().lower()
+    if mode in _VALID_CAPTURE_MODES:
+        return mode
+    return _DEFAULT_CAPTURE_MODE
+
+
+def _get_capture_max_chars() -> int:
+    raw_value = os.getenv(_MAX_CHARS_ENV, str(_DEFAULT_MAX_CHARS)).strip()
+    try:
+        max_chars = int(raw_value)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_CHARS
+    if max_chars <= 0:
+        return _DEFAULT_MAX_CHARS
+    return max_chars
+
+
+def _truncate_value(value: Any, max_chars: Optional[int] = None) -> Any:
     if isinstance(value, str):
-        if len(value) <= max_chars:
+        if _get_capture_mode() == "full":
             return value
-        return value[:max_chars] + f"...[truncated:{len(value) - max_chars}]"
+        limit = max_chars if max_chars is not None else _get_capture_max_chars()
+        if len(value) <= limit:
+            return value
+        return value[:limit] + f"...[truncated:{len(value) - limit}]"
     return value
 
 
@@ -65,6 +95,58 @@ def _sanitize_payload(value: Any) -> Any:
     if isinstance(value, list):
         return [_sanitize_payload(v) for v in value]
     return _truncate_value(value)
+
+
+def _set_trace_attribute(observation: Any, key: str, value: Any) -> None:
+    otel_span = getattr(observation, "_otel_span", None)
+    if otel_span is None or not hasattr(otel_span, "is_recording"):
+        return
+    try:
+        if otel_span.is_recording():
+            otel_span.set_attribute(key, value)
+    except Exception:
+        return
+
+
+def _propagate_trace_dimensions(
+    observation: Any,
+    *,
+    trace_name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+    parent: Any = None,
+) -> Any:
+    inherited_trace_name = trace_name
+    inherited_session_id = session_id
+    inherited_user_id = user_id
+    inherited_tags = tags
+
+    parent_span = getattr(parent, "_otel_span", None)
+    parent_attrs = getattr(parent_span, "attributes", None) if parent_span is not None else None
+    if parent_attrs:
+        if inherited_trace_name is None:
+            inherited_trace_name = parent_attrs.get(_TRACE_NAME_ATTR)
+        if inherited_session_id is None:
+            inherited_session_id = parent_attrs.get(_TRACE_SESSION_ID_ATTR)
+        if inherited_user_id is None:
+            inherited_user_id = parent_attrs.get(_TRACE_USER_ID_ATTR)
+        if inherited_tags is None:
+            parent_tags = parent_attrs.get(_TRACE_TAGS_ATTR)
+            if isinstance(parent_tags, list):
+                inherited_tags = parent_tags
+            elif isinstance(parent_tags, tuple):
+                inherited_tags = list(parent_tags)
+
+    if inherited_trace_name is not None:
+        _set_trace_attribute(observation, _TRACE_NAME_ATTR, inherited_trace_name)
+    if inherited_session_id is not None:
+        _set_trace_attribute(observation, _TRACE_SESSION_ID_ATTR, inherited_session_id)
+    if inherited_user_id is not None:
+        _set_trace_attribute(observation, _TRACE_USER_ID_ATTR, inherited_user_id)
+    if inherited_tags is not None:
+        _set_trace_attribute(observation, _TRACE_TAGS_ATTR, inherited_tags)
+    return observation
 
 
 def initialize() -> None:
@@ -140,26 +222,48 @@ def create_trace(
     )
     try:
         # Old SDKs may expose .trace(), newer SDKs are OTEL-native and expose
-        # .start_span() / .start_observation().
+        # .start_observation().
         if hasattr(client, "trace"):
             return client.trace(**payload)
-        trace_obs = client.start_span(
-            name=name,
-            input=payload.get("input"),
-            metadata=payload.get("metadata"),
-        )
-        # Best-effort enrich current trace with session/user dimensions.
-        try:
-            client.update_current_trace(
+        if hasattr(client, "start_observation"):
+            trace_metadata = dict(payload.get("metadata") or {})
+            if session_id is not None:
+                trace_metadata.setdefault("session_id", session_id)
+            if user_id is not None:
+                trace_metadata.setdefault("user_id", user_id)
+            if tags is not None:
+                trace_metadata.setdefault("tags", tags)
+            trace_obs = client.start_observation(
+                name=name,
+                as_type="span",
+                input=payload.get("input"),
+                metadata=trace_metadata or None,
+            )
+            return _propagate_trace_dimensions(
+                trace_obs,
+                trace_name=name,
                 session_id=session_id,
                 user_id=user_id,
                 tags=tags,
+            )
+        if hasattr(client, "start_span"):
+            trace_obs = client.start_span(
+                name=name,
                 input=payload.get("input"),
                 metadata=payload.get("metadata"),
             )
-        except Exception:
-            pass
-        return trace_obs
+            # Best-effort enrich current trace with session/user dimensions.
+            try:
+                client.update_current_trace(
+                    session_id=session_id,
+                    user_id=user_id,
+                    tags=tags,
+                    input=payload.get("input"),
+                    metadata=payload.get("metadata"),
+                )
+            except Exception:
+                pass
+            return trace_obs
     except Exception as exc:
         log.warn("langfuse.trace_failed", {"error": str(exc), "name": name})
         return _NoopObservation("trace")
@@ -189,15 +293,21 @@ def create_generation(
     )
     try:
         if parent and hasattr(parent, "generation"):
-            return parent.generation(**payload)
+            return _propagate_trace_dimensions(parent.generation(**payload), parent=parent)
         if parent and hasattr(parent, "start_generation"):
-            return parent.start_generation(**payload)
+            return _propagate_trace_dimensions(parent.start_generation(**payload), parent=parent)
         if parent and hasattr(parent, "start_observation"):
-            return parent.start_observation(as_type="generation", **payload)
+            return _propagate_trace_dimensions(
+                parent.start_observation(as_type="generation", **payload),
+                parent=parent,
+            )
         if hasattr(client, "start_generation"):
-            return client.start_generation(**payload)
+            return _propagate_trace_dimensions(client.start_generation(**payload), parent=parent)
         if hasattr(client, "start_observation"):
-            return client.start_observation(as_type="generation", **payload)
+            return _propagate_trace_dimensions(
+                client.start_observation(as_type="generation", **payload),
+                parent=parent,
+            )
     except Exception as exc:
         log.warn("langfuse.generation_failed", {"error": str(exc), "name": name})
     return _NoopObservation("generation")
@@ -225,15 +335,21 @@ def create_span(
     )
     try:
         if parent and hasattr(parent, "span"):
-            return parent.span(**payload)
+            return _propagate_trace_dimensions(parent.span(**payload), parent=parent)
         if parent and hasattr(parent, "start_span"):
-            return parent.start_span(**payload)
+            return _propagate_trace_dimensions(parent.start_span(**payload), parent=parent)
         if parent and hasattr(parent, "start_observation"):
-            return parent.start_observation(as_type="span", **payload)
+            return _propagate_trace_dimensions(
+                parent.start_observation(as_type="span", **payload),
+                parent=parent,
+            )
         if hasattr(client, "start_span"):
-            return client.start_span(**payload)
+            return _propagate_trace_dimensions(client.start_span(**payload), parent=parent)
         if hasattr(client, "start_observation"):
-            return client.start_observation(as_type="span", **payload)
+            return _propagate_trace_dimensions(
+                client.start_observation(as_type="span", **payload),
+                parent=parent,
+            )
     except Exception as exc:
         log.warn("langfuse.span_failed", {"error": str(exc), "name": name})
     return _NoopObservation("span")
@@ -267,19 +383,31 @@ def end_observation(
             observation.end(**payload)
             return
     except TypeError:
-        try:
-            observation.end()
-            return
-        except Exception:
-            pass
+        pass
     except Exception:
         pass
 
     try:
         if hasattr(observation, "update"):
-            observation.update(**payload)
+            update_payload = dict(payload)
+            if usage:
+                update_payload["usage_details"] = usage
+            try:
+                observation.update(**update_payload)
+            except TypeError:
+                fallback_payload = dict(payload)
+                if usage:
+                    fallback_payload["usage"] = usage
+                    fallback_payload.pop("usage_details", None)
+                observation.update(**fallback_payload)
     except Exception as exc:
         log.debug("langfuse.end_fallback_update_failed", {"error": str(exc)})
+
+    try:
+        if hasattr(observation, "end"):
+            observation.end()
+    except Exception as exc:
+        log.debug("langfuse.end_fallback_end_failed", {"error": str(exc)})
 
 
 def is_active() -> bool:

--- a/tests/observability/test_langfuse_observability.py
+++ b/tests/observability/test_langfuse_observability.py
@@ -27,6 +27,15 @@ class _FakeTraceClient:
         return _FakeObservation("trace", kwargs)
 
 
+class _NewSdkTraceClient:
+    def __init__(self):
+        self.start_observation_payload = None
+
+    def start_observation(self, **kwargs):
+        self.start_observation_payload = kwargs
+        return _TrackingObservation("trace", kwargs)
+
+
 class _FakeObservation:
     """Fake Langfuse observation with end/generation/span support."""
 
@@ -43,6 +52,41 @@ class _FakeObservation:
 
     def end(self, **kwargs):
         self.end_payload = kwargs
+
+
+class _TrackingSpan:
+    def __init__(self) -> None:
+        self.attributes = {}
+
+    def is_recording(self):
+        return True
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+class _TrackingObservation(_FakeObservation):
+    def __init__(self, kind: str, payload: dict):
+        super().__init__(kind, payload)
+        self._otel_span = _TrackingSpan()
+
+    def generation(self, **kwargs):
+        return _TrackingObservation("generation", kwargs)
+
+    def span(self, **kwargs):
+        return _TrackingObservation("span", kwargs)
+
+
+class _NewSdkLikeObservation:
+    def __init__(self) -> None:
+        self.update_payload = None
+        self.end_calls = 0
+
+    def update(self, **kwargs):
+        self.update_payload = kwargs
+
+    def end(self):
+        self.end_calls += 1
 
 
 def test_create_span_uses_current_observation(monkeypatch):
@@ -90,6 +134,55 @@ def test_create_trace_forwards_tags(monkeypatch):
     assert obs.kind == "trace"
     assert client.trace_payload is not None
     assert client.trace_payload["tags"] == ["session:s1", "step:2", "session_step:s1:2"]
+
+
+def test_create_trace_uses_start_observation_for_new_sdk(monkeypatch):
+    client = _NewSdkTraceClient()
+    monkeypatch.setattr(lf, "_get_client", lambda: client)
+
+    obs = lf.create_trace(
+        name="SessionRunner.step",
+        session_id="s1",
+        user_id="u1",
+        tags=["session:s1", "step:2"],
+        input={"step": 2},
+        metadata={"provider_id": "openai"},
+    )
+
+    assert obs.kind == "trace"
+    assert client.start_observation_payload is not None
+    assert client.start_observation_payload["as_type"] == "span"
+    assert client.start_observation_payload["input"] == {"step": 2}
+    assert client.start_observation_payload["metadata"]["provider_id"] == "openai"
+    assert client.start_observation_payload["metadata"]["session_id"] == "s1"
+    assert client.start_observation_payload["metadata"]["user_id"] == "u1"
+    assert client.start_observation_payload["metadata"]["tags"] == ["session:s1", "step:2"]
+    assert obs._otel_span.attributes["langfuse.trace.name"] == "SessionRunner.step"
+    assert obs._otel_span.attributes["session.id"] == "s1"
+    assert obs._otel_span.attributes["user.id"] == "u1"
+    assert obs._otel_span.attributes["langfuse.trace.tags"] == ["session:s1", "step:2"]
+
+
+def test_generation_and_span_inherit_trace_dimensions_from_parent(monkeypatch):
+    monkeypatch.setattr(lf, "_get_client", lambda: object())
+
+    parent = _TrackingObservation("trace", {"name": "trace"})
+    parent._otel_span.attributes["langfuse.trace.name"] = "SessionRunner.step"
+    parent._otel_span.attributes["session.id"] = "s1"
+    parent._otel_span.attributes["user.id"] = "u1"
+    parent._otel_span.attributes["langfuse.trace.tags"] = ["session:s1", "step:2"]
+
+    gen = lf.create_generation(parent=parent, name="LLM.generate", model="gpt-5", input={"x": 1})
+    span = lf.create_span(parent=parent, name="Tool.execute.read", input={"path": "/tmp/a"})
+
+    assert gen._otel_span.attributes["langfuse.trace.name"] == "SessionRunner.step"
+    assert gen._otel_span.attributes["session.id"] == "s1"
+    assert gen._otel_span.attributes["user.id"] == "u1"
+    assert gen._otel_span.attributes["langfuse.trace.tags"] == ["session:s1", "step:2"]
+    assert span._otel_span.attributes["langfuse.trace.name"] == "SessionRunner.step"
+    assert span._otel_span.attributes["session.id"] == "s1"
+    assert span._otel_span.attributes["user.id"] == "u1"
+    assert span._otel_span.attributes["langfuse.trace.tags"] == ["session:s1", "step:2"]
 
 
 def test_initialize_supports_langfuse_base_url(monkeypatch):
@@ -156,6 +249,29 @@ def test_end_observation_passes_usage(monkeypatch):
     assert gen_obs.end_payload.get("output") == "result"
 
 
+def test_end_observation_updates_before_end_for_new_sdk():
+    """Langfuse v4-style observations require update(...), then end()."""
+    obs = _NewSdkLikeObservation()
+    usage = {"prompt_tokens": 100, "completion_tokens": 50}
+
+    lf.end_observation(
+        obs,
+        output={"content": "result"},
+        metadata={"status": "ok"},
+        usage=usage,
+        level="ERROR",
+        status_message="done",
+    )
+
+    assert obs.update_payload is not None
+    assert obs.update_payload["output"] == {"content": "result"}
+    assert obs.update_payload["metadata"] == {"status": "ok"}
+    assert obs.update_payload["usage_details"] == usage
+    assert obs.update_payload["level"] == "ERROR"
+    assert obs.update_payload["status_message"] == "done"
+    assert obs.end_calls == 1
+
+
 def test_scope_end_is_idempotent():
     """Calling end() twice on a scope should not raise."""
     noop = lf._NoopObservation("test")
@@ -164,11 +280,21 @@ def test_scope_end_is_idempotent():
     scope.end(output="second")
 
 
-def test_sanitize_truncates_long_strings():
+def test_sanitize_keeps_full_strings_in_full_mode(monkeypatch):
     long_str = "a" * 10000
+    monkeypatch.setenv("FLOCKS_LANGFUSE_CAPTURE_MODE", "full")
+    result = lf._sanitize_payload(long_str)
+    assert result == long_str
+
+
+def test_sanitize_truncates_long_strings_in_truncated_mode(monkeypatch):
+    long_str = "a" * 10000
+    monkeypatch.setenv("FLOCKS_LANGFUSE_CAPTURE_MODE", "truncated")
+    monkeypatch.setenv("FLOCKS_LANGFUSE_MAX_CHARS", "128")
     result = lf._sanitize_payload(long_str)
     assert len(result) < 10000
     assert "truncated" in result
+    assert result.startswith("a" * 128)
 
 
 def test_observation_scope_exception_handling():

--- a/tests/session/test_runner_langfuse_payloads.py
+++ b/tests/session/test_runner_langfuse_payloads.py
@@ -1,0 +1,81 @@
+from flocks.provider.provider import ChatMessage
+from flocks.session.runner import SessionRunner, ToolCall
+
+
+def test_build_langfuse_request_payload_keeps_full_messages_and_system_prompt() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+    messages = [
+        ChatMessage(role="system", content="system prompt"),
+        ChatMessage(role="user", content="user question"),
+        ChatMessage(
+            role="assistant",
+            content="calling tool",
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": "{\"path\":\"/tmp/demo.txt\"}",
+                    },
+                }
+            ],
+        ),
+    ]
+
+    payload = SessionRunner._build_langfuse_request_payload(
+        step=3,
+        messages=messages,
+        request_tools=tools,
+        available_tools=tools,
+        provider_options={"temperature": 0.1, "max_tokens": 1024},
+    )
+
+    assert payload["step"] == 3
+    assert payload["messages"][0]["role"] == "system"
+    assert payload["messages"][0]["content"] == "system prompt"
+    assert payload["messages"][1]["content"] == "user question"
+    assert payload["messages"][2]["tool_calls"][0]["function"]["arguments"] == "{\"path\":\"/tmp/demo.txt\"}"
+    assert payload["request_tools"] == tools
+    assert payload["available_tools"] == tools
+    assert payload["provider_options"] == {"temperature": 0.1, "max_tokens": 1024}
+
+
+def test_build_langfuse_response_payload_keeps_full_content_reasoning_and_tool_arguments() -> None:
+    full_content = "assistant output " * 80
+    full_reasoning = "reasoning output " * 60
+    tool_calls = [
+        ToolCall(
+            id="call_1",
+            name="read_file",
+            arguments={"path": "/tmp/demo.txt", "offset": 1, "limit": 1000},
+        )
+    ]
+
+    payload = SessionRunner._build_langfuse_response_payload(
+        action="continue",
+        content=full_content,
+        reasoning=full_reasoning,
+        finish_reason="tool_calls",
+        tool_calls=tool_calls,
+    )
+
+    assert payload["action"] == "continue"
+    assert payload["content"] == full_content
+    assert payload["reasoning"] == full_reasoning
+    assert payload["finish_reason"] == "tool_calls"
+    assert payload["tool_calls"] == [
+        {
+            "id": "call_1",
+            "name": "read_file",
+            "arguments": {"path": "/tmp/demo.txt", "offset": 1, "limit": 1000},
+        }
+    ]

--- a/tests/session/test_stream_processor.py
+++ b/tests/session/test_stream_processor.py
@@ -372,6 +372,68 @@ class TestToolCallExecution:
         callback.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_tool_span_records_full_output(self):
+        proc = _make_processor()
+        proc._langfuse_generation = object()
+        long_output = "tool output " * 120
+        span_ctx = MagicMock()
+
+        successful_result = ToolResult(
+            success=True,
+            output=long_output,
+            title="bash",
+            metadata={},
+        )
+
+        with (
+            patch("flocks.session.streaming.stream_processor.Message.store_part", new=AsyncMock()),
+            patch("flocks.session.streaming.stream_processor.Message.update_part", new=AsyncMock()),
+            patch(
+                "flocks.session.streaming.stream_processor.ToolRegistry.execute",
+                new=AsyncMock(return_value=successful_result),
+            ),
+            patch("flocks.session.streaming.stream_processor.span_scope", return_value=span_ctx),
+        ):
+            await proc.process_event(ToolInputStartEvent(id="tc_span_output", tool_name="bash"))
+            await proc.process_event(
+                ToolCallEvent(tool_call_id="tc_span_output", tool_name="bash", input={"command": "ls -la"})
+            )
+
+        assert span_ctx.end.call_count == 1
+        assert span_ctx.end.call_args.kwargs["output"] == long_output
+
+    @pytest.mark.asyncio
+    async def test_tool_span_records_full_error(self):
+        proc = _make_processor()
+        proc._langfuse_generation = object()
+        long_error = "tool error " * 120
+        span_ctx = MagicMock()
+
+        failed_result = ToolResult(
+            success=False,
+            error=long_error,
+            metadata={},
+        )
+
+        with (
+            patch("flocks.session.streaming.stream_processor.Message.store_part", new=AsyncMock()),
+            patch("flocks.session.streaming.stream_processor.Message.update_part", new=AsyncMock()),
+            patch(
+                "flocks.session.streaming.stream_processor.ToolRegistry.execute",
+                new=AsyncMock(return_value=failed_result),
+            ),
+            patch("flocks.session.streaming.stream_processor.span_scope", return_value=span_ctx),
+        ):
+            await proc.process_event(ToolInputStartEvent(id="tc_span_error", tool_name="bash"))
+            await proc.process_event(
+                ToolCallEvent(tool_call_id="tc_span_error", tool_name="bash", input={"command": "false"})
+            )
+
+        assert span_ctx.end.call_count == 1
+        assert span_ctx.end.call_args.kwargs["output"] == long_error
+        assert span_ctx.end.call_args.kwargs["level"] == "ERROR"
+
+    @pytest.mark.asyncio
     async def test_tool_error_falls_back_to_metadata_output(self):
         event_callback = AsyncMock()
         proc = _make_processor(event_callback=event_callback)


### PR DESCRIPTION
Use the OTEL-based Langfuse observation flow so session traces actually reach Langfuse again, and record full model/tool inputs and outputs for later debugging and analysis.