### PR TITLE
feat(onesec): DNS/time handling, skill docs, handler, and tests

### DIFF
--- a/.flocks/plugins/skills/onesec-use/SKILL.md
+++ b/.flocks/plugins/skills/onesec-use/SKILL.md
@@ -34,6 +34,11 @@ description: 用于处理 OneSEC 终端安全平台相关任务，适合通过AP
 - 用户说“威胁事件”“最近有什么事件”“事件详情”“有哪些事件”时，优先走 `onesec_edr` 的事件类 action
 - 用户说“终端告警”“告警日志”“查某终端的告警”“查某进程行为”“行为记录”“时间线”“IOC”“恶意文件”时，优先走 `onesec_edr` 的告警/日志类 action
 - 用户说“DNS 拦截”“DNS 告警”“解析日志”“受威胁终端”“域名放行/阻断”时，优先走 `onesec_dns`
+- 涉及任何时间查询时，必须动态计算 `time_from` / `time_to` / `begin_time` / `end_time`，禁止手动估算时间戳
+- 查询单个域名是否被 DNS 拦截时，优先构造 `dns_search_blocked_queries + domain + time_from + time_to`；未显式给 `keyword` 时，工具会默认复用 `domain`
+- DNS 查询优先使用 Unix 秒级时间戳；如果用户给的是常见日期字符串（如 `2026-05-08 00:00:00`），工具会自动换算
+- 查询指定域名或关键字的 DNS 拦截明细时，优先使用 `dns_search_blocked_queries`
+- `dns_get_recent_blocked_queries` 只用于最近 24 小时增量拉取，不支持 `domain` / `keyword` / `private_ip` / `threat_type` / 分页参数
 - 用户说“安装了什么软件”“哪些终端装了某软件”时，优先走 `onesec_software`
 - 用户说“终端管理”“任务列表”“任务执行进度”“审计日志”“策略范围”时，优先走 `onesec_ops`
 - 用户说“病毒库版本”“病毒扫描”“停止扫描”“升级病毒库”时，优先走 `onesec_threat`

--- a/.flocks/plugins/skills/onesec-use/references/api-reference.md
+++ b/.flocks/plugins/skills/onesec-use/references/api-reference.md
@@ -9,7 +9,7 @@ OneSEC 当前优先复用 grouped tool，而不是直接从页面做数据获取
 | 查威胁事件 | `onesec_edr` | `edr_get_incidents`（默认） / `edr_get_recent_incidents`（仅最近 24 小时增量） | 建议显式带 `time_from`、`time_to` |
 | 查终端告警 | `onesec_edr` | `edr_get_endpoint_alerts` / `edr_get_recent_endpoint_alerts` | 常见至少带 `time_from`、`time_to` |
 | 查恶意文件 / 威胁行为 / 时间线 / IOC | `onesec_edr` | 对应 `edr_get_*` action | 时间范围、分页、筛选字段 |
-| 查 DNS 拦截 / 解析日志 / 受威胁终端 | `onesec_dns` | `dns_search_blocked_queries` / `dns_search_queries` / `dns_search_threatened_endpoint` | 多数需要 `time_from`、`time_to` |
+| 查 DNS 拦截 / 解析日志 / 受威胁终端 | `onesec_dns` | `dns_search_blocked_queries` / `dns_get_recent_blocked_queries` / `dns_search_queries` / `dns_search_threatened_endpoint` | 多数需要 `time_from`、`time_to` |
 | 查软件清单或安装终端 | `onesec_software` | `software_query_page_list` / `software_query_agent_list` | 软件终端查询要 `name` + `publisher` |
 | 查终端、任务、审计 | `onesec_ops` | `ops_query_agent_page_list` / `ops_query_task_page_list` / `ops_query_audit_log` | 审计/任务通常要时间范围 |
 | 查病毒库 / 下发扫描 | `onesec_threat` | `threat_query_bd_version` / `threat_virus_scan` | 查询通常空参，写操作需明确目标终端 |
@@ -21,32 +21,46 @@ OneSEC 当前优先复用 grouped tool，而不是直接从页面做数据获取
 - 时间字段多数为秒级 Unix 时间戳
 - 查询类 action 默认优先；写操作只有在用户明确授权时才执行
 
-## 时间参数规则
+## 时间参数注意事项（重点）
 
-OneSEC 高频查询动作通常使用：
+### 时间参数计算
+调用任何时间相关 OneSEC API 时，必须**动态计算**时间戳，禁止手动估算。
 
-- `time_from`
-- `time_to`
+**错误方法（禁止）**
 
-单位：
+```python
+# 手动估算，硬编码
+time_from = 1741536000
+time_to = 1741622400
+```
 
-- 秒级时间戳，不是毫秒
+**正确方法**
 
+```python
+import datetime
+
+# 按执行时刻动态计算最近 24 小时窗口
+now = datetime.datetime.now()
+time_to = int(now.timestamp())
+time_from = int((now - datetime.timedelta(hours=24)).timestamp())
+```
+
+使用动态计算的时间戳调用工具执行
+```
+onesec_dns(action="dns_get_recent_blocked_queries", time_from=time_from, time_to=time_to)
+```
+
+如果要查“今天”或“最近 7 天”，也必须动态计算，不要手填固定时间戳。
+
+###  时间参数规则
+- 秒级时间戳，不是毫秒，UTC+8 时区
 - 分页接口建议显式传 `time_from`、`time_to`
 - `recent` 系列只适合最近 24 小时的增量查询
+- DNS `dns_search_queries` 也只支持最近 24 小时内的数据
+- `edr_get_threat_files`、`edr_get_threat_activities`、`edr_get_incidents`、`edr_get_endpoint_alerts` 的时间窗口最长三个月
+- `ops_query_audit_log` 仅支持最近 30 天内的审计日志
 - 未传时间时，返回范围由服务端默认窗口决定，仅作兜底，不推荐依赖
 
-示例：
-
-```json
-{
-  "action": "edr_get_incidents",
-  "time_from": 1741536000,
-  "time_to": 1741622400,
-  "cur_page": 1,
-  "page_size": 20
-}
-```
 
 ## 时间窗口选择表
 
