### PR TITLE
feat(update): CN mirror prompt and uv sync timeout handling

### DIFF
--- a/flocks/cli/commands/update.py
+++ b/flocks/cli/commands/update.py
@@ -37,13 +37,23 @@ def update_command(
 async def _update(check: bool, yes: bool, force: bool = False, region: str | None = None) -> None:
     from flocks.updater import check_update, perform_update, detect_deploy_mode
 
-    with console.status("[cyan]正在检查版本...[/cyan]", spinner="dots"):
-        info = await check_update(region=region)
+    if not yes and not check and region is None:
+        use_cn_mirror = typer.confirm("\n是否使用中国镜像进行升级？", default=False)
+        if use_cn_mirror:
+            region = "cn"
 
-    if info.error:
-        append_upgrade_text_log(f"ERROR version_check: {info.error}")
-        console.print(f"[red]检查失败：{info.error}[/red]")
-        raise typer.Exit(1)
+    async def _load_update_info(selected_region: str | None):
+        with console.status("[cyan]正在检查版本...[/cyan]", spinner="dots"):
+            info = await check_update(region=selected_region)
+
+        if info.error:
+            append_upgrade_text_log(f"ERROR version_check: {info.error}")
+            console.print(f"[red]检查失败：{info.error}[/red]")
+            raise typer.Exit(1)
+
+        return info
+
+    info = await _load_update_info(region)
 
     _print_version_table(info)
 

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -1431,7 +1431,7 @@ def tail_lines(path: Path, lines: int) -> list[str]:
         return [line.rstrip("\n") for line in deque(handle, maxlen=max(lines, 0))]
 
 
-def _emit_service_log_tail(console, log_path: Path, service_label: str, lines: int = 40) -> None:
+def _emit_service_log_tail(console, log_path: Path, service_label: str, lines: int = 10) -> None:
     """Print the last *lines* lines of *log_path* to help diagnose failed daemon startups."""
     if lines <= 0:
         return

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -51,6 +51,8 @@ _CN_PIP_INDEX_URL = _CN_UV_DEFAULT_INDEX
 _CURL_USER_AGENT = "curl/8.7.1"
 _FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS = 300
 _FRONTEND_BUILD_TIMEOUT_SECONDS = 300
+_DEPENDENCY_SYNC_TIMEOUT_SECONDS = 180
+_WINDOWS_DEPENDENCY_SYNC_TIMEOUT_SECONDS = 300
 
 _PRESERVE_NAMES: set[str] = {
     ".venv",
@@ -362,6 +364,13 @@ def _build_frontend_subprocess_env(*, npm_registry: str | None = None) -> dict[s
             env["PATH"] = node_bin if not current_path else node_bin + os.pathsep + current_path
 
     return env or None
+
+
+def _dependency_sync_timeout_seconds() -> int:
+    """Return the timeout budget for ``uv sync`` during self-update."""
+    if sys.platform == "win32":
+        return _WINDOWS_DEPENDENCY_SYNC_TIMEOUT_SECONDS
+    return _DEPENDENCY_SYNC_TIMEOUT_SECONDS
 
 
 # ------------------------------------------------------------------ #
@@ -2150,10 +2159,29 @@ async def perform_update(
         uv_cmd.extend(["--default-index", profile.uv_default_index])
 
     sync_env = _build_uv_sync_env()
+    sync_timeout = _dependency_sync_timeout_seconds()
     retried_after_managed_python_repair = False
-    code, _, err = await _run_async(
-        uv_cmd, cwd=install_root, timeout=180, env=sync_env,
-    )
+
+    async def _run_uv_sync(cmd: list[str]) -> tuple[int, str, str]:
+        return await _run_async(
+            cmd,
+            cwd=install_root,
+            timeout=sync_timeout,
+            env=sync_env,
+        )
+
+    def _dependency_sync_timeout_message() -> str:
+        return f"Dependency sync timed out after {sync_timeout}s while running uv sync."
+
+    try:
+        code, _, err = await _run_uv_sync(uv_cmd)
+    except subprocess.TimeoutExpired:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        await _restore_after_apply_failure()
+        timeout_message = _dependency_sync_timeout_message()
+        _record_update_journal(f"ERROR {timeout_message}")
+        yield UpdateProgress(stage="error", message=timeout_message, success=False)
+        return
     if (
         code != 0
         and sys.platform == "win32"
@@ -2173,9 +2201,15 @@ async def perform_update(
                 {"error": err},
             )
         await asyncio.sleep(2)
-        code, _, err = await _run_async(
-            uv_cmd, cwd=install_root, timeout=180, env=sync_env,
-        )
+        try:
+            code, _, err = await _run_uv_sync(uv_cmd)
+        except subprocess.TimeoutExpired:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            await _restore_after_apply_failure()
+            timeout_message = _dependency_sync_timeout_message()
+            _record_update_journal(f"ERROR {timeout_message}")
+            yield UpdateProgress(stage="error", message=timeout_message, success=False)
+            return
     if code != 0 and profile.uv_default_index:
         log.warning(
             "updater.dependencies.sync_retry_default_index",
@@ -2186,15 +2220,27 @@ async def perform_update(
         )
         await asyncio.sleep(3)
         uv_cmd = [uv_path, "sync"]
-        code, _, err = await _run_async(
-            uv_cmd, cwd=install_root, timeout=180, env=sync_env,
-        )
+        try:
+            code, _, err = await _run_uv_sync(uv_cmd)
+        except subprocess.TimeoutExpired:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            await _restore_after_apply_failure()
+            timeout_message = _dependency_sync_timeout_message()
+            _record_update_journal(f"ERROR {timeout_message}")
+            yield UpdateProgress(stage="error", message=timeout_message, success=False)
+            return
     if code != 0:
         log.warning("updater.dependencies.sync_retry", {"first_error": err})
         await asyncio.sleep(3)
-        code, _, err = await _run_async(
-            uv_cmd, cwd=install_root, timeout=180, env=sync_env,
-        )
+        try:
+            code, _, err = await _run_uv_sync(uv_cmd)
+        except subprocess.TimeoutExpired:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            await _restore_after_apply_failure()
+            timeout_message = _dependency_sync_timeout_message()
+            _record_update_journal(f"ERROR {timeout_message}")
+            yield UpdateProgress(stage="error", message=timeout_message, success=False)
+            return
 
     if code != 0:
         shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -35,6 +35,78 @@ def test_update_cli_accepts_force_option(monkeypatch, tmp_path) -> None:
     assert captured == {"check": False, "yes": True, "force": True, "region": "cn"}
 
 
+def test_update_prompts_for_cn_mirror_before_upgrade_confirmation(monkeypatch) -> None:
+    output = StringIO()
+    monkeypatch.setattr(
+        update_cmd,
+        "console",
+        Console(file=output, force_terminal=False, color_system=None, width=120),
+    )
+
+    check_regions: list[str | None] = []
+    confirm_prompts: list[str] = []
+    captured: dict[str, object] = {}
+    answers = iter([True, True])
+
+    async def fake_check_update(*, locale: str | None = None, region: str | None = None) -> VersionInfo:
+        check_regions.append(region)
+        zipball_url = "https://example.com/flocks.zip"
+        tarball_url = "https://example.com/flocks.tar.gz"
+        if region == "cn":
+            zipball_url = "https://gitee.example.com/flocks.zip"
+            tarball_url = "https://gitee.example.com/flocks.tar.gz"
+        return VersionInfo(
+            current_version="2026.4.1",
+            latest_version="2026.4.2",
+            has_update=True,
+            zipball_url=zipball_url,
+            tarball_url=tarball_url,
+            deploy_mode="source",
+            update_allowed=True,
+        )
+
+    async def fake_perform_update(
+        latest_tag: str,
+        *,
+        zipball_url: str | None = None,
+        tarball_url: str | None = None,
+        restart: bool = True,
+        locale: str | None = None,
+        region: str | None = None,
+    ):
+        captured["latest_tag"] = latest_tag
+        captured["zipball_url"] = zipball_url
+        captured["tarball_url"] = tarball_url
+        captured["perform_region"] = region
+        captured["restart"] = restart
+        async for step in _fake_progress():
+            yield step
+
+    def fake_confirm(prompt: str, default: bool = False) -> bool:
+        confirm_prompts.append(prompt)
+        return next(answers)
+
+    monkeypatch.setattr(updater_pkg, "check_update", fake_check_update)
+    monkeypatch.setattr(updater_pkg, "perform_update", fake_perform_update)
+    monkeypatch.setattr(updater_pkg, "detect_deploy_mode", lambda: "source")
+    monkeypatch.setattr(update_cmd.typer, "confirm", fake_confirm)
+
+    import asyncio
+
+    asyncio.run(update_cmd._update(check=False, yes=False, force=False, region=None))
+
+    assert check_regions == ["cn"]
+    assert confirm_prompts == ["\n是否使用中国镜像进行升级？", "\n是否立即升级？"]
+    assert captured == {
+        "latest_tag": "2026.4.2",
+        "zipball_url": "https://gitee.example.com/flocks.zip",
+        "tarball_url": "https://gitee.example.com/flocks.tar.gz",
+        "perform_region": "cn",
+        "restart": False,
+    }
+    assert "已切换为中国镜像源" not in output.getvalue()
+
+
 async def _fake_progress():
     yield UpdateProgress(stage="fetching", message="fetching")
     yield UpdateProgress(stage="done", message="done", success=True)

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1746,6 +1746,69 @@ async def test_perform_update_retries_uv_sync_on_first_failure(
 
 
 @pytest.mark.asyncio
+async def test_perform_update_rolls_back_when_windows_uv_sync_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "flocks.zip"
+    archive_path.write_text("archive", encoding="utf-8")
+    staged_root = tmp_path / "staged"
+    staged_webui = staged_root / "webui"
+    staged_webui.mkdir(parents=True)
+    (staged_webui / "package.json").write_text("{}", encoding="utf-8")
+    (staged_webui / "dist").mkdir()
+    (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    events: list[str] = []
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            archive_format="zip",
+            sources=["github"],
+            repo="AgentFlocks/Flocks",
+            token=None,
+            gitee_token=None,
+            backup_retain_count=3,
+            base_url=None,
+            gitee_repo=None,
+        )
+
+    async def fake_download(**_kw):
+        return archive_path
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        if "sync" in cmd:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout or 0)
+        return 0, "", ""
+
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater, "_download_with_fallback", fake_download)
+    monkeypatch.setattr(updater, "_backup_current_version", lambda *_a, **_kw: tmp_path / "backup.tar.gz")
+    monkeypatch.setattr(updater, "_extract_archive", lambda *_a, **_kw: staged_root)
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(
+        updater,
+        "_find_executable",
+        lambda name: "/usr/bin/npm" if name in {"npm", "npm.cmd"} else r"C:\tools\uv.exe",
+    )
+    monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
+    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_a, **_kw: None)
+    monkeypatch.setattr(updater, "_restore_backup_if_possible", lambda *_a: events.append("restore"))
+
+    progresses = [step async for step in updater.perform_update("2026.4.1", restart=False)]
+
+    assert progresses[-1].stage == "error"
+    expected_timeout = updater._dependency_sync_timeout_seconds()
+    assert progresses[-1].message == (
+        f"Dependency sync timed out after {expected_timeout}s while running uv sync."
+    )
+    assert events == ["restore"]
+
+
+@pytest.mark.asyncio
 async def test_perform_update_fails_after_uv_sync_retry_exhausted(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
- Prompt for China mirror before version check when region is unset
- Refactor version check into _load_update_info after mirror choice
- Use longer uv sync timeout on Windows; catch TimeoutExpired and rollback
- Reduce default service log tail lines for failed daemon startups
- Add tests for mirror prompt and Windows sync timeout rollback