### PR TITLE
fix: remove update card action button

### DIFF
--- a/webui/src/components/layout/Layout.tsx
+++ b/webui/src/components/layout/Layout.tsx
@@ -52,10 +52,6 @@ function buildUpdateNotification(info: VersionInfo | null, language: string): Us
     summary: isZh ? '这里是本次版本值得关注的新功能和变化。' : 'Here are the highlights from this version.',
     body: releaseNotes,
     highlights: [],
-    primary_action: {
-      label: isZh ? '开始体验' : 'Start exploring',
-      url: info.release_url,
-    },
     version,
     priority: 20,
   };


### PR DESCRIPTION
Remove the per-card action link from the whats-new notification so the modal only shows dismiss controls.

Made-with: Cursor