@@ -107,8 +121,8 @@ OneSEC 中几个相邻页面经常被混用，建议先按语义路由：
 ```json
 {
   "action": "edr_get_incidents",
-  "time_from": 1741536000,
-  "time_to": 1741622400,
+  "time_from": 动态计算秒级时间戳,
+  "time_to": 动态计算秒级时间戳,
   "cur_page": 1,
   "page_size": 20
 }
@@ -142,8 +156,8 @@ OneSEC 中几个相邻页面经常被混用，建议先按语义路由：
 ```json
 {
   "action": "edr_get_endpoint_alerts",
-  "time_from": 1741536000,
-  "time_to": 1741622400,
+  "time_from": 动态计算秒级时间戳,
+  "time_to": 动态计算秒级时间戳,
   "sql": "threat.level = 'attack'",
   "cur_page": 1,
   "page_size": 20
@@ -183,8 +197,8 @@ OneSEC 中几个相邻页面经常被混用，建议先按语义路由：
 ```json
 {
   "action": "edr_get_threat_files",
-  "time_from": 1741536000,
-  "time_to": 1741622400,
+  "time_from": 动态计算秒级时间戳,
+  "time_to": 动态计算秒级时间戳,
   "cur_page": 1,
   "page_size": 20
 }
@@ -202,6 +216,7 @@ OneSEC 中几个相邻页面经常被混用，建议先按语义路由：
 - `edr_get_recent_threat_timeline` 也需要 `incident_id`
 - 如果还没有 `incident_id`，应先调用 `edr_get_incidents`
 - `edr_get_recent_threat_timeline` 仅适合最近 24 小时内的增量时间线查询
+- `edr_get_threat_files`、`edr_get_threat_activities` 等分页接口按文档时间窗口最长三个月
 
 ### 4. 查询威胁处置清单
 
@@ -238,6 +253,7 @@ OneSEC 中几个相邻页面经常被混用，建议先按语义路由：
 高频 action：
 
 - `dns_search_blocked_queries`
+- `dns_get_recent_blocked_queries`
 - `dns_search_queries`
 - `dns_search_threatened_endpoint`
 - `dns_get_public_ip_list`
@@ -247,10 +263,28 @@ DNS 拦截记录示例：
 ```json
 {
   "action": "dns_search_blocked_queries",
-  "time_from": 1741536000,
-  "time_to": 1741622400,
+  "time_from": 动态计算秒级时间戳,
+  "time_to": 动态计算秒级时间戳,
   "domain": "evil.com",
-  "keyword": "evil"
+  "keyword": "evil",
+  "show_unblocked_threat": 1
+}
+```
+
+如果用户只明确给了一个完整域名，优先把 `domain` 和 `keyword` 都设成该域名；当前工具在缺少 `keyword` 时也会默认复用 `domain`。
+
+如果用户没有给域名/关键字，只有 `public_ip` + 时间范围，并且查询目标是最近 24 小时拦截记录，优先改用 `dns_get_recent_blocked_queries`；不要硬套 `dns_search_blocked_queries`。
+
+DNS 近期拦截增量示例：
+
+```json
+{
+  "action": "dns_get_recent_blocked_queries",
+  "time_from": 动态计算秒级时间戳,
+  "time_to": 动态计算秒级时间戳,
+  "block_reason": "threat",
+  "show_unblocked_threat": 1,
+  "threat_level": [2, 3, 4]
 }
 ```
 
@@ -259,8 +293,8 @@ DNS 解析日志示例：
 ```json
 {
   "action": "dns_search_queries",
-  "time_from": 1741536000,
-  "time_to": 1741622400,
+  "time_from": 动态计算秒级时间戳,
+  "time_to": 动态计算秒级时间戳,
   "domain": "evil.com",
   "page_items_num": 20
 }
@@ -269,7 +303,12 @@ DNS 解析日志示例：
 注意：
 
 - 有些 DNS action 对时间窗口要求严格
+- DNS 查询优先使用 Unix 秒级时间戳；当前工具也会兼容常见日期字符串，如 `YYYY-MM-DD HH:MM:SS`
+- `public_ip` 按文档是数组；当前工具也会兼容单个字符串并自动包装成单元素数组
+- 查询具体域名或关键字的 DNS 拦截明细时，优先使用 `dns_search_blocked_queries`
+- `dns_get_recent_blocked_queries` 仅适合最近 24 小时增量拉取，不支持 `domain`、`keyword`、`private_ip`、`threat_type` 和分页参数
 - `page_items_num` 与 `page_size` 不是同一个字段
+- DNS 拦截结果优先读取 `result` 字段；当前工具也会补充 `is_blocked`
 - 目标地址列表增删改是写操作，不要误用
 
 ### 6. 查询软件资产
@@ -326,8 +365,8 @@ DNS 解析日志示例：
 ```json
 {
   "action": "ops_query_audit_log",
-  "begin_time": 1741536000,
-  "end_time": 1741622400,
+  "begin_time": 动态计算的 begin_time 秒级时间戳,
+  "end_time": 动态计算的 end_time 秒级时间戳,
   "cur_page": 1,
   "page_size": 20
 }
@@ -339,8 +378,8 @@ DNS 解析日志示例：
 {
   "action": "ops_query_task_page_list",
   "time_type": "create_time",
-  "begin_time": 1741536000,
-  "end_time": 1741622400,
+  "begin_time": 动态计算的 begin_time 秒级时间戳,
+  "end_time": 动态计算的 end_time 秒级时间戳,
   "auto": 0,
   "cur_page": 1,
   "page_size": 20
@@ -350,7 +389,10 @@ DNS 解析日志示例：
 注意：
 
 - 审计和任务查询通常要求时间范围
+- `ops_query_audit_log` 仅支持最近 30 天内的日志
 - `ops_query_task_page_list` 还要求 `time_type` 和 `auto`
+- `time_type` 仅支持 `create_time`、`update_time`
+- `auto` 仅支持 `0`（人工响应）和 `1`（自动响应）
 
 ### 8. 病毒库与扫描任务
 
@@ -381,6 +423,9 @@ DNS 解析日志示例：
 
 - 这是写操作
 - 扫描范围越大，对终端影响越大
+- `task_type` 仅支持 `10110`（快速扫描）、`10120`（全盘扫描）、`10130`（自定义扫描）
+- `scanmode` 仅支持 `1`（极速）、`2`（均衡）、`3`（低耗）
+- `threat_update_bd_version` 的 `os_platform` 仅支持 `windows/macos`，macOS 架构仅支持 `Apple Silicon/Intel Chip`
 
 ## 高风险写操作清单
 

--- a/.flocks/plugins/tools/api/onesec_v2_8_2/onesec.handler.py
+++ b/.flocks/plugins/tools/api/onesec_v2_8_2/onesec.handler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import datetime as dt
 import hmac
 import os
 import time
@@ -488,6 +489,42 @@ def _action_task_content(
     return [content]
 
 
+def _normalize_dns_search_blocked_queries(payload: Any) -> Any:
+    if not isinstance(payload, dict):
+        return payload
+
+    items = payload.get("items")
+    if not isinstance(items, list):
+        return payload
+
+    normalized_items: list[Any] = []
+    changed = False
+    for item in items:
+        if not isinstance(item, dict):
+            normalized_items.append(item)
+            continue
+
+        normalized_item = dict(item)
+        if "result" not in normalized_item:
+            normalized_item["result"] = "block"
+            changed = True
+        if "is_blocked" not in normalized_item:
+            normalized_item["is_blocked"] = True
+            changed = True
+        normalized_items.append(normalized_item)
+
+    if not changed:
+        return payload
+
+    return {**payload, "items": normalized_items}
+
+
+def _normalize_output(action: str, payload: Any) -> Any:
+    if action in {"searchBlockedQueries", "dns_search_blocked_queries"}:
+        return _normalize_dns_search_blocked_queries(payload)
+    return payload
+
+
 def _json_result(action: str, payload: Any) -> ToolResult:
     metadata = {"source": "OneSEC", "api": action}
     if isinstance(payload, dict):
@@ -495,7 +532,11 @@ def _json_result(action: str, payload: Any) -> ToolResult:
         if response_code not in (None, 0, 200):
             error_msg = payload.get("verbose_msg") or payload.get("msg") or "Unknown error"
             return ToolResult(success=False, error=f"OneSEC API error: {error_msg}", metadata=metadata)
-        return ToolResult(success=True, output=payload.get("data", payload), metadata=metadata)
+        return ToolResult(
+            success=True,
+            output=_normalize_output(action, payload.get("data", payload)),
+            metadata=metadata,
+        )
     return ToolResult(success=True, output=payload, metadata=metadata)
 
 
@@ -511,6 +552,101 @@ def _has_value(value: Any) -> bool:
 
 def _require_fields(params: dict[str, Any], *fields: str) -> list[str]:
     return [field for field in fields if not _has_value(params.get(field))]
+
+
+def _normalize_unix_seconds(value: Any, field_name: str) -> tuple[Optional[int], Optional[str]]:
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, f"{field_name} ({value}) 必须是 Unix 秒级时间戳。"
+    if isinstance(value, int):
+        return value, None
+    if isinstance(value, float):
+        if value.is_integer():
+            return int(value), None
+        return None, f"{field_name} ({value}) 必须是 Unix 秒级时间戳。"
+    if not isinstance(value, str):
+        return None, f"{field_name} ({value}) 必须是 Unix 秒级时间戳。"
+
+    stripped = value.strip()
+    if not stripped:
+        return None, None
+    if stripped.lstrip("-").isdigit():
+        return int(stripped), None
+
+    try:
+        parsed = dt.datetime.fromisoformat(stripped)
+    except ValueError:
+        return (
+            None,
+            f"{field_name} ({value}) 必须是 Unix 秒级时间戳。"
+            " 当前工具支持自动转换常见日期时间格式，如 `YYYY-MM-DD HH:MM:SS`。",
+        )
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.datetime.now().astimezone().tzinfo)
+    return int(parsed.timestamp()), None
+
+
+def _normalize_action_params(action: str, params: dict[str, Any]) -> tuple[dict[str, Any], Optional[str]]:
+    normalized = dict(params)
+
+    for field_name in ("time_from", "time_to", "begin_time", "end_time"):
+        if not _has_value(normalized.get(field_name)):
+            continue
+        normalized_value, error = _normalize_unix_seconds(normalized.get(field_name), field_name)
+        if error:
+            return params, error
+        normalized[field_name] = normalized_value
+
+    if action in {"dns_search_blocked_queries", "dns_get_recent_blocked_queries"}:
+        public_ip = normalized.get("public_ip")
+        if isinstance(public_ip, str) and public_ip.strip():
+            normalized["public_ip"] = [public_ip.strip()]
+    if action == "dns_search_blocked_queries":
+        if not _has_value(normalized.get("keyword")) and _has_value(normalized.get("domain")):
+            normalized["keyword"] = normalized["domain"]
+    elif action == "dns_search_queries":
+        if isinstance(normalized.get("qType"), str):
+            normalized["qType"] = normalized["qType"].strip().upper()
+        if isinstance(normalized.get("rcode"), str):
+            normalized["rcode"] = normalized["rcode"].strip().upper()
+    elif action in {"dns_search_blocked_queries", "dns_get_recent_blocked_queries"}:
+        if isinstance(normalized.get("block_reason"), str):
+            normalized["block_reason"] = normalized["block_reason"].strip().lower()
+    elif action == "dns_get_all_destination_list":
+        if isinstance(normalized.get("policy_type"), str):
+            normalized["policy_type"] = normalized["policy_type"].strip().lower()
+    elif action == "threat_virus_scan":
+        for field_name in ("task_type", "scan_type", "scanmode"):
+            value = normalized.get(field_name)
+            if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+                normalized[field_name] = int(value.strip())
+    elif action == "threat_upgrade_bd_version_task":
+        value = normalized.get("bd_upgrade_type")
+        if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+            normalized["bd_upgrade_type"] = int(value.strip())
+    elif action == "threat_update_bd_version":
+        if isinstance(normalized.get("os_platform"), str):
+            normalized["os_platform"] = normalized["os_platform"].strip().lower()
+        if isinstance(normalized.get("os_arch"), str):
+            arch_map = {
+                "apple silicon": "Apple Silicon",
+                "intel chip": "Intel Chip",
+            }
+            normalized["os_arch"] = arch_map.get(normalized["os_arch"].strip().lower(), normalized["os_arch"])
+    elif action == "ops_query_task_page_list":
+        if isinstance(normalized.get("time_type"), str):
+            normalized["time_type"] = normalized["time_type"].strip()
+        auto_value = normalized.get("auto")
+        if isinstance(auto_value, str) and auto_value.strip().lstrip("-").isdigit():
+            normalized["auto"] = int(auto_value.strip())
+
+    return normalized, None
+
+
+def _reject_present_fields(params: dict[str, Any], *fields: str) -> list[str]:
+    return [field for field in fields if _has_value(params.get(field))]
 
 
 def _validate_non_empty_aliases(params: dict[str, Any], aliases: tuple[str, ...], label: str) -> list[str]:
@@ -539,23 +675,104 @@ _PAGINATED_ALTERNATIVES: dict[str, str] = {
 }
 
 _ONE_DAY_SECS = 86400
+_THIRTY_DAY_SECS = 30 * _ONE_DAY_SECS
+_THREE_MONTH_SECS = 90 * _ONE_DAY_SECS
+
+_SPAN_LIMIT_RULES: dict[str, tuple[str, str, int, str]] = {
+    "dns_search_blocked_queries": (
+        "time_from",
+        "time_to",
+        _ONE_DAY_SECS,
+        "按 OneSEC API 文档，`dns_search_blocked_queries` 的时间窗口最多 24 小时。请缩小 time_from/time_to 范围。",
+    ),
+    "dns_search_queries": (
+        "time_from",
+        "time_to",
+        _ONE_DAY_SECS,
+        "按 OneSEC API 文档，`dns_search_queries` 的时间窗口最多 24 小时。",
+    ),
+    "edr_get_threat_files": (
+        "time_from",
+        "time_to",
+        _THREE_MONTH_SECS,
+        "按 OneSEC API 文档，`edr_get_threat_files` 的时间窗口最长三个月。请缩小 time_from/time_to 范围。",
+    ),
+    "edr_get_threat_activities": (
+        "time_from",
+        "time_to",
+        _THREE_MONTH_SECS,
+        "按 OneSEC API 文档，`edr_get_threat_activities` 的时间窗口最长三个月。请缩小 time_from/time_to 范围。",
+    ),
+    "edr_get_incidents": (
+        "time_from",
+        "time_to",
+        _THREE_MONTH_SECS,
+        "按 OneSEC API 文档，`edr_get_incidents` 的时间窗口最长三个月。请缩小 time_from/time_to 范围。",
+    ),
+    "edr_get_endpoint_alerts": (
+        "time_from",
+        "time_to",
+        _THREE_MONTH_SECS,
+        "按 OneSEC API 文档，`edr_get_endpoint_alerts` 的时间窗口最长三个月。请缩小 time_from/time_to 范围。",
+    ),
+    "ops_query_audit_log": (
+        "begin_time",
+        "end_time",
+        _THIRTY_DAY_SECS,
+        "按 OneSEC API 文档，`ops_query_audit_log` 的查询窗口最多 30 天。",
+    ),
+}
+
+_AGE_LIMIT_RULES: dict[str, tuple[str, int, str]] = {
+    "dns_search_queries": (
+        "time_from",
+        _ONE_DAY_SECS,
+        "按 OneSEC API 文档，`dns_search_queries` 仅支持最近 24 小时内的数据。请将 time_from 设置在最近 24 小时内。",
+    ),
+    "ops_query_audit_log": (
+        "begin_time",
+        _THIRTY_DAY_SECS,
+        "按 OneSEC API 文档，`ops_query_audit_log` 仅支持最近 30 天内的审计日志。请调整 begin_time。",
+    ),
+}
+
+_DNS_QTYPE_VALUES = {"A", "AAAA", "CNAME", "MX", "TXT", "PTR", "NS", "CERT", "SRV", "SOA", "DS"}
+_DNS_RCODE_VALUES = {"NOERROR", "NXDOMAIN", "FORMERR", "SERVFAIL", "YXDOMAIN"}
+_DNS_BLOCK_REASON_VALUES = {"threat", "custom"}
+_DNS_POLICY_TYPE_VALUES = {"block", "pass"}
+_THREAT_SCAN_TASK_TYPES = {10110, 10120, 10130}
+_THREAT_SCANMODES = {1, 2, 3}
+_THREAT_BD_UPGRADE_TYPES = {1, 2}
+_THREAT_OS_PLATFORMS = {"windows", "macos"}
+_THREAT_MAC_ARCHES = {"Apple Silicon", "Intel Chip"}
+_OPS_TASK_TIME_TYPES = {"create_time", "update_time"}
+_OPS_TASK_AUTO_VALUES = {0, 1}
 
 
 def _validate_time_params(action: str, params: dict[str, Any]) -> Optional[str]:
-    """Check time_from/time_to consistency and recent-API 24-hour window."""
+    """Check time order and documented time-window limits."""
+    for start_field, end_field in (("time_from", "time_to"), ("begin_time", "end_time")):
+        start_value = params.get(start_field)
+        end_value = params.get(end_field)
+        if start_value is None or end_value is None:
+            continue
+        try:
+            start_int, end_int = int(start_value), int(end_value)
+        except (TypeError, ValueError):
+            continue
+        if start_int >= end_int:
+            return (
+                f"{start_field} ({start_int}) 必须小于 {end_field} ({end_int})。"
+                f" 请确认时间范围：`{start_field}` 为开始时间，`{end_field}` 为结束时间。"
+            )
+
     tf = params.get("time_from")
     tt = params.get("time_to")
-
     if tf is not None and tt is not None:
         try:
             tf_int, tt_int = int(tf), int(tt)
         except (TypeError, ValueError):
             return None
-        if tf_int >= tt_int:
-            return (
-                f"time_from ({tf_int}) 必须小于 time_to ({tt_int})。"
-                " 请确认时间范围：time_from 为开始时间，time_to 为结束时间。"
-            )
         if action in _RECENT_ACTIONS:
             span = tt_int - tf_int
             if span > _ONE_DAY_SECS:
@@ -580,6 +797,114 @@ def _validate_time_params(action: str, params: dict[str, Any]) -> Optional[str]:
                 f"{action} 属于 recent 接口，仅支持最近 24 小时的数据。"
                 f" 传入的 time_from ({tf_int}) 距当前时间已超过 {age // 3600} 小时。{alt_hint}"
             )
+
+    span_rule = _SPAN_LIMIT_RULES.get(action)
+    if span_rule is not None:
+        start_field, end_field, max_span, message = span_rule
+        start_value = params.get(start_field)
+        end_value = params.get(end_field)
+        if start_value is not None and end_value is not None:
+            try:
+                start_int, end_int = int(start_value), int(end_value)
+            except (TypeError, ValueError):
+                return None
+            if end_int - start_int > max_span:
+                return message
+
+    age_rule = _AGE_LIMIT_RULES.get(action)
+    if age_rule is not None:
+        field_name, max_age, message = age_rule
+        field_value = params.get(field_name)
+        if field_value is not None:
+            try:
+                field_int = int(field_value)
+            except (TypeError, ValueError):
+                return None
+            if int(time.time()) - field_int > max_age + 3600:
+                return message
+    return None
+
+
+def _validate_enum_params(action: str, params: dict[str, Any]) -> Optional[str]:
+    if action == "dns_search_queries":
+        qtype = params.get("qType")
+        if _has_value(qtype) and str(qtype) not in _DNS_QTYPE_VALUES:
+            allowed = ", ".join(sorted(_DNS_QTYPE_VALUES))
+            return f"`qType` 取值无效：{qtype}。按 OneSEC API 文档仅支持：{allowed}。"
+        rcode = params.get("rcode")
+        if _has_value(rcode) and str(rcode) not in _DNS_RCODE_VALUES:
+            allowed = ", ".join(sorted(_DNS_RCODE_VALUES))
+            return f"`rcode` 取值无效：{rcode}。按 OneSEC API 文档仅支持：{allowed}。"
+
+    if action in {"dns_search_blocked_queries", "dns_get_recent_blocked_queries"}:
+        block_reason = params.get("block_reason")
+        if _has_value(block_reason) and str(block_reason) not in _DNS_BLOCK_REASON_VALUES:
+            allowed = ", ".join(sorted(_DNS_BLOCK_REASON_VALUES))
+            return f"`block_reason` 取值无效：{block_reason}。按 OneSEC API 文档仅支持：{allowed}。"
+
+    if action == "dns_get_all_destination_list":
+        policy_type = params.get("policy_type")
+        if _has_value(policy_type) and str(policy_type) not in _DNS_POLICY_TYPE_VALUES:
+            allowed = ", ".join(sorted(_DNS_POLICY_TYPE_VALUES))
+            return f"`policy_type` 取值无效：{policy_type}。按 OneSEC API 文档仅支持：{allowed}。"
+
+    if action == "threat_virus_scan":
+        task_type = params.get("task_type", params.get("scan_type"))
+        if _has_value(task_type):
+            try:
+                task_type_int = int(task_type)
+            except (TypeError, ValueError):
+                return f"`task_type`/`scan_type` 取值无效：{task_type}。按 OneSEC API 文档应为整数枚举值。"
+            if task_type_int not in _THREAT_SCAN_TASK_TYPES:
+                allowed = ", ".join(str(item) for item in sorted(_THREAT_SCAN_TASK_TYPES))
+                return f"`task_type`/`scan_type` 取值无效：{task_type_int}。按 OneSEC API 文档仅支持：{allowed}。"
+        scanmode = params.get("scanmode")
+        if _has_value(scanmode):
+            try:
+                scanmode_int = int(scanmode)
+            except (TypeError, ValueError):
+                return f"`scanmode` 取值无效：{scanmode}。按 OneSEC API 文档应为整数枚举值。"
+            if scanmode_int not in _THREAT_SCANMODES:
+                allowed = ", ".join(str(item) for item in sorted(_THREAT_SCANMODES))
+                return f"`scanmode` 取值无效：{scanmode_int}。按 OneSEC API 文档仅支持：{allowed}。"
+
+    if action == "threat_upgrade_bd_version_task":
+        bd_upgrade_type = params.get("bd_upgrade_type")
+        if _has_value(bd_upgrade_type):
+            try:
+                upgrade_int = int(bd_upgrade_type)
+            except (TypeError, ValueError):
+                return f"`bd_upgrade_type` 取值无效：{bd_upgrade_type}。按 OneSEC API 文档应为整数枚举值。"
+            if upgrade_int not in _THREAT_BD_UPGRADE_TYPES:
+                allowed = ", ".join(str(item) for item in sorted(_THREAT_BD_UPGRADE_TYPES))
+                return f"`bd_upgrade_type` 取值无效：{upgrade_int}。按 OneSEC API 文档仅支持：{allowed}。"
+
+    if action == "threat_update_bd_version":
+        os_platform = params.get("os_platform")
+        if _has_value(os_platform) and str(os_platform) not in _THREAT_OS_PLATFORMS:
+            allowed = ", ".join(sorted(_THREAT_OS_PLATFORMS))
+            return f"`os_platform` 取值无效：{os_platform}。按 OneSEC API 文档仅支持：{allowed}。"
+        if str(os_platform) == "macos":
+            os_arch = params.get("os_arch")
+            if _has_value(os_arch) and str(os_arch) not in _THREAT_MAC_ARCHES:
+                allowed = ", ".join(sorted(_THREAT_MAC_ARCHES))
+                return f"`os_arch` 取值无效：{os_arch}。当 `os_platform=macos` 时仅支持：{allowed}。"
+
+    if action == "ops_query_task_page_list":
+        time_type = params.get("time_type")
+        if _has_value(time_type) and str(time_type) not in _OPS_TASK_TIME_TYPES:
+            allowed = ", ".join(sorted(_OPS_TASK_TIME_TYPES))
+            return f"`time_type` 取值无效：{time_type}。按 OneSEC API 文档仅支持：{allowed}。"
+        auto = params.get("auto")
+        if _has_value(auto):
+            try:
+                auto_int = int(auto)
+            except (TypeError, ValueError):
+                return f"`auto` 取值无效：{auto}。按 OneSEC API 文档应为整数枚举值。"
+            if auto_int not in _OPS_TASK_AUTO_VALUES:
+                allowed = ", ".join(str(item) for item in sorted(_OPS_TASK_AUTO_VALUES))
+                return f"`auto` 取值无效：{auto_int}。按 OneSEC API 文档仅支持：{allowed}。"
+
     return None
 
 
@@ -587,13 +912,38 @@ def _validate_action_params(action: str, params: dict[str, Any]) -> Optional[str
     time_err = _validate_time_params(action, params)
     if time_err:
         return time_err
+    enum_err = _validate_enum_params(action, params)
+    if enum_err:
+        return enum_err
 
     missing: list[str] = []
+    unsupported: list[str] = []
 
     if action == "dns_search_blocked_queries":
         missing.extend(_require_fields(params, "time_from", "time_to", "domain", "keyword"))
+        if {
+            "domain",
+            "keyword",
+        }.issubset(set(missing)) and _has_value(params.get("public_ip")):
+            return (
+                "`dns_search_blocked_queries` 按 OneSEC API 文档要求必须传 `domain` 和 `keyword`。"
+                " 如果你当前只有 `public_ip` + 时间范围，且要查询最近 24 小时拦截记录，"
+                " 请改用 `dns_get_recent_blocked_queries`。"
+            )
     elif action == "dns_get_recent_blocked_queries":
         missing.extend(_require_fields(params, "time_from", "time_to"))
+        unsupported.extend(
+            _reject_present_fields(
+                params,
+                "domain",
+                "keyword",
+                "private_ip",
+                "threat_type",
+                "cur_page",
+                "pageitemsnum",
+                "page_items_num",
+            )
+        )
     elif action == "dns_search_queries":
         missing.extend(_require_fields(params, "time_from", "time_to"))
     elif action == "dns_search_threatened_endpoint":
@@ -668,13 +1018,24 @@ def _validate_action_params(action: str, params: dict[str, Any]) -> Optional[str
     elif action == "software_query_agent_list":
         missing.extend(_require_fields(params, "name", "publisher"))
 
-    if not missing:
-        return None
     deduped: list[str] = []
     for item in missing:
         if item not in deduped:
             deduped.append(item)
-    return f"Missing required parameters for {action}: {', '.join(deduped)}"
+    if deduped:
+        return f"Missing required parameters for {action}: {', '.join(deduped)}"
+
+    deduped_unsupported: list[str] = []
+    for item in unsupported:
+        if item not in deduped_unsupported:
+            deduped_unsupported.append(item)
+    if deduped_unsupported:
+        fields = ", ".join(deduped_unsupported)
+        return (
+            f"{action} 按 OneSEC API 文档不支持以下参数: {fields}。"
+            " 若需要按域名或关键字筛选 DNS 拦截记录，请改用 `dns_search_blocked_queries`。"
+        )
+    return None
 
 
 class ActionSpec:
@@ -702,6 +1063,7 @@ ACTION_SPECS: dict[str, ActionSpec] = {
             "domain",
             "keyword",
             "block_reason",
+            "show_unblocked_threat",
             "threat_level",
             "threat_type",
             "cur_page",
@@ -710,7 +1072,15 @@ ACTION_SPECS: dict[str, ActionSpec] = {
     "dns_get_recent_blocked_queries": ActionSpec(
         "POST",
         "/open/api/client/getRecentBlockedQueries",
-        lambda p: _pick(p, "time_from", "time_to", "public_ip", "block_reason", "threat_level"),
+        lambda p: _pick(
+            p,
+            "time_from",
+            "time_to",
+            "public_ip",
+            "block_reason",
+            "show_unblocked_threat",
+            "threat_level",
+        ),
     ),
     "dns_search_queries": ActionSpec("POST", "/open/api/client/searchQueries", _dns_search_queries_payload),
     "dns_search_threatened_endpoint": ActionSpec(
@@ -1053,10 +1423,13 @@ async def unified_ops(ctx: ToolContext, action: str, **params: Any) -> ToolResul
             success=False,
             error=f"Unknown action: {action}. Available actions: {available}",
         )
-    validation_error = _validate_action_params(action, params)
+    normalized_params, normalize_error = _normalize_action_params(action, params)
+    if normalize_error:
+        return ToolResult(success=False, error=normalize_error)
+    validation_error = _validate_action_params(action, normalized_params)
     if validation_error:
         return ToolResult(success=False, error=validation_error)
-    result = await _call_onesec_api(spec.method, spec.path, spec.payload_builder(params))
+    result = await _call_onesec_api(spec.method, spec.path, spec.payload_builder(normalized_params))
     if result.success:
         metadata = dict(result.metadata or {})
         metadata["api"] = action

--- a/.flocks/plugins/tools/api/onesec_v2_8_2/onesec_dns.yaml
+++ b/.flocks/plugins/tools/api/onesec_v2_8_2/onesec_dns.yaml
@@ -20,14 +20,15 @@ inputSchema:
         - dns_search_blocked_queries
           用途: 分页查询 DNS 拦截记录
           必填: `time_from`、`time_to`、`domain`、`keyword`
-          常用: `public_ip`、`private_ip`、`block_reason`、`threat_level`、`threat_type`、`cur_page`
-          风险提示: 查询窗口通常不超过 24 小时；缺少 `domain` 或 `keyword` 会被工具层拦截
+          常用: `public_ip`、`private_ip`、`block_reason`、`show_unblocked_threat`、`threat_level`、`threat_type`、`cur_page`
+          风险提示: 推荐使用 Unix 秒级时间戳；工具会兼容常见 `YYYY-MM-DD HH:MM:SS` 日期字符串。若只传 `domain`，工具会默认将 `keyword` 补成相同值；若仅按 `public_ip` + 时间范围查询最近 24 小时数据，请优先改用 `dns_get_recent_blocked_queries`
           是否任务型: 否
         - dns_get_recent_blocked_queries
           用途: 获取近期 DNS 拦截记录（仅适用于增量同步，有严格时间限制）
           必填: `time_from`、`time_to`
-          常用: `public_ip`、`block_reason`、`threat_level`
+          常用: `public_ip`、`block_reason`、`show_unblocked_threat`、`threat_level`
           ⚠️ 限制: 仅支持最近 24 小时的数据；time_from 超出 24 小时将被服务器拒绝
+          ⚠️ 限制: 不支持 `domain`、`keyword`、`private_ip`、`threat_type` 和分页参数；如需按域名/关键字查询，请改用 `dns_search_blocked_queries`
           ⚠️ 推荐: 通用查询请优先使用 `dns_search_blocked_queries`
           是否任务型: 否
         - dns_search_queries
@@ -86,15 +87,18 @@ inputSchema:
       type: integer
       description: >
         开始时间戳，Unix 秒级时间戳。必须小于 time_to。可以使用python datetime动态计算。
+        工具会兼容常见日期时间字符串，如 `YYYY-MM-DD HH:MM:SS`。
         对于 recent 系列接口，time_from 距当前时间不能超过 24 小时。
     time_to:
       type: integer
-      description: 结束时间戳，Unix 秒级时间戳。必须大于 time_from。可以使用python datetime动态计算。
+      description: >
+        结束时间戳，Unix 秒级时间戳。必须大于 time_from。可以使用python datetime动态计算。
+        工具会兼容常见日期时间字符串，如 `YYYY-MM-DD HH:MM:SS`。
     public_ip:
       type: array
       items:
         type: string
-      description: 公网 IP 列表
+      description: 公网 IP 列表；当前工具会兼容单个字符串并自动包装为单元素数组
     private_ip:
       type: string
       description: 私网 IP
@@ -107,6 +111,9 @@ inputSchema:
     block_reason:
       type: string
       description: 拦截原因
+    show_unblocked_threat:
+      type: integer
+      description: 是否返回未拦截的威胁记录，常见取值 `1`
     threat_level:
       type: array
       items:

--- a/.flocks/plugins/tools/api/onesec_v2_8_2/onesec_edr.yaml
+++ b/.flocks/plugins/tools/api/onesec_v2_8_2/onesec_edr.yaml
@@ -24,7 +24,7 @@ inputSchema:
           用途: 分页查询恶意文件（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`group_list`、`umid_list`、`cur_page`、`page_size`
-          风险提示: 更适合全量回溯；如需排序扩展需结合后端实现
+          风险提示: 更适合全量回溯；按 OneSEC API 文档时间窗口最长三个月
           是否任务型: 否
         - edr_get_recent_threat_files
           用途: 查询近期恶意文件（仅适用于增量同步，有严格时间限制）
@@ -37,7 +37,7 @@ inputSchema:
           用途: 分页查询威胁行为（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`group_list`、`threat_phase_list`、`cur_page`、`page_size`
-          风险提示: 行为筛选条件较多，优先显式传时间范围
+          风险提示: 行为筛选条件较多，优先显式传时间范围；按 OneSEC API 文档时间窗口最长三个月
           是否任务型: 否
         - edr_get_recent_threat_activities
           用途: 查询近期威胁行为（仅适用于增量同步，有严格时间限制）
@@ -50,7 +50,7 @@ inputSchema:
           用途: 分页查询威胁事件（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`params`、`cur_page`、`page_size`
-          风险提示: 返回事件对象较复杂，后续常用于提取 `incident_id`
+          风险提示: 返回事件对象较复杂，后续常用于提取 `incident_id`；按 OneSEC API 文档时间窗口最长三个月
           是否任务型: 否
         - edr_get_recent_incidents
           用途: 查询近期威胁事件（仅适用于增量同步，有严格时间限制）
@@ -63,7 +63,7 @@ inputSchema:
           用途: 分页查询终端告警日志（通用查询首选，适合历史回溯）
           必填: 无
           常用: `time_from`、`time_to`、`sql`、`search_fields`、`cur_page`、`page_size`
-          风险提示: 若返回字段过多可能导致接口耗时增加
+          风险提示: 若返回字段过多可能导致接口耗时增加；按 OneSEC API 文档时间窗口最长三个月
           是否任务型: 否
         - edr_get_recent_endpoint_alerts
           用途: 查询近期终端告警日志（仅适用于增量同步，有严格时间限制）

--- a/.flocks/plugins/tools/api/onesec_v2_8_2/onesec_ops.yaml
+++ b/.flocks/plugins/tools/api/onesec_v2_8_2/onesec_ops.yaml
@@ -33,13 +33,13 @@ inputSchema:
           用途: 分页查询审计日志
           必填: `begin_time`、`end_time`
           常用: `cur_page`、`page_size`、`operate_list`、`role_list`、`group_list`、`api_access_type_list`
-          风险提示: 建议限定时间范围，避免返回量过大
+          风险提示: 建议限定时间范围，避免返回量过大；按 OneSEC API 文档仅支持最近 30 天内日志
           是否任务型: 否
         - ops_query_task_page_list
           用途: 分页查询任务列表
           必填: `time_type`、`begin_time`、`end_time`、`auto`
           常用: `cur_page`、`page_size`、`sort_by`、`sort_order`、`task_status_list`、`task_type_list`、`group_id`
-          风险提示: 分页接口通常要求排序对象；缺少关键时间条件会被工具层拦截
+          风险提示: 分页接口通常要求排序对象；`time_type` 仅支持 `create_time/update_time`，`auto` 仅支持 `0/1`
           是否任务型: 否
         - ops_query_task_execute_list
           用途: 分页查询任务执行进度明细
@@ -88,7 +88,7 @@ inputSchema:
       description: 结构化条件列表
     time_type:
       type: string
-      description: 时间字段类型
+      description: 时间字段类型，仅支持 `create_time`、`update_time`
     cur_page:
       type: integer
       default: 1
@@ -158,7 +158,7 @@ inputSchema:
       description: API 访问来源列表
     auto:
       type: integer
-      description: 任务来源
+      description: 任务来源，仅支持 `0` 人工响应、`1` 自动响应
     task_type_list:
       type: array
       items:

--- a/.flocks/plugins/tools/api/onesec_v2_8_2/onesec_threat.yaml
+++ b/.flocks/plugins/tools/api/onesec_v2_8_2/onesec_threat.yaml
@@ -27,7 +27,7 @@ inputSchema:
           用途: 下发病毒扫描任务
           必填: `agent_list`、`task_type`/`scan_type`、`scanmode`；当 `task_type=10130` 时还需 `scan_paths`
           常用: `scan_paths`、`scanmode`、`task_type`
-          风险提示: 高风险任务；扫描范围较大时可能影响终端性能
+          风险提示: 高风险任务；`task_type` 仅支持 `10110/10120/10130`，`scanmode` 仅支持 `1/2/3`
           是否任务型: 是
         - threat_stop_virus_scan
           用途: 下发终止病毒扫描任务
@@ -39,13 +39,13 @@ inputSchema:
           用途: 下发病毒库升级任务
           必填: `agent_list`、`bd_upgrade_type`
           常用: `bd_upgrade_type`
-          风险提示: 写操作；会触发终端更新病毒库
+          风险提示: 写操作；会触发终端更新病毒库，`bd_upgrade_type` 仅支持 `1/2`
           是否任务型: 是
         - threat_update_bd_version
           用途: 修改病毒库应用版本
           必填: `os_platform`；当 `os_platform=macos` 时还需 `os_arch`
           常用: `os_arch`
-          风险提示: 写操作；平台参数不匹配会被工具层拦截
+          风险提示: 写操作；`os_platform` 仅支持 `windows/macos`，macOS 架构仅支持 `Apple Silicon/Intel Chip`
           是否任务型: 否
       enum:
         - threat_query_bd_version
@@ -60,7 +60,7 @@ inputSchema:
       description: 终端 UMID 列表
     task_type:
       type: integer
-      description: 病毒扫描任务类型
+      description: 病毒扫描任务类型，支持 `10110` 快速扫描、`10120` 全盘扫描、`10130` 自定义扫描
     scan_paths:
       type: array
       items:
@@ -68,22 +68,22 @@ inputSchema:
       description: 自定义扫描路径
     scanmode:
       type: integer
-      description: 扫描模式
+      description: 扫描模式，支持 `1` 极速、`2` 均衡、`3` 低耗
     scan_type:
       type: integer
       description: 兼容旧调用的病毒扫描任务类型别名
     bd_upgrade_type:
       type: integer
-      description: 病毒库升级类型
+      description: 病毒库升级类型，支持 `1` 应用版本、`2` 云端最新版本
     issue_time:
       type: integer
       description: 下发时间
     os_platform:
       type: string
-      description: 操作系统平台
+      description: 操作系统平台，仅支持 `windows`、`macos`
     os_arch:
       type: string
-      description: 系统架构
+      description: 系统架构；当 `os_platform=macos` 时仅支持 `Apple Silicon`、`Intel Chip`
   required:
     - action
 handler:

--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -2519,6 +2519,11 @@ async def test_provider_credentials(provider_id: str, body: Optional[TestCredent
                 # actions (which would each trigger a fresh login attempt).
                 if _is_login_probe(t) or _is_action_dispatch_login_probe(t):
                     priority = -1
+                # OneSEC grouped tools all look equally generic to the default
+                # heuristic, but the threat probe maps to a safer read-only
+                # version query than the legacy DNS probe.
+                elif provider_id == "onesec_api" and name_lower == "onesec_threat":
+                    priority = 0
                 # Prefer query/scan style tools first, and push upload/file tools last.
                 elif "ip" in name_lower:
                     priority = 0

--- a/tests/provider/test_test_credentials.py
+++ b/tests/provider/test_test_credentials.py
@@ -228,10 +228,28 @@ class TestTestCredentialsToolExecution:
             )
 
     @pytest.mark.asyncio
-    async def test_service_uses_enum_action_instead_of_placeholder_string(self):
-        """Connectivity checks should use enum-backed action values, not the generic 'test' placeholder."""
+    async def test_onesec_service_prefers_threat_probe_and_uses_enum_action(self):
+        """OneSEC should prefer the read-only threat probe over the older DNS probe."""
         from flocks.server.routes.provider import test_provider_credentials
 
+        onesec_threat_tool = ToolInfo(
+            name="onesec_threat",
+            description="OneSEC threat grouped tool",
+            category=ToolCategory.CUSTOM,
+            parameters=[
+                ToolParameter(
+                    name="action",
+                    type=ParameterType.STRING,
+                    description="Threat action",
+                    required=True,
+                    enum=[
+                        "threat_query_bd_version",
+                        "threat_virus_scan",
+                        "threat_update_bd_version",
+                    ],
+                )
+            ],
+        )
         onesec_dns_tool = ToolInfo(
             name="onesec_dns",
             description="OneSEC DNS grouped tool",
@@ -265,9 +283,9 @@ class TestTestCredentialsToolExecution:
             mock_provider_cls.get.return_value = None
 
             mock_tr.init = MagicMock()
-            mock_tr.list_tools.return_value = [onesec_dns_tool]
+            mock_tr.list_tools.return_value = [onesec_dns_tool, onesec_threat_tool]
             mock_tr._dynamic_tools_by_module = {
-                "flocks.tool.generated.onesec": ["onesec_dns"],
+                "flocks.tool.generated.onesec": ["onesec_dns", "onesec_threat"],
             }
             mock_tr.execute = AsyncMock(return_value=ToolResult(
                 success=True,
@@ -277,10 +295,10 @@ class TestTestCredentialsToolExecution:
             result = await test_provider_credentials("onesec_api")
 
             assert result["success"] is True, result
-            assert result["tool_tested"] == "onesec_dns"
+            assert result["tool_tested"] == "onesec_threat"
             mock_tr.execute.assert_awaited_once_with(
-                tool_name="onesec_dns",
-                action="dns_get_public_ip_list",
+                tool_name="onesec_threat",
+                action="threat_query_bd_version",
             )
 
     @pytest.mark.asyncio

--- a/tests/tool/test_onesec_api_tool.py
+++ b/tests/tool/test_onesec_api_tool.py
@@ -1,4 +1,5 @@
 import base64
+import datetime as dt
 import hmac
 from hashlib import sha1
 from pathlib import Path
@@ -192,6 +193,303 @@ async def test_onesec_dns_get_public_ip_list_honors_verify_ssl_true():
 
 
 @pytest.mark.asyncio
+async def test_onesec_dns_search_blocked_queries_normalizes_block_status():
+    tool = _load_tool("onesec_dns.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "data": {
+                        "total_num": 1,
+                        "items": [
+                            {
+                                "domain": "blocked.example",
+                                "block_reason": "threat",
+                            }
+                        ],
+                    }
+                }
+            )
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "api-key-1|secret-1"
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="dns_search_blocked_queries",
+            time_from=1699990000,
+            time_to=1700000000,
+            domain="blocked.example",
+            keyword="blocked.example",
+            show_unblocked_threat=1,
+            cur_page=2,
+        )
+
+    assert result.success is True
+    assert result.output["items"] == [
+        {
+            "domain": "blocked.example",
+            "block_reason": "threat",
+            "result": "block",
+            "is_blocked": True,
+        }
+    ]
+
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "POST"
+    assert url == "https://console.onesec.net/open/api/client/searchBlockedQueries"
+    assert kwargs["json"] == {
+        "time_from": 1699990000,
+        "time_to": 1700000000,
+        "domain": "blocked.example",
+        "keyword": "blocked.example",
+        "show_unblocked_threat": 1,
+        "cur_page": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_onesec_dns_search_blocked_queries_defaults_keyword_and_parses_datetime_strings():
+    tool = _load_tool("onesec_dns.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "data": {
+                        "total_num": 1,
+                        "items": [{"domain": "bilibili.com", "result": "block"}],
+                    }
+                }
+            )
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "api-key-1|secret-1"
+    local_tz = dt.datetime.now().astimezone().tzinfo
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="dns_search_blocked_queries",
+            domain="bilibili.com",
+            time_from="2026-05-08 00:00:00",
+            time_to="2026-05-08 23:59:59",
+        )
+
+    assert result.success is True
+
+    expected_time_from = int(dt.datetime(2026, 5, 8, 0, 0, 0, tzinfo=local_tz).timestamp())
+    expected_time_to = int(dt.datetime(2026, 5, 8, 23, 59, 59, tzinfo=local_tz).timestamp())
+
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "POST"
+    assert url == "https://console.onesec.net/open/api/client/searchBlockedQueries"
+    assert kwargs["json"] == {
+        "time_from": expected_time_from,
+        "time_to": expected_time_to,
+        "domain": "bilibili.com",
+        "keyword": "bilibili.com",
+    }
+
+
+@pytest.mark.asyncio
+async def test_onesec_dns_search_blocked_queries_rejects_invalid_datetime_string():
+    tool = _load_tool("onesec_dns.yaml")
+
+    result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="dns_search_blocked_queries",
+        domain="bilibili.com",
+        keyword="bilibili.com",
+        time_from="tomorrow morning",
+        time_to=1700000000,
+    )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "time_from (tomorrow morning) 必须是 Unix 秒级时间戳。"
+        " 当前工具支持自动转换常见日期时间格式，如 `YYYY-MM-DD HH:MM:SS`。"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onesec_dns_search_queries_rejects_time_from_older_than_24_hours():
+    tool = _load_tool("onesec_dns.yaml")
+
+    with patch("time.time", return_value=1700000000):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="dns_search_queries",
+            time_from=1699900000,
+            time_to=1699950000,
+            domain="example.com",
+        )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "按 OneSEC API 文档，`dns_search_queries` 仅支持最近 24 小时内的数据。请将 time_from 设置在最近 24 小时内。"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onesec_dns_search_blocked_queries_suggests_recent_for_public_ip_only():
+    tool = _load_tool("onesec_dns.yaml")
+
+    result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="dns_search_blocked_queries",
+        public_ip="203.0.113.10",
+        time_from="2026-05-07 17:30:00",
+        time_to="2026-05-08 17:30:00",
+    )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "`dns_search_blocked_queries` 按 OneSEC API 文档要求必须传 `domain` 和 `keyword`。"
+        " 如果你当前只有 `public_ip` + 时间范围，且要查询最近 24 小时拦截记录，"
+        " 请改用 `dns_get_recent_blocked_queries`。"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onesec_dns_get_recent_blocked_queries_rejects_doc_unsupported_filters():
+    tool = _load_tool("onesec_dns.yaml")
+
+    with patch("time.time", return_value=1700000000):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="dns_get_recent_blocked_queries",
+            time_from=1699990000,
+            time_to=1700000000,
+            domain="blocked.example",
+            keyword="blocked",
+        )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "dns_get_recent_blocked_queries 按 OneSEC API 文档不支持以下参数: domain, keyword。"
+        " 若需要按域名或关键字筛选 DNS 拦截记录，请改用 `dns_search_blocked_queries`。"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onesec_dns_get_recent_blocked_queries_passes_doc_example_fields():
+    tool = _load_tool("onesec_dns.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "data": {
+                        "total_num": 1,
+                        "items": [{"result": "block"}],
+                    }
+                }
+            )
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "api-key-1|secret-1"
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="dns_get_recent_blocked_queries",
+            time_from=1699990000,
+            time_to=1700000000,
+            public_ip=["1.1.1.1"],
+            block_reason="threat",
+            show_unblocked_threat=1,
+            threat_level=[2, 3],
+        )
+
+    assert result.success is True
+
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "POST"
+    assert url == "https://console.onesec.net/open/api/client/getRecentBlockedQueries"
+    assert kwargs["json"] == {
+        "time_from": 1699990000,
+        "time_to": 1700000000,
+        "public_ip": ["1.1.1.1"],
+        "block_reason": "threat",
+        "show_unblocked_threat": 1,
+        "threat_level": [2, 3],
+    }
+
+
+@pytest.mark.asyncio
+async def test_onesec_dns_get_recent_blocked_queries_wraps_single_public_ip_string():
+    tool = _load_tool("onesec_dns.yaml")
+    fake_session = _FakeSession(
+        [
+            _FakeResponse(
+                json_payload={
+                    "data": {
+                        "total_num": 1,
+                        "items": [{"result": "block"}],
+                    }
+                }
+            )
+        ]
+    )
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.return_value = "api-key-1|secret-1"
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={"apiKey": "{secret:onesec_credentials}"},
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+        patch("time.time", return_value=1700000000),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="dns_get_recent_blocked_queries",
+            public_ip="203.0.113.10",
+            time_from="2026-05-07 17:30:00",
+            time_to="2026-05-08 17:30:00",
+        )
+
+    assert result.success is True
+
+    method, url, kwargs = fake_session.calls[0]
+    assert method == "POST"
+    assert url == "https://console.onesec.net/open/api/client/getRecentBlockedQueries"
+    assert kwargs["json"]["public_ip"] == ["203.0.113.10"]
+
+
+@pytest.mark.asyncio
 async def test_onesec_edr_get_threat_files_uses_doc_page_structure():
     tool = _load_tool("onesec_edr.yaml")
     fake_session = _FakeSession(
@@ -289,6 +587,43 @@ async def test_onesec_threat_virus_scan_returns_integer_task_id():
         "task_type": 10110,
         "task_content": {"scanmode": 2},
     }
+
+
+@pytest.mark.asyncio
+async def test_onesec_threat_virus_scan_rejects_invalid_task_type():
+    tool = _load_tool("onesec_threat.yaml")
+
+    result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="threat_virus_scan",
+        agent_list=["umid-1"],
+        task_type=99999,
+        scanmode=1,
+    )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "`task_type`/`scan_type` 取值无效：99999。按 OneSEC API 文档仅支持：10110, 10120, 10130。"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onesec_threat_update_bd_version_rejects_invalid_os_arch():
+    tool = _load_tool("onesec_threat.yaml")
+
+    result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="threat_update_bd_version",
+        os_platform="macos",
+        os_arch="ARM64",
+    )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "`os_arch` 取值无效：ARM64。当 `os_platform=macos` 时仅支持：Apple Silicon, Intel Chip。"
+    )
 
 
 @pytest.mark.asyncio
@@ -437,6 +772,45 @@ async def test_onesec_ops_query_task_page_list_uses_sort_object_payload():
 
 
 @pytest.mark.asyncio
+async def test_onesec_ops_query_task_page_list_rejects_invalid_time_type():
+    tool = _load_tool("onesec_ops.yaml")
+
+    result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="ops_query_task_page_list",
+        time_type="last_seen",
+        begin_time=1699990000,
+        end_time=1700000000,
+        auto=0,
+    )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "`time_type` 取值无效：last_seen。按 OneSEC API 文档仅支持：create_time, update_time。"
+    )
+
+
+@pytest.mark.asyncio
+async def test_onesec_ops_query_audit_log_rejects_begin_time_older_than_30_days():
+    tool = _load_tool("onesec_ops.yaml")
+
+    with patch("time.time", return_value=1700000000):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            action="ops_query_audit_log",
+            begin_time=1690000000,
+            end_time=1690100000,
+        )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "按 OneSEC API 文档，`ops_query_audit_log` 仅支持最近 30 天内的审计日志。请调整 begin_time。"
+    )
+
+
+@pytest.mark.asyncio
 async def test_onesec_edr_get_ioc_list_uses_doc_payload():
     tool = _load_tool("onesec_edr.yaml")
     fake_session = _FakeSession(
@@ -550,6 +924,24 @@ async def test_onesec_edr_get_threat_disposals_uses_incident_and_sort_payload():
         "umid": "umid-1",
         "sort": [{"sort_by": "update_time", "sort_order": "desc"}],
     }
+
+
+@pytest.mark.asyncio
+async def test_onesec_edr_get_threat_files_rejects_span_over_three_months():
+    tool = _load_tool("onesec_edr.yaml")
+
+    result = await tool.handler(
+        ToolContext(session_id="test", message_id="test"),
+        action="edr_get_threat_files",
+        time_from=1690000000,
+        time_to=1700000000,
+    )
+
+    assert result.success is False
+    assert (
+        result.error
+        == "按 OneSEC API 文档，`edr_get_threat_files` 的时间窗口最长三个月。请缩小 time_from/time_to 范围。"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Document dynamic `time_from`/`time_to` and DNS action routing in `onesec-use` skill and API reference.
- Extend OneSEC handler/YAML (DNS recent queries, time parsing, related actions).
- Provider credential flow adjustments and expanded `test_test_credentials` / `test_onesec_api_tool` coverage.