### PR TITLE
fix notification release modal flow

### DIFF
--- a/flocks/notifications/service.py
+++ b/flocks/notifications/service.py
@@ -78,6 +78,12 @@ class NotificationAck(BaseModel):
     acknowledged_at: str
 
 
+class NotificationAckStatus(BaseModel):
+    notification_id: str
+    user_id: str
+    acknowledged: bool
+
+
 DEFAULT_NOTIFICATIONS: tuple[NotificationConfig, ...] = (
     NotificationConfig(
         id="token-free-period-extended-2026-04",
@@ -115,50 +121,6 @@ DEFAULT_NOTIFICATIONS: tuple[NotificationConfig, ...] = (
     ),
 )
 
-
-def _default_whats_new(current_version: str) -> NotificationConfig:
-    return NotificationConfig(
-        id=f"whats-new-{current_version}",
-        kind="whats_new",
-        priority=20,
-        version=current_version,
-        locales={
-            "zh-CN": NotificationContent(
-                title=f"已升级到 Flocks v{current_version}",
-                summary="这里是本次版本值得关注的新功能和变化。",
-                body="升级完成后，你可以先快速浏览重点变化，再继续回到工作区。",
-                highlights=[
-                    "账号与鉴权：新增本地登录账号模块。更新到新版本后，需要在页面上设置账密信息",
-                    "钉钉渠道：使用 Python Stream Mode 插件替换原官方插件。因收到较多钉钉问题反馈，我们移除了官方插件并重写了钉钉 Channel",
-                    "Windows 安装与升级：修复内置 Chrome 浏览器路径覆盖等问题",
-                    "工具体系优化：严格 schema 预校验，skill 工具改为渐进式加载",
-                    "优化 OneSEC API 工具参数",
-                    "统一输入与命令",
-                    "新增独立的 SQLite 数据库恢复脚本",
-                    "新增 Gemini 3 稳健支持",
-                ],
-                primaryAction=NotificationAction(label="开始体验"),
-            ),
-            "en-US": NotificationContent(
-                title=f"Flocks upgraded to v{current_version}",
-                summary="Here are the highlights from this version.",
-                body="Take a quick look at what changed, then continue your work.",
-                highlights=[
-                    "Accounts and authentication: added local login accounts. After upgrading, users need to set account credentials on the page",
-                    "DingTalk channel: replaced the previous official plugin with a Python Stream Mode plugin. Based on user feedback about DingTalk issues, we removed the official plugin and rewrote the DingTalk Channel",
-                    "Windows installation and upgrade: fixed issues including built-in Chrome browser path overrides",
-                    "Tooling improvements: stricter schema pre-validation and progressive loading for skill tools",
-                    "Optimized OneSEC API tool parameters",
-                    "Unified input and commands",
-                    "Added a standalone SQLite database recovery script",
-                    "Added robust Gemini 3 support",
-                ],
-                primaryAction=NotificationAction(label="Start exploring"),
-            ),
-        },
-    )
-
-
 class NotificationService:
     """Load active notifications and track per-user acknowledgements."""
 
@@ -188,19 +150,6 @@ class NotificationService:
         if expires_at and now >= expires_at:
             return False
         return True
-
-    @classmethod
-    def _resolve_current_version(cls, current_version: str | None) -> str | None:
-        if current_version:
-            return current_version
-        try:
-            from flocks.updater import get_current_version
-
-            version = get_current_version()
-            return version if version and version != "unknown" else None
-        except Exception as exc:
-            log.warn("notifications.version.resolve_failed", {"error": str(exc)})
-            return None
 
     @classmethod
     def _notification_sort_key(
@@ -242,6 +191,16 @@ class NotificationService:
         return await Storage.get(cls._ack_key(user_id, notification_id)) is not None
 
     @classmethod
+    async def acknowledgement_status(
+        cls, *, user_id: str, notification_id: str
+    ) -> NotificationAckStatus:
+        return NotificationAckStatus(
+            user_id=user_id,
+            notification_id=notification_id,
+            acknowledged=await cls._is_acknowledged(user_id, notification_id),
+        )
+
+    @classmethod
     async def list_active(
         cls,
         *,
@@ -250,7 +209,6 @@ class NotificationService:
         current_version: str | None = None,
     ) -> list[NotificationResponse]:
         target_locale = _normalize_locale(locale)
-        resolved_version = cls._resolve_current_version(current_version)
         config_notifications = await cls._load_config_notifications()
         config_ids = {notification.id for notification in config_notifications}
 
@@ -258,8 +216,6 @@ class NotificationService:
             *config_notifications,
             *(notification for notification in DEFAULT_NOTIFICATIONS if notification.id not in config_ids),
         ]
-        if resolved_version and f"whats-new-{resolved_version}" not in config_ids:
-            notifications.append(_default_whats_new(resolved_version))
 
         active: list[NotificationResponse] = []
         seen_ids: set[str] = set()

--- a/flocks/notifications/service.py
+++ b/flocks/notifications/service.py
@@ -90,7 +90,6 @@ DEFAULT_NOTIFICATIONS: tuple[NotificationConfig, ...] = (
         kind="benefit",
         priority=10,
         starts_at="2026-03-30T00:00:00+08:00",
-        expires_at="2026-04-30T00:00:00+08:00",
         locales={
             "zh-CN": NotificationContent(
                 title="Token 免费期已延长",
@@ -120,6 +119,7 @@ DEFAULT_NOTIFICATIONS: tuple[NotificationConfig, ...] = (
         },
     ),
 )
+
 
 class NotificationService:
     """Load active notifications and track per-user acknowledgements."""

--- a/flocks/server/routes/notifications.py
+++ b/flocks/server/routes/notifications.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Path, Request
 
 from flocks.notifications.service import (
     NotificationAck,
+    NotificationAckStatus,
     NotificationResponse,
     NotificationService,
 )
@@ -32,6 +33,22 @@ async def list_active_notifications(
         user_id=user.id,
         locale=locale,
         current_version=current_version,
+    )
+
+
+@router.get(
+    "/{notification_id}/ack",
+    response_model=NotificationAckStatus,
+    summary="Get notification acknowledgement status",
+)
+async def get_notification_acknowledgement(
+    request: Request,
+    notification_id: str = Path(..., pattern=r"^[a-zA-Z0-9._:-]{1,128}$"),
+) -> NotificationAckStatus:
+    user = require_user(request)
+    return await NotificationService.acknowledgement_status(
+        user_id=user.id,
+        notification_id=notification_id,
     )
 
 

--- a/tests/server/routes/test_notifications_routes.py
+++ b/tests/server/routes/test_notifications_routes.py
@@ -29,24 +29,12 @@ async def test_active_notifications_and_dismiss_forever(client: AsyncClient):
     )
     assert response.status_code == 200, response.text
     items = response.json()
-    assert [item["id"] for item in items] == [
-        "token-free-period-extended-2026-04",
-        "whats-new-2026.04.27",
-    ]
+    assert [item["id"] for item in items] == ["token-free-period-extended-2026-04"]
     assert items[0]["kind"] == "benefit"
-    assert items[1]["kind"] == "whats_new"
 
     ack_response = await client.post("/api/notifications/token-free-period-extended-2026-04/ack")
     assert ack_response.status_code == 200, ack_response.text
 
-    response = await client.get(
-        "/api/notifications/active",
-        params={"locale": "zh-CN", "current_version": "2026.04.27"},
-    )
-    assert response.status_code == 200, response.text
-    assert [item["id"] for item in response.json()] == ["whats-new-2026.04.27"]
-
-    await client.post("/api/notifications/whats-new-2026.04.27/ack")
     response = await client.get(
         "/api/notifications/active",
         params={"locale": "zh-CN", "current_version": "2026.04.27"},
@@ -59,7 +47,7 @@ async def test_active_notifications_and_dismiss_forever(client: AsyncClient):
         params={"locale": "zh-CN", "current_version": "2026.05.01"},
     )
     assert response.status_code == 200, response.text
-    assert [item["id"] for item in response.json()] == ["whats-new-2026.05.01"]
+    assert response.json() == []
 
 
 @pytest.mark.asyncio
@@ -146,19 +134,17 @@ async def test_notification_time_window_filters_expired(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_notifications_fallback_to_backend_current_version(monkeypatch):
-    monkeypatch.setattr(
-        NotificationService,
-        "_resolve_current_version",
-        lambda current_version: current_version or "2026.06.01",
-    )
+async def test_arbitrary_whats_new_ack_status(client: AsyncClient):
+    status_response = await client.get("/api/notifications/whats-new-2026.04.28/ack")
+    assert status_response.status_code == 200, status_response.text
+    assert status_response.json()["acknowledged"] is False
 
-    items = await NotificationService.list_active(
-        user_id="user-a",
-        locale="zh-CN",
-        current_version=None,
-    )
-    assert "whats-new-2026.06.01" in {item.id for item in items}
+    ack_response = await client.post("/api/notifications/whats-new-2026.04.28/ack")
+    assert ack_response.status_code == 200, ack_response.text
+
+    status_response = await client.get("/api/notifications/whats-new-2026.04.28/ack")
+    assert status_response.status_code == 200, status_response.text
+    assert status_response.json()["acknowledged"] is True
 
 
 @pytest.mark.asyncio

--- a/webui/src/api/notifications.ts
+++ b/webui/src/api/notifications.ts
@@ -26,6 +26,12 @@ export interface NotificationAck {
   acknowledged_at: string;
 }
 
+export interface NotificationAckStatus {
+  notification_id: string;
+  user_id: string;
+  acknowledged: boolean;
+}
+
 export const getActiveNotifications = async (
   locale?: string,
   currentVersion?: string | null,
@@ -41,6 +47,15 @@ export const getActiveNotifications = async (
 
 export const ackNotification = async (notificationId: string): Promise<NotificationAck> => {
   const response = await client.post<NotificationAck>(
+    `/api/notifications/${encodeURIComponent(notificationId)}/ack`,
+  );
+  return response.data;
+};
+
+export const getNotificationAckStatus = async (
+  notificationId: string,
+): Promise<NotificationAckStatus> => {
+  const response = await client.get<NotificationAckStatus>(
     `/api/notifications/${encodeURIComponent(notificationId)}/ack`,
   );
   return response.data;

--- a/webui/src/components/common/NotificationModal.tsx
+++ b/webui/src/components/common/NotificationModal.tsx
@@ -90,7 +90,7 @@ export default function NotificationModal({
 
   return createPortal(
     <>
-      <div className="fixed inset-0 z-[90] bg-black/30" onClick={onClose} />
+      <div className="fixed inset-0 z-[90] bg-black/30" onClick={() => onClose()} />
       <div className="fixed inset-0 z-[100] flex items-center justify-center pointer-events-none">
         <div
           className={`pointer-events-auto w-full max-w-lg mx-4 overflow-hidden rounded-2xl border ${accent.ring} bg-white shadow-2xl`}
@@ -108,7 +108,7 @@ export default function NotificationModal({
               <p className={`mt-1 text-sm leading-6 ${accent.text}`}>{t('subtitle')}</p>
             </div>
             <button
-              onClick={onClose}
+              onClick={() => onClose()}
               disabled={isBusy}
               className="rounded p-1 text-gray-400 transition-colors hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-50"
               aria-label={t('close')}
@@ -144,7 +144,7 @@ export default function NotificationModal({
                     </div>
 
                     {notification.body && (
-                      <p className="mt-3 text-sm leading-6 text-gray-600">{notification.body}</p>
+                      <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-gray-600">{notification.body}</p>
                     )}
 
                     {notification.highlights.length > 0 && (

--- a/webui/src/components/common/UpdateModal.tsx
+++ b/webui/src/components/common/UpdateModal.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { checkUpdate, applyUpdate, VersionInfo, UpdateProgress } from '@/api/update';
+import { getLocalizedReleaseNotes } from '@/utils/releaseNotes';
 
 // ------------------------------------------------------------------ //
 
@@ -26,19 +27,21 @@ const HEALTH_POLL_TIMEOUT = 5 * 60 * 1000;
 export const UPDATE_DISMISSED_KEY = 'flocks-update-dismissed';
 
 interface UpdateModalProps {
+  initialInfo?: VersionInfo | null;
   onClose: () => void;
   onDismiss?: () => void;
 }
 
-export default function UpdateModal({ onClose, onDismiss }: UpdateModalProps) {
+export default function UpdateModal({ initialInfo, onClose, onDismiss }: UpdateModalProps) {
   const { t, i18n } = useTranslation('update');
-  const [info, setInfo] = useState<VersionInfo | null>(null);
+  const [info, setInfo] = useState<VersionInfo | null>(initialInfo ?? null);
   const [checking, setChecking] = useState(false);
   const [upgrading, setUpgrading] = useState(false);
   const [steps, setSteps] = useState<UpdateProgress[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [restarting, setRestarting] = useState(false);
   const [showReleaseNotes, setShowReleaseNotes] = useState(false);
+  const localizedReleaseNotes = getLocalizedReleaseNotes(info?.release_notes, i18n.language);
   // useRef avoids stale closure: the `restarting` value inside async callbacks
   // always reflects the latest state even after re-renders.
   const restartingRef = useRef(false);
@@ -46,10 +49,6 @@ export default function UpdateModal({ onClose, onDismiss }: UpdateModalProps) {
     restartingRef.current = val;
     setRestarting(val);
   };
-
-  useEffect(() => {
-    fetchVersion();
-  }, []);
 
   const fetchVersion = useCallback(async () => {
     setChecking(true);
@@ -64,6 +63,12 @@ export default function UpdateModal({ onClose, onDismiss }: UpdateModalProps) {
       setChecking(false);
     }
   }, [i18n.language, t]);
+
+  useEffect(() => {
+    if (!initialInfo) {
+      fetchVersion();
+    }
+  }, [fetchVersion, initialInfo]);
 
   const handleUpgrade = useCallback(async () => {
     if (!info?.has_update) return;
@@ -336,7 +341,7 @@ export default function UpdateModal({ onClose, onDismiss }: UpdateModalProps) {
             </div>
           </div>
 
-          {info?.has_update && info.release_notes && (
+          {info?.has_update && localizedReleaseNotes && (
             <div className="px-4 pb-3">
               <button
                 onClick={() => setShowReleaseNotes((prev) => !prev)}
@@ -366,7 +371,7 @@ export default function UpdateModal({ onClose, onDismiss }: UpdateModalProps) {
                     )}
                   </div>
                   <pre className="text-xs text-gray-500 bg-gray-50 rounded-lg p-2.5 whitespace-pre-wrap max-h-32 overflow-y-auto leading-relaxed">
-                    {info.release_notes.trim()}
+                    {localizedReleaseNotes}
                   </pre>
                 </div>
               )}

--- a/webui/src/components/layout/Layout.test.tsx
+++ b/webui/src/components/layout/Layout.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import Layout from './Layout';
@@ -16,6 +16,7 @@ const {
   sessionApi,
   getActiveNotifications,
   ackNotification,
+  getNotificationAckStatus,
   useAuth,
   useStats,
 } = vi.hoisted(() => ({
@@ -41,6 +42,7 @@ const {
   },
   getActiveNotifications: vi.fn(),
   ackNotification: vi.fn(),
+  getNotificationAckStatus: vi.fn(),
   useAuth: vi.fn(),
   useStats: vi.fn(),
 }));
@@ -70,6 +72,7 @@ vi.mock('@/api/update', () => ({
 vi.mock('@/api/notifications', () => ({
   getActiveNotifications,
   ackNotification,
+  getNotificationAckStatus,
 }));
 
 vi.mock('@/contexts/AuthContext', () => ({
@@ -150,6 +153,14 @@ async function flushEffects() {
   });
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe('Layout onboarding entry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -163,6 +174,11 @@ describe('Layout onboarding entry', () => {
       error: null,
     });
     getActiveNotifications.mockResolvedValue([]);
+    getNotificationAckStatus.mockResolvedValue({
+      notification_id: 'whats-new-0.2.0',
+      user_id: 'user-1',
+      acknowledged: false,
+    });
     ackNotification.mockResolvedValue({
       notification_id: 'notice-1',
       user_id: 'user-1',
@@ -295,5 +311,137 @@ describe('Layout onboarding entry', () => {
     });
     await flushEffects();
     expect(checkUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses update check release notes for the notification modal', async () => {
+    localStorage.setItem('flocks_onboarding_dismissed', 'true');
+    checkUpdate.mockResolvedValue({
+      has_update: false,
+      latest_version: '2026.04.28',
+      current_version: '2026.04.28',
+      release_notes: [
+        '## 中文',
+        '中文更新 1',
+        '中文更新 2',
+        '',
+        '## English',
+        'English update 1',
+      ].join('\n'),
+      release_url: 'https://example.com/release',
+      error: null,
+    });
+    getNotificationAckStatus.mockResolvedValue({
+      notification_id: 'whats-new-2026.04.28',
+      user_id: 'user-1',
+      acknowledged: false,
+    });
+
+    renderHomeWithLayout();
+
+    expect(await screen.findByText('Flocks v2026.04.28 更新内容')).toBeInTheDocument();
+    expect(screen.getByText(/中文更新 1/)).toBeInTheDocument();
+    expect(screen.queryByText(/English update 1/)).not.toBeInTheDocument();
+    expect(getActiveNotifications).toHaveBeenCalledTimes(1);
+    expect(getNotificationAckStatus).toHaveBeenCalledWith('whats-new-2026.04.28');
+    expect(checkUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show acknowledged update release notes again', async () => {
+    localStorage.setItem('flocks_onboarding_dismissed', 'true');
+    checkUpdate.mockResolvedValue({
+      has_update: false,
+      latest_version: '2026.04.28',
+      current_version: '2026.04.28',
+      release_notes: 'Release line 1\nRelease line 2',
+      release_url: 'https://example.com/release',
+      error: null,
+    });
+    getNotificationAckStatus.mockResolvedValue({
+      notification_id: 'whats-new-2026.04.28',
+      user_id: 'user-1',
+      acknowledged: true,
+    });
+
+    renderHomeWithLayout();
+
+    await waitFor(() => {
+      expect(getNotificationAckStatus).toHaveBeenCalledWith('whats-new-2026.04.28');
+    });
+    expect(screen.queryByText('Flocks v2026.04.28 更新内容')).not.toBeInTheDocument();
+  });
+
+  it('closes the notification modal from the top-right close button', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('flocks_onboarding_dismissed', 'true');
+    getActiveNotifications.mockResolvedValue([
+      {
+        id: 'notice-1',
+        kind: 'announcement',
+        title: 'Notice title',
+        summary: null,
+        body: 'Notice body',
+        highlights: [],
+        primary_action: null,
+        secondary_action: null,
+        version: null,
+        priority: 10,
+      },
+    ]);
+
+    renderHomeWithLayout();
+
+    expect(await screen.findByText('Notice title')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'close' }));
+    expect(screen.queryByText('Notice title')).not.toBeInTheDocument();
+  });
+
+  it('waits for benefit and release notifications before opening the combined modal', async () => {
+    localStorage.setItem('flocks_onboarding_dismissed', 'true');
+    checkUpdate.mockResolvedValue({
+      has_update: false,
+      latest_version: '2026.04.28',
+      current_version: '2026.04.28',
+      release_notes: 'Release line 1',
+      release_url: 'https://example.com/release',
+      error: null,
+    });
+    const ackStatus = deferred<{
+      notification_id: string;
+      user_id: string;
+      acknowledged: boolean;
+    }>();
+    getNotificationAckStatus.mockReturnValue(ackStatus.promise);
+    getActiveNotifications.mockResolvedValue([
+      {
+        id: 'token-free-period-extended-2026-04',
+        kind: 'benefit',
+        title: 'Token 免费期已延长',
+        summary: null,
+        body: '福利内容',
+        highlights: [],
+        primary_action: null,
+        secondary_action: null,
+        version: null,
+        priority: 10,
+      },
+    ]);
+
+    renderHomeWithLayout();
+
+    await waitFor(() => {
+      expect(getActiveNotifications).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText('Token 免费期已延长')).not.toBeInTheDocument();
+
+    await act(async () => {
+      ackStatus.resolve({
+        notification_id: 'whats-new-2026.04.28',
+        user_id: 'user-1',
+        acknowledged: false,
+      });
+    });
+
+    expect(await screen.findByText('Token 免费期已延长')).toBeInTheDocument();
+    expect(screen.getByText('Flocks v2026.04.28 更新内容')).toBeInTheDocument();
   });
 });

--- a/webui/src/components/layout/Layout.tsx
+++ b/webui/src/components/layout/Layout.tsx
@@ -24,12 +24,42 @@ import LanguageSwitcher from '@/components/common/LanguageSwitcher';
 import OnboardingModal, { isOnboardingDismissed } from '@/components/common/OnboardingModal';
 import UpdateModal, { UPDATE_DISMISSED_KEY } from '@/components/common/UpdateModal';
 import NotificationModal from '@/components/common/NotificationModal';
-import { checkUpdate } from '@/api/update';
-import { ackNotification, getActiveNotifications, type UserNotification } from '@/api/notifications';
+import { checkUpdate, type VersionInfo } from '@/api/update';
+import {
+  ackNotification,
+  getActiveNotifications,
+  getNotificationAckStatus,
+  type UserNotification,
+} from '@/api/notifications';
 import { useAuth } from '@/contexts/AuthContext';
+import { getLocalizedReleaseNotes } from '@/utils/releaseNotes';
 
 const UPDATE_CHECK_INTERVAL_MS = 3_600_000;
 const UPDATE_CHECK_MIN_GAP_MS = 60_000;
+
+function buildUpdateNotification(info: VersionInfo | null, language: string): UserNotification | null {
+  const releaseNotes = getLocalizedReleaseNotes(info?.release_notes, language);
+  if (!info || info.error || !releaseNotes) return null;
+
+  const version = info.latest_version ?? info.current_version;
+  if (!version || version === 'unknown') return null;
+
+  const isZh = language.toLowerCase().startsWith('zh');
+  return {
+    id: `whats-new-${version}`,
+    kind: 'whats_new',
+    title: isZh ? `Flocks v${version} 更新内容` : `What's new in Flocks v${version}`,
+    summary: isZh ? '这里是本次版本值得关注的新功能和变化。' : 'Here are the highlights from this version.',
+    body: releaseNotes,
+    highlights: [],
+    primary_action: {
+      label: isZh ? '开始体验' : 'Start exploring',
+      url: info.release_url,
+    },
+    version,
+    priority: 20,
+  };
+}
 
 export default function Layout() {
   const location = useLocation();
@@ -43,10 +73,15 @@ export default function Layout() {
   const [hasUpdate, setHasUpdate] = useState(false);
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [currentVersion, setCurrentVersion] = useState<string | null>(null);
+  const [updateInfo, setUpdateInfo] = useState<VersionInfo | null>(null);
+  const [hasCompletedUpdateCheck, setHasCompletedUpdateCheck] = useState(false);
   const lastUpdateCheckAtRef = useRef(0);
   const checkingUpdateRef = useRef(false);
   const lastPromptedVersionRef = useRef<string | null>(null);
   const [notifications, setNotifications] = useState<UserNotification[]>([]);
+  const [updateNotification, setUpdateNotification] = useState<UserNotification | null>(null);
+  const [backendNotificationsReady, setBackendNotificationsReady] = useState(false);
+  const [updateNotificationReady, setUpdateNotificationReady] = useState(false);
   const [acknowledgingNotificationIds, setAcknowledgingNotificationIds] = useState<string[]>([]);
   const lastNotificationFetchKeyRef = useRef<string | null>(null);
   // useLayoutEffect runs synchronously before paint, so there's no flash on initial load.
@@ -74,6 +109,7 @@ export default function Layout() {
 
     try {
       const info = await checkUpdate(i18n.language);
+      setUpdateInfo(info);
 
       if (info.current_version) {
         setCurrentVersion(info.current_version);
@@ -101,6 +137,7 @@ export default function Layout() {
       // Keep the last known update state on transient failures.
     } finally {
       checkingUpdateRef.current = false;
+      setHasCompletedUpdateCheck(true);
     }
   }, [i18n.language]);
 
@@ -136,15 +173,20 @@ export default function Layout() {
   useEffect(() => {
     if (!user?.id) {
       setNotifications([]);
+      setUpdateNotification(null);
+      setBackendNotificationsReady(false);
+      setUpdateNotificationReady(false);
       setAcknowledgingNotificationIds([]);
       lastNotificationFetchKeyRef.current = null;
       return;
     }
+    if (!hasCompletedUpdateCheck) return;
 
     const fetchKey = `${user.id}:${i18n.language}:${currentVersion ?? 'pending-version'}`;
     if (lastNotificationFetchKeyRef.current === fetchKey) return;
     const previousFetchKey = lastNotificationFetchKeyRef.current;
     lastNotificationFetchKeyRef.current = fetchKey;
+    setBackendNotificationsReady(false);
 
     let cancelled = false;
     void getActiveNotifications(i18n.language, currentVersion)
@@ -157,26 +199,68 @@ export default function Layout() {
           }
           return Array.from(byId.values()).sort((a, b) => a.priority - b.priority);
         });
+        setBackendNotificationsReady(true);
       })
       .catch(() => {
         // Notification failures should never block the main product surface.
         if (lastNotificationFetchKeyRef.current === fetchKey) {
           lastNotificationFetchKeyRef.current = previousFetchKey;
         }
+        if (!cancelled) {
+          setBackendNotificationsReady(true);
+        }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [currentVersion, i18n.language, user?.id]);
+  }, [currentVersion, hasCompletedUpdateCheck, i18n.language, user?.id]);
 
-  const visibleNotifications = !showOnboarding && !showUpdate && notifications.length > 0
-    ? notifications
+  useEffect(() => {
+    if (!user?.id) {
+      setUpdateNotification(null);
+      setUpdateNotificationReady(false);
+      return;
+    }
+    if (!hasCompletedUpdateCheck) return;
+
+    setUpdateNotificationReady(false);
+    const notification = buildUpdateNotification(updateInfo, i18n.language);
+    if (!notification) {
+      setUpdateNotification(null);
+      setUpdateNotificationReady(true);
+      return;
+    }
+
+    let cancelled = false;
+    void getNotificationAckStatus(notification.id)
+      .then((status) => {
+        if (cancelled) return;
+        setUpdateNotification(status.acknowledged ? null : notification);
+        setUpdateNotificationReady(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setUpdateNotification(notification);
+        setUpdateNotificationReady(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasCompletedUpdateCheck, i18n.language, updateInfo, user?.id]);
+
+  const allNotifications = updateNotification
+    ? [...notifications, updateNotification].sort((a, b) => a.priority - b.priority)
+    : notifications;
+  const visibleNotifications = backendNotificationsReady && updateNotificationReady && !showOnboarding && !showUpdate && allNotifications.length > 0
+    ? allNotifications
     : [];
 
   const removeNotifications = useCallback((items: UserNotification[]) => {
     const visibleIds = new Set(items.map((item) => item.id));
     setNotifications((prev) => prev.filter((item) => !visibleIds.has(item.id)));
+    setUpdateNotification((prev) => (prev && visibleIds.has(prev.id) ? null : prev));
   }, []);
 
   const closeVisibleNotification = useCallback((notification?: UserNotification) => {
@@ -248,6 +332,7 @@ export default function Layout() {
       )}
       {showUpdate && (
         <UpdateModal
+          initialInfo={updateInfo}
           onClose={() => setShowUpdate(false)}
           onDismiss={() => setShowUpdate(false)}
         />

--- a/webui/src/utils/releaseNotes.test.ts
+++ b/webui/src/utils/releaseNotes.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getLocalizedReleaseNotes } from './releaseNotes';
+
+describe('getLocalizedReleaseNotes', () => {
+  it('extracts the Chinese section for Chinese locales', () => {
+    const notes = [
+      '## 中文',
+      '中文更新 1',
+      '中文更新 2',
+      '',
+      '## English',
+      'English update 1',
+    ].join('\n');
+
+    expect(getLocalizedReleaseNotes(notes, 'zh-CN')).toBe('中文更新 1\n中文更新 2');
+  });
+
+  it('extracts the English section for English locales', () => {
+    const notes = [
+      '## 简体中文',
+      '中文更新',
+      '',
+      '## English',
+      '### Authentication',
+      'English update 1',
+      'English update 2',
+    ].join('\n');
+
+    expect(getLocalizedReleaseNotes(notes, 'en-US')).toBe('### Authentication\nEnglish update 1\nEnglish update 2');
+  });
+
+  it('falls back to full release notes when the target section is missing', () => {
+    const notes = [
+      '## 中文',
+      '中文更新',
+    ].join('\n');
+
+    expect(getLocalizedReleaseNotes(notes, 'en-US')).toBe(notes);
+  });
+});

--- a/webui/src/utils/releaseNotes.ts
+++ b/webui/src/utils/releaseNotes.ts
@@ -1,0 +1,68 @@
+const CHINESE_SECTION_ALIASES = new Set(['中文', '简体中文', 'zh-cn', 'zh_cn', 'chinese']);
+const ENGLISH_SECTION_ALIASES = new Set(['english', 'en-us', 'en_us']);
+
+interface ReleaseNoteSection {
+  title: string;
+  body: string;
+}
+
+const normalizeSectionTitle = (title: string) => (
+  title
+    .trim()
+    .replace(/^#+\s*/, '')
+    .replace(/\s*#+$/, '')
+    .toLowerCase()
+);
+
+const getSectionLanguage = (title: string): 'zh' | 'en' | null => {
+  const normalized = normalizeSectionTitle(title);
+  if (CHINESE_SECTION_ALIASES.has(normalized)) return 'zh';
+  if (ENGLISH_SECTION_ALIASES.has(normalized)) return 'en';
+  return null;
+};
+
+const parseReleaseNoteSections = (notes: string): ReleaseNoteSection[] => {
+  const lines = notes.split(/\r?\n/);
+  const sections: ReleaseNoteSection[] = [];
+  let currentTitle: string | null = null;
+  let currentBody: string[] = [];
+
+  const flush = () => {
+    if (currentTitle === null) return;
+    sections.push({
+      title: currentTitle,
+      body: currentBody.join('\n').trim(),
+    });
+  };
+
+  for (const line of lines) {
+    const heading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
+    if (heading && getSectionLanguage(heading[1]) !== null) {
+      flush();
+      currentTitle = heading[1];
+      currentBody = [];
+      continue;
+    }
+
+    if (currentTitle !== null) {
+      currentBody.push(line);
+    }
+  }
+
+  flush();
+  return sections;
+};
+
+export const getLocalizedReleaseNotes = (
+  notes: string | null | undefined,
+  language: string | null | undefined,
+): string => {
+  const fallback = notes?.trim() ?? '';
+  if (!fallback) return '';
+
+  const targetLanguage = (language ?? '').toLowerCase().startsWith('zh') ? 'zh' : 'en';
+  const sections = parseReleaseNoteSections(fallback);
+  const matched = sections.find((section) => getSectionLanguage(section.title) === targetLanguage);
+
+  return matched?.body || fallback;
+};


### PR DESCRIPTION
Made-with: Cursor
## Summary
- Reuse the existing `/api/update/check` result to build version update notifications, avoiding extra `check_update()` calls from the notification service.
- Combine benefit notifications and release-note notifications into one synchronized modal, preventing one section from appearing before the other is ready.
- Add localized release notes display by extracting Chinese or English sections from the same release body.
- Fix notification modal close behavior and preserve “don’t remind me again” acknowledgement for version notifications.

## Test Plan
- `source .venv/bin/activate && pytest tests/server/routes/test_notifications_routes.py tests/updater/test_updater.py::test_fetch_gitee_release_returns_web_archive_urls`
- `npm run lint`
- `npm run test:run -- src/components/layout/Layout.test.tsx`
- `npm run test:run -- src/components/layout/Layout.test.tsx src/utils/releaseNotes.test.ts`

## Notes
- `check_update()` core logic is intentionally unchanged to avoid impacting update/apply and CLI upgrade flows.
- Release notes localization expects the release body to contain language sections such as `## 中文` and `## English`; if no matching section is found, the full release notes are shown.