### PR TITLE
fix: support Chinese release notes summary

### DIFF
--- a/webui/src/utils/releaseNotes.test.ts
+++ b/webui/src/utils/releaseNotes.test.ts
@@ -36,6 +36,38 @@ describe('getLocalizedReleaseNotes', () => {
     expect(getLocalizedReleaseNotes(notes, 'zh-CN')).toBe('### 更新内容\n\n- 中文更新 1\n- 中文更新 2');
   });
 
+  it('recognizes Chinese Release Notes as a Chinese details summary', () => {
+    const notes = [
+      '## What\'s Changed',
+      '',
+      '### Authentication & Session',
+      '',
+      '- English update 1',
+      '',
+      '<details>',
+      '',
+      '<summary>Chinese Release Notes</summary>',
+      '## 更新内容',
+      '',
+      '### 认证与会话',
+      '',
+      '- 中文更新 1',
+      '',
+      '</details>',
+    ].join('\n');
+
+    expect(getLocalizedReleaseNotes(notes, 'zh-CN')).toBe('## 更新内容\n\n### 认证与会话\n\n- 中文更新 1');
+    expect(getLocalizedReleaseNotes(notes, 'en-US')).toBe(
+      [
+        '## What\'s Changed',
+        '',
+        '### Authentication & Session',
+        '',
+        '- English update 1',
+      ].join('\n'),
+    );
+  });
+
   it('removes Chinese details blocks for English release notes', () => {
     const notes = [
       '### What\'s Changed',

--- a/webui/src/utils/releaseNotes.ts
+++ b/webui/src/utils/releaseNotes.ts
@@ -1,4 +1,11 @@
-const CHINESE_SECTION_ALIASES = new Set(['中文', '简体中文', 'zh-cn', 'zh_cn', 'chinese']);
+const CHINESE_SECTION_ALIASES = new Set([
+  '中文',
+  '简体中文',
+  'zh-cn',
+  'zh_cn',
+  'chinese',
+  'chinese release notes',
+]);
 const ENGLISH_SECTION_ALIASES = new Set(['english', 'en-us', 'en_us']);
 
 interface DetailsSection {


### PR DESCRIPTION
Recognize GitHub details blocks labeled "Chinese Release Notes" as Chinese localized release notes.

Made-with: Cursor