### PR TITLE
fix(install): harden zh installer fallback flow

### DIFF
--- a/install_zh.ps1
+++ b/install_zh.ps1
@@ -120,6 +120,9 @@ function Show-Usage {
     Write-Host "默认会在当前目录下创建 'flocks' 子目录。"
     Write-Host "如果当前目录是 Windows System32，则会自动回退到用户主目录。"
     Write-Host "请在“以管理员身份运行”的 PowerShell 窗口中执行此安装脚本。"
+    Write-Host "默认会为 scripts/install_zh.ps1 注入国内软件源与 uv 安装镜像。"
+    Write-Host "  uv 备用源: https://uv.agentsmirror.com/install-cn.ps1"
+    Write-Host "  uv 官方回退: https://astral.sh/uv/install.ps1"
     Write-Host ""
     Write-Host "远程使用："
     Write-Host "  curl -fsSL $RawInstallZhShUrl | bash"
@@ -229,11 +232,20 @@ function Set-CnInstallerEnvironment {
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_SH_URL)) {
         $env:FLOCKS_UV_INSTALL_SH_URL = "https://astral.org.cn/uv/install.sh"
     }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_SH_FALLBACK_URL)) {
+        $env:FLOCKS_UV_INSTALL_SH_FALLBACK_URL = "https://uv.agentsmirror.com/install-cn.sh"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL)) {
+        $env:FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL = "https://astral.sh/uv/install.sh"
+    }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) {
         $env:FLOCKS_UV_INSTALL_PS1_URL = "https://astral.org.cn/uv/install.ps1"
     }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL)) {
         $env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL = "https://uv.agentsmirror.com/install-cn.ps1"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL)) {
+        $env:FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL = "https://astral.sh/uv/install.ps1"
     }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) {
         $env:FLOCKS_NPM_REGISTRY = "https://registry.npmmirror.com/"

--- a/install_zh.sh
+++ b/install_zh.sh
@@ -45,6 +45,7 @@ Flocks 中国用户一键安装脚本。
   npm 源: https://registry.npmmirror.com/
   nvm 源: https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh
   uv 备用源: https://uv.agentsmirror.com/install-cn.sh
+  uv 官方回退: https://astral.sh/uv/install.sh
 
 远程使用：
   curl -fsSL $RAW_INSTALL_ZH_SH_URL | bash
@@ -136,7 +137,9 @@ configure_cn_environment() {
   export FLOCKS_NVM_INSTALL_SCRIPT_URL="${FLOCKS_NVM_INSTALL_SCRIPT_URL:-https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh}"
   export FLOCKS_UV_INSTALL_SH_URL="${FLOCKS_UV_INSTALL_SH_URL:-https://astral.org.cn/uv/install.sh}"
   export FLOCKS_UV_INSTALL_SH_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_FALLBACK_URL:-https://uv.agentsmirror.com/install-cn.sh}"
+  export FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL:-https://astral.sh/uv/install.sh}"
   export FLOCKS_UV_INSTALL_PS1_URL="${FLOCKS_UV_INSTALL_PS1_URL:-https://astral.org.cn/uv/install.ps1}"
+  export FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL="${FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL:-https://astral.sh/uv/install.ps1}"
   export PUPPETEER_CHROME_DOWNLOAD_BASE_URL="${PUPPETEER_CHROME_DOWNLOAD_BASE_URL:-https://cdn.npmmirror.com/binaries/chrome-for-testing}"
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -14,6 +14,7 @@ $script:InstallLanguage = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_INSTALL_L
 $script:UvDefaultIndex = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_DEFAULT_INDEX)) { "https://pypi.org/simple" } else { $env:FLOCKS_UV_DEFAULT_INDEX }
 $script:UvInstallPs1Url = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) { "https://astral.sh/uv/install.ps1" } else { $env:FLOCKS_UV_INSTALL_PS1_URL }
 $script:UvInstallPs1FallbackUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL)) { "https://uv.agentsmirror.com/install-cn.ps1" } else { $env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL }
+$script:UvInstallPs1SecondaryFallbackUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL)) { "https://astral.sh/uv/install.ps1" } else { $env:FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL }
 $script:NpmRegistry = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) { "https://registry.npmjs.org/" } else { $env:FLOCKS_NPM_REGISTRY }
 $script:NodejsManualDownloadUrl = if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL)) { "https://nodejs.org/en/download" } else { $env:FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL }
 
