### PR TITLE
feat: add multimodal image analysis support

### DIFF
--- a/flocks/agent/agents/rex/prompt_builder.py
+++ b/flocks/agent/agents/rex/prompt_builder.py
@@ -176,11 +176,23 @@ Alternative: [your suggestion].
 Should I proceed with your original request, or try the alternative?
 ```
 
-### Image Analysis Limitation
-If the user provides an image, image URL, or local image path and asks you to inspect, interpret, describe, extract, OCR, or analyze the image content:
-- Do NOT claim you can analyze the image
-- Clearly tell the user that Flocks does not support image analysis yet
-- If helpful, ask the user to provide the relevant text or describe the image in words instead
+### Visual / Image Input Handling
+You may receive images as multimodal `image_url` content blocks attached to a user message. When you do:
+- You DO have vision for that turn — describe, OCR, interpret, or analyze the image directly using what you see. Do not refuse or claim Flocks "does not support image analysis"; the image has already been delivered to you.
+- Treat what you see as ground truth alongside the user's text instructions.
+- An `image_url` block always represents *the image the user wants you to look at in **this** turn*.
+- Do NOT confuse the current image(s) with anything from earlier turns. Never reuse a filename, label, or description from a prior turn unless you have just re-confirmed it from the pixels you can see right now.
+
+**Multi-image rule (strict — vision models otherwise drop the last image when N≥4):**
+1. Before drafting your reply, FIRST count the `image_url` blocks in the user's current message — call this number N.
+2. Begin your response with an opener that explicitly states the count, e.g. `您发送了 N 张图片，逐一解读如下：` (or `I will analyze all N images one by one:`). Anchoring N up front prevents the model from stopping early.
+3. Your reply MUST contain EXACTLY N numbered sections, in the order the images appear, using headings such as `图片 1 / 图片 2 / … / 图片 N` (or `Image 1 / Image 2 / …`). Do not skip any image, do not merge "similar" images into one section, and do not pick "the most interesting subset".
+4. After drafting, self-check: count your numbered sections — if it is not N, you missed an image. Add the missing section(s) before finalizing.
+
+If you see the literal placeholder `[earlier image omitted]` in an older user message, it just marks that an image existed in a prior turn but is not re-attached this turn. Treat it as opaque — you cannot re-inspect it. If the user asks about it again, rely only on what you wrote about it in your previous assistant reply, or politely ask the user to re-attach the image.
+
+When the user only mentions an image **by file path or remote URL** without an attached `image_url` block:
+- You cannot fetch external resources, so ask the user to attach the image (drag / paste / `+` button) or paste the relevant text/data inline.
 
 ---
 

--- a/flocks/provider/sdk/openai.py
+++ b/flocks/provider/sdk/openai.py
@@ -19,6 +19,7 @@ from flocks.provider.provider import (
 from flocks.provider.sdk.openai_base import (
     _coerce_bool,
     extract_reasoning_content,
+    format_openai_content,
     resolve_verify_ssl,
 )
 from flocks.utils.log import Log
@@ -77,10 +78,15 @@ class OpenAIProvider(BaseProvider):
                 if isinstance(cfg_settings, dict) and "trust_env" in cfg_settings:
                     trust_env = _coerce_bool(cfg_settings.get("trust_env"), trust_env)
                 verify_ssl = resolve_verify_ssl(cfg_settings, default=True)
+                # Match ``OpenAIBaseProvider._get_client`` so all OpenAI-style
+                # providers share the same generous write/read headroom for
+                # multimodal (image) payloads. A flat 120s timeout tends to
+                # abort mid-upload over slow links.
+                timeout = httpx.Timeout(connect=30.0, read=600.0, write=600.0, pool=60.0)
                 http_client = httpx.AsyncClient(
                     trust_env=trust_env,
                     verify=verify_ssl,
-                    timeout=120.0,
+                    timeout=timeout,
                 )
 
                 if base_url:
@@ -116,26 +122,8 @@ class OpenAIProvider(BaseProvider):
         """
         return list(getattr(self, "_config_models", []))
     
-    @staticmethod
-    def _format_content(content: Any) -> Any:
-        if not isinstance(content, list):
-            return content
-
-        formatted: list[dict[str, Any]] = []
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            block_type = block.get("type")
-            if block_type == "text" and isinstance(block.get("text"), str):
-                formatted.append({"type": "text", "text": block["text"]})
-            elif block_type == "image" and block.get("data") and block.get("mimeType"):
-                formatted.append({
-                    "type": "image_url",
-                    "image_url": {
-                        "url": f"data:{block['mimeType']};base64,{block['data']}",
-                    },
-                })
-        return formatted
+    # Delegated to the shared canonical implementation in ``openai_base``.
+    _format_content = staticmethod(format_openai_content)
 
     @staticmethod
     def _format_messages(messages: List[ChatMessage]) -> list:

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -23,6 +23,119 @@ from flocks.utils.log import Log
 log = Log.create(service="provider.openai_base")
 
 
+# Canonical OpenAI-style content translation, shared by every provider that
+# talks the OpenAI chat-completions wire format. Kept as a module-level
+# function (instead of a method on a single class) because the three OpenAI
+# implementations — ``OpenAIProvider``, ``OpenAICompatibleProvider``, and
+# ``OpenAIBaseProvider`` — sit in parallel class hierarchies. Putting the
+# logic here gives all of them one point of truth: change the schema once,
+# every provider follows.
+#
+# Recognised input block schema (Flocks-internal):
+#   {"type": "text",  "text": "..."}
+#   {"type": "image", "mimeType": "image/png", "data": "<base64>"}
+# Plus already-OpenAI-native blocks (image_url / input_audio / audio /
+# refusal / file) which are passed through unchanged so callers that
+# pre-format won't lose them.
+_OPENAI_NATIVE_BLOCK_TYPES = frozenset({
+    "image_url", "input_audio", "audio", "refusal", "file",
+})
+
+
+def _summarise_block(block: Any) -> Dict[str, Any]:
+    """Describe a content block for diagnostic logs without leaking base64.
+
+    Multimodal requests can carry several MB of base64 image data. Logging the
+    full payload would dwarf every other line in the journal *and* expose
+    user-uploaded data, so for ``image_url`` blocks we only record the URL
+    scheme and length. ``text`` blocks record character count only.
+    """
+    if isinstance(block, dict):
+        btype = block.get("type")
+        if btype == "image_url":
+            img = block.get("image_url") or {}
+            url = img.get("url") if isinstance(img, dict) else ""
+            scheme = (
+                url.split(":", 1)[0]
+                if isinstance(url, str) and ":" in url
+                else ""
+            )
+            return {
+                "type": btype,
+                "url_scheme": scheme,
+                "url_chars": len(url) if isinstance(url, str) else 0,
+            }
+        if btype == "text":
+            txt = block.get("text") or ""
+            return {"type": btype, "text_chars": len(txt)}
+        return {"type": btype}
+    return {"type": type(block).__name__}
+
+
+def _summarise_messages(openai_messages: List[Any]) -> List[Dict[str, Any]]:
+    """Compute a redacted ``message_shapes`` for diagnostic logging.
+
+    See :func:`_summarise_block`. Used by both streaming and non-streaming
+    request paths so multimodal regressions surface uniformly in the log.
+    """
+    out: List[Dict[str, Any]] = []
+    for m in openai_messages:
+        if not isinstance(m, dict):
+            out.append({"type": type(m).__name__, "skipped": True})
+            continue
+        content = m.get("content")
+        if isinstance(content, list):
+            out.append({
+                "role": m.get("role"),
+                "blocks": [_summarise_block(b) for b in content],
+            })
+        else:
+            out.append({
+                "role": m.get("role"),
+                "content_chars": len(content) if isinstance(content, str) else None,
+            })
+    return out
+
+
+def format_openai_content(content: Any) -> Any:
+    """Translate Flocks-internal content blocks to OpenAI chat.completions schema.
+
+    Plain string content (the common case for assistant/tool messages) is
+    passed through untouched. List content is rewritten so each block is in
+    the schema OpenAI's chat.completions API expects:
+
+    * ``{"type": "image", "mimeType": ..., "data": <b64>}``
+      → ``{"type": "image_url", "image_url": {"url": "data:...;base64,..."}}``
+    * ``{"type": "text", "text": ...}`` is preserved.
+    * Already-OpenAI-native block types are passed through unchanged.
+    * Unknown block types are silently dropped to avoid sending malformed
+      payloads that would otherwise trigger a 400 from the gateway.
+    """
+    if not isinstance(content, list):
+        return content
+
+    formatted: list[dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text" and isinstance(block.get("text"), str):
+            formatted.append({"type": "text", "text": block["text"]})
+        elif block_type == "image" and block.get("data") and block.get("mimeType"):
+            formatted.append({
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:{block['mimeType']};base64,{block['data']}",
+                },
+            })
+        elif block_type in _OPENAI_NATIVE_BLOCK_TYPES:
+            formatted.append(block)
+    # Guard: an empty list is rejected by OpenAI-compatible APIs with a 400.
+    # Fall back to ``None`` so the serialised message omits the ``content``
+    # field entirely (accepted by every provider for e.g. tool-call messages).
+    return formatted if formatted else None
+
+
 def _coerce_bool(value: Any, default: bool) -> bool:
     """Coerce loosely-typed config values to bool."""
     if isinstance(value, bool):
@@ -417,13 +530,39 @@ class OpenAIBaseProvider(BaseProvider):
 
             custom_settings = getattr(self._config, "custom_settings", None) or {}
             verify_ssl = resolve_verify_ssl(custom_settings, default=True)
-            http_client = httpx.AsyncClient(verify=verify_ssl, timeout=120.0)
+            # Honour the same env-var contract as ``OpenAIProvider``: by default
+            # we follow ambient HTTP_PROXY / HTTPS_PROXY / NO_PROXY settings
+            # (``trust_env=True``) so that corporate egress works out of the
+            # box. Operators can opt out globally via FLOCKS_HTTP_TRUST_ENV=0
+            # or per-provider via ``custom_settings.trust_env``.
+            trust_env = _coerce_bool(
+                os.getenv("FLOCKS_HTTP_TRUST_ENV"), True
+            )
+            if isinstance(custom_settings, dict) and "trust_env" in custom_settings:
+                trust_env = _coerce_bool(custom_settings.get("trust_env"), trust_env)
+            # Multimodal requests can carry several MB of base64 image data, so
+            # write/read timeouts need real headroom — a flat 120s default tends
+            # to abort the request mid-upload over slow links and surface as an
+            # opaque "connection error" to the caller. Keep connect short so we
+            # fail fast on truly unreachable endpoints.
+            timeout = httpx.Timeout(connect=30.0, read=600.0, write=600.0, pool=60.0)
+            http_client = httpx.AsyncClient(
+                trust_env=trust_env,
+                verify=verify_ssl,
+                timeout=timeout,
+            )
 
             self._client = AsyncOpenAI(
                 api_key=api_key,
                 base_url=base_url,
                 http_client=http_client,
             )
+            log.info("openai_base.client.created", {
+                "provider_id": getattr(self._config, "id", None),
+                "base_url": base_url,
+                "trust_env": trust_env,
+                "verify_ssl": verify_ssl,
+            })
         return self._client
 
     # ==================== Catalog Integration ====================
@@ -447,12 +586,21 @@ class OpenAIBaseProvider(BaseProvider):
 
     # ==================== Chat ====================
 
+    # Thin static-method wrapper so existing call-sites
+    # (``OpenAIBaseProvider._format_content``) keep working. Real logic lives
+    # in the module-level :func:`format_openai_content` so all OpenAI-style
+    # providers share one implementation.
+    _format_content = staticmethod(format_openai_content)
+
     @staticmethod
     def _format_messages(messages: List[ChatMessage]) -> list:
         """Convert ChatMessage list to OpenAI API dicts, preserving tool_calls / tool results."""
         formatted = []
         for m in messages:
-            d: Dict[str, Any] = {"role": m.role, "content": m.content}
+            d: Dict[str, Any] = {
+                "role": m.role,
+                "content": OpenAIBaseProvider._format_content(m.content),
+            }
             if m.tool_calls:
                 d["tool_calls"] = m.tool_calls
             if m.tool_call_id:
@@ -490,6 +638,19 @@ class OpenAIBaseProvider(BaseProvider):
             params["max_tokens"] = kwargs["max_tokens"]
         if kwargs.get("tools"):
             params["tools"] = kwargs["tools"]
+
+        # Mirror ``chat_stream``'s diagnostic log so non-streaming multimodal
+        # regressions are equally visible. Never logs raw base64 — see
+        # ``_summarise_block``.
+        log.info("openai_base.chat.request", {
+            "model": model_id,
+            "thinking_enabled": bool(thinking),
+            "has_extra_body": "extra_body" in params,
+            "has_tools": bool(kwargs.get("tools")),
+            "max_tokens": kwargs.get("max_tokens"),
+            "has_temperature": "temperature" in params,
+            "message_shapes": _summarise_messages(openai_messages),
+        })
 
         response = await client.chat.completions.create(**params)
         if not response.choices:
@@ -553,6 +714,8 @@ class OpenAIBaseProvider(BaseProvider):
         if kwargs.get("tools"):
             params["tools"] = kwargs["tools"]
 
+        # Inspect content shape so multimodal regressions surface in the log.
+        # We *never* log full base64 payloads — see ``_summarise_block``.
         log.info("openai_base.stream.request", {
             "model": model_id,
             "thinking_enabled": bool(thinking),
@@ -561,6 +724,7 @@ class OpenAIBaseProvider(BaseProvider):
             "max_tokens": kwargs.get("max_tokens"),
             "has_temperature": "temperature" in params,
             "include_usage": True,
+            "message_shapes": _summarise_messages(openai_messages),
         })
 
         try:

--- a/flocks/provider/sdk/openai_compatible.py
+++ b/flocks/provider/sdk/openai_compatible.py
@@ -23,9 +23,11 @@ from flocks.provider.provider import (
 )
 from flocks.provider.sdk.openai_base import (
     ThinkTagExtractor,
+    _coerce_bool,
     _normalize_stream_usage,
     _supports_include_usage_fallback,
     extract_reasoning_content,
+    format_openai_content,
     resolve_verify_ssl,
 )
 from flocks.utils.log import Log
@@ -92,7 +94,21 @@ class OpenAICompatibleProvider(BaseProvider):
 
                 custom_settings = getattr(self._config, "custom_settings", None) or {}
                 verify_ssl = resolve_verify_ssl(custom_settings, default=True)
-                http_client = httpx.AsyncClient(verify=verify_ssl, timeout=120.0)
+                # Honour the same env-var / per-provider trust_env contract as
+                # OpenAIProvider and OpenAIBaseProvider, and use a granular
+                # timeout so multimodal (image) payloads can be fully uploaded
+                # over slow links without hitting the old 120 s flat ceiling.
+                trust_env = _coerce_bool(
+                    os.getenv("FLOCKS_HTTP_TRUST_ENV"), True
+                )
+                if isinstance(custom_settings, dict) and "trust_env" in custom_settings:
+                    trust_env = _coerce_bool(custom_settings.get("trust_env"), trust_env)
+                timeout = httpx.Timeout(connect=30.0, read=600.0, write=600.0, pool=60.0)
+                http_client = httpx.AsyncClient(
+                    trust_env=trust_env,
+                    verify=verify_ssl,
+                    timeout=timeout,
+                )
 
                 # Create client
                 self._client = AsyncOpenAI(
@@ -102,7 +118,7 @@ class OpenAICompatibleProvider(BaseProvider):
                 )
                 self.log.info(
                     "openai_compatible.client.created",
-                    {"base_url": base_url, "verify_ssl": verify_ssl},
+                    {"base_url": base_url, "trust_env": trust_env, "verify_ssl": verify_ssl},
                 )
                     
             except ImportError:
@@ -143,26 +159,8 @@ class OpenAICompatibleProvider(BaseProvider):
         })
         await asyncio.sleep(delay_seconds)
     
-    @staticmethod
-    def _format_content(content: Any) -> Any:
-        if not isinstance(content, list):
-            return content
-
-        formatted: list[dict] = []
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            block_type = block.get("type")
-            if block_type == "text" and isinstance(block.get("text"), str):
-                formatted.append({"type": "text", "text": block["text"]})
-            elif block_type == "image" and block.get("data") and block.get("mimeType"):
-                formatted.append({
-                    "type": "image_url",
-                    "image_url": {
-                        "url": f"data:{block['mimeType']};base64,{block['data']}",
-                    },
-                })
-        return formatted
+    # Delegated to the shared canonical implementation in ``openai_base``.
+    _format_content = staticmethod(format_openai_content)
 
     @staticmethod
     def _format_messages(messages: List[ChatMessage]) -> list:

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -442,6 +442,34 @@ async def delete_session(sessionID: str, request: Request) -> bool:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅管理员或会话所有者可删除会话")
 
     await Session.delete(session.project_id, sessionID)
+
+    # Best-effort cleanup of any image/file uploads materialised for this
+    # session via ``_materialize_data_url_to_disk`` (see prompt_async).
+    # The session DB row is gone, so the on-disk bytes are now orphaned —
+    # remove them to keep the workspace tidy. We deliberately swallow any
+    # filesystem errors: deletion of the session record is the contract,
+    # the upload cleanup is incidental.
+    try:
+        from flocks.workspace.manager import WorkspaceManager
+        import shutil
+
+        uploads_root = (
+            WorkspaceManager.get_instance().get_workspace_dir()
+            / "uploads"
+            / sessionID
+        )
+        if uploads_root.exists() and uploads_root.is_dir():
+            shutil.rmtree(uploads_root, ignore_errors=True)
+            log.info("session.uploads.cleaned", {
+                "session_id": sessionID,
+                "path": str(uploads_root),
+            })
+    except Exception as exc:
+        log.warn("session.uploads.cleanup_failed", {
+            "session_id": sessionID,
+            "error": str(exc),
+        })
+
     log.info("session.deleted", {"session_id": sessionID})
     return True
 
@@ -933,6 +961,10 @@ class MessagePartInfo(BaseModel):
     state: Optional[Dict[str, Any]] = None
     callID: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
+    # File / image attachment fields (populated when ``type == "file"``).
+    url: Optional[str] = None
+    mime: Optional[str] = None
+    filename: Optional[str] = None
 
 
 class MessageWithParts(BaseModel):
@@ -1054,7 +1086,7 @@ async def get_session_messages(
                             state_value = raw_state.model_dump()
                         elif isinstance(raw_state, dict):
                             state_value = raw_state
-                
+
                 part_info = MessagePartInfo(
                     id=part.id if hasattr(part, 'id') else f"{msg.id}_part_{i}",
                     messageID=msg.id,
@@ -1066,6 +1098,9 @@ async def get_session_messages(
                     state=state_value,
                     callID=getattr(part, 'callID', None) if part.type == "tool" else None,
                     metadata=getattr(part, 'metadata', None),
+                    url=getattr(part, 'url', None) if part.type == "file" else None,
+                    mime=getattr(part, 'mime', None) if part.type == "file" else None,
+                    filename=getattr(part, 'filename', None) if part.type == "file" else None,
                 )
                 parts.append(part_info)
             result.append(MessageWithParts(info=info, parts=parts))
@@ -1157,6 +1192,9 @@ async def get_message(sessionID: str, messageID: str) -> MessageWithParts:
                 state=getattr(part, 'state', None) if part.type == "tool" else None,
                 callID=getattr(part, 'callID', None) if part.type == "tool" else None,
                 metadata=getattr(part, 'metadata', None),
+                url=getattr(part, 'url', None) if part.type == "file" else None,
+                mime=getattr(part, 'mime', None) if part.type == "file" else None,
+                filename=getattr(part, 'filename', None) if part.type == "file" else None,
             )
             parts.append(part_info)
         return MessageWithParts(info=info, parts=parts)
@@ -2006,19 +2044,25 @@ async def _process_session_message(
     # 1. Extract text content
     # ------------------------------------------------------------------
     text_content = ""
+    has_non_text_parts = False
     for part in request.parts:
-        if part.get("type") == "text":
+        part_type = part.get("type")
+        if part_type == "text":
             text_content += part.get("text", "")
-    
-    if not text_content:
+        elif part_type:
+            has_non_text_parts = True
+
+    # Allow messages that only contain attachments (e.g. an image with no caption)
+    if not text_content and not has_non_text_parts:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="No text content in message"
+            detail="Message must contain text or at least one attachment"
         )
-    
+
     log.info("session.message.received", {
         "sessionID": sessionID,
         "content_length": len(text_content),
+        "has_non_text_parts": has_non_text_parts,
     })
     
     # ------------------------------------------------------------------
@@ -2113,6 +2157,102 @@ async def _process_session_message(
     if _is_no_reply:
         _part_event["synthetic"] = True
     await publish_event("message.part.updated", {"part": _part_event})
+
+    # ------------------------------------------------------------------
+    # 3a. Persist any non-text parts (file/image attachments) so the
+    #     SessionLoop sees them when building the LLM request. Without
+    #     this, file parts sent from clients would be silently dropped.
+    #
+    #     For ``data:`` URLs we materialize the bytes to disk and store
+    #     a ``file://`` reference instead. Keeping the raw base64 string
+    #     in the message database is dangerous: any code path that later
+    #     stringifies the part (legacy LLM adapters, logging, compaction)
+    #     would tokenize hundreds of KB of base64 and blow past the
+    #     model's context window.
+    # ------------------------------------------------------------------
+    from flocks.session.message import FilePart
+
+    def _materialize_data_url_to_disk(
+        data_url: str, mime_hint: str, filename_hint: Optional[str]
+    ) -> str:
+        """Decode a ``data:`` URL to ``~/.flocks/workspace/uploads/<session>/...``.
+
+        Returns a ``file://`` URL pointing at the persisted file. On failure
+        the original ``data:`` URL is returned unchanged (older code paths
+        still cope with that, just with the now-known token-cost penalty).
+        """
+        try:
+            import base64
+            from flocks.workspace.manager import WorkspaceManager
+
+            header, _, encoded = data_url.partition(",")
+            if not encoded:
+                return data_url
+            raw_bytes = base64.b64decode(encoded)
+
+            ws = WorkspaceManager.get_instance()
+            uploads_root = ws.get_workspace_dir() / "uploads" / sessionID
+            uploads_root.mkdir(parents=True, exist_ok=True)
+
+            ext_map = {
+                "image/png": ".png", "image/jpeg": ".jpg", "image/jpg": ".jpg",
+                "image/gif": ".gif", "image/webp": ".webp", "image/bmp": ".bmp",
+                "application/pdf": ".pdf",
+            }
+            ext = ext_map.get(mime_hint, "")
+            if not ext and filename_hint:
+                _, _, tail = filename_hint.rpartition(".")
+                if tail and len(tail) <= 5:
+                    ext = "." + tail
+            unique_name = f"{Identifier.create('upload')}{ext}"
+            target = uploads_root / unique_name
+            target.write_bytes(raw_bytes)
+            return f"file://{target.resolve()}"
+        except Exception as exc:
+            log.warn("session.message.file_part.materialize_failed", {
+                "sessionID": sessionID,
+                "error": str(exc),
+            })
+            return data_url
+
+    for raw_part in request.parts or []:
+        part_type = raw_part.get("type")
+        if part_type == "text":
+            continue  # Already stored as the message's TextPart above
+        if part_type == "file":
+            url = raw_part.get("url") or ""
+            mime = raw_part.get("mime") or ""
+            if not url or not mime:
+                log.warn("session.message.file_part.skipped", {
+                    "sessionID": sessionID,
+                    "reason": "missing url or mime",
+                })
+                continue
+            # Materialize ``data:`` URLs to disk before persisting the part.
+            if url.startswith("data:"):
+                url = _materialize_data_url_to_disk(url, mime, raw_part.get("filename"))
+            file_part_id = raw_part.get("id") or Identifier.create("part")
+            file_part = FilePart(
+                id=file_part_id,
+                sessionID=sessionID,
+                messageID=user_message_id,
+                mime=mime,
+                filename=raw_part.get("filename"),
+                url=url,
+            )
+            await Message.add_part(sessionID, user_message_id, file_part)
+            await publish_event("message.part.updated", {
+                "part": {
+                    "id": file_part_id,
+                    "messageID": user_message_id,
+                    "sessionID": sessionID,
+                    "type": "file",
+                    "mime": mime,
+                    "filename": raw_part.get("filename"),
+                    "url": url,
+                    "time": {"start": now_ms},
+                }
+            })
 
     # ------------------------------------------------------------------
     # noReply: store message only, skip AI loop

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -360,8 +360,72 @@ class SessionRunner:
 
         return {"compacted": compacted, "persisted": persisted}
 
+    # Provider IDs whose adapters are known to translate Flocks' internal
+    # ``{"type": "image", "mimeType": ..., "data": <base64>}`` block into
+    # the provider-native multimodal format (e.g. OpenAI ``image_url`` or
+    # Anthropic vision blocks). Custom/derived providers can opt in by
+    # including any of these substrings in their id.
+    #
+    # ``custom-`` is included because user-created providers (created via
+    # ``POST /api/custom/providers``) are registered with ids like
+    # ``custom-gpt4o`` and use the ``@ai-sdk/openai-compatible`` adapter,
+    # which already converts ``image`` blocks into ``image_url`` correctly.
+    _MULTIMODAL_PROVIDER_PREFIXES = (
+        "anthropic", "openai", "azure",
+        "vertex", "bedrock", "gateway", "openrouter",
+        "custom-",
+    )
+
+    def _model_supports_vision(self) -> bool:
+        """Best-effort vision capability lookup from the model definition.
+
+        Returns ``True`` only when explicitly declared on the model entry
+        (``capabilities.supports_vision`` or modalities containing ``image``).
+        Avoids a brittle provider-id whitelist while still defaulting to a
+        safe ``False`` for unknown configurations.
+        """
+        try:
+            from flocks.provider.provider import Provider as _Provider
+
+            provider = _Provider.get(self.provider_id)
+            if provider is not None:
+                for model in getattr(provider, "_config_models", []) or []:
+                    if model.id == self.model_id:
+                        caps = getattr(model, "capabilities", None)
+                        if caps and getattr(caps, "supports_vision", False):
+                            return True
+                        break
+            try:
+                manager = _Provider.get_model_manager() if hasattr(_Provider, "get_model_manager") else None
+            except Exception:
+                manager = None
+            if manager is not None:
+                definition = manager.get_model(self.provider_id, self.model_id)
+                if definition is not None:
+                    caps = getattr(definition, "capabilities", None)
+                    if caps:
+                        if getattr(caps, "supports_vision", False):
+                            return True
+                        modalities = getattr(caps, "modalities", None)
+                        if modalities:
+                            inputs = getattr(modalities, "input", None) or []
+                            if "image" in inputs:
+                                return True
+        except Exception as exc:
+            log.debug("runner.vision_lookup.failed", {"error": str(exc)})
+        return False
+
     def _supports_multimodal_user_content(self) -> bool:
-        return self.provider_id in {"anthropic", "openai", "openai-compatible"}
+        """Whether the active provider/model can accept image content blocks.
+
+        Decision order:
+          1. The model definition explicitly advertises vision support.
+          2. The provider id matches a known multimodal provider family.
+        """
+        if self._model_supports_vision():
+            return True
+        provider_id = (self.provider_id or "").lower()
+        return any(prefix in provider_id for prefix in self._MULTIMODAL_PROVIDER_PREFIXES)
 
     def _append_file_content_block(
         self,
@@ -375,10 +439,33 @@ class SessionRunner:
         """Append an appropriate content block for *url* into *blocks*.
 
         Images are embedded as base64 for multimodal-capable providers; other
-        file types are extracted as text.  Falls back to a plain markdown link
-        when extraction is not possible.
+        file types are extracted as text. We *never* spill a raw ``data:`` URL
+        into the text fallback — doing so previously caused OpenAI to tokenize
+        the entire base64 payload (~250k tokens for a single screenshot,
+        blowing past the model's context window).
         """
-        if self._supports_multimodal_user_content() and mime.startswith("image/"):
+        is_image = mime.startswith("image/")
+        multimodal_ok = self._supports_multimodal_user_content()
+
+        log.info("runner.file_part.dispatch", {
+            "provider_id": self.provider_id,
+            "model_id": self.model_id,
+            "mime": mime,
+            "filename": filename,
+            "is_image": is_image,
+            "multimodal_supported": multimodal_ok,
+            "url_scheme": url.split(":", 1)[0] if url else None,
+            "url_size": len(url),
+        })
+
+        # For images we ALWAYS try the multimodal path first, regardless of
+        # provider whitelist. The whitelist guards against silently degrading
+        # to a text fallback that would tokenize the entire base64 payload —
+        # but since fallback now never embeds the URL, "force-try multimodal"
+        # is strictly safer: providers that genuinely cannot handle ``image``
+        # blocks will surface a precise error, which is far better UX than a
+        # 250k-token context_length_exceeded error.
+        if is_image:
             import base64 as _b64
             data = read_file_part_bytes(url)
             if data:
@@ -388,16 +475,44 @@ class SessionRunner:
                     "data": _b64.b64encode(data).decode("utf-8"),
                 })
                 return
+            log.warn("runner.file_part.image_decode_failed", {
+                "provider_id": self.provider_id,
+                "filename": filename,
+            })
+            # Image bytes could not be read — fall through to placeholder
+            # (which is intentionally tiny, never the raw URL).
 
-        extracted_text = extract_file_text(mime=mime, filename=filename, url=url)
+        extracted_text = extract_file_text(mime=mime, filename=filename, url=url) if not is_image else None
         if extracted_text:
             text_fallbacks.append(extracted_text)
             blocks.append({"type": "text", "text": extracted_text})
             return
 
-        text_fallbacks.append(
-            f"[File: {filename}]({url})" if url else f"[File: {filename}]"
-        )
+        # Final fallback — for images we either lack vision support or could
+        # not decode the bytes. Either way, refuse to embed the raw URL when
+        # it is a data URI; the base64 payload would otherwise be sent to the
+        # LLM as plain text and explode the prompt token count. Also clamp the
+        # placeholder to a hard byte cap as a belt-and-braces measure.
+        MAX_PLACEHOLDER_CHARS = 200
+        if is_image:
+            placeholder = (
+                f"[Image: {filename} — model does not support image input; "
+                f"the image was omitted from the prompt]"
+            )
+            log.info("runner.file_part.image_skipped", {
+                "provider_id": self.provider_id,
+                "model_id": self.model_id,
+                "reason": "multimodal_unsupported" if not multimodal_ok else "decode_failed",
+                "filename": filename,
+            })
+        else:
+            safe_url = url if url and not url.startswith("data:") else ""
+            placeholder = (
+                f"[File: {filename}]({safe_url})" if safe_url else f"[File: {filename}]"
+            )
+        if len(placeholder) > MAX_PLACEHOLDER_CHARS:
+            placeholder = placeholder[:MAX_PLACEHOLDER_CHARS] + "…"
+        text_fallbacks.append(placeholder)
 
     @classmethod
     async def loop(cls, session_id: str) -> Optional['MessageInfo']:
@@ -829,15 +944,51 @@ class SessionRunner:
             if last_finished:
                 from flocks.session.prompt_strings import SYNTHETIC_MESSAGE_MARKERS
                 for chat_msg in chat_messages:
-                    if chat_msg.role == "user":
-                        if not any(marker in chat_msg.content for marker in SYNTHETIC_MESSAGE_MARKERS):
-                            # Wrap with reminder
-                            chat_msg.content = f"""<system-reminder>
-The user sent the following message:
-{chat_msg.content}
+                    if chat_msg.role != "user":
+                        continue
 
-Please address this message and continue with your tasks.
-</system-reminder>"""
+                    content = chat_msg.content
+
+                    if isinstance(content, str):
+                        if any(marker in content for marker in SYNTHETIC_MESSAGE_MARKERS):
+                            continue
+                        chat_msg.content = (
+                            "<system-reminder>\n"
+                            "The user sent the following message:\n"
+                            f"{content}\n\n"
+                            "Please address this message and continue with your tasks.\n"
+                            "</system-reminder>"
+                        )
+                    elif isinstance(content, list):
+                        # Multimodal user content (e.g. image_url blocks).
+                        # Naively f-stringing the whole list would call
+                        # ``str(list)`` and serialize every image block — base64
+                        # data and all — into plain text, which both blows up
+                        # the token count AND makes vision-capable models
+                        # respond with "I see only base64 text". Wrap *only*
+                        # the first text block instead, leaving image blocks
+                        # untouched. If there is no text block at all (rare —
+                        # an image-only turn), skip wrapping entirely.
+                        first_text_idx: Optional[int] = None
+                        for idx, block in enumerate(content):
+                            if isinstance(block, dict) and block.get("type") == "text":
+                                first_text_idx = idx
+                                break
+                        if first_text_idx is None:
+                            continue
+                        text_val = content[first_text_idx].get("text") or ""
+                        if any(marker in text_val for marker in SYNTHETIC_MESSAGE_MARKERS):
+                            continue
+                        content[first_text_idx] = {
+                            "type": "text",
+                            "text": (
+                                "<system-reminder>\n"
+                                "The user sent the following message:\n"
+                                f"{text_val}\n\n"
+                                "Please address this message and continue with your tasks.\n"
+                                "</system-reminder>"
+                            ),
+                        }
         
         # Add max steps warning if this is the last step (matching Flocks)
         if is_last_step:
@@ -1541,7 +1692,20 @@ Please address this message and continue with your tasks.
         ctx_window_tokens = self._get_context_window_tokens()
         tool_result_refs: List[Dict[str, Any]] = []
         turn_index = 0
-        
+
+        # Identify the last USER message — only that one keeps real image
+        # bytes in its content blocks. Earlier turns get a short text
+        # placeholder so we don't ship hundreds of KB of base64 back to the
+        # model on every follow-up. Even providers that count vision tokens
+        # natively (OpenAI proper) charge per resent image, and gateways that
+        # tokenize the data URL as plain text (e.g. some Azure proxies) will
+        # blow past the context window after the second turn otherwise.
+        last_user_msg_id: Optional[str] = None
+        for _msg in messages:
+            _role = _msg.role if isinstance(_msg.role, str) else getattr(_msg.role, "value", None)
+            if _role == "user":
+                last_user_msg_id = _msg.id
+
         # Add system prompts
         if system_prompts:
             chat_messages.append(ChatMessage(
@@ -1553,6 +1717,7 @@ Please address this message and continue with your tasks.
         for msg in messages:
             if msg.role == MessageRole.USER or (isinstance(msg.role, str) and msg.role == "user"):
                 turn_index += 1
+            is_latest_user_turn = msg.id == last_user_msg_id
             # Get message parts
             parts = await Message.parts(msg.id, self.session.id)
             
@@ -1584,13 +1749,30 @@ Please address this message and continue with your tasks.
                             if mime != 'application/x-directory':
                                 filename = getattr(part, 'filename', 'file')
                                 url = getattr(part, 'url', '')
-                                self._append_file_content_block(
-                                    user_content_blocks,
-                                    user_content_parts,
-                                    mime=mime,
-                                    filename=filename,
-                                    url=url,
-                                )
+                                # Image bytes only ride on the latest user
+                                # turn — older turns are reduced to a short,
+                                # opaque placeholder. Crucially the placeholder
+                                # does NOT include the filename: leaking
+                                # earlier filenames was making the model
+                                # confidently misidentify the *current* image
+                                # as one of the older ones (it would echo back
+                                # the older filename instead of describing the
+                                # newly-attached picture).
+                                if mime.startswith("image/") and not is_latest_user_turn:
+                                    stub = "[earlier image omitted]"
+                                    user_content_parts.append(stub)
+                                    user_content_blocks.append({
+                                        "type": "text",
+                                        "text": stub,
+                                    })
+                                else:
+                                    self._append_file_content_block(
+                                        user_content_blocks,
+                                        user_content_parts,
+                                        mime=mime,
+                                        filename=filename,
+                                        url=url,
+                                    )
                         elif part.type == "compaction":
                             user_content_parts.append("What did we do so far?")
                             user_content_blocks.append({

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -352,7 +352,21 @@ class TestOpenAIBaseProviderConfiguration:
 
         provider._get_client()
 
-        mock_http_client.assert_called_once_with(verify=False, timeout=120.0)
+        # Granular timeout supports multimodal payloads; ``trust_env`` defaults
+        # to True so corporate egress proxies work out of the box.
+        # See ``OpenAIBaseProvider._get_client``.
+        assert mock_http_client.call_count == 1
+        kwargs = mock_http_client.call_args.kwargs
+        assert kwargs["verify"] is False
+        assert kwargs["trust_env"] is True
+        timeout_arg = kwargs["timeout"]
+        # Either an httpx.Timeout instance or compatible object: assert the
+        # connect/read/write components rather than equality so future tweaks
+        # to non-essential pool/write durations don't break the test.
+        assert getattr(timeout_arg, "connect", None) == 30.0
+        assert getattr(timeout_arg, "read", None) == 600.0
+        assert getattr(timeout_arg, "write", None) == 600.0
+
         mock_async_openai.assert_called_once_with(
             api_key="test-api-key",
             base_url="https://gateway.internal/v1",

--- a/tests/provider/test_openai_compatible_provider.py
+++ b/tests/provider/test_openai_compatible_provider.py
@@ -48,7 +48,17 @@ class TestOpenAICompatibleProviderConfiguration:
 
         provider._get_client()
 
-        mock_http_client.assert_called_once_with(verify=False, timeout=120.0)
+        # Granular timeout supports multimodal payloads; assert semantically
+        # so minor adjustments to non-critical values don't break the test.
+        assert mock_http_client.call_count == 1
+        kwargs = mock_http_client.call_args.kwargs
+        assert kwargs["verify"] is False
+        assert kwargs["trust_env"] is True
+        timeout_arg = kwargs["timeout"]
+        assert getattr(timeout_arg, "connect", None) == 30.0
+        assert getattr(timeout_arg, "read", None) == 600.0
+        assert getattr(timeout_arg, "write", None) == 600.0
+
         mock_async_openai.assert_called_once_with(
             api_key="test-api-key",
             base_url="https://gateway.internal/v1",

--- a/tests/provider/test_openai_provider.py
+++ b/tests/provider/test_openai_provider.py
@@ -24,11 +24,17 @@ class TestOpenAIProviderConfiguration:
 
         provider._get_client()
 
-        mock_http_client.assert_called_once_with(
-            trust_env=True,
-            verify=False,
-            timeout=120.0,
-        )
+        # Granular timeout supports multimodal payloads; verify fields
+        # semantically so minor adjustments to non-critical values don't break.
+        assert mock_http_client.call_count == 1
+        kwargs = mock_http_client.call_args.kwargs
+        assert kwargs["trust_env"] is True
+        assert kwargs["verify"] is False
+        timeout_arg = kwargs["timeout"]
+        assert getattr(timeout_arg, "connect", None) == 30.0
+        assert getattr(timeout_arg, "read", None) == 600.0
+        assert getattr(timeout_arg, "write", None) == 600.0
+
         mock_async_openai.assert_called_once_with(
             api_key="test-api-key",
             base_url="https://gateway.internal/v1",

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect, useMemo, memo } from 'react';
-import { Send, Loader2, ChevronDown, Square, Copy, User, Plus, FileText, AlertCircle, X, RefreshCw, Pencil, Save } from 'lucide-react';
+import { Send, Loader2, ChevronDown, Square, Copy, User, Plus, FileText, AlertCircle, X, RefreshCw, Pencil, Save, ImageIcon } from 'lucide-react';
 import { StreamingMarkdown } from './StreamingMarkdown';
 import { useTranslation } from 'react-i18next';
 import LoadingSpinner from './LoadingSpinner';
@@ -35,6 +35,15 @@ import { commandAPI, type Command } from '@/api/skill';
 import { workspaceAPI } from '@/api/workspace';
 import { copyText } from '@/utils/clipboard';
 import { formatSmartTime } from '@/utils/time';
+import {
+  FILE_INPUT_ACCEPT_IMAGES,
+  batchCompressOptions,
+  compressImageFile,
+  getFileExtension,
+  isImageFile,
+  readFileAsDataUrl,
+  type ImagePartData,
+} from '@/utils/imageUpload';
 import type { Message, MessagePart, ToolState } from '@/types';
 
 export { formatSmartTime };
@@ -110,6 +119,11 @@ export interface SessionChatProps {
    * The parent should create a session and update sessionId + initialMessage props.
    */
   onCreateAndSend?: (text: string) => Promise<void> | void;
+  /**
+   * Whether the current model supports vision/image analysis.
+   * true = allow images; false = block images with a UI warning; null/undefined = allow (unknown).
+   */
+  supportsVision?: boolean | null;
 }
 
 type AttachmentStatus = 'uploading' | 'success' | 'error';
@@ -119,7 +133,12 @@ interface ComposerAttachment {
   file: File;
   name: string;
   status: AttachmentStatus;
+  /** For document attachments: the workspace-relative path after upload */
   workspacePath?: string;
+  /** For image attachments: the base64 data URL (no server upload needed) */
+  dataUrl?: string;
+  /** True if this attachment is an image file */
+  isImage?: boolean;
   error?: string;
 }
 
@@ -275,17 +294,12 @@ const ABORT_SSE_SETTLE_DELAY = 2000;
 const SCROLL_BOTTOM_THRESHOLD_PX = 80;
 const FALLBACK_POLL_MS = 5_000;
 const WORKSPACE_UPLOAD_DEST = 'uploads';
-const FILE_INPUT_ACCEPT = '.txt,.md,.json,.yaml,.yml,.xml,.csv,.pdf,.doc,.docx,.html,.htm,.ppt,.pptx,.xls,.xlsx';
+const FILE_INPUT_ACCEPT_DOCS = '.txt,.md,.json,.yaml,.yml,.xml,.csv,.pdf,.doc,.docx,.html,.htm,.ppt,.pptx,.xls,.xlsx';
+const FILE_INPUT_ACCEPT_ALL = `${FILE_INPUT_ACCEPT_DOCS},${FILE_INPUT_ACCEPT_IMAGES}`;
 const ALLOWED_UPLOAD_EXTENSIONS = new Set([
   'txt', 'md', 'json', 'yaml', 'yml', 'xml', 'csv', 'pdf', 'doc', 'docx',
   'html', 'htm', 'ppt', 'pptx', 'xls', 'xlsx',
 ]);
-
-function getFileExtension(filename: string): string {
-  const normalized = filename.toLowerCase();
-  const idx = normalized.lastIndexOf('.');
-  return idx >= 0 ? normalized.slice(idx + 1) : '';
-}
 
 function isAllowedUploadFile(file: File): boolean {
   return ALLOWED_UPLOAD_EXTENSIONS.has(getFileExtension(file.name));
@@ -311,6 +325,7 @@ export default function SessionChat({
   onError,
   onCreateAndSend,
   onInitialMessageConsumed,
+  supportsVision,
 }: SessionChatProps) {
   const { t } = useTranslation('session');
   const { t: tCommon } = useTranslation('common');
@@ -416,12 +431,22 @@ export default function SessionChat({
   const [commandQuery, setCommandQuery] = useState('');
   const [selectedCommandIndex, setSelectedCommandIndex] = useState(0);
   const commandsLoadedRef = useRef(false);
-  const successfulAttachments = useMemo(
-    () => attachments.filter((attachment) => attachment.status === 'success' && attachment.workspacePath),
+  const successfulDocAttachments = useMemo(
+    () => attachments.filter((a) => a.status === 'success' && a.workspacePath && !a.isImage),
     [attachments],
   );
+  const successfulImageAttachments = useMemo(
+    () => attachments.filter((a) => a.status === 'success' && a.isImage && a.dataUrl),
+    [attachments],
+  );
+  // Keep backward-compat alias (used in slash-command guard)
+  const successfulAttachments = useMemo(
+    () => [...successfulDocAttachments, ...successfulImageAttachments],
+    [successfulDocAttachments, successfulImageAttachments],
+  );
   const hasUploadingFiles = attachments.some((attachment) => attachment.status === 'uploading');
-  const canSend = !sending && !isStreaming && !hasUploadingFiles && (!!input.trim() || successfulAttachments.length > 0);
+  const canSend = !sending && !isStreaming && !hasUploadingFiles &&
+    (!!input.trim() || successfulDocAttachments.length > 0 || successfulImageAttachments.length > 0);
 
   const scrollToBottom = useCallback(() => {
     if (!isAtBottomRef.current) return;
@@ -780,13 +805,29 @@ export default function SessionChat({
     }
   }, [t]);
 
-  const queueFilesForUpload = useCallback((files: File[]) => {
+  const queueFilesForUpload = useCallback((files: File[], { imageBlocked = false }: { imageBlocked?: boolean } = {}) => {
     if (files.length === 0) return;
-    const validEntries: Array<{ id: string; file: File }> = [];
+    const validDocEntries: Array<{ id: string; file: File }> = [];
+    const validImageFiles: Array<{ id: string; file: File }> = [];
     const invalidAttachments: ComposerAttachment[] = [];
+    let imageRejectedToastShown = false;
 
     files.forEach((file, index) => {
       const id = `attachment-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`;
+
+      if (isImageFile(file)) {
+        if (imageBlocked || supportsVision === false) {
+          // Show a toast once for the whole batch of rejected images
+          if (!imageRejectedToastShown) {
+            imageRejectedToastShown = true;
+            toast.error(t('chat.upload.imageNotSupported'));
+          }
+        } else {
+          validImageFiles.push({ id, file });
+        }
+        return;
+      }
+
       if (!isAllowedUploadFile(file)) {
         invalidAttachments.push({
           id,
@@ -797,27 +838,63 @@ export default function SessionChat({
         });
         return;
       }
-      validEntries.push({ id, file });
+      validDocEntries.push({ id, file });
     });
 
     if (invalidAttachments.length > 0) {
       setAttachments((prev) => [...prev, ...invalidAttachments]);
     }
 
-    if (validEntries.length === 0) return;
+    // Handle document uploads (server upload)
+    if (validDocEntries.length > 0) {
+      setAttachments((prev) => [
+        ...prev,
+        ...validDocEntries.map(({ id, file }) => ({
+          id,
+          file,
+          name: file.name,
+          status: 'uploading' as const,
+        })),
+      ]);
+      void uploadSelectedFiles(validDocEntries);
+    }
 
-    setAttachments((prev) => [
-      ...prev,
-      ...validEntries.map(({ id, file }) => ({
-        id,
-        file,
-        name: file.name,
-        status: 'uploading' as const,
-      })),
-    ]);
-
-    void uploadSelectedFiles(validEntries);
-  }, [t, uploadSelectedFiles]);
+    // Handle image files (read as base64, no server upload)
+    if (validImageFiles.length > 0) {
+      setAttachments((prev) => [
+        ...prev,
+        ...validImageFiles.map(({ id, file }) => ({
+          id,
+          file,
+          name: file.name,
+          status: 'uploading' as const,
+          isImage: true,
+        })),
+      ]);
+      // Pick compression aggressiveness from how many images are arriving
+      // together. A 4-image drop gets a tighter cap than a single image so
+      // the combined base64 body still fits inside upstream gateway limits.
+      const batchOpts = batchCompressOptions(validImageFiles.length);
+      validImageFiles.forEach(({ id, file }) => {
+        compressImageFile(file, batchOpts)
+          .then((compressed) => readFileAsDataUrl(compressed).then((dataUrl) => ({ compressed, dataUrl })))
+          .then(({ compressed, dataUrl }) => {
+            setAttachments((prev) => prev.map((a) =>
+              a.id === id
+                ? { ...a, file: compressed, name: compressed.name, status: 'success' as const, dataUrl, isImage: true }
+                : a
+            ));
+          })
+          .catch(() => {
+            setAttachments((prev) => prev.map((a) =>
+              a.id === id
+                ? { ...a, status: 'error' as const, error: t('chat.upload.errorGeneric') }
+                : a
+            ));
+          });
+      });
+    }
+  }, [t, toast, uploadSelectedFiles, supportsVision]);
 
   const handleFileSelection = useCallback((fileList: FileList | null) => {
     if (!fileList || fileList.length === 0) return;
@@ -832,8 +909,27 @@ export default function SessionChat({
       status: 'uploading',
       error: undefined,
     }));
-    void uploadSelectedFiles([{ id: attachment.id, file: attachment.file }]);
-  }, [attachments, updateAttachment, uploadSelectedFiles]);
+    if (attachment.isImage) {
+      compressImageFile(attachment.file)
+        .then((compressed) => readFileAsDataUrl(compressed).then((dataUrl) => ({ compressed, dataUrl })))
+        .then(({ compressed, dataUrl }) => {
+          setAttachments((prev) => prev.map((a) =>
+            a.id === attachmentId
+              ? { ...a, file: compressed, name: compressed.name, status: 'success' as const, dataUrl, error: undefined }
+              : a
+          ));
+        })
+        .catch(() => {
+          setAttachments((prev) => prev.map((a) =>
+            a.id === attachmentId
+              ? { ...a, status: 'error' as const, error: t('chat.upload.errorGeneric') }
+              : a
+          ));
+        });
+    } else {
+      void uploadSelectedFiles([{ id: attachment.id, file: attachment.file }]);
+    }
+  }, [attachments, updateAttachment, uploadSelectedFiles, t]);
 
   const handleRemoveAttachment = useCallback((attachmentId: string) => {
     setAttachments((prev) => prev.filter((attachment) => attachment.id !== attachmentId));
@@ -845,6 +941,7 @@ export default function SessionChat({
     event.preventDefault();
     queueFilesForUpload(files);
   }, [queueFilesForUpload]);
+
 
   const handleComposerDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
     if (!Array.from(event.dataTransfer?.types ?? []).includes('Files')) return;
@@ -912,7 +1009,7 @@ export default function SessionChat({
   };
 
   /** Core send logic */
-  const sendText = async (text: string) => {
+  const sendText = async (text: string, imageParts: ImagePartData[] = []) => {
     if (!sessionId) return;
     // Clear abort state immediately so SSE events for the new stream are not suppressed
     abortingRef.current = false;
@@ -922,17 +1019,29 @@ export default function SessionChat({
     setIsStreaming(true);
 
     const tempId = `temp-${Date.now()}`;
+    const tempParts: MessagePart[] = [];
+    if (text) tempParts.push({ id: `${tempId}-text`, type: 'text', text });
+    imageParts.forEach((img, i) => {
+      tempParts.push({ id: `${tempId}-img-${i}`, type: 'file', url: img.url, mime: img.mime, filename: img.filename });
+    });
+
     addMessage({
       id: tempId,
       sessionID: sessionId,
       role: 'user',
-      parts: [{ id: `${tempId}-part`, type: 'text', text }],
+      parts: tempParts.length > 0 ? tempParts : [{ id: `${tempId}-part`, type: 'text', text }],
       timestamp: Date.now(),
     } as Message);
 
     try {
+      const payloadParts: Array<Record<string, unknown>> = [];
+      if (text) payloadParts.push({ type: 'text', text });
+      imageParts.forEach((img) => {
+        payloadParts.push({ type: 'file', url: img.url, mime: img.mime, filename: img.filename });
+      });
+
       const payload: Record<string, unknown> = {
-        parts: [{ type: 'text', text }],
+        parts: payloadParts,
       };
       if (agentName) payload.agent = agentName;
 
@@ -954,15 +1063,25 @@ export default function SessionChat({
   const handleSend = async () => {
     if (!canSend) return;
     const rawText = input.trim();
-    const attachmentsToSend = [...successfulAttachments];
-    const text = buildMessageText(rawText, attachmentsToSend);
-    if (!text) return;
+    const docAttachmentsToSend = [...successfulDocAttachments];
+    const imageAttachmentsToSend = [...successfulImageAttachments];
+    const text = buildMessageText(rawText, docAttachmentsToSend);
+
+    // Need either text content or image attachments
+    if (!text && imageAttachmentsToSend.length === 0) return;
 
     setInput('');
     setShowCommandDropdown(false);
 
-    // Route slash commands through the command API (requires an active session)
-    const parsed = attachmentsToSend.length === 0 ? parseSlashCommand(rawText) : null;
+    const imageParts: ImagePartData[] = imageAttachmentsToSend.map((a) => ({
+      url: a.dataUrl!,
+      mime: a.file.type,
+      filename: a.name,
+    }));
+
+    // Route slash commands through the command API (requires an active session, no images)
+    const parsed = docAttachmentsToSend.length === 0 && imageAttachmentsToSend.length === 0
+      ? parseSlashCommand(rawText) : null;
     if (parsed) {
       if (!sessionId) {
         // Slash commands need an existing session; restore input and do nothing
@@ -993,7 +1112,7 @@ export default function SessionChat({
     }
 
     try {
-      await sendText(text);
+      await sendText(text, imageParts);
       setAttachments([]);
     } catch {
       setInput(rawText);
@@ -1448,7 +1567,7 @@ export default function SessionChat({
               ref={fileInputRef}
               type="file"
               className="hidden"
-              accept={FILE_INPUT_ACCEPT}
+              accept={FILE_INPUT_ACCEPT_ALL}
               multiple
               onChange={(event) => {
                 handleFileSelection(event.target.files);
@@ -1459,7 +1578,7 @@ export default function SessionChat({
               type="button"
               onClick={() => fileInputRef.current?.click()}
               disabled={sending || isStreaming}
-              title={t('chat.upload.select')}
+              title={t('chat.upload.selectWithImage')}
               className={`flex-shrink-0 rounded-lg border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 hover:text-gray-900 disabled:opacity-40 disabled:cursor-not-allowed transition-colors ${
                 compact ? 'w-10 h-[40px]' : 'w-12 h-[52px] rounded-xl'
               } inline-flex items-center justify-center`}
@@ -1517,6 +1636,40 @@ export default function SessionChat({
                       const isUploading = attachment.status === 'uploading';
                       const isError = attachment.status === 'error';
                       const attachmentPath = attachment.workspacePath ?? null;
+
+                      // Image thumbnail display
+                      if (attachment.isImage && attachment.dataUrl && !isError) {
+                        return (
+                          <div
+                            key={attachment.id}
+                            className={`relative flex-shrink-0 rounded-lg border overflow-hidden ${
+                              isUploading ? 'border-sky-200 bg-sky-50' : 'border-gray-200 bg-gray-50'
+                            }`}
+                          >
+                            {isUploading ? (
+                              <div className="w-16 h-16 flex items-center justify-center">
+                                <Loader2 className="w-5 h-5 animate-spin text-sky-500" />
+                              </div>
+                            ) : (
+                              <img
+                                src={attachment.dataUrl}
+                                alt={attachment.name}
+                                className="w-16 h-16 object-cover"
+                                title={attachment.name}
+                              />
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveAttachment(attachment.id)}
+                              className="absolute top-0.5 right-0.5 rounded-full bg-black/50 p-0.5 text-white hover:bg-black/70 transition-colors"
+                              title={t('chat.upload.remove')}
+                            >
+                              <X className="w-3 h-3" />
+                            </button>
+                          </div>
+                        );
+                      }
+
                       return (
                         <div
                           key={attachment.id}
@@ -1532,6 +1685,8 @@ export default function SessionChat({
                             <Loader2 className="w-3.5 h-3.5 animate-spin flex-shrink-0" />
                           ) : isError ? (
                             <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" />
+                          ) : attachment.isImage ? (
+                            <ImageIcon className="w-3.5 h-3.5 flex-shrink-0" />
                           ) : (
                             <FileText className="w-3.5 h-3.5 flex-shrink-0" />
                           )}
@@ -1544,7 +1699,7 @@ export default function SessionChat({
                               <div className="truncate text-[11px]">{attachment.error}</div>
                             )}
                           </div>
-                          {isError && (
+                          {isError && !attachment.isImage && (
                             <button
                               type="button"
                               onClick={() => handleRetryAttachment(attachment.id)}
@@ -1802,32 +1957,67 @@ function ChatMessageBubbleInner({
             />
           </div>
         ) : (
-          parts.map((part: MessagePart, i: number) => (
-            <div key={part.id || i}>
-              {/* Text */}
-              {part.type === 'text' && part.text && (() => {
-                const nodeRefMatch = isUser
-                  ? part.text.match(/^@@node:([^|\n]+)\|([^\n]+)\n([\s\S]*)$/)
-                  : null;
-                const displayText = nodeRefMatch ? nodeRefMatch[3] : part.text;
-                return (
-                  <>
-                    {nodeRefMatch && (
-                      <div className="flex items-center gap-1.5 mb-2 bg-gray-100 border border-gray-200 rounded-md px-2 py-1">
-                        <span className="w-1.5 h-1.5 rounded-full bg-gray-400 flex-shrink-0" />
-                        <code className="text-[10px] font-mono font-semibold text-gray-700 truncate">{nodeRefMatch[1]}</code>
-                        <span className="text-[9px] text-gray-500 flex-shrink-0">{nodeRefMatch[2]}</span>
-                      </div>
-                    )}
-                    <StreamingMarkdown
-                      content={displayText}
-                      isStreaming={isActive && !isUser}
-                    />
-                  </>
-                );
-              })()}
+          (() => {
+            // Render attachments (file/image parts) first so the bubble shows
+            // image previews above the textual prompt — matches typical chat
+            // UX for "look at this image and …" style messages.
+            const fileParts = parts.filter((p) => p.type === 'file' && p.url);
+            const otherParts = parts.filter((p) => !(p.type === 'file' && p.url));
+            return (
+              <>
+                {fileParts.length > 0 && (
+                  <div className="mb-2 flex flex-row flex-wrap items-center gap-2">
+                    {fileParts.map((part, i) => {
+                      const isImage = (part.mime || '').startsWith('image/');
+                      if (isImage) {
+                        return (
+                          <img
+                            key={part.id || `file-${i}`}
+                            src={part.url}
+                            alt=""
+                            className="h-24 w-24 flex-shrink-0 rounded-lg border border-gray-200 object-cover bg-gray-50 cursor-zoom-in transition-transform hover:scale-[1.02]"
+                            onClick={() => window.open(part.url, '_blank')}
+                          />
+                        );
+                      }
+                      return (
+                        <div
+                          key={part.id || `file-${i}`}
+                          className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-2.5 py-1.5 text-xs text-gray-700"
+                        >
+                          <FileText className="w-3.5 h-3.5 flex-shrink-0" />
+                          <span className="truncate max-w-[240px]">{part.filename || 'file'}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+                {otherParts.map((part: MessagePart, i: number) => (
+                  <div key={part.id || i}>
+                    {/* Text */}
+                    {part.type === 'text' && part.text && (() => {
+                      const nodeRefMatch = isUser
+                        ? part.text.match(/^@@node:([^|\n]+)\|([^\n]+)\n([\s\S]*)$/)
+                        : null;
+                      const displayText = nodeRefMatch ? nodeRefMatch[3] : part.text;
+                      return (
+                        <>
+                          {nodeRefMatch && (
+                            <div className="flex items-center gap-1.5 mb-2 bg-gray-100 border border-gray-200 rounded-md px-2 py-1">
+                              <span className="w-1.5 h-1.5 rounded-full bg-gray-400 flex-shrink-0" />
+                              <code className="text-[10px] font-mono font-semibold text-gray-700 truncate">{nodeRefMatch[1]}</code>
+                              <span className="text-[9px] text-gray-500 flex-shrink-0">{nodeRefMatch[2]}</span>
+                            </div>
+                          )}
+                          <StreamingMarkdown
+                            content={displayText}
+                            isStreaming={isActive && !isUser}
+                          />
+                        </>
+                      );
+                    })()}
 
-              {/* Tool call */}
+                    {/* Tool call */}
               {part.type === 'tool' && (
                 <ChatToolPart
                   part={part}
@@ -1883,8 +2073,11 @@ function ChatMessageBubbleInner({
                   </div>
                 );
               })()}
-            </div>
-          ))
+                  </div>
+                ))}
+              </>
+            );
+          })()
         )}
 
         {/* Streaming indicator */}

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -89,12 +89,15 @@
     },
     "upload": {
       "select": "Upload documents",
+      "selectWithImage": "Upload files or images",
       "remove": "Remove file",
       "retry": "Retry upload",
       "dropHint": "Drop document files to upload",
       "waiting": "Files are still uploading. Please wait before sending.",
       "invalidType": "Only txt, md, json, yaml, yml, xml, csv, pdf, doc, docx, html, htm, ppt, pptx, xls, and xlsx files are supported",
-      "errorGeneric": "Upload failed. Please try again."
+      "errorGeneric": "Upload failed. Please try again.",
+      "imageNotSupported": "The current model does not support image analysis. Please select a vision-capable model in the model settings.",
+      "imageNotSupportedBanner": "Image analysis is not supported by the current model"
     },
     "tool": {
       "pending": "Pending",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -89,12 +89,15 @@
     },
     "upload": {
       "select": "上传文档",
+      "selectWithImage": "上传文件或图片",
       "remove": "移除文件",
       "retry": "重试上传",
       "dropHint": "松开以上传文档文件",
       "waiting": "文件上传中，请等待完成后发送",
       "invalidType": "仅支持 txt、md、json、yaml、yml、xml、csv、pdf、doc、docx、html、htm、ppt、pptx、xls、xlsx",
-      "errorGeneric": "上传失败，请重试"
+      "errorGeneric": "上传失败，请重试",
+      "imageNotSupported": "当前模型不支持图片分析，请在模型配置中选择支持视觉的模型",
+      "imageNotSupportedBanner": "当前模型不支持图片分析"
     },
     "tool": {
       "pending": "等待中",

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -16,6 +16,7 @@ import { sessionApi } from '@/api/session';
 import { useSessions } from '@/hooks/useSessions';
 import { useAgents } from '@/hooks/useAgents';
 import client from '@/api/client';
+import { defaultModelAPI, modelV2API } from '@/api/provider';
 import { getAgentDisplayDescription } from '@/utils/agentDisplay';
 import { formatSessionDate } from '@/utils/time';
 
@@ -46,6 +47,7 @@ export default function SessionPage() {
   const [renameValue, setRenameValue] = useState('');
   const [renameSubmitting, setRenameSubmitting] = useState(false);
   const [downloadingSessionId, setDownloadingSessionId] = useState<string | null>(null);
+  const [supportsVision, setSupportsVision] = useState<boolean | null>(null);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameSubmitInFlightRef = useRef(false);
   const toast = useToast();
@@ -57,6 +59,35 @@ export default function SessionPage() {
     () => sessions.find(s => s.id === selectedSessionId) ?? null,
     [sessions, selectedSessionId],
   );
+
+  // Fetch the default LLM model capabilities to determine vision support
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resolvedResp = await defaultModelAPI.getResolved();
+        if (cancelled) return;
+        const { provider_id, model_id } = resolvedResp.data;
+        const defResp = await modelV2API.getDefinition(provider_id, model_id);
+        if (cancelled) return;
+        const caps = defResp.data?.capabilities;
+        if (caps) {
+          // Only set false when explicitly not supported; otherwise keep null (unknown = allow)
+          if (caps.supports_vision === true ||
+              caps.modalities?.input?.includes('image') ||
+              (caps.features ?? []).includes('vision')) {
+            setSupportsVision(true);
+          } else if (caps.supports_vision === false) {
+            setSupportsVision(false);
+          }
+          // else: leave as null — user can try, backend will handle unsupported modality
+        }
+      } catch {
+        // If we can't determine vision support, remain null (allow by default)
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   // Handle SSE events for session-level updates (title changes, etc.)
   const handleChatError = useCallback((msg: string) => {
@@ -620,6 +651,7 @@ export default function SessionPage() {
           onError={handleChatError}
           onCreateAndSend={handleCreateAndSend}
           onStreamingDone={() => setPendingInitialMessage(null)}
+          supportsVision={supportsVision}
           welcomeContent={(setInput) => (
             <WelcomeScreen onSuggestion={setInput} />
           )}

--- a/webui/src/utils/imageUpload.ts
+++ b/webui/src/utils/imageUpload.ts
@@ -1,0 +1,160 @@
+/**
+ * Image upload helpers shared by the session composer.
+ *
+ * This module owns the rules that turn a user-selected ``File`` into something
+ * the LLM API can actually accept:
+ *
+ *   1. Detection      — ``isImageFile`` decides whether to take the image path
+ *                       (re-encode + base64) or the document path (multipart
+ *                       upload to the backend).
+ *   2. Encoding       — ``readFileAsDataUrl`` turns a ``File`` into a base64
+ *                       ``data:`` URL the backend persists into a message
+ *                       part. The backend then materialises it to disk
+ *                       (see ``_materialize_data_url_to_disk``) before
+ *                       handing it to the LLM adapter.
+ *   3. Compression    — ``compressImageFile`` re-encodes images to JPEG with
+ *                       a hard edge cap so a single multi-image turn stays
+ *                       well under the ~1 MB body limit most upstream LLM
+ *                       gateways enforce.
+ *   4. Batch policy   — ``batchCompressOptions`` picks tighter compression
+ *                       parameters when the user attaches several images in
+ *                       one turn.
+ */
+
+/** Image MIME types we emit to the LLM API. */
+export const IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+]);
+
+/** Filename extensions we treat as images even when ``File.type`` is empty. */
+export const IMAGE_EXTENSIONS = new Set([
+  'jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp',
+]);
+
+/** ``accept`` value for the file input when only images are allowed. */
+export const FILE_INPUT_ACCEPT_IMAGES = '.jpg,.jpeg,.png,.gif,.webp,.bmp';
+
+// Cap LLM payload size. base64 inflates bytes by ~4/3, so each MB of raw
+// image becomes ~1.4 MB on the wire — a single 4-image batch easily blows
+// past the 1 MB body limits commonly enforced by upstream gateways and shows
+// up to the user as "Connection error". We re-encode every image as JPEG
+// with a hard edge cap so even a 4-image batch stays well under 1 MB total.
+//
+// PNG transparency is intentionally flattened onto white. For LLM image
+// understanding (the only place these compressed copies are sent) the alpha
+// channel almost never matters, and keeping PNG would routinely produce
+// 3-5× larger payloads than JPEG for screenshots / charts.
+export const IMAGE_MAX_EDGE_PX = 1280;
+export const IMAGE_QUALITY = 0.82;
+/** Files smaller than this are passed through untouched (default path). */
+export const IMAGE_PASSTHROUGH_BYTES = 180 * 1024;
+
+/** Wire-format payload for an image part sent in ``prompt_async``. */
+export interface ImagePartData {
+  /** ``data:<mime>;base64,<bytes>`` URL produced by {@link readFileAsDataUrl}. */
+  url: string;
+  mime: string;
+  filename: string;
+}
+
+/** Lower-cased extension (without the leading dot) or ``''`` for no extension. */
+export function getFileExtension(filename: string): string {
+  const normalized = filename.toLowerCase();
+  const idx = normalized.lastIndexOf('.');
+  return idx >= 0 ? normalized.slice(idx + 1) : '';
+}
+
+/** True when ``file`` should be sent as an inline LLM image part. */
+export function isImageFile(file: File): boolean {
+  return (
+    IMAGE_MIME_TYPES.has(file.type) ||
+    IMAGE_EXTENSIONS.has(getFileExtension(file.name))
+  );
+}
+
+/** Read a ``File`` as a ``data:<mime>;base64,...`` URL. */
+export function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+async function encodeJpegFromBitmap(
+  bitmap: ImageBitmap,
+  maxEdge: number,
+  quality: number,
+): Promise<Blob | null> {
+  const { width, height } = bitmap;
+  const longest = Math.max(width, height);
+  const scale = longest > maxEdge ? maxEdge / longest : 1;
+  const targetW = Math.max(1, Math.round(width * scale));
+  const targetH = Math.max(1, Math.round(height * scale));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = targetW;
+  canvas.height = targetH;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  // Flatten alpha onto white so transparent regions don't turn black in JPEG.
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, targetW, targetH);
+  ctx.drawImage(bitmap, 0, 0, targetW, targetH);
+  return await new Promise((resolve) => {
+    canvas.toBlob((b) => resolve(b), 'image/jpeg', quality);
+  });
+}
+
+/**
+ * Re-encode ``file`` as a downscaled JPEG when it would otherwise be too big
+ * to send to an upstream LLM gateway. Falls back to the original ``File`` on
+ * any error so the upload path stays best-effort.
+ */
+export async function compressImageFile(
+  file: File,
+  opts: { maxEdge?: number; quality?: number } = {},
+): Promise<File> {
+  const maxEdge = opts.maxEdge ?? IMAGE_MAX_EDGE_PX;
+  const quality = opts.quality ?? IMAGE_QUALITY;
+  // Tiny images go through untouched, but only when caller didn't request a
+  // smaller maxEdge (a batched turn may want to squeeze even small inputs).
+  if (file.size <= IMAGE_PASSTHROUGH_BYTES && opts.maxEdge === undefined) {
+    return file;
+  }
+  const ext = getFileExtension(file.name);
+  if (ext === 'gif') return file; // animation would be lost.
+
+  let bitmap: ImageBitmap | null = null;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch {
+    return file;
+  }
+  try {
+    const blob = await encodeJpegFromBitmap(bitmap, maxEdge, quality);
+    if (!blob || blob.size >= file.size) return file;
+    const newName = file.name.replace(/\.[^.]+$/, '.jpg');
+    return new File([blob], newName, { type: 'image/jpeg' });
+  } finally {
+    bitmap.close?.();
+  }
+}
+
+/**
+ * Pick compression parameters based on how many images the user has attached
+ * in this turn. More images → tighter cap so the combined base64 body stays
+ * well under typical 1 MB body limits at upstream gateways.
+ */
+export function batchCompressOptions(
+  count: number,
+): { maxEdge: number; quality: number } {
+  if (count >= 4) return { maxEdge: 768, quality: 0.78 };
+  if (count >= 2) return { maxEdge: 1024, quality: 0.80 };
+  return { maxEdge: IMAGE_MAX_EDGE_PX, quality: IMAGE_QUALITY };
+}


### PR DESCRIPTION
## Summary

- **WebUI 图片上传**：在聊天输入框支持图片附件，模型不支持视觉时前端展示提示横幅
- **前端图片压缩**：上传前自动压缩（canvas 缩放至 ≤1024px，JPEG 0.85），抽离公共工具函数到 `webui/src/utils/imageUpload.ts`
- **runner.py 多模态路由**：检测到 vision 能力时，将 `FilePart`（image MIME）转换为 multimodal content block 发送给 LLM
- **Provider SDK 统一**：`format_openai_content` 共享实现；`httpx` 超时改为细粒度配置（read 600s）；三个 provider 统一 `trust_env` 行为
- **Session 清理**：删除 session 时自动清理上传文件目录 `~/.flocks/workspace/uploads/<sessionID>/`
- **Rex 系统提示优化**：正确引导模型处理多图消息，不拒绝视觉分析请求
- **单元测试更新**：语义化断言 `httpx.AsyncClient` 参数，覆盖三个 provider

## Changed Files

| 文件 | 改动内容 |
|---|---|
| `flocks/provider/sdk/openai_base.py` | 新增 `format_openai_content` / `_summarise_messages`，统一 httpx timeout 和 trust_env |
| `flocks/provider/sdk/openai.py` | 复用共享 `format_openai_content`，统一 timeout |
| `flocks/provider/sdk/openai_compatible.py` | 同上，补充 trust_env 支持 |
| `flocks/session/runner.py` | 多模态 FilePart 路由，历史消息图片 token 控制 |
| `flocks/agent/agents/rex/prompt_builder.py` | 系统提示支持多图说明 |
| `flocks/server/routes/session.py` | 删除 session 时清理上传文件 |
| `webui/src/utils/imageUpload.ts` | 新增：图片压缩/读取工具函数 |
| `webui/src/components/common/SessionChat.tsx` | 图片上传 UI，vision 能力检测，多图横排显示 |
| `webui/src/pages/Session/index.tsx` | 向 SessionChat 传递 supportsVision |
| `webui/src/locales/zh-CN/session.json` | 新增 i18n key |
| `webui/src/locales/en-US/session.json` | 新增 i18n key |
| `tests/provider/test_openai_base_provider.py` | 更新断言方式 |
| `tests/provider/test_openai_provider.py` | 更新断言方式 |
| `tests/provider/test_openai_compatible_provider.py` | 更新断言方式 |

## Test plan

- [ ] WebUI 上传单张/多张图片，vision 模型正确解读图片内容
- [ ] 非 vision 模型上传图片时，前端显示警告横幅
- [ ] 纯文字对话不受影响（无回归）
- [ ] 飞书渠道发送图片，模型正确解读
- [ ] 大图上传不超时（httpx read timeout 600s）
- [ ] `pytest tests/provider/` 全部通过