### PR TITLE
fix(provider): align max_output_tokens in provider catalog

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -61,7 +61,7 @@
         },
         "limits": {
           "context_window": 196608,
-          "max_output_tokens": 196608
+          "max_output_tokens": 128000
         },
         "pricing": {
           "input": 2.1,
@@ -78,7 +78,7 @@
         },
         "limits": {
           "context_window": 196608,
-          "max_output_tokens": 196608
+          "max_output_tokens": 128000
         },
         "pricing": {
           "input": 2.1,
@@ -194,7 +194,7 @@
         },
         "limits": {
           "context_window": 196608,
-          "max_output_tokens": 196608
+          "max_output_tokens": 128000
         },
         "pricing": {
           "input": 2.1,
@@ -211,7 +211,7 @@
         },
         "limits": {
           "context_window": 196608,
-          "max_output_tokens": 196608
+          "max_output_tokens": 128000
         },
         "pricing": {
           "input": 2.1,
@@ -1202,7 +1202,7 @@
         },
         "limits": {
           "context_window": 196608,
-          "max_output_tokens": 196608
+          "max_output_tokens": 128000
         },
         "pricing": {
           "input": 2.1,
@@ -1219,7 +1219,7 @@
         },
         "limits": {
           "context_window": 196608,
-          "max_output_tokens": 196608
+          "max_output_tokens": 128000
         },
         "pricing": {
           "input": 2.1,


### PR DESCRIPTION
## Summary
Updates `max_output_tokens` from 196608 to 128000 for the affected entries in `flocks/provider/catalog.json` to align with typical provider output limits (avoid equating max output with full context window).

## Changes
- Single file: `flocks/provider/catalog.json` (6 replacements)

## Testing
- N/A (catalog metadata only)

Made with [Cursor](https://cursor.com)