### PR TITLE
fix(skill): hide form tab when creating a new skill

### DIFF
--- a/webui/src/pages/Skill/SkillSheet.tsx
+++ b/webui/src/pages/Skill/SkillSheet.tsx
@@ -184,6 +184,7 @@ export default function SkillSheet({ skill, onClose, onSaved, onDeleted }: Skill
       submitDisabled={!canSubmit}
       submitLoading={loading}
       submitLabel={isReadonly ? t('sheet.submitClose') : undefined}
+      hideForm={!isEdit}
       width={700}
       maxWidth={900}
       onClose={onClose}


### PR DESCRIPTION
When clicking "创建技能", only the Rex AI chat tab is now shown, consistent with the "创建子 Agent" behavior on the Agent page. The detail/form tab continues to appear when clicking an existing skill card.