### PR TITLE
feat(provider): expose service version end-to-end (UI + LLM tool desc…

### DIFF
--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -20,6 +20,7 @@ from flocks.security.secrets import SecretManager
 from flocks.config.config import Config
 from flocks.config.config_writer import ConfigWriter
 from flocks.storage.storage import Storage
+from flocks.tool.tool_loader import extract_provider_version
 
 
 router = APIRouter()
@@ -870,6 +871,7 @@ class APIServiceSummary(BaseModel):
     """API service summary for the Tool API page."""
     id: str
     name: str
+    version: Optional[str] = None
     enabled: bool = True
     status: str = "unknown"
     message: Optional[str] = None
@@ -1273,9 +1275,12 @@ def _build_api_service_summary(
         verify_ssl = verify_ssl_raw.strip().lower() in {"1", "true", "yes", "on"}
     else:
         verify_ssl = bool(verify_ssl_raw)
+    version = extract_provider_version(meta)
+
     return APIServiceSummary(
         id=provider_id,
         name=meta.get("name", provider_id),
+        version=version,
         enabled=enabled,
         status=status,
         message=cached_status.get("message"),
@@ -1542,6 +1547,7 @@ def _load_provider_yaml_metadata(provider_id: str) -> Optional[Dict[str, Any]]:
         return {
             "name": prov.get("name", provider_id),
             "service_id": prov.get("service_id", provider_id),
+            "version": extract_provider_version(prov),
             "description": prov.get("description"),
             "description_cn": prov.get("description_cn"),
             "auth": prov.get("auth"),

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -58,6 +58,29 @@ log = Log.create(service="session.runner")
 TOOL_RESULT_CHAR_BUDGET_RATIO = 0.70
 TOOL_RESULT_TURN_BUDGET_RATIO = 0.35
 TOOL_RESULT_MIN_CHAR_BUDGET = 8_000
+
+
+def _annotate_with_provider_version(tool_info: Any, description: Optional[str]) -> str:
+    """Append a provider-version annotation so the LLM sees which service version backs the tool.
+
+    Returns the original description (or empty string) unchanged when the tool
+    has no ``provider_version``. Format::
+
+        <original description>
+
+        [Provider: <provider> | Version: <version>]
+
+    The original ``ToolInfo`` is never mutated — a new string is returned.
+    """
+    base = description or ""
+    provider_version = getattr(tool_info, "provider_version", None)
+    if not provider_version:
+        return base
+    provider_label = getattr(tool_info, "provider", None) or "service"
+    note = f"[Provider: {provider_label} | Version: {provider_version}]"
+    if not base.strip():
+        return note
+    return f"{base.rstrip()}\n\n{note}"
 TOOL_RESULT_MIN_TURN_BUDGET = 4_000
 TOOL_RESULT_PREVIEW_CHARS = 160
 
@@ -1417,7 +1440,11 @@ Please address this message and continue with your tasks.
                     "skill_count": len(skills),
                     "description_preview": description[:100]
                 })
-            
+
+            # Surface provider/service version to the model so it can pick
+            # version-appropriate parameters (e.g. SIP v9.2 vs older spec).
+            description = _annotate_with_provider_version(tool_info, description)
+
             schema = tool_info.get_schema()
             tool_def = {
                 "type": "function",

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -92,6 +92,14 @@ class ToolInfo(BaseModel):
     enabled: bool = Field(True, description="Is tool enabled")
     requires_confirmation: bool = Field(False, description="Requires user confirmation")
     provider: Optional[str] = Field(None, description="Tool provider name (for grouped plugin tools)")
+    provider_version: Optional[str] = Field(
+        None,
+        description=(
+            "Provider/service version string (e.g. '9.2'). Sourced from the "
+            "`version` field in `_provider.yaml`. Surfaced to the LLM via the "
+            "tool description so the model can pick version-appropriate behavior."
+        ),
+    )
     source: Optional[str] = Field(None, description="Tool source: builtin, dynamic, plugin_py, plugin_yaml, mcp")
     native: bool = Field(False, description=(
         "True for built-in tools (registered via @register_function) and project-level "

--- a/flocks/tool/tool_loader.py
+++ b/flocks/tool/tool_loader.py
@@ -81,6 +81,30 @@ def _load_provider_config(yaml_path: Path) -> Optional[Dict[str, Any]]:
         return None
 
 
+def extract_provider_version(provider_cfg: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Extract a provider/service version string from a ``_provider.yaml`` dict.
+
+    Lookup order (first non-null wins):
+    1. top-level ``version``
+    2. ``defaults.product_version``
+    3. ``defaults.version``
+
+    Always coerces the result to ``str`` so YAML-decoded floats like ``9.2``
+    (which would otherwise round-trip lossy) are stable.
+    Returns ``None`` when no version is declared anywhere.
+    """
+    if not isinstance(provider_cfg, dict):
+        return None
+    raw = provider_cfg.get("version")
+    if raw is None:
+        defaults = provider_cfg.get("defaults") or {}
+        if isinstance(defaults, dict):
+            raw = defaults.get("product_version") or defaults.get("version")
+    if raw is None:
+        return None
+    return str(raw)
+
+
 def _merge_provider_defaults(raw: dict, provider: Optional[Dict[str, Any]]) -> dict:
     """Apply provider defaults (base_url, timeout, category, auth) to a tool config."""
     if provider is None:
@@ -544,6 +568,8 @@ def yaml_to_tool(raw: dict, yaml_path: Path) -> Tool:
     if not provider_name and provider_cfg:
         provider_name = provider_cfg.get("name")
 
+    provider_version = extract_provider_version(provider_cfg)
+
     cat_str = raw.get("category", "custom")
     try:
         category = ToolCategory(cat_str)
@@ -578,17 +604,20 @@ def yaml_to_tool(raw: dict, yaml_path: Path) -> Tool:
         enabled=raw.get("enabled", True),
         requires_confirmation=requires_confirm,
         provider=provider_name,
+        provider_version=provider_version,
         source=source,
     )
 
     tool = Tool(info=info, handler=handler)
     tool._yaml_path = yaml_path  # type: ignore[attr-defined]
     tool._provider = provider_name  # type: ignore[attr-defined]
+    tool._provider_version = provider_version  # type: ignore[attr-defined]
     tool._source = source or "yaml_plugin"  # type: ignore[attr-defined]
 
     log.info("tool.yaml.loaded", {
         "name": name,
         "provider": provider_name,
+        "provider_version": provider_version,
         "handler_type": handler_type,
         "path": str(yaml_path),
     })

--- a/tests/session/test_runner_provider_version.py
+++ b/tests/session/test_runner_provider_version.py
@@ -1,0 +1,100 @@
+"""
+Tests for ``flocks.session.runner._annotate_with_provider_version``.
+
+Ensures that when a tool's ``ToolInfo`` carries a ``provider_version`` (sourced
+from ``_provider.yaml``), the description handed to the LLM in the function
+schema is augmented with a ``[Provider: ... | Version: ...]`` annotation.
+
+Without this annotation the model has no way to distinguish e.g. Sangfor SIP
+v9.2 vs v9.3 when picking parameter values, since the same Python tool name
+can be backed by different upstream API versions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from flocks.session.runner import _annotate_with_provider_version
+
+
+@dataclass
+class _FakeToolInfo:
+    """Minimal stand-in for ``ToolInfo`` exposing only the attrs we need."""
+
+    description: str = ""
+    provider: Optional[str] = None
+    provider_version: Optional[str] = None
+
+
+class TestAnnotateWithProviderVersion:
+    def test_appends_version_when_present(self):
+        info = _FakeToolInfo(
+            description="Query asset data.",
+            provider="sangfor_sip",
+            provider_version="9.2",
+        )
+        result = _annotate_with_provider_version(info, info.description)
+
+        assert result.startswith("Query asset data.")
+        assert result.endswith("[Provider: sangfor_sip | Version: 9.2]")
+        # Annotation is separated from the body by a blank line so the LLM
+        # treats it as a distinct hint rather than part of the last sentence.
+        assert "\n\n[Provider:" in result
+
+    def test_returns_description_unchanged_when_no_version(self):
+        info = _FakeToolInfo(description="Plain tool.", provider="foo")
+        assert _annotate_with_provider_version(info, info.description) == "Plain tool."
+
+    def test_handles_none_description(self):
+        info = _FakeToolInfo(
+            description="",
+            provider="sangfor_sip",
+            provider_version="9.2",
+        )
+        # Pass None explicitly to mirror what runner does when ToolInfo had
+        # no description.
+        result = _annotate_with_provider_version(info, None)
+        # Without a body we should NOT emit a leading blank line — the model
+        # would otherwise see a stray newline before the hint.
+        assert result == "[Provider: sangfor_sip | Version: 9.2]"
+
+    def test_falls_back_to_service_label_when_provider_missing(self):
+        info = _FakeToolInfo(
+            description="Generic tool.",
+            provider=None,
+            provider_version="1.0",
+        )
+        result = _annotate_with_provider_version(info, info.description)
+        assert "[Provider: service | Version: 1.0]" in result
+
+    def test_does_not_mutate_original_description(self):
+        info = _FakeToolInfo(
+            description="Original.",
+            provider="x",
+            provider_version="2",
+        )
+        original = info.description
+        _ = _annotate_with_provider_version(info, info.description)
+        # ToolInfo objects are reused across turns; the helper must not mutate
+        # them in place.
+        assert info.description == original
+
+    def test_strips_trailing_whitespace_before_annotation(self):
+        info = _FakeToolInfo(
+            description="Body with trailing spaces.   \n\n",
+            provider="x",
+            provider_version="3",
+        )
+        result = _annotate_with_provider_version(info, info.description)
+        # Exactly one blank line (\n\n) between body and annotation.
+        assert "Body with trailing spaces.\n\n[Provider: x | Version: 3]" == result
+
+    def test_tool_info_without_provider_version_attr(self):
+        """Builtin tools / MCP tools may not declare provider_version at all."""
+
+        class _Bare:
+            description = "I have nothing extra."
+
+        result = _annotate_with_provider_version(_Bare(), _Bare.description)
+        assert result == "I have nothing extra."

--- a/tests/tool/test_tool_plugin.py
+++ b/tests/tool/test_tool_plugin.py
@@ -468,6 +468,58 @@ class TestYamlToTool:
 
         assert tool.info.source is None
 
+    def test_provider_version_from_provider_yaml(self, tmp_path: Path, monkeypatch):
+        """`version` in _provider.yaml should be propagated to ToolInfo.provider_version."""
+        monkeypatch.setattr("flocks.tool.tool_loader._TOOLS_SUBDIR", tmp_path)
+
+        api_dir = tmp_path / "api" / "sangfor_sip_v92"
+        api_dir.mkdir(parents=True)
+        _write_yaml(api_dir / "_provider.yaml", {
+            "name": "sangfor_sip",
+            "version": "9.2",
+            "defaults": {"base_url": "https://sip.test/api"},
+        })
+        data = _make_tool_yaml(name="sangfor_sip_assets", url="{base_url}/assets")
+        yaml_path = _write_yaml(api_dir / "sangfor_sip_assets.yaml", data)
+        tool = yaml_to_tool(data, yaml_path)
+
+        assert tool.info.provider == "sangfor_sip"
+        assert tool.info.provider_version == "9.2"
+        assert getattr(tool, "_provider_version", None) == "9.2"
+
+    def test_provider_version_falls_back_to_defaults_product_version(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        """When top-level `version` is missing, fall back to defaults.product_version."""
+        monkeypatch.setattr("flocks.tool.tool_loader._TOOLS_SUBDIR", tmp_path)
+
+        api_dir = tmp_path / "api" / "legacy_provider"
+        api_dir.mkdir(parents=True)
+        _write_yaml(api_dir / "_provider.yaml", {
+            "name": "legacy_provider",
+            "defaults": {"base_url": "https://x.test", "product_version": "8.1"},
+        })
+        data = _make_tool_yaml(name="legacy_tool", url="{base_url}/x")
+        yaml_path = _write_yaml(api_dir / "legacy_tool.yaml", data)
+        tool = yaml_to_tool(data, yaml_path)
+
+        assert tool.info.provider_version == "8.1"
+
+    def test_provider_version_absent_when_not_declared(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        """No `version` anywhere → provider_version stays None."""
+        monkeypatch.setattr("flocks.tool.tool_loader._TOOLS_SUBDIR", tmp_path)
+
+        api_dir = tmp_path / "api" / "no_version"
+        api_dir.mkdir(parents=True)
+        _write_yaml(api_dir / "_provider.yaml", {"name": "no_version"})
+        data = _make_tool_yaml(name="no_version_tool")
+        yaml_path = _write_yaml(api_dir / "no_version_tool.yaml", data)
+        tool = yaml_to_tool(data, yaml_path)
+
+        assert tool.info.provider_version is None
+
 
 # ---------------------------------------------------------------------------
 # CRUD helpers

--- a/webui/src/pages/Tool/components/APITabContent.tsx
+++ b/webui/src/pages/Tool/components/APITabContent.tsx
@@ -341,6 +341,14 @@ export default function APITabContent({
                       {statusLabel}
                     </span>
                     <span className="px-1.5 py-0.5 bg-purple-100 text-purple-700 text-xs font-medium rounded-full shrink-0">API</span>
+                    {service.version && (
+                      <span
+                        className="px-1.5 py-0.5 bg-sky-50 text-sky-700 border border-sky-200 text-xs font-medium rounded-full shrink-0"
+                        title={t('serviceInfo.version')}
+                      >
+                        v{service.version.replace(/^v/i, '')}
+                      </span>
+                    )}
                   </div>
                   <p className="text-xs text-gray-500 line-clamp-2 leading-relaxed min-h-[40px]">
                     {cardDescription}

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -211,6 +211,8 @@ export interface MCPServer {
 export interface APIServiceSummary {
   id: string;
   name: string;
+  /** Provider/service version, e.g. "9.2", sourced from _provider.yaml */
+  version?: string;
   enabled: boolean;
   status: string;
   message?: string;


### PR DESCRIPTION
Surface the optional `version` field declared in `_provider.yaml` (e.g. `sangfor_sip_v92` → 9.2) to both the WebUI and the agent-facing tool schema, so operators see which upstream API version a service binds to and the model can pick version-appropriate parameters at call time.

Backend:
- Add reusable `extract_provider_version(provider_cfg)` helper that reads top-level `version`, falling back to `defaults.product_version` / `defaults.version`, and coerces to str (handles YAML floats).
- `ToolInfo` gains optional `provider_version`; `yaml_to_tool` fills it from the loaded `_provider.yaml`.
- `_load_provider_yaml_metadata` and `_build_api_service_summary` use the same helper so `GET /api/provider/{id}/metadata` and `GET /api/provider/api-services` both return `version`.
- `APIServiceSummary` adds `version: Optional[str]`.
- Session runner appends `\n\n[Provider: <name> | Version: <ver>]` to each tool's description before sending it to the LLM, gated on the tool actually carrying a `provider_version`. Annotation is built by the new module-level `_annotate_with_provider_version` helper to keep it pure and testable; original `ToolInfo` is never mutated.

Frontend:
- `APIServiceSummary` type gains `version?: string`.
- API service card renders a `v9.2` badge next to the existing API tag, with `^v` prefix stripped to avoid a `vv9.2` double-prefix when an operator writes `version: "v9.2"` in the YAML.
- Detail panel already supported `metadata?.version` via existing i18n key `serviceInfo.version`, no change needed there.

Tests:
- 3 new cases in `test_tool_plugin.py` cover top-level `version`, fallback to `defaults.product_version`, and the absent case.
- New `tests/session/test_runner_provider_version.py` (7 cases) pins the description-annotation contract: presence/absence of version, empty/None description, missing provider, no mutation, whitespace handling, and tools that don't declare the attr at all (builtin/MCP).