### PR TITLE
feat(tools): raise read tool and truncation limits

### DIFF
--- a/flocks/tool/file/read.py
+++ b/flocks/tool/file/read.py
@@ -24,10 +24,10 @@ from flocks.utils.id import Identifier
 
 log = Log.create(service="tool.read")
 
-# Constants — keep output within the 10 K-char tool result budget
-DEFAULT_READ_LIMIT = 200
-MAX_LINE_LENGTH = 500
-MAX_BYTES = 8 * 1024  # 8 KB
+# Constants — keep file reads paginated while allowing larger local context.
+DEFAULT_READ_LIMIT = 2000
+MAX_LINE_LENGTH = 2000
+MAX_BYTES = 20 * 1024  # 20 KB
 
 # Binary file extensions
 BINARY_EXTENSIONS = {
@@ -47,9 +47,9 @@ Assume this tool is able to read all files on the machine. If the User provides 
 
 Usage:
 - The filePath parameter must be an absolute path, not a relative path
-- By default, it reads up to 200 lines starting from the beginning of the file
-- For files longer than 200 lines, you MUST use offset and limit to read in segments (e.g. offset=0 limit=200, then offset=200 limit=200, etc.)
-- Any lines longer than 500 characters will be truncated
+- By default, it reads up to 2000 lines starting from the beginning of the file
+- For files longer than 2000 lines, you MUST use offset and limit to read in segments (e.g. offset=0 limit=2000, then offset=2000 limit=2000, etc.)
+- Any lines longer than 2000 characters will be truncated
 - Results are returned using cat -n format, with line numbers starting at 1
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.
@@ -194,7 +194,7 @@ async def _resolve_sandbox_file_path(ctx: ToolContext, filepath: str) -> tuple[O
         ToolParameter(
             name="limit",
             type=ParameterType.INTEGER,
-            description="The number of lines to read (defaults to 200)",
+            description="The number of lines to read (defaults to 2000)",
             required=False,
             default=DEFAULT_READ_LIMIT
         ),

--- a/flocks/tool/system/skill.py
+++ b/flocks/tool/system/skill.py
@@ -173,7 +173,7 @@ async def skill_tool_impl(
     # already handled it") to leave our payload alone. The `skill` tool is the
     # *load-on-demand* counterpart of the tiny preview that ships in the system
     # prompt -- if the model just decided to load this skill, it needs the
-    # FULL SKILL.md to act on. Cropping it at 10 KB / 200 lines (the
+    # FULL SKILL.md to act on. Cropping it at 100 KB / 1000 lines (the
     # registry's defaults) silently drops the workflow steps, references, and
     # constraints that authors typically place at the *end* of the file, which
     # is the exact bug users were hitting (skill.md tail "感觉就完全丢失了").

--- a/flocks/tool/truncation.py
+++ b/flocks/tool/truncation.py
@@ -27,11 +27,11 @@ from flocks.workspace.manager import WorkspaceManager
 
 log = Log.create(service="tool.truncation")
 
-MAX_LINES = 200
-MAX_BYTES = 10 * 1024  # 10 KB
+MAX_LINES = 1000
+MAX_BYTES = 100 * 1024  # 100 KB
 
 MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3
-HARD_MAX_TOOL_RESULT_CHARS = 10_000
+HARD_MAX_TOOL_RESULT_CHARS = 100_000
 MIN_KEEP_CHARS = 1_000
 
 _OUTPUT_DIR: Optional[Path] = None

--- a/tests/tool/test_read_tool_limits.py
+++ b/tests/tool/test_read_tool_limits.py
@@ -1,0 +1,69 @@
+"""Tests for read tool pagination and truncation limits."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from flocks.tool.file import read as read_tool_module
+from flocks.tool.registry import ToolContext, ToolRegistry
+
+
+@pytest.fixture
+def tool_context() -> ToolContext:
+    return ToolContext(
+        session_id="test-read-limits-session",
+        message_id="test-read-limits-message",
+        agent="test",
+    )
+
+
+def test_read_tool_limit_constants():
+    assert read_tool_module.DEFAULT_READ_LIMIT == 2000
+    assert read_tool_module.MAX_LINE_LENGTH == 2000
+    assert read_tool_module.MAX_BYTES == 20 * 1024
+
+
+@pytest.mark.asyncio
+async def test_default_read_limit_is_2000_lines(tool_context, tmp_path):
+    file_path = tmp_path / "many-lines.txt"
+    file_path.write_text(
+        "\n".join(f"line {i}" for i in range(1, 2002)),
+        encoding="utf-8",
+    )
+
+    result = await ToolRegistry.execute("read", ctx=tool_context, filePath=str(file_path))
+
+    assert result.success is True
+    assert "02000| line 2000" in result.output
+    assert "02001| line 2001" not in result.output
+    assert "To continue reading, call read with offset=2000" in result.output
+
+
+@pytest.mark.asyncio
+async def test_long_lines_are_truncated_at_2000_characters(tool_context, tmp_path):
+    file_path = tmp_path / "long-line.txt"
+    file_path.write_text("a" * 2001, encoding="utf-8")
+
+    result = await ToolRegistry.execute("read", ctx=tool_context, filePath=str(file_path))
+
+    assert result.success is True
+    assert ("a" * 2000) + "..." in result.output
+    assert ("a" * 2001) not in result.output
+
+
+@pytest.mark.asyncio
+async def test_byte_limit_truncation_prompts_offset_continue(tool_context, tmp_path):
+    file_path = tmp_path / "wide-lines.txt"
+    file_path.write_text(
+        "\n".join("x" * 100 for _ in range(300)),
+        encoding="utf-8",
+    )
+
+    result = await ToolRegistry.execute("read", ctx=tool_context, filePath=str(file_path))
+
+    assert result.success is True
+    assert result.truncated is True
+    assert f"Output truncated at {read_tool_module.MAX_BYTES} bytes" in result.output
+    assert "To continue reading, call read with offset=" in result.output

--- a/tests/tool/test_skill_tool_description.py
+++ b/tests/tool/test_skill_tool_description.py
@@ -14,7 +14,7 @@ are exercised here:
    the FULL SKILL.md must come back unredacted. This is the load-on-demand
    counterpart of the truncated preview, mirroring hermes-agent's
    ``skill_view``. Without the explicit opt-out the registry would silently
-   crop SKILL.md at 10 KB / 200 lines (head-only), dropping the workflow
+   crop SKILL.md at 100 KB / 1000 lines (head-only), dropping the workflow
    steps and references that authors put at the file's tail.
 """
 
@@ -35,6 +35,8 @@ from flocks.tool.system.skill import (
     build_description,
     skill_tool_impl,
 )
+from flocks.tool.truncation import MAX_BYTES as REGISTRY_MAX_BYTES
+from flocks.tool.truncation import MAX_LINES as REGISTRY_MAX_LINES
 
 
 def _skill(name: str, description: str) -> SkillInfo:
@@ -163,7 +165,7 @@ class TestBuildDescription:
 @pytest.fixture
 def fake_skill_dir():
     """Create a temp directory with a SKILL.md that exceeds default truncation
-    limits (>10 KB AND >200 lines) so we can prove the registry's auto-truncate
+    limits so we can prove the registry's auto-truncate
     pass leaves it alone.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -171,14 +173,15 @@ def fake_skill_dir():
         skill_dir.mkdir()
 
         body_lines = [
-            f"## Step {i}: do something important and clearly identifiable" for i in range(1, 401)
+            f"## Step {i}: do something important and clearly identifiable"
+            for i in range(1, REGISTRY_MAX_LINES + 201)
         ]
         # Tail sentinel proves we kept the END of the file (where authors
         # typically put the operational steps and references).
         body_lines.append("# TAIL_SENTINEL: this line MUST survive end-to-end")
         body = "\n".join(body_lines)
-        # Pad with extra bytes so total comfortably exceeds the 10 KB cap.
-        padding = "x" * (15 * 1024)
+        # Pad with extra bytes so total comfortably exceeds the byte cap.
+        padding = "x" * (REGISTRY_MAX_BYTES + 1024)
 
         (skill_dir / "SKILL.md").write_text(
             f"""---
@@ -206,8 +209,8 @@ class TestSkillLoadNoTruncation:
         original = skill_md.read_text(encoding="utf-8")
         # Sanity-check the fixture: it MUST exceed the registry defaults,
         # otherwise the test isn't actually exercising the bypass.
-        assert len(original.encode("utf-8")) > 10 * 1024
-        assert original.count("\n") > 200
+        assert len(original.encode("utf-8")) > REGISTRY_MAX_BYTES
+        assert original.count("\n") > REGISTRY_MAX_LINES
 
         skill_info = SkillInfo(
             name="huge-skill",

--- a/tests/tool/test_truncation.py
+++ b/tests/tool/test_truncation.py
@@ -1,0 +1,32 @@
+"""Tests for central tool output truncation limits."""
+
+from __future__ import annotations
+
+from flocks.tool import truncation
+
+
+def test_default_limits_are_1000_lines_and_100kb():
+    assert truncation.MAX_LINES == 1000
+    assert truncation.MAX_BYTES == 100 * 1024
+    assert truncation.HARD_MAX_TOOL_RESULT_CHARS == 100_000
+
+
+def test_output_at_default_line_limit_is_not_truncated():
+    text = "\n".join(f"line {i}" for i in range(truncation.MAX_LINES))
+
+    result = truncation.truncate_output(text)
+
+    assert result.truncated is False
+    assert result.content == text
+
+
+def test_output_over_default_byte_limit_is_truncated(monkeypatch, tmp_path):
+    monkeypatch.setattr(truncation, "_ensure_output_dir", lambda: tmp_path)
+    monkeypatch.setattr(truncation, "_maybe_cleanup", lambda _output_dir: None)
+    text = "x" * (truncation.MAX_BYTES + 1)
+
+    result = truncation.truncate_output(text)
+
+    assert result.truncated is True
+    assert result.output_path is not None
+    assert "bytes truncated" in result.content


### PR DESCRIPTION
- Increase file read defaults: 2000 lines, 2000 chars/line, 20 KB cap
- Raise registry truncation: 1000 lines, 100 KB, 100k hard max chars
- Add tests for read limits and truncation constants
- Align skill tool tests with registry defaults

Made-with: Cursor
