### PR TITLE
fix(provider): support custom Azure deployments

### DIFF
--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -2320,9 +2320,15 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
             requested_model_id = body.model_id if body else None
             test_model_id = requested_model_id or models[0].id
 
-            # Validate model belongs to this provider
+            # Validate model belongs to this provider. Azure OpenAI is the
+            # exception: users may test a deployment name before saving it.
             valid_ids = {m.id for m in models}
-            if test_model_id not in valid_ids:
+            is_unsaved_azure_deployment = (
+                requested_model_id
+                and provider_id in {"azure-openai", "azure"}
+                and test_model_id not in valid_ids
+            )
+            if test_model_id not in valid_ids and not is_unsaved_azure_deployment:
                 response = {
                     "success": False,
                     "message": f"模型 '{test_model_id}' 不属于该 Provider",

--- a/tests/provider/test_azure_provider.py
+++ b/tests/provider/test_azure_provider.py
@@ -22,3 +22,12 @@ def test_azure_provider_returns_configured_deployment_models():
 
     assert [m.id for m in models] == ["customer-prod-deployment"]
     assert models[0].name == "Customer Production Deployment"
+
+
+def test_azure_provider_returns_fallback_models_without_config():
+    provider = AzureProvider()
+
+    models = provider.get_models()
+
+    assert {m.id for m in models} == {"gpt-5.4", "gpt-5-mini"}
+    assert all(m.provider_id == "azure" for m in models)

--- a/tests/provider/test_azure_provider.py
+++ b/tests/provider/test_azure_provider.py
@@ -1,0 +1,24 @@
+from flocks.provider.provider import ModelCapabilities, ModelInfo
+from flocks.provider.sdk.azure import AzureProvider
+
+
+def test_azure_provider_returns_configured_deployment_models():
+    provider = AzureProvider()
+    provider._config_models = [
+        ModelInfo(
+            id="customer-prod-deployment",
+            name="Customer Production Deployment",
+            provider_id="azure",
+            capabilities=ModelCapabilities(
+                supports_tools=True,
+                supports_streaming=True,
+                context_window=128000,
+                max_tokens=4096,
+            ),
+        )
+    ]
+
+    models = provider.get_models()
+
+    assert [m.id for m in models] == ["customer-prod-deployment"]
+    assert models[0].name == "Customer Production Deployment"

--- a/tests/provider/test_test_credentials.py
+++ b/tests/provider/test_test_credentials.py
@@ -754,3 +754,43 @@ class TestTestCredentialsInlineConfigFallback:
             assert configured.api_key == "gateway-api-key"
             assert configured.base_url == "https://gateway.internal/v1"
             assert configured.custom_settings["verify_ssl"] is False
+
+    @pytest.mark.asyncio
+    async def test_requested_azure_deployment_model_is_used_for_provider_test(self):
+        from flocks.server.routes.provider import TestCredentialRequest, test_provider_credentials
+
+        provider = MagicMock()
+        provider._config = MagicMock(
+            custom_settings={},
+            base_url="https://example-resource.openai.azure.com/",
+        )
+        provider.chat = AsyncMock(return_value=MagicMock(content="Paris"))
+
+        model = MagicMock()
+        model.id = "customer-prod-deployment"
+
+        mock_secrets = MagicMock()
+        mock_secrets.get.return_value = "azure-api-key"
+
+        mock_config = MagicMock()
+
+        with (
+            patch(_PATCH_SECRET_MGR, return_value=mock_secrets),
+            patch(_PATCH_CONFIG_GET, new_callable=AsyncMock, return_value=mock_config),
+            patch(_PATCH_PROVIDER) as mock_provider_cls,
+        ):
+            mock_provider_cls._ensure_initialized = MagicMock()
+            mock_provider_cls._load_dynamic_providers = MagicMock()
+            mock_provider_cls.apply_config = AsyncMock()
+            mock_provider_cls.get.return_value = provider
+            mock_provider_cls.list_models.return_value = [model]
+
+            result = await test_provider_credentials(
+                "azure-openai",
+                TestCredentialRequest(model_id="customer-prod-deployment"),
+            )
+
+            assert result["success"] is True, result
+            assert result["model_id"] == "customer-prod-deployment"
+            provider.chat.assert_awaited_once()
+            assert provider.chat.await_args.args[0] == "customer-prod-deployment"

--- a/tests/provider/test_test_credentials.py
+++ b/tests/provider/test_test_credentials.py
@@ -794,3 +794,43 @@ class TestTestCredentialsInlineConfigFallback:
             assert result["model_id"] == "customer-prod-deployment"
             provider.chat.assert_awaited_once()
             assert provider.chat.await_args.args[0] == "customer-prod-deployment"
+
+    @pytest.mark.asyncio
+    async def test_unsaved_azure_deployment_can_be_tested_without_model_definition(self):
+        from flocks.server.routes.provider import TestCredentialRequest, test_provider_credentials
+
+        provider = MagicMock()
+        provider._config = MagicMock(
+            custom_settings={},
+            base_url="https://example-resource.openai.azure.com/",
+        )
+        provider.chat = AsyncMock(return_value=MagicMock(content="Paris"))
+
+        catalog_model = MagicMock()
+        catalog_model.id = "gpt-5.4"
+
+        mock_secrets = MagicMock()
+        mock_secrets.get.return_value = "azure-api-key"
+
+        mock_config = MagicMock()
+
+        with (
+            patch(_PATCH_SECRET_MGR, return_value=mock_secrets),
+            patch(_PATCH_CONFIG_GET, new_callable=AsyncMock, return_value=mock_config),
+            patch(_PATCH_PROVIDER) as mock_provider_cls,
+        ):
+            mock_provider_cls._ensure_initialized = MagicMock()
+            mock_provider_cls._load_dynamic_providers = MagicMock()
+            mock_provider_cls.apply_config = AsyncMock()
+            mock_provider_cls.get.return_value = provider
+            mock_provider_cls.list_models.return_value = [catalog_model]
+
+            result = await test_provider_credentials(
+                "azure-openai",
+                TestCredentialRequest(model_id="unsaved-prod-deployment"),
+            )
+
+            assert result["success"] is True, result
+            assert result["model_id"] == "unsaved-prod-deployment"
+            provider.chat.assert_awaited_once()
+            assert provider.chat.await_args.args[0] == "unsaved-prod-deployment"

--- a/tests/server/routes/test_custom_provider_runtime.py
+++ b/tests/server/routes/test_custom_provider_runtime.py
@@ -48,3 +48,36 @@ def test_add_model_to_runtime_preserves_reasoning_and_currency(monkeypatch):
         assert provider._config_models[0].capabilities.supports_reasoning is True
     finally:
         Provider._models = original_models
+
+
+def test_add_azure_deployment_to_runtime_config_models(monkeypatch):
+    class DynamicAzureProvider:
+        _config_models = []
+
+    provider = DynamicAzureProvider()
+    body = CreateModelReq(
+        model_id="customer-prod-deployment",
+        name="Customer Production Deployment",
+        context_window=128000,
+        max_output_tokens=4096,
+        supports_vision=False,
+        supports_tools=True,
+        supports_streaming=True,
+        supports_reasoning=False,
+        input_price=0.0,
+        output_price=0.0,
+        currency="USD",
+    )
+
+    original_models = Provider._models
+    Provider._models = {}
+    monkeypatch.setattr(Provider, "get", classmethod(lambda cls, provider_id: provider))
+
+    try:
+        _add_model_to_runtime("azure-openai", body)
+
+        assert Provider._models[body.model_id].provider_id == "azure-openai"
+        assert provider._config_models[0].id == "customer-prod-deployment"
+        assert provider._config_models[0].name == "Customer Production Deployment"
+    finally:
+        Provider._models = original_models

--- a/tests/server/routes/test_custom_provider_runtime.py
+++ b/tests/server/routes/test_custom_provider_runtime.py
@@ -1,4 +1,5 @@
 from flocks.provider.provider import ModelCapabilities, ModelInfo, Provider
+from flocks.provider.sdk.azure import AzureProvider
 from flocks.server.routes.custom_provider import CreateModelReq, _add_model_to_runtime
 
 
@@ -51,10 +52,9 @@ def test_add_model_to_runtime_preserves_reasoning_and_currency(monkeypatch):
 
 
 def test_add_azure_deployment_to_runtime_config_models(monkeypatch):
-    class DynamicAzureProvider:
-        _config_models = []
-
-    provider = DynamicAzureProvider()
+    provider = AzureProvider()
+    provider.id = "azure-openai"
+    provider._config_models = []
     body = CreateModelReq(
         model_id="customer-prod-deployment",
         name="Customer Production Deployment",

--- a/webui/src/locales/en-US/model.json
+++ b/webui/src/locales/en-US/model.json
@@ -119,7 +119,14 @@
     "loadFailed": "Failed to load provider catalog",
     "noModelsToTest": "No enabled models to test",
     "batchTestDone": "Batch test complete",
-    "batchTestSummary": "{{success}} succeeded, {{failed}} failed"
+    "batchTestSummary": "{{success}} succeeded, {{failed}} failed",
+    "azureDeploymentName": "Azure Deployment Name",
+    "azureDeploymentPlaceholder": "e.g. my-gpt-4o-prod",
+    "azureDeploymentHint": "Azure OpenAI requests use the deployment name, not a fixed model name. The preset models are examples; enter your own deployment name here.",
+    "azureDeploymentDisplayName": "Display Name (optional)",
+    "azureDeploymentDisplayPlaceholder": "e.g. GPT-4o Production",
+    "azureDeploymentRequired": "Select at least one preset model or enter an Azure deployment name",
+    "azureModelIdHint": "For Azure OpenAI, Model ID should be the deployment name from Azure Portal."
   },
   "wizard": {
     "providerSaved": "Provider Saved",

--- a/webui/src/locales/en-US/model.json
+++ b/webui/src/locales/en-US/model.json
@@ -126,7 +126,9 @@
     "azureDeploymentDisplayName": "Display Name (optional)",
     "azureDeploymentDisplayPlaceholder": "e.g. GPT-4o Production",
     "azureDeploymentRequired": "Select at least one preset model or enter an Azure deployment name",
-    "azureModelIdHint": "For Azure OpenAI, Model ID should be the deployment name from Azure Portal."
+    "azureModelIdHint": "For Azure OpenAI, Model ID should be the deployment name from Azure Portal.",
+    "azureCustomDeployments": "Custom Azure Deployments",
+    "azureNoCustomDeployments": "No custom Azure deployment has been added yet."
   },
   "wizard": {
     "providerSaved": "Provider Saved",

--- a/webui/src/locales/zh-CN/model.json
+++ b/webui/src/locales/zh-CN/model.json
@@ -120,7 +120,7 @@
     "noModelsToTest": "没有已启用的模型可测试",
     "batchTestDone": "批量测试完成",
     "batchTestSummary": "{{success}} 成功, {{failed}} 失败",
-    "azureDeploymentName": "Azure Deployment Name",
+    "azureDeploymentName": "Azure 部署名称",
     "azureDeploymentPlaceholder": "例如 my-gpt-4o-prod",
     "azureDeploymentHint": "Azure OpenAI 请求使用 deployment name，而不是固定模型名。预设模型只是常用示例，你可以在这里填写自己的部署名称。",
     "azureDeploymentDisplayName": "显示名称（可选）",

--- a/webui/src/locales/zh-CN/model.json
+++ b/webui/src/locales/zh-CN/model.json
@@ -119,7 +119,14 @@
     "loadFailed": "加载 Provider 目录失败",
     "noModelsToTest": "没有已启用的模型可测试",
     "batchTestDone": "批量测试完成",
-    "batchTestSummary": "{{success}} 成功, {{failed}} 失败"
+    "batchTestSummary": "{{success}} 成功, {{failed}} 失败",
+    "azureDeploymentName": "Azure Deployment Name",
+    "azureDeploymentPlaceholder": "例如 my-gpt-4o-prod",
+    "azureDeploymentHint": "Azure OpenAI 请求使用 deployment name，而不是固定模型名。预设模型只是常用示例，你可以在这里填写自己的部署名称。",
+    "azureDeploymentDisplayName": "显示名称（可选）",
+    "azureDeploymentDisplayPlaceholder": "例如 GPT-4o Production",
+    "azureDeploymentRequired": "请至少选择一个预设模型，或填写 Azure deployment name",
+    "azureModelIdHint": "对于 Azure OpenAI，模型 ID 请填写 Azure Portal 中的 deployment name。"
   },
   "wizard": {
     "providerSaved": "Provider 已保存",

--- a/webui/src/locales/zh-CN/model.json
+++ b/webui/src/locales/zh-CN/model.json
@@ -126,7 +126,9 @@
     "azureDeploymentDisplayName": "显示名称（可选）",
     "azureDeploymentDisplayPlaceholder": "例如 GPT-4o Production",
     "azureDeploymentRequired": "请至少选择一个预设模型，或填写 Azure deployment name",
-    "azureModelIdHint": "对于 Azure OpenAI，模型 ID 请填写 Azure Portal 中的 deployment name。"
+    "azureModelIdHint": "对于 Azure OpenAI，模型 ID 请填写 Azure Portal 中的 deployment name。",
+    "azureCustomDeployments": "自定义 Azure Deployments",
+    "azureNoCustomDeployments": "尚未添加自定义 Azure deployment。"
   },
   "wizard": {
     "providerSaved": "Provider 已保存",

--- a/webui/src/pages/Model/index.tsx
+++ b/webui/src/pages/Model/index.tsx
@@ -2161,6 +2161,18 @@ function ConfigureProviderDialog({ provider, existingCredentials, models, onClos
   // Catalog model management
   const [catalogModels, setCatalogModels] = useState<CatalogModel[]>([]);
   const [selectedModelIds, setSelectedModelIds] = useState<Set<string>>(new Set(models.map(m => m.id)));
+  const [newAzureDeploymentName, setNewAzureDeploymentName] = useState('');
+  const [newAzureDeploymentDisplayName, setNewAzureDeploymentDisplayName] = useState('');
+  const isAzureProvider = provider.id === 'azure-openai' || provider.id === 'azure';
+  const catalogModelIds = useMemo(() => new Set(catalogModels.map(m => m.id)), [catalogModels]);
+  const selectedCatalogModelCount = useMemo(
+    () => catalogModels.filter(m => selectedModelIds.has(m.id)).length,
+    [catalogModels, selectedModelIds]
+  );
+  const azureCustomModels = useMemo(
+    () => isAzureProvider ? models.filter(m => !catalogModelIds.has(m.id)) : [],
+    [catalogModelIds, isAzureProvider, models]
+  );
 
   useEffect(() => {
     setApiKey(existingKey);
@@ -2222,6 +2234,13 @@ function ConfigureProviderDialog({ provider, existingCredentials, models, onClos
           ...toDelete.map(m => modelV2API.deleteDefinition(provider.id, m.id).catch(() => {})),
           ...toAdd.map(m => modelV2API.createDefinition(provider.id, { model_id: m.id, name: m.name }).catch(() => {})),
         ]);
+      }
+      const azureModelId = newAzureDeploymentName.trim();
+      if (isAzureProvider && azureModelId) {
+        await modelV2API.createDefinition(provider.id, {
+          model_id: azureModelId,
+          name: newAzureDeploymentDisplayName.trim() || azureModelId,
+        });
       }
 
       toast.success(t('credentialsSaved'));
@@ -2418,7 +2437,7 @@ ${hasExisting ? '你已有凭证配置，可以更新或测试连接。' : '请�
               <label className="text-sm font-medium text-gray-700">
                 {t('form.availableModels')}
                 <span className="text-gray-400 font-normal ml-1">
-                  ({selectedModelIds.size}/{catalogModels.length} {t('form.selected')})
+                  ({selectedCatalogModelCount}/{catalogModels.length} {t('form.selected')})
                 </span>
               </label>
               <button type="button" onClick={handleToggleAllCatalogModels} className="text-xs text-slate-600 hover:text-slate-800">
@@ -2452,6 +2471,55 @@ ${hasExisting ? '你已有凭证配置，可以更新或测试连接。' : '请�
                   </div>
                 </label>
               ))}
+            </div>
+          </div>
+        )}
+
+        {isAzureProvider && (
+          <div className="space-y-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+            <div>
+              <h4 className="text-sm font-medium text-gray-900">{t('form.azureCustomDeployments')}</h4>
+              <p className="mt-1 text-xs text-blue-800">{t('form.azureDeploymentHint')}</p>
+            </div>
+
+            {azureCustomModels.length > 0 ? (
+              <div className="space-y-2">
+                {azureCustomModels.map(model => (
+                  <div key={model.id} className="px-3 py-2 bg-white border border-blue-100 rounded-lg">
+                    <div className="text-sm font-medium text-gray-900">{model.name || model.id}</div>
+                    <div className="text-xs text-gray-500 font-mono mt-0.5">{model.id}</div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-gray-500">{t('form.azureNoCustomDeployments')}</p>
+            )}
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  {t('form.azureDeploymentName')}
+                </label>
+                <input
+                  type="text"
+                  value={newAzureDeploymentName}
+                  onChange={e => setNewAzureDeploymentName(e.target.value)}
+                  className="w-full px-3 py-2 border border-blue-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-300 text-sm bg-white"
+                  placeholder={t('form.azureDeploymentPlaceholder')}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  {t('form.azureDeploymentDisplayName')}
+                </label>
+                <input
+                  type="text"
+                  value={newAzureDeploymentDisplayName}
+                  onChange={e => setNewAzureDeploymentDisplayName(e.target.value)}
+                  className="w-full px-3 py-2 border border-blue-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-300 text-sm bg-white"
+                  placeholder={newAzureDeploymentName.trim() || t('form.azureDeploymentDisplayPlaceholder')}
+                />
+              </div>
             </div>
           </div>
         )}

--- a/webui/src/pages/Model/index.tsx
+++ b/webui/src/pages/Model/index.tsx
@@ -1088,6 +1088,8 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
   const [baseUrl, setBaseUrl] = useState('');
   const [description, setDescription] = useState('');
   const [providerName, setProviderName] = useState('');
+  const [azureDeploymentName, setAzureDeploymentName] = useState('');
+  const [azureDeploymentDisplayName, setAzureDeploymentDisplayName] = useState('');
 
   // Model selection (for catalog providers)
   const [selectedModelIds, setSelectedModelIds] = useState<Set<string>>(new Set());
@@ -1172,6 +1174,8 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
       setDescription(provider.description || '');
       setSelectedModelIds(new Set(provider.models.map(m => m.id)));
       setProviderName('');
+      setAzureDeploymentName('');
+      setAzureDeploymentDisplayName('');
     }
   };
 
@@ -1212,7 +1216,14 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
         base_url: baseUrl.trim() || undefined,
         provider_name: selectedCatalogId === 'openai-compatible' && providerName.trim() ? providerName.trim() : undefined,
       });
-      const res = await providerAPI.testCredentials(selectedCatalogId);
+      const azureModelId = selectedCatalogId === 'azure-openai' ? azureDeploymentName.trim() : '';
+      if (azureModelId) {
+        await modelV2API.createDefinition(selectedCatalogId, {
+          model_id: azureModelId,
+          name: azureDeploymentDisplayName.trim() || azureModelId,
+        });
+      }
+      const res = await providerAPI.testCredentials(selectedCatalogId, azureModelId || undefined);
       setTestResult({
         success: res.data.success,
         message: res.data.message || (res.data.success ? t('status.connected') : t('form.testFailed')),
@@ -1233,6 +1244,11 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
     }
     if (!apiKey.trim() && !providerAllowsEmptyApiKey(selectedCatalogId)) {
       toast.warning('Please enter API Key');
+      return;
+    }
+    const azureModelId = selectedCatalogId === 'azure-openai' ? azureDeploymentName.trim() : '';
+    if (selectedCatalogId === 'azure-openai' && selectedModelIds.size === 0 && !azureModelId) {
+      toast.warning(t('form.azureDeploymentRequired'));
       return;
     }
     try {
@@ -1258,6 +1274,20 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
       if (selectedCatalog) {
         const unselected = selectedCatalog.models.filter(m => !selectedModelIds.has(m.id)).map(m => m.id);
         await Promise.all(unselected.map(id => modelV2API.deleteDefinition(selectedCatalogId, id).catch(() => {})));
+      }
+      if (azureModelId) {
+        await modelV2API.createDefinition(selectedCatalogId, {
+          model_id: azureModelId,
+          name: azureDeploymentDisplayName.trim() || azureModelId,
+        });
+        try {
+          const res = await providerAPI.testCredentials(selectedCatalogId, azureModelId);
+          if (!res.data.success) {
+            toast.error(t('form.testFailed'), res.data.error || res.data.message);
+          }
+        } catch (testErr: any) {
+          toast.error(t('form.testFailed'), testErr.response?.data?.detail || testErr.message);
+        }
       }
       toast.success(t('providerAdded'), displayName);
       setSavedProviderId(selectedCatalogId);
@@ -1600,6 +1630,36 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
                         </div>
                       )}
 
+                      {selectedCatalogId === 'azure-openai' && (
+                        <div className="space-y-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                          <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                              {t('form.azureDeploymentName')}
+                            </label>
+                            <input
+                              type="text"
+                              value={azureDeploymentName}
+                              onChange={e => setAzureDeploymentName(e.target.value)}
+                              className="w-full px-3 py-2 border border-blue-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-300 text-sm bg-white"
+                              placeholder={t('form.azureDeploymentPlaceholder')}
+                            />
+                            <p className="mt-1 text-xs text-blue-800">{t('form.azureDeploymentHint')}</p>
+                          </div>
+                          <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                              {t('form.azureDeploymentDisplayName')}
+                            </label>
+                            <input
+                              type="text"
+                              value={azureDeploymentDisplayName}
+                              onChange={e => setAzureDeploymentDisplayName(e.target.value)}
+                              className="w-full px-3 py-2 border border-blue-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-300 text-sm bg-white"
+                              placeholder={azureDeploymentName.trim() || t('form.azureDeploymentDisplayPlaceholder')}
+                            />
+                          </div>
+                        </div>
+                      )}
+
                       {selectedCatalog.models.length > 0 && (
                         <div>
                           <div className="flex items-center justify-between mb-2">
@@ -1712,7 +1772,13 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
               <p className="text-xs text-green-800">{t('wizard.modelsAdded', { count: addedModelCount })}</p>
             </div>
           )}
-          <ModelFormFields form={modelForm} testResult={modelTestResult} testing={modelTesting} />
+          <ModelFormFields
+            form={modelForm}
+            testResult={modelTestResult}
+            testing={modelTesting}
+            modelIdPlaceholder={savedProviderId === 'azure-openai' ? t('form.azureDeploymentPlaceholder') : undefined}
+            modelIdHint={savedProviderId === 'azure-openai' ? t('form.azureModelIdHint') : undefined}
+          />
         </div>
       )}
     </EntitySheet>
