### PR TITLE
fix(cli): align session import with runtime message storage

### DIFF
--- a/flocks/cli/commands/import_.py
+++ b/flocks/cli/commands/import_.py
@@ -10,13 +10,11 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 from rich.console import Console
 
-from flocks.session.session import SessionInfo
-from flocks.session.message import MessageInfo, MessagePart
 from flocks.project.project import Project
 from flocks.storage.storage import Storage
 
@@ -31,6 +29,124 @@ console = Console()
 
 # Pattern for share URLs
 SHARE_URL_PATTERN = re.compile(r"https?://(?:opncd\.ai|flocks\.ai)/share/([a-zA-Z0-9_-]+)")
+
+
+def _default_part_time(message_time: Optional[dict[str, Any]] = None) -> dict[str, int | None]:
+    """Provide best-effort timestamps for legacy imported parts."""
+    time_info = message_time if isinstance(message_time, dict) else {}
+    start = time_info.get("created") or time_info.get("start") or 0
+    end = time_info.get("updated") or time_info.get("completed") or time_info.get("end")
+    if end is None and start:
+        end = start
+    return {"start": int(start), "end": int(end) if end is not None else None}
+
+
+def _normalize_tool_state(
+    raw_state: Any,
+    *,
+    message_time: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Convert legacy tool state payloads to the current shape."""
+    fallback_time = _default_part_time(message_time)
+    if isinstance(raw_state, dict):
+        normalized = dict(raw_state)
+    else:
+        normalized = {}
+        if isinstance(raw_state, str):
+            normalized["status"] = raw_state
+
+    status = normalized.get("status")
+    if status not in {"pending", "running", "completed", "error"}:
+        if "output" in normalized:
+            status = "completed"
+        elif "error" in normalized:
+            status = "error"
+        elif "time" in normalized:
+            status = "running"
+        else:
+            status = "pending"
+    normalized["status"] = status
+
+    if status == "pending":
+        normalized.setdefault("input", {})
+        normalized.setdefault("raw", "")
+    elif status == "running":
+        normalized.setdefault("input", {})
+        normalized.setdefault("time", fallback_time)
+    elif status == "completed":
+        normalized.setdefault("input", {})
+        normalized.setdefault("output", "")
+        normalized.setdefault("title", "")
+        normalized.setdefault("metadata", {})
+        normalized.setdefault("time", fallback_time)
+    elif status == "error":
+        normalized.setdefault("input", {})
+        normalized.setdefault("error", "")
+        normalized.setdefault("time", fallback_time)
+
+    return normalized
+
+
+def _normalize_part_data(
+    part_data: dict[str, Any],
+    *,
+    message_time: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Normalize legacy/exported part payloads before persisting."""
+    normalized = dict(part_data)
+    part_type = normalized.get("type", "text")
+    metadata = normalized.get("metadata")
+    metadata_dict = metadata if isinstance(metadata, dict) else {}
+
+    if "content" in normalized and "text" not in normalized:
+        normalized["text"] = normalized.get("content", "")
+
+    if part_type == "text":
+        normalized.setdefault("text", "")
+    elif part_type == "reasoning":
+        normalized.setdefault("text", normalized.get("content", ""))
+        normalized.setdefault("metadata", metadata_dict or None)
+        normalized.setdefault("time", _default_part_time(message_time))
+    elif part_type == "tool":
+        normalized.setdefault("callID", metadata_dict.get("callID") or normalized.get("id", ""))
+        normalized.setdefault("tool", metadata_dict.get("tool") or normalized.get("tool", "unknown"))
+        raw_state = normalized.get("state")
+        if raw_state is None and metadata_dict:
+            raw_state = metadata_dict.get("state")
+        normalized["state"] = _normalize_tool_state(raw_state, message_time=message_time)
+        normalized.setdefault("metadata", metadata_dict or None)
+    elif part_type == "file":
+        normalized.setdefault("mime", metadata_dict.get("mime") or "application/octet-stream")
+        normalized.setdefault("filename", metadata_dict.get("filename"))
+        normalized.setdefault("url", metadata_dict.get("url") or normalized.get("content", ""))
+    elif part_type == "snapshot":
+        normalized.setdefault("snapshot", metadata_dict.get("snapshot") or normalized.get("content", ""))
+    elif part_type == "patch":
+        normalized.setdefault("hash", metadata_dict.get("hash") or "")
+        normalized.setdefault("files", metadata_dict.get("files") or [])
+    elif part_type == "step-finish":
+        normalized.setdefault("reason", metadata_dict.get("reason") or "completed")
+        normalized.setdefault("snapshot", metadata_dict.get("snapshot"))
+        normalized.setdefault("cost", metadata_dict.get("cost") or 0.0)
+        normalized.setdefault(
+            "tokens",
+            metadata_dict.get("tokens")
+            or {"input": 0, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+        )
+    elif part_type == "agent":
+        normalized.setdefault("name", metadata_dict.get("name") or normalized.get("content") or "agent")
+    elif part_type == "subtask":
+        normalized.setdefault("prompt", metadata_dict.get("prompt") or normalized.get("content", ""))
+        normalized.setdefault("description", metadata_dict.get("description") or "")
+        normalized.setdefault("agent", metadata_dict.get("agent") or "agent")
+    elif part_type == "retry":
+        normalized.setdefault("attempt", metadata_dict.get("attempt") or 1)
+        normalized.setdefault("error", metadata_dict.get("error") or {})
+        normalized.setdefault("time", metadata_dict.get("time") or _default_part_time(message_time))
+    elif part_type == "compaction":
+        normalized.setdefault("auto", bool(metadata_dict.get("auto", False)))
+
+    return normalized
 
 
 @import_app.callback(invoke_without_command=True)
@@ -159,22 +275,28 @@ async def _import_session(file_or_url: str, project_id: Optional[str]):
         session_key = f"session:{project_id}:{session_info['id']}"
         await Storage.set(session_key, session_info, "session")
         
-        # Store messages
+        # Store messages using the runtime's aggregated storage format.
+        # WebUI/back-end reads `message:<session_id>` and
+        # `message_parts:<session_id>` instead of legacy per-message keys.
         message_count = 0
+        serialized_messages = []
+        serialized_parts = {}
         for msg_data in export_data["messages"]:
             msg_info = msg_data.get("info", {})
             parts = msg_data.get("parts", [])
-            
-            # Store message
-            msg_key = f"message:{session_info['id']}:{msg_info['id']}"
-            await Storage.set(msg_key, msg_info, "message")
-            
-            # Store parts
-            for part in parts:
-                part_key = f"part:{msg_info['id']}:{part['id']}"
-                await Storage.set(part_key, part, "part")
-            
+
+            serialized_messages.append(msg_info)
+            if "id" in msg_info:
+                serialized_parts[msg_info["id"]] = [
+                    _normalize_part_data(part, message_time=msg_info.get("time"))
+                    for part in parts
+                ]
+
             message_count += 1
+
+        session_id = session_info["id"]
+        await Storage.set(f"message:{session_id}", serialized_messages, "message")
+        await Storage.set(f"message_parts:{session_id}", serialized_parts, "message_parts")
         
         console.print(f"[green]Imported session: {session_info['id']}[/green]")
         console.print(f"  Title: {session_info.get('title', 'Untitled')}")

--- a/tests/cli/test_export_import.py
+++ b/tests/cli/test_export_import.py
@@ -6,7 +6,7 @@ from typer.testing import CliRunner
 import flocks.cli.commands.export as export_cmd
 import flocks.cli.commands.import_ as import_cmd
 import flocks.mcp.server as mcp_server
-from flocks.session.message import MessageWithParts, TextPart, UserMessageInfo
+from flocks.session.message import Message, MessageWithParts, TextPart, UserMessageInfo
 from flocks.session.session import SessionInfo, SessionTime
 
 if not hasattr(mcp_server, "get_manager"):
@@ -98,8 +98,107 @@ def test_export_and_import_round_trip(monkeypatch, tmp_path) -> None:
 
     stored = {key: (value, category) for key, value, category in stored_entries}
     assert stored["session:proj_imported:ses_export_test"][0]["projectID"] == "proj_imported"
-    assert stored["message:ses_export_test:msg_export_test"][0]["id"] == "msg_export_test"
-    assert stored["part:msg_export_test:part_export_test"][0]["text"] == "hello export"
+    assert stored["message:ses_export_test"][0][0]["id"] == "msg_export_test"
+    assert stored["message_parts:ses_export_test"][0]["msg_export_test"][0]["text"] == "hello export"
+
+
+@pytest.mark.asyncio
+async def test_import_writes_messages_in_runtime_storage_format(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
+
+    session = _build_session()
+    message = _build_message_with_parts(session.id)
+    payload = {
+        "info": session.model_dump(by_alias=True),
+        "messages": [
+            {
+                "info": message.info.model_dump(by_alias=True),
+                "parts": [part.model_dump() for part in message.parts],
+            }
+        ],
+    }
+    input_path = tmp_path / "session-import.json"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    await import_cmd._import_session(str(input_path), "proj_imported")
+
+    Message.invalidate_cache(session.id)
+    imported = await Message.list_with_parts(session.id)
+
+    assert len(imported) == 1
+    assert imported[0].info.id == "msg_export_test"
+    assert len(imported[0].parts) == 1
+    assert imported[0].parts[0].id == "part_export_test"
+    assert imported[0].parts[0].text == "hello export"
+
+
+@pytest.mark.asyncio
+async def test_import_normalizes_legacy_reasoning_parts(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
+
+    session = _build_session()
+    payload = {
+        "info": session.model_dump(by_alias=True),
+        "messages": [
+            {
+                "info": {
+                    "id": "msg_user",
+                    "sessionID": session.id,
+                    "role": "user",
+                    "time": {"created": 1},
+                    "agent": "rex",
+                    "model": {"providerID": "anthropic", "modelID": "claude-sonnet"},
+                },
+                "parts": [
+                    {
+                        "id": "part_user",
+                        "sessionID": session.id,
+                        "messageID": "msg_user",
+                        "type": "text",
+                        "text": "hello",
+                    }
+                ],
+            },
+            {
+                "info": {
+                    "id": "msg_assistant",
+                    "sessionID": session.id,
+                    "role": "assistant",
+                    "time": {"created": 2, "updated": 3},
+                    "parentID": "msg_user",
+                    "modelID": "claude-sonnet",
+                    "providerID": "anthropic",
+                    "mode": "rex",
+                    "agent": "rex",
+                    "path": {"cwd": "./", "root": ""},
+                    "tokens": {"input": 0, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+                },
+                "parts": [
+                    {
+                        "id": "part_reasoning",
+                        "sessionID": session.id,
+                        "messageID": "msg_assistant",
+                        "type": "reasoning",
+                        "text": "thinking",
+                        "metadata": {},
+                    }
+                ],
+            },
+        ],
+    }
+    input_path = tmp_path / "legacy-session-import.json"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    await import_cmd._import_session(str(input_path), "proj_imported")
+
+    Message.invalidate_cache(session.id)
+    imported = await Message.list_with_parts(session.id, include_archived=True)
+
+    assert len(imported) == 2
+    assert imported[1].parts[0].type == "reasoning"
+    assert imported[1].parts[0].text == "thinking"
+    assert imported[1].parts[0].time.start == 2
+    assert imported[1].parts[0].time.end == 3
 
 
 def test_export_help_does_not_show_project_option() -> None:


### PR DESCRIPTION
## Summary
Session import now writes the same aggregated keys the runtime and WebUI expect (`message:<session_id>`, `message_parts:<session_id>`) instead of legacy per-message keys.

## Changes
- Normalize legacy/exported part payloads (tool `state`, reasoning timestamps, etc.) before persistence.
- Update round-trip tests and add coverage for aggregated storage and legacy reasoning parts.

## Testing
`uv run pytest tests/cli/test_export_import.py -q` — all passed.

Made with [Cursor](https://cursor.com)