@@ -96,6 +97,7 @@ function Initialize-InstallSources {
     Write-Info (Get-LocalizedText -English "Using uv install script: $script:UvInstallPs1Url" -Chinese "使用 uv 安装脚本: $script:UvInstallPs1Url")
     if (Test-IsZhInstall) {
         Write-Info (Get-LocalizedText -English "Using uv fallback script: $script:UvInstallPs1FallbackUrl" -Chinese "使用 uv 备用安装脚本: $script:UvInstallPs1FallbackUrl")
+        Write-Info (Get-LocalizedText -English "Using official uv fallback script: $script:UvInstallPs1SecondaryFallbackUrl" -Chinese "使用 uv 官方回退安装脚本: $script:UvInstallPs1SecondaryFallbackUrl")
     }
 }
 
@@ -380,6 +382,9 @@ function Install-Uv {
 
     Write-Info (Get-LocalizedText -English "uv was not found. Installing it automatically..." -Chinese "未检测到 uv，正在自动安装...")
     $primaryInstallError = $null
+    $fallbackInstallError = $null
+    $secondaryFallbackInstallError = $null
+
     try {
         powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm '$script:UvInstallPs1Url' | iex"
     }
@@ -392,7 +397,7 @@ function Install-Uv {
         return
     }
 
-    if (Test-IsZhInstall) {
+    if (Test-IsZhInstall -and -not [string]::IsNullOrWhiteSpace($script:UvInstallPs1FallbackUrl)) {
         if ($null -ne $primaryInstallError) {
             Write-Info (Get-LocalizedText -English "Primary uv install script failed. Trying the mainland China fallback script..." -Chinese "默认 uv 安装脚本失败，正在尝试中国大陆备用源...")
             Write-Warning $primaryInstallError
@@ -401,7 +406,6 @@ function Install-Uv {
             Write-Info (Get-LocalizedText -English "uv is still unavailable after the primary install script. Trying the mainland China fallback script..." -Chinese "默认 uv 安装脚本执行后仍未检测到 uv，正在尝试中国大陆备用源...")
         }
 
-        $fallbackInstallError = $null
         try {
             powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm '$script:UvInstallPs1FallbackUrl' | iex"
         }
@@ -413,9 +417,40 @@ function Install-Uv {
         if (Test-Command "uv") {
             return
         }
+    }
 
-        if ($null -ne $fallbackInstallError) {
-            Fail (Get-LocalizedText -English "uv installation failed with both the primary script and the mainland China fallback script. Check network access or PATH and retry." -Chinese "默认 uv 安装脚本和中国大陆备用源都执行失败。请检查网络连通性或 PATH 后重试。")
+    if (Test-IsZhInstall -and -not [string]::IsNullOrWhiteSpace($script:UvInstallPs1SecondaryFallbackUrl)) {
+        if (-not [string]::IsNullOrWhiteSpace($script:UvInstallPs1FallbackUrl)) {
+            if ($null -ne $fallbackInstallError) {
+                Write-Info (Get-LocalizedText -English "The mainland China fallback script failed. Trying the official uv install script..." -Chinese "中国大陆备用源失败，正在尝试官方 uv 安装脚本...")
+                Write-Warning $fallbackInstallError
+            }
+            else {
+                Write-Info (Get-LocalizedText -English "uv is still unavailable after the mainland China fallback script. Trying the official uv install script..." -Chinese "中国大陆备用源执行后仍未检测到 uv，正在尝试官方 uv 安装脚本...")
+            }
+        }
+        elseif ($null -ne $primaryInstallError) {
+            Write-Info (Get-LocalizedText -English "Primary uv install script failed. Trying the official uv install script..." -Chinese "默认 uv 安装脚本失败，正在尝试官方 uv 安装脚本...")
+            Write-Warning $primaryInstallError
+        }
+        else {
+            Write-Info (Get-LocalizedText -English "uv is still unavailable after the primary install script. Trying the official uv install script..." -Chinese "默认 uv 安装脚本执行后仍未检测到 uv，正在尝试官方 uv 安装脚本...")
+        }
+
+        try {
+            powershell -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; irm '$script:UvInstallPs1SecondaryFallbackUrl' | iex"
+        }
+        catch {
+            $secondaryFallbackInstallError = $_.Exception.Message
+        }
+        Refresh-Path
+
+        if (Test-Command "uv") {
+            return
+        }
+
+        if ($null -ne $secondaryFallbackInstallError) {
+            Fail (Get-LocalizedText -English "uv installation failed with the primary script, the mainland China fallback script, and the official fallback script. Check network access or PATH and retry." -Chinese "默认 uv 安装脚本、中国大陆备用源和官方 uv 安装脚本都执行失败。请检查网络连通性或 PATH 后重试。")
         }
     }
 
@@ -1016,9 +1051,10 @@ function Resolve-ExplicitBrowserPath {
         return $browserOverride
     }
 
-    Write-Warning (Get-LocalizedText `
+    $warningMessage = Get-LocalizedText `
         -English "The explicit browser override path does not exist and will be ignored: $browserOverride" `
-        -Chinese "显式指定的浏览器路径不存在，已忽略：$browserOverride")
+        -Chinese "显式指定的浏览器路径不存在，已忽略：$browserOverride"
+    Write-Warning $warningMessage
     return $null
 }
 
@@ -1178,39 +1214,6 @@ function Install-AgentBrowser {
     Configure-AgentBrowserBrowser
 }
 
-function Install-DingtalkChannelDeps {
-    $connectorDir = Join-Path $RootDir ".flocks\plugins\channels\dingtalk\dingtalk-openclaw-connector"
-    $packageJson  = Join-Path $connectorDir "package.json"
-
-    if (-not (Test-Path $packageJson)) {
-        return
-    }
-
-    $nodeModulesDir = Join-Path $connectorDir "node_modules"
-    if (Test-Path $nodeModulesDir) {
-        Write-Info (Get-LocalizedText -English "DingTalk channel dependencies already exist. Skipping installation." -Chinese "钉钉频道依赖已存在，跳过安装。")
-        return
-    }
-
-    Write-Info (Get-LocalizedText -English "Detected DingTalk channel plugin. Installing npm dependencies..." -Chinese "检测到钉钉频道插件，正在安装 npm 依赖...")
-
-    Push-Location $connectorDir
-    try {
-        $null = Invoke-NativeCommandOrFail `
-            -Description "DingTalk channel npm dependency installation" `
-            -FilePath "npm.cmd" `
-            -ArgumentList @("install") `
-            -WorkingDirectory $connectorDir `
-            -Environment @{ npm_config_registry = $script:NpmRegistry } `
-            -StreamOutput
-    }
-    finally {
-        Pop-Location
-    }
-
-    Write-Info (Get-LocalizedText -English "DingTalk channel dependencies installed." -Chinese "钉钉频道依赖安装完成。")
-}
-
 function Main {
     if ($Help) {
         Show-Usage
@@ -1260,8 +1263,6 @@ function Main {
     finally {
         Pop-Location
     }
-
-    Install-DingtalkChannelDeps
 
     if ($InstallTui) {
         Install-Bun

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,7 @@ INSTALL_LANGUAGE="${FLOCKS_INSTALL_LANGUAGE:-en}"
 UV_DEFAULT_INDEX="${FLOCKS_UV_DEFAULT_INDEX:-https://pypi.org/simple}"
 UV_INSTALL_SH_URL="${FLOCKS_UV_INSTALL_SH_URL:-https://astral.sh/uv/install.sh}"
 UV_INSTALL_SH_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_FALLBACK_URL:-}"
+UV_INSTALL_SH_SECONDARY_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL:-https://astral.sh/uv/install.sh}"
 NPM_REGISTRY="${FLOCKS_NPM_REGISTRY:-https://registry.npmjs.org/}"
 NODEJS_MANUAL_DOWNLOAD_URL="${FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL:-https://nodejs.org/en/download}"
 NVM_INSTALL_SCRIPT_URL="${FLOCKS_NVM_INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh}"
@@ -69,6 +70,9 @@ select_install_sources() {
     info "使用 nvm 安装脚本: $NVM_INSTALL_SCRIPT_URL"
     if [[ -n "$UV_INSTALL_SH_FALLBACK_URL" ]]; then
       info "使用 uv 备用安装脚本: $UV_INSTALL_SH_FALLBACK_URL"
+    fi
+    if [[ -n "$UV_INSTALL_SH_SECONDARY_FALLBACK_URL" ]]; then
+      info "使用 uv 官方回退安装脚本: $UV_INSTALL_SH_SECONDARY_FALLBACK_URL"
     fi
   else
     info "Using PyPI index: $UV_DEFAULT_INDEX"
@@ -629,6 +633,7 @@ ensure_npm_global_prefix_writable() {
 
 install_uv() {
   local primary_install_failed=0
+  local fallback_install_failed=0
   if has_cmd uv; then
     return
   fi
@@ -658,7 +663,31 @@ install_uv() {
     fi
 
     if ! curl -LsSf "$UV_INSTALL_SH_FALLBACK_URL" | sh; then
-      fail "默认 uv 安装脚本和中国大陆备用源都执行失败。请检查网络连通性或 PATH 后重试。"
+      fallback_install_failed=1
+    fi
+    refresh_path
+    ensure_path_persisted "$HOME/.local/bin"
+  fi
+
+  if has_cmd uv; then
+    return
+  fi
+
+  if is_zh_install && [[ -n "$UV_INSTALL_SH_SECONDARY_FALLBACK_URL" ]]; then
+    if [[ -n "$UV_INSTALL_SH_FALLBACK_URL" ]]; then
+      if [[ "$fallback_install_failed" -eq 1 ]]; then
+        info "中国大陆备用源失败，正在尝试官方 uv 安装脚本..."
+      else
+        info "中国大陆备用源执行后仍未检测到 uv，正在尝试官方 uv 安装脚本..."
+      fi
+    elif [[ "$primary_install_failed" -eq 1 ]]; then
+      info "默认 uv 安装脚本失败，正在尝试官方 uv 安装脚本..."
+    else
+      info "默认 uv 安装脚本执行后仍未检测到 uv，正在尝试官方 uv 安装脚本..."
+    fi
+
+    if ! curl -LsSf "$UV_INSTALL_SH_SECONDARY_FALLBACK_URL" | sh; then
+      fail "默认 uv 安装脚本、中国大陆备用源和官方 uv 安装脚本都执行失败。请检查网络连通性或 PATH 后重试。"
     fi
     refresh_path
     ensure_path_persisted "$HOME/.local/bin"
@@ -831,36 +860,6 @@ install_bun() {
   refresh_path
   ensure_path_persisted "$HOME/.bun/bin"
   has_cmd bun || fail "bun finished installing, but it is still not available. Check PATH and retry."
-}
-
-install_dingtalk_channel_deps() {
-  local connector_dir="$ROOT_DIR/.flocks/plugins/channels/dingtalk/dingtalk-openclaw-connector"
-  [[ -f "$connector_dir/package.json" ]] || return 0
-
-  local node_modules_dir="$connector_dir/node_modules"
-  if [[ -d "$node_modules_dir" ]]; then
-    if is_zh_install; then
-      info "钉钉频道依赖已存在，跳过安装。"
-    else
-      info "DingTalk channel dependencies already exist. Skipping installation."
-    fi
-    return 0
-  fi
-
-  if is_zh_install; then
-    info "检测到钉钉频道插件，正在安装 npm 依赖..."
-  else
-    info "Detected DingTalk channel plugin. Installing npm dependencies..."
-  fi
-  (
-    cd "$connector_dir"
-    npm_config_registry="$NPM_REGISTRY" npm install
-  )
-  if is_zh_install; then
-    info "钉钉频道依赖安装完成。"
-  else
-    info "DingTalk channel dependencies installed."
-  fi
 }
 
 ensure_env_var_persisted() {
@@ -1069,8 +1068,6 @@ main() {
     cd "$ROOT_DIR/webui"
     npm_config_registry="$NPM_REGISTRY" npm install
   )
-
-  install_dingtalk_channel_deps
 
   if [[ "$INSTALL_TUI" -eq 1 ]]; then
     install_bun

--- a/scripts/install_zh.ps1
+++ b/scripts/install_zh.ps1
@@ -49,6 +49,7 @@ function Show-Usage {
     Write-Host "  npm : https://registry.npmmirror.com/"
     Write-Host "  uv  : https://astral.org.cn/uv/install.ps1"
     Write-Host "  uv 备用源: https://uv.agentsmirror.com/install-cn.ps1"
+    Write-Host "  uv 官方回退: https://astral.sh/uv/install.ps1"
     Write-Host ""
     Write-Host "一键安装入口："
     Write-Host "  curl -fsSL $RawInstallZhShUrl | bash"
@@ -78,11 +79,20 @@ function Set-CnInstallerEnvironment {
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_SH_URL)) {
         $env:FLOCKS_UV_INSTALL_SH_URL = "https://astral.org.cn/uv/install.sh"
     }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_SH_FALLBACK_URL)) {
+        $env:FLOCKS_UV_INSTALL_SH_FALLBACK_URL = "https://uv.agentsmirror.com/install-cn.sh"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL)) {
+        $env:FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL = "https://astral.sh/uv/install.sh"
+    }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_URL)) {
         $env:FLOCKS_UV_INSTALL_PS1_URL = "https://astral.org.cn/uv/install.ps1"
     }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL)) {
         $env:FLOCKS_UV_INSTALL_PS1_FALLBACK_URL = "https://uv.agentsmirror.com/install-cn.ps1"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL)) {
+        $env:FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL = "https://astral.sh/uv/install.ps1"
     }
     if ([string]::IsNullOrWhiteSpace($env:FLOCKS_NPM_REGISTRY)) {
         $env:FLOCKS_NPM_REGISTRY = "https://registry.npmmirror.com/"

--- a/scripts/install_zh.sh
+++ b/scripts/install_zh.sh
@@ -21,6 +21,7 @@ Flocks 中国用户源码安装脚本。
   uv  : https://astral.org.cn/uv/install.sh
   nvm : https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh
   uv 备用源: https://uv.agentsmirror.com/install-cn.sh
+  uv 官方回退: https://astral.sh/uv/install.sh
 
 一键安装入口：
   curl -fsSL $RAW_INSTALL_ZH_SH_URL | bash
@@ -41,7 +42,9 @@ configure_cn_environment() {
   export FLOCKS_UV_DEFAULT_INDEX="${FLOCKS_UV_DEFAULT_INDEX:-https://mirrors.aliyun.com/pypi/simple}"
   export FLOCKS_UV_INSTALL_SH_URL="${FLOCKS_UV_INSTALL_SH_URL:-https://astral.org.cn/uv/install.sh}"
   export FLOCKS_UV_INSTALL_SH_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_FALLBACK_URL:-https://uv.agentsmirror.com/install-cn.sh}"
+  export FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL="${FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL:-https://astral.sh/uv/install.sh}"
   export FLOCKS_UV_INSTALL_PS1_URL="${FLOCKS_UV_INSTALL_PS1_URL:-https://astral.org.cn/uv/install.ps1}"
+  export FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL="${FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL:-https://astral.sh/uv/install.ps1}"
   export FLOCKS_NPM_REGISTRY="${FLOCKS_NPM_REGISTRY:-https://registry.npmmirror.com/}"
   export FLOCKS_NVM_INSTALL_SCRIPT_URL="${FLOCKS_NVM_INSTALL_SCRIPT_URL:-https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh}"
   export PUPPETEER_CHROME_DOWNLOAD_BASE_URL="${PUPPETEER_CHROME_DOWNLOAD_BASE_URL:-https://cdn.npmmirror.com/binaries/chrome-for-testing}"

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -25,8 +25,12 @@ def test_install_zh_bash_bootstrap_uses_gitee_archive_and_delegates_to_zh_worksp
     assert 'https://astral.org.cn/uv/install.sh' in script
     assert 'FLOCKS_UV_INSTALL_SH_FALLBACK_URL' in script
     assert 'https://uv.agentsmirror.com/install-cn.sh' in script
+    assert 'FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL' in script
+    assert 'https://astral.sh/uv/install.sh' in script
     assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
     assert 'https://astral.org.cn/uv/install.ps1' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL' in script
+    assert 'https://astral.sh/uv/install.ps1' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'https://registry.npmmirror.com/' in script
     assert 'FLOCKS_NVM_INSTALL_SCRIPT_URL' in script
@@ -55,6 +59,8 @@ def test_install_zh_powershell_bootstrap_uses_gitee_archive_and_delegates_to_zh_
     assert 'https://astral.org.cn/uv/install.ps1' in script
     assert 'FLOCKS_UV_INSTALL_PS1_FALLBACK_URL' in script
     assert 'https://uv.agentsmirror.com/install-cn.ps1' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL' in script
+    assert 'https://astral.sh/uv/install.ps1' in script
     assert 'PUPPETEER_CHROME_DOWNLOAD_BASE_URL' in script
     assert 'https://cdn.npmmirror.com/binaries/chrome-for-testing' in script
 
@@ -76,8 +82,14 @@ def test_install_zh_bash_wrapper_sets_cn_sources_and_reuses_main_installer() -> 
     assert 'https://mirrors.aliyun.com/pypi/simple' in script
     assert 'FLOCKS_UV_INSTALL_SH_URL' in script
     assert 'https://astral.org.cn/uv/install.sh' in script
+    assert 'FLOCKS_UV_INSTALL_SH_FALLBACK_URL' in script
+    assert 'https://uv.agentsmirror.com/install-cn.sh' in script
+    assert 'FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL' in script
+    assert 'https://astral.sh/uv/install.sh' in script
     assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
     assert 'https://astral.org.cn/uv/install.ps1' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL' in script
+    assert 'https://astral.sh/uv/install.ps1' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'https://registry.npmmirror.com/' in script
     assert 'FLOCKS_NVM_INSTALL_SCRIPT_URL' in script
@@ -108,6 +120,8 @@ def test_install_zh_powershell_wrapper_sets_cn_sources_and_reuses_main_installer
     assert 'https://astral.org.cn/uv/install.ps1' in script
     assert 'FLOCKS_UV_INSTALL_PS1_FALLBACK_URL' in script
     assert 'https://uv.agentsmirror.com/install-cn.ps1' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL' in script
+    assert 'https://astral.sh/uv/install.ps1' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'https://registry.npmmirror.com/' in script
     assert 'FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL' in script
@@ -123,6 +137,7 @@ def test_main_bash_installer_uses_configured_default_sources_without_probing() -
     assert 'FLOCKS_UV_INSTALL_SH_URL' in script
     assert 'https://astral.sh/uv/install.sh' in script
     assert 'FLOCKS_UV_INSTALL_SH_FALLBACK_URL' in script
+    assert 'FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL' in script
     assert 'FLOCKS_NPM_REGISTRY' in script
     assert 'Using PyPI index: $UV_DEFAULT_INDEX' in script
     assert 'Using npm registry: $NPM_REGISTRY' in script
@@ -130,12 +145,12 @@ def test_main_bash_installer_uses_configured_default_sources_without_probing() -
     assert 'Using nvm install script: $NVM_INSTALL_SCRIPT_URL' in script
     assert 'Using uv fallback script' not in script
     assert '使用 uv 备用安装脚本: $UV_INSTALL_SH_FALLBACK_URL' in script
+    assert '使用 uv 官方回退安装脚本: $UV_INSTALL_SH_SECONDARY_FALLBACK_URL' in script
     assert 'pick_fastest_url' not in script
     assert 'Probing PyPI and npm registries to choose the faster source' not in script
     assert 'npm_config_registry="$NPM_REGISTRY" npm install' in script
     assert 'npm_config_registry="$NPM_REGISTRY" npx --yes @puppeteer/browsers install chrome@stable --path "$browser_dir"' in script
     assert 'npm_config_registry="$NPM_REGISTRY" npm install --global agent-browser' in script
-    assert 'local connector_dir="$ROOT_DIR/.flocks/plugins/channels/dingtalk/dingtalk-openclaw-connector"' in script
     assert "FLOCKS_NODEJS_MANUAL_DOWNLOAD_URL" in script
     assert "https://nodejs.org/en/download" in script
     assert "nodejs_manual_download_hint" in script
@@ -154,6 +169,7 @@ def test_main_bash_installer_uses_configured_default_sources_without_probing() -
     assert 'curl -fsSL "$NVM_INSTALL_SCRIPT_URL" -o "$install_script"' in script
     assert 'curl -LsSf "$UV_INSTALL_SH_URL" | sh' in script
     assert 'curl -LsSf "$UV_INSTALL_SH_FALLBACK_URL" | sh' in script
+    assert 'curl -LsSf "$UV_INSTALL_SH_SECONDARY_FALLBACK_URL" | sh' in script
     assert 'nvm install "$MIN_NODE_MAJOR"' in script
     assert 'nvm use "$MIN_NODE_MAJOR" >/dev/null' in script
     assert "Homebrew failed to install Node.js. Falling back to nvm..." in script
@@ -170,6 +186,7 @@ def test_main_powershell_installer_uses_configured_default_sources_and_admin_pre
     assert 'FLOCKS_UV_DEFAULT_INDEX' in script
     assert 'FLOCKS_UV_INSTALL_PS1_URL' in script
     assert 'FLOCKS_UV_INSTALL_PS1_FALLBACK_URL' in script
+    assert 'FLOCKS_UV_INSTALL_PS1_SECONDARY_FALLBACK_URL' in script
     assert 'https://astral.sh/uv/install.ps1' in script
     assert 'https://uv.agentsmirror.com/install-cn.ps1' in script
     assert 'Using PyPI index: $script:UvDefaultIndex' in script
@@ -177,6 +194,7 @@ def test_main_powershell_installer_uses_configured_default_sources_and_admin_pre
     assert 'Using uv install script: $script:UvInstallPs1Url' in script
     assert "irm '$script:UvInstallPs1Url' | iex" in script
     assert "irm '$script:UvInstallPs1FallbackUrl' | iex" in script
+    assert "irm '$script:UvInstallPs1SecondaryFallbackUrl' | iex" in script
     assert 'function Assert-Administrator' in script
     assert 'Assert-Administrator' in script
 
@@ -539,7 +557,7 @@ def test_main_bash_installer_checks_node_modules_dir_before_accepting_global_pre
     assert result.returncode == 0, output
 
 
-def test_main_bash_installer_uses_cn_uv_fallback_when_primary_script_fails() -> None:
+def test_main_bash_installer_uses_cn_uv_official_fallback_after_agentsmirror() -> None:
     script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
     script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)
     test_script = script_without_main + textwrap.dedent(
@@ -549,10 +567,12 @@ def test_main_bash_installer_uses_cn_uv_fallback_when_primary_script_fails() -> 
         export FLOCKS_INSTALL_LANGUAGE="zh-CN"
         export FLOCKS_UV_INSTALL_SH_URL="https://primary.example/install.sh"
         export FLOCKS_UV_INSTALL_SH_FALLBACK_URL="https://uv.agentsmirror.com/install-cn.sh"
+        export FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL="https://astral.sh/uv/install.sh"
         export TEST_LOG="$HOME/install-uv.log"
         INSTALL_LANGUAGE="$FLOCKS_INSTALL_LANGUAGE"
         UV_INSTALL_SH_URL="$FLOCKS_UV_INSTALL_SH_URL"
         UV_INSTALL_SH_FALLBACK_URL="$FLOCKS_UV_INSTALL_SH_FALLBACK_URL"
+        UV_INSTALL_SH_SECONDARY_FALLBACK_URL="$FLOCKS_UV_INSTALL_SH_SECONDARY_FALLBACK_URL"
 
         has_cmd() {
           case "$1" in
@@ -588,7 +608,7 @@ def test_main_bash_installer_uses_cn_uv_fallback_when_primary_script_fails() -> 
 
         curl() {
           printf '%s\n' "$*" >> "$HOME/curl-commands.log"
-          if [[ "$*" == *"primary.example"* ]]; then
+          if [[ "$*" == *"primary.example"* || "$*" == *"uv.agentsmirror.com"* ]]; then
             return 22
           fi
 
@@ -611,11 +631,19 @@ def test_main_bash_installer_uses_cn_uv_fallback_when_primary_script_fails() -> 
           exit 1
         }
         [[ "$curl_commands" == *"https://uv.agentsmirror.com/install-cn.sh"* ]] || {
-          printf 'fallback uv script was not attempted: %s\n' "$curl_commands" >&2
+          printf 'agentsmirror fallback uv script was not attempted: %s\n' "$curl_commands" >&2
+          exit 1
+        }
+        [[ "$curl_commands" == *"https://astral.sh/uv/install.sh"* ]] || {
+          printf 'official fallback uv script was not attempted: %s\n' "$curl_commands" >&2
           exit 1
         }
         [[ "$install_log" == *"默认 uv 安装脚本失败，正在尝试中国大陆备用源"* ]] || {
-          printf 'fallback log missing: %s\n' "$install_log" >&2
+          printf 'agentsmirror fallback log missing: %s\n' "$install_log" >&2
+          exit 1
+        }
+        [[ "$install_log" == *"中国大陆备用源失败，正在尝试官方 uv 安装脚本"* ]] || {
+          printf 'official fallback log missing: %s\n' "$install_log" >&2
           exit 1
         }
         """


### PR DESCRIPTION
## Summary
- add an official `astral.sh` fallback after the zh installer's mainland `uv.agentsmirror.com` fallback for both shell and PowerShell flows
- remove automatic DingTalk connector dependency installation from the install scripts so setup only installs core runtime dependencies
- update installer source tests to cover the new fallback chain and keep PowerShell encoding expectations intact