### PR TITLE
fix(cli): reuse runtime host/port on restart; harden Windows PID checks

### DIFF
--- a/flocks/cli/main.py
+++ b/flocks/cli/main.py
@@ -30,8 +30,10 @@ from flocks.cli.commands.update import update_command
 from flocks.cli.service_manager import (
     ServiceConfig,
     ServiceError,
+    read_runtime_record,
     resolve_flocks_cli_command,
     restart_all,
+    runtime_paths,
     show_logs,
     show_status,
     start_all,
@@ -121,6 +123,10 @@ def _service_config(
     server_port: Optional[int] = None,
     webui_host: Optional[str] = None,
     webui_port: Optional[int] = None,
+    default_server_host: Optional[str] = None,
+    default_server_port: Optional[int] = None,
+    default_webui_host: Optional[str] = None,
+    default_webui_port: Optional[int] = None,
 ) -> ServiceConfig:
     """Build service config from environment and CLI toggles."""
     global_config = Config.get_global()
@@ -128,23 +134,23 @@ def _service_config(
         backend_host=_resolve_host(
             cli_value=server_host,
             env_names=("FLOCKS_SERVER_HOST", "FLOCKS_BACKEND_HOST"),
-            default=global_config.server_host,
+            default=default_server_host or global_config.server_host,
         ),
         backend_port=_resolve_port(
             cli_value=server_port,
             env_names=("FLOCKS_SERVER_PORT", "FLOCKS_BACKEND_PORT"),
-            default=global_config.server_port,
+            default=default_server_port or global_config.server_port,
             label="server",
         ),
         frontend_host=_resolve_host(
             cli_value=webui_host,
             env_names=("FLOCKS_WEBUI_HOST", "FLOCKS_FRONTEND_HOST"),
-            default="127.0.0.1",
+            default=default_webui_host or "127.0.0.1",
         ),
         frontend_port=_resolve_port(
             cli_value=webui_port,
             env_names=("FLOCKS_WEBUI_PORT", "FLOCKS_FRONTEND_PORT"),
-            default=5173,
+            default=default_webui_port or 5173,
             label="webui",
         ),
         no_browser=no_browser,
@@ -181,6 +187,45 @@ def _resolve_port(
         except ValueError as error:
             raise ServiceError(f"{label} port from {env_name} must be an integer.") from error
     return default
+
+
+def _restart_runtime_defaults() -> dict[str, Any]:
+    """Load host/port defaults from the last recorded service runtime."""
+    paths = runtime_paths()
+    backend = read_runtime_record(paths.backend_pid)
+    frontend = read_runtime_record(paths.frontend_pid)
+    defaults: dict[str, Any] = {}
+    if backend is not None:
+        if backend.host:
+            defaults["default_server_host"] = backend.host
+        if backend.port is not None:
+            defaults["default_server_port"] = backend.port
+    if frontend is not None:
+        if frontend.host:
+            defaults["default_webui_host"] = frontend.host
+        if frontend.port is not None:
+            defaults["default_webui_port"] = frontend.port
+    return defaults
+
+
+def _restart_service_config(
+    no_browser: bool = False,
+    skip_webui_build: bool = False,
+    server_host: Optional[str] = None,
+    server_port: Optional[int] = None,
+    webui_host: Optional[str] = None,
+    webui_port: Optional[int] = None,
+) -> ServiceConfig:
+    """Build restart config, reusing recorded host/port when CLI/env omit them."""
+    return _service_config(
+        no_browser=no_browser,
+        skip_webui_build=skip_webui_build,
+        server_host=server_host,
+        server_port=server_port,
+        webui_host=webui_host,
+        webui_port=webui_port,
+        **_restart_runtime_defaults(),
+    )
 
 
 def _handle_service_error(error: Exception) -> None:
@@ -250,7 +295,7 @@ def restart(
     """
     try:
         restart_all(
-            _service_config(
+            _restart_service_config(
                 no_browser=no_browser,
                 skip_webui_build=skip_webui_build,
                 server_host=server_host,

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -500,6 +500,142 @@ def pid_is_running(pid: int | None) -> bool:
     return True
 
 
+def _windows_tasklist_process_name(pid: int) -> str | None:
+    """Return the Windows image name for a pid via tasklist when possible."""
+    if sys.platform != "win32" or pid <= 0:
+        return None
+    completed = subprocess.run(
+        ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    line = completed.stdout.strip()
+    if not line or line.startswith("INFO:"):
+        return None
+    with contextlib.suppress(Exception):
+        import csv
+
+        rows = list(csv.reader([line]))
+        if rows and rows[0]:
+            value = rows[0][0].strip()
+            return value or None
+    return None
+
+
+def _windows_process_snapshot(pid: int) -> dict[str, str] | None:
+    """Return lightweight process details for Windows pid identity checks."""
+    if sys.platform != "win32" or pid <= 0:
+        return None
+
+    powershell = which("powershell") or which("powershell.exe")
+    if powershell:
+        script = (
+            f'$p = Get-CimInstance Win32_Process -Filter "ProcessId = {pid}"; '
+            'if ($null -eq $p) { exit 1 }; '
+            '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; '
+            '[PSCustomObject]@{'
+            'Name = $p.Name; '
+            'CommandLine = $p.CommandLine; '
+            'ExecutablePath = $p.ExecutablePath'
+            '} | ConvertTo-Json -Compress'
+        )
+        completed = subprocess.run(
+            [powershell, "-NoProfile", "-Command", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode == 0:
+            with contextlib.suppress(json.JSONDecodeError):
+                payload = json.loads(completed.stdout.strip() or "{}")
+                if isinstance(payload, dict):
+                    return {
+                        "name": str(payload.get("Name") or ""),
+                        "command_line": str(payload.get("CommandLine") or ""),
+                        "executable_path": str(payload.get("ExecutablePath") or ""),
+                    }
+
+    name = _windows_tasklist_process_name(pid)
+    if name is None:
+        return None
+    return {"name": name, "command_line": "", "executable_path": ""}
+
+
+def _expected_windows_images(record: RuntimeRecord) -> set[str]:
+    """Return plausible Windows image names for a runtime record."""
+    if not record.command:
+        return set()
+
+    executable = Path(record.command[0]).name.lower()
+    result = {executable} if executable else set()
+    if executable.endswith((".cmd", ".bat")):
+        result.add("cmd.exe")
+    if executable.startswith("python"):
+        result.update({"python.exe", "python"})
+    if executable.startswith("npm"):
+        result.update({"cmd.exe", "node.exe", "npm.cmd", "npm.exe"})
+    return result
+
+
+def _windows_identity_clauses(record: RuntimeRecord) -> list[tuple[str, ...]]:
+    """Return command-line token clauses that strongly identify a service pid."""
+    payload = " ".join(record.command).lower()
+    clauses: list[tuple[str, ...]] = []
+    if "flocks.cli.main" in payload:
+        clauses.append(("flocks.cli.main", "serve"))
+    elif record.command and Path(record.command[0]).name.lower().startswith("flocks"):
+        clauses.append(("flocks", "serve"))
+
+    if record.command and Path(record.command[0]).name.lower().startswith("npm"):
+        clauses.append(("npm", "preview"))
+    return clauses
+
+
+def _windows_runtime_record_matches_pid(
+    record: RuntimeRecord,
+    pid: int,
+    listeners: Iterable[int] | None = None,
+) -> bool:
+    """Return True when a Windows pid still looks like the recorded service."""
+    if sys.platform != "win32":
+        return False
+    if pid <= 0 or not pid_is_running(pid):
+        return False
+
+    listener_set = set(listeners or [])
+    if listener_set and pid in listener_set:
+        return True
+    if not record.command:
+        return True
+
+    snapshot = _windows_process_snapshot(pid)
+    if snapshot is None:
+        # If Windows refuses to provide identity details, keep the record to
+        # avoid tearing down a healthy service based on incomplete evidence.
+        return True
+
+    name = snapshot.get("name", "").strip().lower()
+    command_line = snapshot.get("command_line", "").strip().lower()
+    executable_path = snapshot.get("executable_path", "").strip().lower()
+
+    expected_images = _expected_windows_images(record)
+    actual_image = Path(executable_path).name.lower() if executable_path else name
+    if actual_image and actual_image in expected_images:
+        return True
+
+    if command_line:
+        for clause in _windows_identity_clauses(record):
+            if all(token in command_line for token in clause):
+                return True
+
+    if not name and not command_line and not executable_path:
+        return True
+    return False
+
+
 def _process_group_member_pids(pgid: int) -> list[int]:
     """Return pids that belong to a Unix process group."""
     if sys.platform == "win32" or pgid <= 0:
@@ -554,6 +690,9 @@ def runtime_record_is_running(record: RuntimeRecord | None) -> bool:
     """Return True if the tracked pid or process group is still alive."""
     if record is None:
         return False
+    if sys.platform == "win32":
+        listeners = port_owner_pids(record.port) if record.port is not None else []
+        return _windows_runtime_record_matches_pid(record, record.pid, listeners)
     return pid_is_running(record.pid) or process_group_is_running(record.pgid)
 
 
@@ -952,6 +1091,16 @@ def stop_one(port: int, pid_file: Path, name: str, console) -> None:
     if tracked_pid is not None:
         target_pids = append_unique_pids(target_pids, collect_process_tree_pids(tracked_pid))
     target_pids = append_unique_pids(target_pids, listeners)
+    if sys.platform == "win32" and runtime_record is not None:
+        filtered_targets: list[int] = []
+        for pid in target_pids:
+            if pid in listeners:
+                filtered_targets = append_unique_pids(filtered_targets, [pid])
+                continue
+            if pid == runtime_record.pid and not _windows_runtime_record_matches_pid(runtime_record, pid, listeners):
+                continue
+            filtered_targets = append_unique_pids(filtered_targets, [pid])
+        target_pids = filtered_targets
 
     group_running = process_group_is_running(runtime_record.pgid if runtime_record else None)
     if not target_pids and not group_running:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -281,6 +281,36 @@ def test_cleanup_stale_pid_file_keeps_live_process_group(monkeypatch, tmp_path: 
     assert pid_file.exists()
 
 
+def test_cleanup_stale_pid_file_removes_reused_windows_pid(monkeypatch, tmp_path: Path) -> None:
+    pid_file = tmp_path / "backend.pid"
+    service_manager.write_runtime_record(
+        pid_file,
+        service_manager.RuntimeRecord(
+            pid=1232,
+            host="127.0.0.1",
+            port=8000,
+            command=("python.exe", "-m", "flocks.cli.main", "serve"),
+        ),
+    )
+
+    monkeypatch.setattr(service_manager.sys, "platform", "win32")
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
+    monkeypatch.setattr(service_manager, "pid_is_running", lambda pid: pid == 1232)
+    monkeypatch.setattr(
+        service_manager,
+        "_windows_process_snapshot",
+        lambda _pid: {
+            "name": "svchost.exe",
+            "command_line": r"C:\Windows\System32\svchost.exe -k netsvcs",
+            "executable_path": r"C:\Windows\System32\svchost.exe",
+        },
+    )
+
+    service_manager.cleanup_stale_pid_file(pid_file)
+
+    assert not pid_file.exists()
+
+
 def test_selected_log_paths_support_specific_targets(tmp_path: Path) -> None:
     paths = service_manager.RuntimePaths(
         root=tmp_path,
@@ -1315,6 +1345,44 @@ def test_stop_one_uses_taskkill_on_windows(monkeypatch, tmp_path: Path) -> None:
         ["taskkill", "/PID", "111", "/T", "/F"],
         ["taskkill", "/PID", "222", "/T", "/F"],
     ]
+
+
+def test_stop_one_skips_taskkill_for_reused_windows_pid(monkeypatch, tmp_path: Path) -> None:
+    pid_file = tmp_path / "backend.pid"
+    service_manager.write_runtime_record(
+        pid_file,
+        service_manager.RuntimeRecord(
+            pid=111,
+            host="127.0.0.1",
+            port=8000,
+            command=("python.exe", "-m", "flocks.cli.main", "serve"),
+        ),
+    )
+    console = DummyConsole()
+
+    monkeypatch.setattr(service_manager.sys, "platform", "win32")
+    monkeypatch.setattr(service_manager, "collect_process_tree_pids", lambda _pid: [111])
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
+    monkeypatch.setattr(service_manager, "pid_is_running", lambda pid: pid == 111)
+    monkeypatch.setattr(
+        service_manager,
+        "_windows_process_snapshot",
+        lambda _pid: {
+            "name": "svchost.exe",
+            "command_line": r"C:\Windows\System32\svchost.exe -k netsvcs",
+            "executable_path": r"C:\Windows\System32\svchost.exe",
+        },
+    )
+    monkeypatch.setattr(
+        service_manager.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("taskkill should not run")),
+    )
+
+    service_manager.stop_one(8000, pid_file, "后端", console)
+
+    assert console.messages[-1] == "[flocks] 后端 未运行。"
+    assert not pid_file.exists()
 
 
 def test_stop_one_force_kill_refreshes_process_group_members(monkeypatch, tmp_path: Path) -> None:

--- a/tests/server/test_server_port_config.py
+++ b/tests/server/test_server_port_config.py
@@ -12,6 +12,8 @@ Tests various scenarios:
 import os
 import re
 import socket
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -237,6 +239,113 @@ class TestCommandLinePortConfiguration:
         assert captured["config"].backend_port == 9100
         assert captured["config"].frontend_host == "127.0.0.1"
         assert captured["config"].frontend_port == 5273
+
+    def test_restart_reuses_runtime_recorded_host_and_port(self, monkeypatch, tmp_path: Path):
+        """Test restart reuses last runtime host/port when CLI and env omit them."""
+        captured = {}
+        paths = SimpleNamespace(
+            backend_pid=tmp_path / "backend.pid",
+            frontend_pid=tmp_path / "webui.pid",
+        )
+        records = {
+            paths.backend_pid: SimpleNamespace(host="0.0.0.0", port=9000),
+            paths.frontend_pid: SimpleNamespace(host="0.0.0.0", port=5174),
+        }
+
+        def fake_restart_all(config, _console):
+            captured["config"] = config
+
+        monkeypatch.setattr(cli_main, "restart_all", fake_restart_all)
+        monkeypatch.setattr(cli_main, "runtime_paths", lambda: paths)
+        monkeypatch.setattr(cli_main, "read_runtime_record", lambda path: records.get(path))
+        Config._global_config = None
+
+        result = CliRunner().invoke(cli_main.app, ["restart"])
+
+        assert result.exit_code == 0
+        assert captured["config"].backend_host == "0.0.0.0"
+        assert captured["config"].backend_port == 9000
+        assert captured["config"].frontend_host == "0.0.0.0"
+        assert captured["config"].frontend_port == 5174
+
+    def test_restart_cli_options_override_runtime_record(self, monkeypatch, tmp_path: Path):
+        """Test explicit restart CLI options override runtime-recorded host/port."""
+        captured = {}
+        paths = SimpleNamespace(
+            backend_pid=tmp_path / "backend.pid",
+            frontend_pid=tmp_path / "webui.pid",
+        )
+
+        def fake_restart_all(config, _console):
+            captured["config"] = config
+
+        monkeypatch.setattr(cli_main, "restart_all", fake_restart_all)
+        monkeypatch.setattr(cli_main, "runtime_paths", lambda: paths)
+        monkeypatch.setattr(
+            cli_main,
+            "read_runtime_record",
+            lambda path: SimpleNamespace(
+                host="0.0.0.0",
+                port=9000 if Path(path) == paths.backend_pid else 5174,
+            ),
+        )
+        Config._global_config = None
+
+        result = CliRunner().invoke(
+            cli_main.app,
+            [
+                "restart",
+                "--server-host",
+                "127.0.0.1",
+                "--server-port",
+                "9100",
+                "--webui-host",
+                "127.0.0.1",
+                "--webui-port",
+                "5273",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured["config"].backend_host == "127.0.0.1"
+        assert captured["config"].backend_port == 9100
+        assert captured["config"].frontend_host == "127.0.0.1"
+        assert captured["config"].frontend_port == 5273
+
+    def test_restart_environment_overrides_runtime_record(self, monkeypatch, tmp_path: Path):
+        """Test restart environment variables still override runtime-recorded host/port."""
+        captured = {}
+        paths = SimpleNamespace(
+            backend_pid=tmp_path / "backend.pid",
+            frontend_pid=tmp_path / "webui.pid",
+        )
+
+        def fake_restart_all(config, _console):
+            captured["config"] = config
+
+        monkeypatch.setattr(cli_main, "restart_all", fake_restart_all)
+        monkeypatch.setattr(cli_main, "runtime_paths", lambda: paths)
+        monkeypatch.setattr(
+            cli_main,
+            "read_runtime_record",
+            lambda path: SimpleNamespace(
+                host="0.0.0.0",
+                port=9000 if Path(path) == paths.backend_pid else 5174,
+            ),
+        )
+        monkeypatch.setenv("FLOCKS_SERVER_HOST", "127.0.0.1")
+        monkeypatch.setenv("FLOCKS_SERVER_PORT", "9101")
+        monkeypatch.setenv("FLOCKS_WEBUI_HOST", "127.0.0.1")
+        monkeypatch.setenv("FLOCKS_WEBUI_PORT", "5275")
+        Config._global_config = None
+
+        result = CliRunner().invoke(cli_main.app, ["restart"])
+
+        assert result.exit_code == 0
+        assert captured["config"].backend_host == "127.0.0.1"
+        assert captured["config"].backend_port == 9101
+        assert captured["config"].frontend_host == "127.0.0.1"
+        assert captured["config"].frontend_port == 5275
 
     def test_service_config_prefers_cli_values(self, monkeypatch):
         """Test CLI values override environment and default values."""


### PR DESCRIPTION
## Summary

- **Restart defaults**: `flocks restart` now loads the last recorded backend and WebUI host/port from runtime PID files when the CLI and environment omit them. Explicit CLI flags and `FLOCKS_*_HOST` / `FLOCKS_*_PORT` env vars still win over those defaults.
- **Windows PID safety**: On Windows, the service manager validates whether a tracked PID still matches the recorded service (command line / image name, with listener PID hints) so a reused PID does not trigger taskkill on the wrong process, and stale PID files can still be cleaned up.

## Tests

- `tests/cli/test_service_manager.py` — Windows stale PID cleanup and `stop_one` without taskkill when PID is reused
- `tests/server/test_server_port_config.py` — restart reuses runtime host/port; CLI and env overrides

## Checklist

- [x] Unit tests added/updated and passing locally

Made with [Cursor](https://cursor.com)