### PR TITLE
feat: more robust upgrader, log noise reduction, and tail-safe log API

### DIFF
--- a/flocks/channel/builtin/wecom/channel.py
+++ b/flocks/channel/builtin/wecom/channel.py
@@ -34,6 +34,29 @@ _FRAME_CACHE_MAX = 500
 _DEFAULT_RECONNECT_TIMEOUT_SECONDS = 60.0
 
 
+class _WeComSdkLogger:
+    """Bridge wecom-aibot-sdk logs into Flocks logs while dropping heartbeat debug noise."""
+
+    def debug(self, message: str, *args: Any) -> None:
+        return None
+
+    def info(self, message: str, *args: Any) -> None:
+        return None
+
+    def warn(self, message: str, *args: Any) -> None:
+        log.warning("wecom.sdk.warn", {"message": _format_sdk_log_message(message, args)})
+
+    def error(self, message: str, *args: Any) -> None:
+        log.error("wecom.sdk.error", {"message": _format_sdk_log_message(message, args)})
+
+
+def _format_sdk_log_message(message: str, args: tuple[Any, ...]) -> str:
+    if not args:
+        return str(message)
+    extra = " ".join(str(arg) for arg in args)
+    return f"{message} {extra}"
+
+
 def _parse_reconnect_timeout_seconds(raw: Any) -> tuple[float, Optional[str]]:
     """Parse and validate the reconnect watchdog timeout."""
     if raw is None:
@@ -125,6 +148,7 @@ class WeComChannel(ChannelPlugin):
             heartbeat_interval=30_000,
             scene=1,            # SCENE_WECOM_OPENCLAW — 标识为 OpenClaw 连接，MCP 能力依赖此字段
             plug_version="1.0.0",  # 企微服务端用于下发 MCP Server URL 时的版本校验
+            logger=_WeComSdkLogger(),
         )
 
         self._ws_client.on("authenticated", self._handle_authenticated)