@@ -1791,10 +1857,12 @@ function useModelForm() {
   };
 }
 
-function ModelFormFields({ form, testResult, testing }: {
+function ModelFormFields({ form, testResult, testing, modelIdPlaceholder, modelIdHint }: {
   form: ReturnType<typeof useModelForm>;
   testResult: { success: boolean; message: string; latency?: number } | null;
   testing: boolean;
+  modelIdPlaceholder?: string;
+  modelIdHint?: string;
 }) {
   const { t } = useTranslation('model');
   return (
@@ -1809,8 +1877,9 @@ function ModelFormFields({ form, testResult, testing }: {
             value={form.modelId}
             onChange={e => form.setModelId(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-400 text-sm"
-            placeholder="gpt-4o-custom"
+            placeholder={modelIdPlaceholder || 'gpt-4o-custom'}
           />
+          {modelIdHint && <p className="mt-1 text-xs text-gray-500">{modelIdHint}</p>}
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -2013,7 +2082,13 @@ Provider: ${provider.name} (${provider.id})
             className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 text-sm text-gray-900 cursor-default"
           />
         </div>
-        <ModelFormFields form={form} testResult={testResult} testing={testing} />
+        <ModelFormFields
+          form={form}
+          testResult={testResult}
+          testing={testing}
+          modelIdPlaceholder={(provider.id === 'azure-openai' || provider.id === 'azure') ? t('form.azureDeploymentPlaceholder') : undefined}
+          modelIdHint={(provider.id === 'azure-openai' || provider.id === 'azure') ? t('form.azureModelIdHint') : undefined}
+        />
       </div>
     </EntitySheet>
   );

--- a/webui/src/pages/Model/index.tsx
+++ b/webui/src/pages/Model/index.tsx
@@ -55,6 +55,12 @@ function providerAllowsEmptyApiKey(providerId: string): boolean {
   );
 }
 
+const AZURE_PROVIDER_IDS = new Set(['azure-openai', 'azure']);
+
+function isAzureProviderId(providerId: string): boolean {
+  return AZURE_PROVIDER_IDS.has(providerId);
+}
+
 // ==================== Connection Cache ====================
 
 const CONNECTION_CACHE_KEY = 'flocks_provider_connection_cache';
@@ -1216,13 +1222,7 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
         base_url: baseUrl.trim() || undefined,
         provider_name: selectedCatalogId === 'openai-compatible' && providerName.trim() ? providerName.trim() : undefined,
       });
-      const azureModelId = selectedCatalogId === 'azure-openai' ? azureDeploymentName.trim() : '';
-      if (azureModelId) {
-        await modelV2API.createDefinition(selectedCatalogId, {
-          model_id: azureModelId,
-          name: azureDeploymentDisplayName.trim() || azureModelId,
-        });
-      }
+      const azureModelId = isAzureProviderId(selectedCatalogId) ? azureDeploymentName.trim() : '';
       const res = await providerAPI.testCredentials(selectedCatalogId, azureModelId || undefined);
       setTestResult({
         success: res.data.success,
@@ -1246,8 +1246,8 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
       toast.warning('Please enter API Key');
       return;
     }
-    const azureModelId = selectedCatalogId === 'azure-openai' ? azureDeploymentName.trim() : '';
-    if (selectedCatalogId === 'azure-openai' && selectedModelIds.size === 0 && !azureModelId) {
+    const azureModelId = isAzureProviderId(selectedCatalogId) ? azureDeploymentName.trim() : '';
+    if (isAzureProviderId(selectedCatalogId) && selectedModelIds.size === 0 && !azureModelId) {
       toast.warning(t('form.azureDeploymentRequired'));
       return;
     }
@@ -1283,10 +1283,10 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
         try {
           const res = await providerAPI.testCredentials(selectedCatalogId, azureModelId);
           if (!res.data.success) {
-            toast.error(t('form.testFailed'), res.data.error || res.data.message);
+            toast.warning(t('form.testFailed'), res.data.error || res.data.message);
           }
         } catch (testErr: any) {
-          toast.error(t('form.testFailed'), testErr.response?.data?.detail || testErr.message);
+          toast.warning(t('form.testFailed'), testErr.response?.data?.detail || testErr.message);
         }
       }
       toast.success(t('providerAdded'), displayName);
@@ -1630,7 +1630,7 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
                         </div>
                       )}
 
-                      {selectedCatalogId === 'azure-openai' && (
+                      {isAzureProviderId(selectedCatalogId) && (
                         <div className="space-y-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
                           <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -1776,8 +1776,8 @@ function AddProviderDialog({ connectedIds, onClose, onAdded }: {
             form={modelForm}
             testResult={modelTestResult}
             testing={modelTesting}
-            modelIdPlaceholder={savedProviderId === 'azure-openai' ? t('form.azureDeploymentPlaceholder') : undefined}
-            modelIdHint={savedProviderId === 'azure-openai' ? t('form.azureModelIdHint') : undefined}
+            modelIdPlaceholder={savedProviderId && isAzureProviderId(savedProviderId) ? t('form.azureDeploymentPlaceholder') : undefined}
+            modelIdHint={savedProviderId && isAzureProviderId(savedProviderId) ? t('form.azureModelIdHint') : undefined}
           />
         </div>
       )}
@@ -2086,8 +2086,8 @@ Provider: ${provider.name} (${provider.id})
           form={form}
           testResult={testResult}
           testing={testing}
-          modelIdPlaceholder={(provider.id === 'azure-openai' || provider.id === 'azure') ? t('form.azureDeploymentPlaceholder') : undefined}
-          modelIdHint={(provider.id === 'azure-openai' || provider.id === 'azure') ? t('form.azureModelIdHint') : undefined}
+          modelIdPlaceholder={isAzureProviderId(provider.id) ? t('form.azureDeploymentPlaceholder') : undefined}
+          modelIdHint={isAzureProviderId(provider.id) ? t('form.azureModelIdHint') : undefined}
         />
       </div>
     </EntitySheet>
@@ -2160,18 +2160,19 @@ function ConfigureProviderDialog({ provider, existingCredentials, models, onClos
 
   // Catalog model management
   const [catalogModels, setCatalogModels] = useState<CatalogModel[]>([]);
+  const [catalogModelsLoaded, setCatalogModelsLoaded] = useState(false);
   const [selectedModelIds, setSelectedModelIds] = useState<Set<string>>(new Set(models.map(m => m.id)));
   const [newAzureDeploymentName, setNewAzureDeploymentName] = useState('');
   const [newAzureDeploymentDisplayName, setNewAzureDeploymentDisplayName] = useState('');
-  const isAzureProvider = provider.id === 'azure-openai' || provider.id === 'azure';
+  const isAzureProvider = isAzureProviderId(provider.id);
   const catalogModelIds = useMemo(() => new Set(catalogModels.map(m => m.id)), [catalogModels]);
   const selectedCatalogModelCount = useMemo(
     () => catalogModels.filter(m => selectedModelIds.has(m.id)).length,
     [catalogModels, selectedModelIds]
   );
   const azureCustomModels = useMemo(
-    () => isAzureProvider ? models.filter(m => !catalogModelIds.has(m.id)) : [],
-    [catalogModelIds, isAzureProvider, models]
+    () => isAzureProvider && catalogModelsLoaded ? models.filter(m => !catalogModelIds.has(m.id)) : [],
+    [catalogModelIds, catalogModelsLoaded, isAzureProvider, models]
   );
 
   useEffect(() => {
@@ -2190,10 +2191,19 @@ function ConfigureProviderDialog({ provider, existingCredentials, models, onClos
   }, [provider.id, models]);
 
   useEffect(() => {
+    setCatalogModelsLoaded(false);
     catalogAPI.list().then(res => {
       const found = res.data.providers.find(p => p.id === provider.id);
-      if (found) setCatalogModels(found.models);
-    }).catch(() => {});
+      if (found) {
+        setCatalogModels(found.models);
+        setCatalogModelsLoaded(true);
+      } else {
+        setCatalogModels([]);
+      }
+    }).catch(() => {
+      setCatalogModels([]);
+      setCatalogModelsLoaded(false);
+    });
   }, [provider.id]);
 
   const handleToggleCatalogModel = (modelId: string) => {
@@ -2475,7 +2485,7 @@ ${hasExisting ? '你已有凭证配置，可以更新或测试连接。' : '请�
           </div>
         )}
 
-        {isAzureProvider && (
+        {isAzureProvider && catalogModelsLoaded && (
           <div className="space-y-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
             <div>
               <h4 className="text-sm font-medium text-gray-900">{t('form.azureCustomDeployments')}</h4>


### PR DESCRIPTION
Allow Azure OpenAI users to configure deployment names directly in the provider setup flow and cover the runtime/test-credentials path so custom deployments are usable.