### PR TITLE
fix(webui): align regenerate truncation with parent user turn

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { getMessageBubbleClassName } from './SessionChat';
+import type { Message } from '@/types';
+
+import { getMessageBubbleClassName, getRegenerateTruncateTarget } from './SessionChat';
+
+function makeMessage(overrides: Partial<Message> & { id: string }): Message {
+  return {
+    id: overrides.id,
+    sessionID: 'sess-1',
+    role: 'assistant',
+    parts: [],
+    timestamp: 0,
+    ...overrides,
+  } as Message;
+}
 
 describe('getMessageBubbleClassName', () => {
   it('keeps non-editing user bubbles auto-sized in full layout', () => {
@@ -32,5 +45,25 @@ describe('getMessageBubbleClassName', () => {
     });
 
     expect(className).toContain('max-w-2xl w-full');
+  });
+});
+
+describe('getRegenerateTruncateTarget', () => {
+  it('truncates back to the parent user message for assistant regenerations', () => {
+    const target = getRegenerateTruncateTarget([
+      makeMessage({ id: 'user-1', role: 'user' }),
+      makeMessage({ id: 'assistant-1', role: 'assistant', parentID: 'user-1' }),
+      makeMessage({ id: 'assistant-2', role: 'assistant', parentID: 'user-1' }),
+    ], 'assistant-2');
+
+    expect(target).toEqual({ messageId: 'user-1' });
+  });
+
+  it('falls back to removing the target message when parent linkage is unavailable', () => {
+    const target = getRegenerateTruncateTarget([
+      makeMessage({ id: 'assistant-1', role: 'assistant' }),
+    ], 'assistant-1');
+
+    expect(target).toEqual({ messageId: 'assistant-1', includeTarget: true });
   });
 });

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -267,6 +267,17 @@ export function getMessageBubbleClassName({
   }`;
 }
 
+export function getRegenerateTruncateTarget(
+  messages: Message[],
+  messageId: string,
+): { messageId: string; includeTarget?: boolean } {
+  const targetMessage = messages.find((message) => message.id === messageId);
+  if (targetMessage?.role === 'assistant' && targetMessage.parentID) {
+    return { messageId: targetMessage.parentID };
+  }
+  return { messageId, includeTarget: true };
+}
+
 // ============================================================================
 // Main component
 // ============================================================================
@@ -1216,7 +1227,11 @@ export default function SessionChat({
     setActionMessageId(messageId);
     try {
       await sessionApi.regenerateMessage(sessionId, messageId);
-      truncateAfterMessage(messageId, { includeTarget: true });
+      const truncateTarget = getRegenerateTruncateTarget(messagesRef.current, messageId);
+      truncateAfterMessage(
+        truncateTarget.messageId,
+        truncateTarget.includeTarget ? { includeTarget: true } : undefined,
+      );
       setIsStreaming(true);
       if (editingMessageId === messageId) {
         resetEditingState();

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { applyMessagePartUpdate, useSessionMessages } from './useSessions';
+import client from '@/api/client';
 import type { Message } from '@/types';
 
 // ---------------------------------------------------------------------------
@@ -137,6 +138,28 @@ describe('applyMessagePartUpdate', () => {
 describe('updateMessagePart scheduling', () => {
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('keeps parentID from fetched messages for regenerate truncation', async () => {
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: [{
+        info: {
+          id: 'msg-2',
+          sessionID: 'sess-1',
+          role: 'assistant',
+          parentID: 'msg-1',
+          time: { created: 123 },
+        },
+        parts: [],
+      }],
+    } as any);
+
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+
+    await act(async () => {});
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].parentID).toBe('msg-1');
   });
 
   it('first appearance of a new part updates messages state immediately', async () => {

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -177,6 +177,7 @@ export function useSessionMessages(sessionId?: string) {
         sessionID: msg.info.sessionID,
         role: msg.info.role,
         parts: msg.parts || [],
+        parentID: msg.info.parentID,
         agent: msg.info.agent,
         model: msg.info.model,
         timestamp: msg.info.time?.created || Date.now(),
@@ -226,6 +227,7 @@ export function useSessionMessages(sessionId?: string) {
           updated[existingIndex] = {
             ...existing,
             ...messageInfo,
+            parentID: messageInfo.parentID ?? existing.parentID,
             timestamp: messageInfo.time?.created || existing.timestamp,
             // Preserve compacted/finish from the authoritative refetch data —
             // SSE events never carry these fields, so a naive spread would
@@ -273,6 +275,7 @@ export function useSessionMessages(sessionId?: string) {
           sessionID: messageInfo.sessionID,
           role: messageInfo.role,
           parts: [],
+          parentID: messageInfo.parentID,
           agent: messageInfo.agent,
           model: messageInfo.model,
           timestamp: messageInfo.time?.created || Date.now(),


### PR DESCRIPTION
## Summary
- preserve assistant `parentID` in `useSessionMessages` so regenerate logic can follow the same parent turn the backend replays
- truncate optimistic regenerate updates back to the parent user message instead of only removing the last assistant message block
- add focused tests for the truncate-target helper and the fetched `parentID` mapping