--- a/flocks/cli/main.py
+++ b/flocks/cli/main.py
@@ -337,7 +337,7 @@ def logs(
 
 
 def _uvicorn_log_config() -> dict[str, Any]:
-    """Uvicorn logging with wall-clock timestamps (visible in ``backend.log`` when daemonized)."""
+    """Uvicorn logging with timestamps, but without noisy access logs."""
     import copy
 
     from uvicorn.config import LOGGING_CONFIG
@@ -348,6 +348,8 @@ def _uvicorn_log_config() -> dict[str, Any]:
         formatter = cfg["formatters"][name]
         formatter["fmt"] = "%(asctime)s | " + formatter["fmt"]
         formatter["datefmt"] = stamp_fmt
+    cfg["loggers"]["uvicorn.access"]["handlers"] = []
+    cfg["loggers"]["uvicorn.access"]["propagate"] = False
     return cfg
 
 
@@ -374,6 +376,7 @@ def serve(
         reload=reload,
         log_level="info",
         log_config=_uvicorn_log_config(),
+        access_log=False,
     )
 
 

--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -6,6 +6,7 @@ Main HTTP API server for AI-Native SecOps Platform
 
 import asyncio
 import os
+import time
 from pathlib import Path
 from typing import Optional
 from contextlib import asynccontextmanager
@@ -317,6 +318,35 @@ app = FastAPI(
 log = Log.create(service="server")
 
 
+_REQUEST_LOG_SKIP_EXACT = frozenset({
+    "/health",
+    "/api/health",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/api/event",
+    "/api/session/status",
+})
+
+
+def _is_noisy_request_path(path: str) -> bool:
+    """Return True for high-frequency polling endpoints that are noisy on success."""
+    if path in _REQUEST_LOG_SKIP_EXACT:
+        return True
+    if path.startswith("/api/session/") and path.endswith("/message"):
+        return True
+    if path.startswith("/api/question/session/") and path.endswith("/pending"):
+        return True
+    return False
+
+
+def _should_log_request(path: str, status_code: int) -> bool:
+    """Keep abnormal responses visible while suppressing successful polling noise."""
+    if status_code >= 400:
+        return True
+    return not _is_noisy_request_path(path)
+
+
 # CORS Configuration
 #
 # Priority order:
@@ -481,33 +511,31 @@ async def instance_context_middleware(request: Request, call_next):
 # Request Logging Middleware
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
-    """Log all incoming requests"""
-    # Skip logging for certain paths
-    skip_paths = {"/health", "/docs", "/redoc", "/openapi.json"}
-    
-    if request.url.path not in skip_paths:
-        log.info("request.start", {
-            "method": request.method,
-            "path": request.url.path,
-            "client": request.client.host if request.client else None,
-        })
-    
-    # Time the request
-    timer = log.time("request.complete", {
-        "method": request.method,
-        "path": request.url.path,
-    })
-    
-    with timer:
+    """Log one completion line for useful requests; suppress successful polling noise."""
+    path = request.url.path
+    started_at = time.monotonic()
+
+    try:
         response = await call_next(request)
-    
-    if request.url.path not in skip_paths:
+    except Exception as exc:
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        log.error("request.error", {
+            "method": request.method,
+            "path": path,
+            "duration": duration_ms,
+            "error": str(exc),
+        })
+        raise
+
+    if _should_log_request(path, response.status_code):
+        duration_ms = int((time.monotonic() - started_at) * 1000)
         log.info("request.complete", {
             "method": request.method,
-            "path": request.url.path,
+            "path": path,
             "status": response.status_code,
+            "duration": duration_ms,
         })
-    
+
     return response
 
 

--- a/flocks/server/routes/logs.py
+++ b/flocks/server/routes/logs.py
@@ -4,6 +4,7 @@ Log viewing routes for WebUI.
 Provides endpoints to list and read log files from ~/.flocks/logs.
 """
 
+from collections import deque
 from pathlib import Path
 from typing import List
 
@@ -95,14 +96,17 @@ async def read_log(
 
 def _read_log_file(path: Path, tail: int) -> LogContentResponse:
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")
+        lines: deque[str] = deque(maxlen=tail)
+        total = 0
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                total += 1
+                lines.append(line.rstrip("\n"))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to read log: {e}")
 
-    lines = text.splitlines()
-    total = len(lines)
     truncated = total > tail
-    content = "\n".join(lines[-tail:]) if truncated else text
+    content = "\n".join(lines)
 
     return LogContentResponse(
         filename=path.name,

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -49,6 +49,8 @@ _CN_NPM_REGISTRY = "https://registry.npmmirror.com/"
 _CN_UV_DEFAULT_INDEX = "https://mirrors.aliyun.com/pypi/simple"
 _CN_PIP_INDEX_URL = _CN_UV_DEFAULT_INDEX
 _CURL_USER_AGENT = "curl/8.7.1"
+_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS = 300
+_FRONTEND_BUILD_TIMEOUT_SECONDS = 300
 
 _PRESERVE_NAMES: set[str] = {
     ".venv",
@@ -1967,15 +1969,32 @@ async def perform_update(
         if npm:
             yield UpdateProgress(stage="building", message="Installing frontend dependencies...")
             npm_env = _build_frontend_subprocess_env(npm_registry=profile.npm_registry)
-            code, _, err = await _run_async(
-                [npm, "install"],
-                cwd=staged_webui_dir,
-                timeout=180,
-                env=npm_env,
-            )
+            install_subcommand = "ci" if (staged_webui_dir / "package-lock.json").exists() else "install"
+            install_cmd = [npm, install_subcommand]
+            install_label = f"npm {install_subcommand}"
+            try:
+                code, _, err = await _run_async(
+                    install_cmd,
+                    cwd=staged_webui_dir,
+                    timeout=_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS,
+                    env=npm_env,
+                )
+            except subprocess.TimeoutExpired:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                _fe_dep_timeout = (
+                    "Frontend dependency install timed out after "
+                    f"{_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS}s while running {install_label}."
+                )
+                _record_update_journal(f"ERROR {_fe_dep_timeout}")
+                yield UpdateProgress(
+                    stage="error",
+                    message=_fe_dep_timeout,
+                    success=False,
+                )
+                return
             if code != 0:
                 shutil.rmtree(tmp_dir, ignore_errors=True)
-                _fe_dep = f"Frontend dependency install failed: {err}"
+                _fe_dep = f"Frontend dependency install failed ({install_label}): {err}"
                 _record_update_journal(f"ERROR {_fe_dep}")
                 yield UpdateProgress(
                     stage="error",
@@ -1985,12 +2004,25 @@ async def perform_update(
                 return
 
             yield UpdateProgress(stage="building", message="Building frontend...")
-            code, _, err = await _run_async(
-                [npm, "run", "build"],
-                cwd=staged_webui_dir,
-                timeout=300,
-                env=npm_env,
-            )
+            try:
+                code, _, err = await _run_async(
+                    [npm, "run", "build"],
+                    cwd=staged_webui_dir,
+                    timeout=_FRONTEND_BUILD_TIMEOUT_SECONDS,
+                    env=npm_env,
+                )
+            except subprocess.TimeoutExpired:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                _fe_build_timeout = (
+                    f"Frontend build timed out after {_FRONTEND_BUILD_TIMEOUT_SECONDS}s while running npm run build."
+                )
+                _record_update_journal(f"ERROR {_fe_build_timeout}")
+                yield UpdateProgress(
+                    stage="error",
+                    message=_fe_build_timeout,
+                    success=False,
+                )
+                return
             if code != 0:
                 shutil.rmtree(tmp_dir, ignore_errors=True)
                 _fe_build = f"Frontend build failed: {err}"
@@ -2144,6 +2176,19 @@ async def perform_update(
         code, _, err = await _run_async(
             uv_cmd, cwd=install_root, timeout=180, env=sync_env,
         )
+    if code != 0 and profile.uv_default_index:
+        log.warning(
+            "updater.dependencies.sync_retry_default_index",
+            {
+                "first_error": err,
+                "default_index": profile.uv_default_index,
+            },
+        )
+        await asyncio.sleep(3)
+        uv_cmd = [uv_path, "sync"]
+        code, _, err = await _run_async(
+            uv_cmd, cwd=install_root, timeout=180, env=sync_env,
+        )
     if code != 0:
         log.warning("updater.dependencies.sync_retry", {"first_error": err})
         await asyncio.sleep(3)
@@ -2220,7 +2265,7 @@ async def perform_update(
             handover_active = False
         yield UpdateProgress(
             stage="error",
-            message=_rb_msg,
+            message=f"Failed to build restart command: {exc}",
             success=False,
         )
         return
@@ -2251,7 +2296,7 @@ async def perform_update(
                 handover_active = False
             yield UpdateProgress(
                 stage="error",
-                message=_rs_win,
+                message=f"Failed to restart service: {exc}",
                 success=False,
             )
             return
@@ -2269,7 +2314,7 @@ async def perform_update(
             handover_active = False
         yield UpdateProgress(
             stage="error",
-            message=_rs_unix,
+            message=f"Failed to restart service: {exc}",
             success=False,
         )
         return

--- a/tests/channel/test_wecom.py
+++ b/tests/channel/test_wecom.py
@@ -20,6 +20,7 @@ from flocks.channel.base import (
 )
 from flocks.channel.builtin.wecom.channel import (
     WeComChannel,
+    _WeComSdkLogger,
     _extract_content,
     _extract_mixed,
     _parse_frame,
@@ -176,6 +177,39 @@ class TestWeComSendText:
 # ------------------------------------------------------------------
 
 class TestWeComReconnectWatchdog:
+    def test_sdk_logger_drops_debug_and_info_stdout(self, capsys):
+        logger = _WeComSdkLogger()
+
+        logger.debug("Heartbeat sent")
+        logger.info("Connected")
+
+        assert capsys.readouterr().out == ""
+
+    async def test_start_passes_quiet_sdk_logger(self):
+        class FakeWSClient:
+            last_kwargs = None
+
+            def __init__(self, *args, **kwargs):
+                self.handlers = {}
+                self.disconnect = AsyncMock()
+                FakeWSClient.last_kwargs = kwargs
+
+            def on(self, event, handler):
+                self.handlers[event] = handler
+
+            async def connect(self):
+                return None
+
+        ch = WeComChannel()
+        abort_event = asyncio.Event()
+        abort_event.set()
+        config = {"botId": "bot-1", "secret": "secret-1"}
+
+        with patch("wecom_aibot_sdk.WSClient", FakeWSClient):
+            await ch.start(config, AsyncMock(), abort_event)
+
+        assert isinstance(FakeWSClient.last_kwargs["logger"], _WeComSdkLogger)
+
     async def test_watchdog_sets_timeout_event(self):
         ch = WeComChannel()
         ch._ws_client = object()

--- a/tests/cli/test_uvicorn_log_config.py
+++ b/tests/cli/test_uvicorn_log_config.py
@@ -9,3 +9,5 @@ def test_uvicorn_log_config_adds_asctime_to_formatters() -> None:
     assert "%(asctime)s |" in cfg["formatters"]["access"]["fmt"]
     assert cfg["formatters"]["default"]["datefmt"] == "%Y-%m-%d %H:%M:%S"
     assert cfg["formatters"]["access"]["datefmt"] == "%Y-%m-%d %H:%M:%S"
+    assert cfg["loggers"]["uvicorn.access"]["handlers"] == []
+    assert cfg["loggers"]["uvicorn.access"]["propagate"] is False

--- a/tests/server/test_log_routes.py
+++ b/tests/server/test_log_routes.py
@@ -1,0 +1,36 @@
+"""Log route helpers."""
+
+from pathlib import Path
+
+from flocks.server.routes import logs as log_routes
+
+
+def test_read_log_file_tails_without_reading_entire_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    log_path = tmp_path / "backend.log"
+    log_path.write_text("one\ntwo\nthree\nfour\n", encoding="utf-8")
+
+    def fail_read_text(*args, **kwargs):
+        raise AssertionError("read_text should not be used for tail reads")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    response = log_routes._read_log_file(log_path, tail=2)
+
+    assert response.filename == "backend.log"
+    assert response.content == "three\nfour"
+    assert response.total_lines == 4
+    assert response.truncated is True
+
+
+def test_read_log_file_reports_untruncated_small_file(tmp_path: Path) -> None:
+    log_path = tmp_path / "backend.log"
+    log_path.write_text("one\ntwo\n", encoding="utf-8")
+
+    response = log_routes._read_log_file(log_path, tail=5)
+
+    assert response.content == "one\ntwo"
+    assert response.total_lines == 2
+    assert response.truncated is False

--- a/tests/server/test_request_logging.py
+++ b/tests/server/test_request_logging.py
@@ -1,0 +1,36 @@
+"""Request logging noise filters."""
+
+import pytest
+
+from flocks.server import app as server_app
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/health",
+        "/api/health",
+        "/api/event",
+        "/api/session/status",
+        "/api/session/ses_123/message",
+        "/api/question/session/ses_123/pending",
+    ],
+)
+def test_successful_polling_requests_are_not_logged(path: str) -> None:
+    assert not server_app._should_log_request(path, 200)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/provider",
+        "/api/tools",
+        "/api/session",
+    ],
+)
+def test_regular_successful_requests_are_logged(path: str) -> None:
+    assert server_app._should_log_request(path, 200)
+
+
+def test_noisy_request_errors_are_still_logged() -> None:
+    assert server_app._should_log_request("/api/session/ses_123/message", 500)

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1431,6 +1431,7 @@ async def test_perform_update_uses_cn_mirror_profile_for_sources_and_dependency_
     staged_webui = staged_root / "webui"
     staged_webui.mkdir(parents=True)
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
+    (staged_webui / "package-lock.json").write_text("{}", encoding="utf-8")
     (staged_webui / "dist").mkdir()
     (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
 
@@ -1486,7 +1487,7 @@ async def test_perform_update_uses_cn_mirror_profile_for_sources_and_dependency_
     assert captured["sources"] == ["gitee", "github"]
     assert run_calls == [
         (
-            ["/usr/bin/npm", "install"],
+            ["/usr/bin/npm", "ci"],
             {"npm_config_registry": "https://registry.npmmirror.com/"},
         ),
         (
@@ -1497,6 +1498,63 @@ async def test_perform_update_uses_cn_mirror_profile_for_sources_and_dependency_
             ["/usr/bin/uv", "sync", "--default-index", "https://mirrors.aliyun.com/pypi/simple"],
             None,
         ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_perform_update_retries_cn_uv_sync_with_default_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "flocks.tar.gz"
+    archive_path.write_text("archive", encoding="utf-8")
+    staged_root = tmp_path / "staged"
+
+    run_calls: list[list[str]] = []
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            archive_format="tar.gz",
+            sources=["github"],
+            repo="AgentFlocks/Flocks",
+            token=None,
+            gitee_token=None,
+            backup_retain_count=3,
+            base_url=None,
+            gitee_repo=None,
+        )
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        run_calls.append(list(cmd))
+        if cmd == ["/usr/bin/uv", "sync", "--default-index", "https://mirrors.aliyun.com/pypi/simple"]:
+            return 1, "", "403 Forbidden"
+        return 0, "", ""
+
+    async def fake_download_with_fallback(**_kwargs):
+        return archive_path
+
+    async def fake_sleep(_seconds) -> None:
+        pass
+
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
+    monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
+    monkeypatch.setattr(updater, "_extract_archive", lambda *_args, **_kwargs: staged_root)
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(updater, "_find_executable", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
+    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
+    monkeypatch.setattr(updater.asyncio, "sleep", fake_sleep)
+
+    progresses = [step async for step in updater.perform_update("2026.4.1", restart=False, locale="zh-CN")]
+
+    assert progresses[-1].stage == "done"
+    assert run_calls == [
+        ["/usr/bin/uv", "sync", "--default-index", "https://mirrors.aliyun.com/pypi/simple"],
+        ["/usr/bin/uv", "sync"],
     ]
 
 
@@ -1980,6 +2038,62 @@ async def test_perform_update_retries_after_windows_file_lock_and_rolls_back_han
         "rollback",
     ]
     assert "restore" not in events
+
+
+@pytest.mark.asyncio
+async def test_perform_update_reports_frontend_dependency_install_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "flocks.zip"
+    archive_path.write_text("archive", encoding="utf-8")
+    staged_root = tmp_path / "staged"
+    staged_webui = staged_root / "webui"
+    staged_webui.mkdir(parents=True)
+    (staged_webui / "package.json").write_text("{}", encoding="utf-8")
+    (staged_webui / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    events: list[str] = []
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            archive_format="zip",
+            sources=["github"],
+            repo="AgentFlocks/Flocks",
+            token=None,
+            gitee_token=None,
+            backup_retain_count=3,
+            base_url=None,
+            gitee_repo=None,
+        )
+
+    async def fake_download_with_fallback(**_kwargs):
+        return archive_path
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        events.append(" ".join(cmd))
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
+    monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
+    monkeypatch.setattr(updater, "_extract_archive", lambda *_args, **_kwargs: staged_root)
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(
+        updater,
+        "_find_executable",
+        lambda name: "/usr/bin/npm" if name in {"npm", "npm.cmd"} else "/usr/bin/uv",
+    )
+    monkeypatch.setattr(updater, "_prepare_upgrade_handover", lambda _version: events.append("handover") or {})
+    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: events.append("replace"))
+
+    progresses = [step async for step in updater.perform_update("2026.4.1")]
+
+    assert progresses[-1].stage == "error"
+    assert progresses[-1].message == "Frontend dependency install timed out after 300s while running npm ci."
+    assert events == ["/usr/bin/npm ci"]
 
 
 @pytest.mark.asyncio

--- a/webui/src/components/layout/Layout.test.tsx
+++ b/webui/src/components/layout/Layout.test.tsx
@@ -270,7 +270,7 @@ describe('Layout onboarding entry', () => {
     expect(checkUpdate).toHaveBeenCalledTimes(2);
   });
 
-  it('enforces a one-minute minimum gap for focus-triggered update checks', async () => {
+  it('enforces a ten-minute minimum gap for focus-triggered update checks', async () => {
     vi.useFakeTimers();
 
     renderHomeWithLayout();
@@ -279,7 +279,7 @@ describe('Layout onboarding entry', () => {
     expect(checkUpdate).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(59_000);
+      await vi.advanceTimersByTimeAsync(599_000);
     });
     act(() => {
       window.dispatchEvent(new Event('focus'));

--- a/webui/src/components/layout/Layout.tsx
+++ b/webui/src/components/layout/Layout.tsx
@@ -29,7 +29,7 @@ import { ackNotification, getActiveNotifications, type UserNotification } from '
 import { useAuth } from '@/contexts/AuthContext';
 
 const UPDATE_CHECK_INTERVAL_MS = 3_600_000;
-const UPDATE_CHECK_MIN_GAP_MS = 60_000;
+const UPDATE_CHECK_MIN_GAP_MS = 600_000;
 
 export default function Layout() {
   const location = useLocation();


### PR DESCRIPTION
## Summary
Harden the in-app upgrade path and cut log volume from hot paths, while keeping errors visible.

## Upgrader
- Use `npm ci` when `package-lock.json` is present; 300s timeouts for install/build with clear `TimeoutExpired` handling and journal entries.
- When `uv sync` with a configured default index fails (e.g. mirror issues), retry once with plain `uv sync` before the generic retry.
- Restart/handover error messages now include the underlying exception text.

## Server & CLI
- Request middleware: one completion line with duration; skip successful high-frequency polling paths; always log 4xx/5xx and exceptions.
- Log viewer API: tail large files via streaming + `deque` instead of reading the whole file into memory.
- Uvicorn: disable duplicate access logs (`access_log=False` + empty `uvicorn.access` handlers).

## WeCom
- Custom SDK logger: forward warn/error to Flocks logs; drop debug/info (heartbeat noise).

## WebUI
- Focus-triggered update check minimum gap: 1 minute → 10 minutes.