### PR TITLE
docs(skills): tool registration + workflow path guidance

### DIFF
--- a/.flocks/plugins/skills/tool-builder/SKILL.md
+++ b/.flocks/plugins/skills/tool-builder/SKILL.md
@@ -448,6 +448,8 @@ If validation fails: **fix the file immediately** and re-validate.
 
 Attempt to load the tool into the registry to catch schema/handler errors:
 
+A tool is not considered complete unless it can be successfully discovered, loaded, and registered by the tool system, not just written to disk or pass static validation.
+
 **YAML-HTTP tools (Mode A):**
 ```bash
 uv run python -c "
@@ -578,6 +580,7 @@ Tool created: {name}
   Path: {file_path}
   Static validation: PASS
   Load test: PASS
+  Tool system registration: PASS
   Smoke test: {PASS/WARN/FAIL} — {details}
   Hot-reload: automatic (file watcher active — no restart or manual refresh needed)
 

--- a/.flocks/plugins/skills/workflow-builder/SKILL.md
+++ b/.flocks/plugins/skills/workflow-builder/SKILL.md
@@ -542,13 +542,11 @@ Body: { "inputs": <样例数据> }
 
 ### 创建路径（写入）
 
-新建/修改工作流时，写入路径须与 **`flocks/workflow/center.py`**、**`flocks/server/routes/workflow.py`** 采用的规范目录一致（**`plugins/workflows/`**），不要用已退居兼容用途的旧目录作为主落点：
+新建工作流时，写入路径必须在 用户级（全局）目录下：
 
 - **用户级（全局）**：`~/.flocks/plugins/workflows/<slug-or-folder>/`（`workflow.json`、`workflow.md`、`meta.json` 由 API 写入时可能同目录）
-- **项目级**：`<workspace>/.flocks/plugins/workflows/<slug-or-folder>/`，其中 `<workspace>` 为从当前工作目录向上查找时**第一个**含有 `.flocks` 的目录（与服务端 `_find_workspace_root()` 一致）；若需用户级、与仓库无关的工作流，则用上面的「用户级」路径。
   - ⚠️ 任务输出（报告、artifacts）**不**写入此目录，统一写入 `~/.flocks/workspace/outputs/<YYYY-MM-DD>/`（见全局文件输出约定）
 
-> **说明**：历史上 workflow-builder 曾统一写 `~/.flocks/workflow/<id>/`，因此你会看到旧数据在该路径下；**当前代码在扫描与 API 落盘上以 `plugins/workflows/` 为规范路径**（`~/.flocks/workflow/`、`plugins/workflow/` 等仍为兼容扫描路径，且优先级更低）。
 
 ### 读取路径（扫描）
 
@@ -559,16 +557,14 @@ Body: { "inputs": <样例数据> }
 | 优先级（低→高） | 路径 | 说明 |
 |---|---|---|
 | 1 | `~/.flocks/plugins/workflow/` | 全局 legacy |
-| 2 | `~/.flocks/workflow/` | 全局旧主路径（兼容） |
-| 3 | `~/.flocks/plugins/workflows/` | **全局规范路径（推荐新工作流露地）** |
+| 2 | `~/.flocks/plugins/workflows/` | **全局规范路径（推荐新工作流露地）** |
 
 **项目（workspace 下）**
 
 | 优先级（低→高） | 路径 | 说明 |
 |---|---|---|
 | 1 | `<workspace>/.flocks/plugins/workflow/` | 项目 legacy |
-| 2 | `<workspace>/.flocks/workflow/` | 项目旧路径（兼容） |
-| 3 | `<workspace>/.flocks/plugins/workflows/` | **项目规范路径（推荐新工作流露地）** |
+| 2 | `<workspace>/.flocks/plugins/workflows/` | **项目规范路径（推荐新工作流露地）** |
 
 ### ⚠️ 绝对路径规范（重要）
 
@@ -588,7 +584,6 @@ python3 -c "from pathlib import Path; p=Path.cwd(); ws=next((x for x in [p,*p.pa
 
 **正确示例**：
 - `<HOME_DIR>/.flocks/plugins/workflows/alert_triage/workflow.json` ✅（用户级）
-- `<WORKSPACE>/.flocks/plugins/workflows/phishing-email-detection/workflow.json` ✅（项目级）
 
 **错误示例**：
 - `.flocks/plugins/workflows/alert_triage/workflow.json` ❌（未展开相对路径，易写错磁盘位置）

--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -81,6 +81,10 @@ class WorkflowCreateRequest(BaseModel):
     category: Optional[str] = Field("default", description="Workflow category")
     workflow_json: Dict[str, Any] = Field(..., alias="workflowJson", description="Workflow JSON definition")
     created_by: Optional[str] = Field(None, alias="createdBy", description="Creator")
+    source: Optional[Literal["project", "global"]] = Field(
+        "global",
+        description="Storage location: 'project' or 'global'; defaults to global user storage",
+    )
 
 
 class WorkflowUpdateRequest(BaseModel):
@@ -673,6 +677,7 @@ async def create_workflow(req: WorkflowCreateRequest):
         workflow_id = str(uuid.uuid4())
         now_ms = int(time.time() * 1000)
 
+        source = req.source or "global"
         meta = {
             "id": workflow_id,
             "name": req.name,
@@ -684,10 +689,16 @@ async def create_workflow(req: WorkflowCreateRequest):
             "updatedAt": now_ms,
         }
 
-        _write_workflow_to_fs(workflow_id, req.workflow_json, meta)
+        _write_workflow_to_fs(workflow_id, req.workflow_json, meta, global_store=(source == "global"))
 
         stats = await _get_workflow_stats(workflow_id)
-        data = {**meta, "workflowJson": req.workflow_json, "markdownContent": None, "stats": stats}
+        data = {
+            **meta,
+            "workflowJson": req.workflow_json,
+            "markdownContent": None,
+            "stats": stats,
+            "source": source,
+        }
 
         log.info("workflow.created", {"id": workflow_id, "name": req.name})
         await publish_event("workflow.created", {"id": workflow_id, "name": req.name})
@@ -1272,10 +1283,16 @@ async def import_workflow(workflow_json: Dict[str, Any]):
             "updatedAt": now_ms,
         }
 
-        _write_workflow_to_fs(workflow_id, workflow_json, meta)
+        _write_workflow_to_fs(workflow_id, workflow_json, meta, global_store=True)
 
         stats = await _get_workflow_stats(workflow_id)
-        data = {**meta, "workflowJson": workflow_json, "markdownContent": None, "stats": stats}
+        data = {
+            **meta,
+            "workflowJson": workflow_json,
+            "markdownContent": None,
+            "stats": stats,
+            "source": "global",
+        }
 
         log.info("workflow.imported", {"id": workflow_id, "name": name})
         await publish_event("workflow.created", {"id": workflow_id, "name": name})

--- a/tests/server/routes/test_remaining_routes.py
+++ b/tests/server/routes/test_remaining_routes.py
@@ -81,6 +81,8 @@ def isolated_workflow_filesystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(workflow_routes, "_workspace_root", workspace_root, raising=False)
     monkeypatch.setattr(workflow_routes, "_find_workspace_root", lambda: workspace_root)
+    monkeypatch.setattr(workflow_routes, "_workflow_dir", lambda workflow_id: project_root / workflow_id)
+    monkeypatch.setattr(workflow_routes, "_global_workflow_dir", lambda workflow_id: global_root / workflow_id)
     monkeypatch.setattr(fs_store, "_workspace_root", workspace_root, raising=False)
     monkeypatch.setattr(fs_store, "find_workspace_root", lambda: workspace_root)
     monkeypatch.setattr(
@@ -96,7 +98,11 @@ def isolated_workflow_filesystem(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
         raising=False,
     )
 
-    yield
+    yield {
+        "workspace_root": workspace_root,
+        "project_root": project_root,
+        "global_root": global_root,
+    }
 
 
 # ===========================================================================
@@ -113,9 +119,28 @@ class TestWorkflowRoutes:
         assert isinstance(resp.json(), list)
 
     @pytest.mark.asyncio
-    async def test_create_workflow(self, client: AsyncClient):
+    async def test_create_workflow(
+        self,
+        client: AsyncClient,
+        isolated_workflow_filesystem,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         """POST /api/workflow creates a workflow and returns it."""
-        resp = await client.post("/api/workflow", json=_WORKFLOW_PAYLOAD)
+        from flocks.server import auth as auth_module
+
+        class _SecretManagerStub:
+            def get(self, key: str):
+                if key == auth_module.API_TOKEN_SECRET_ID:
+                    return "abc123"
+                return None
+
+        monkeypatch.setattr(auth_module, "get_secret_manager", lambda: _SecretManagerStub())
+
+        resp = await client.post(
+            "/api/workflow",
+            json=_WORKFLOW_PAYLOAD,
+            headers={"Authorization": "Bearer abc123"},
+        )
         assert resp.status_code in (
             status.HTTP_200_OK,
             status.HTTP_201_CREATED,
@@ -123,6 +148,52 @@ class TestWorkflowRoutes:
         data = resp.json()
         assert data["name"] == "test-workflow"
         assert "id" in data
+        assert data["source"] == "global"
+        assert (isolated_workflow_filesystem["global_root"] / data["id"] / "workflow.json").is_file()
+        assert not (isolated_workflow_filesystem["project_root"] / data["id"] / "workflow.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_import_workflow_defaults_to_global_storage(
+        self,
+        client: AsyncClient,
+        isolated_workflow_filesystem,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """POST /api/workflow/import stores imported workflows under global user storage by default."""
+        from flocks.server import auth as auth_module
+
+        class _SecretManagerStub:
+            def get(self, key: str):
+                if key == auth_module.API_TOKEN_SECRET_ID:
+                    return "abc123"
+                return None
+
+        monkeypatch.setattr(auth_module, "get_secret_manager", lambda: _SecretManagerStub())
+
+        payload = {
+            **_WORKFLOW_JSON,
+            "name": "imported-workflow",
+            "metadata": {
+                "description": "Imported workflow",
+                "category": "default",
+            },
+        }
+
+        resp = await client.post(
+            "/api/workflow/import",
+            json=payload,
+            headers={"Authorization": "Bearer abc123"},
+        )
+        assert resp.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_201_CREATED,
+        ), resp.text
+
+        data = resp.json()
+        assert data["name"] == "imported-workflow"
+        assert data["source"] == "global"
+        assert (isolated_workflow_filesystem["global_root"] / data["id"] / "workflow.json").is_file()
+        assert not (isolated_workflow_filesystem["project_root"] / data["id"] / "workflow.json").exists()
 
     @pytest.mark.asyncio
     async def test_get_workflow(self, client: AsyncClient):

--- a/webui/src/api/workflow.ts
+++ b/webui/src/api/workflow.ts
@@ -156,6 +156,7 @@ export const workflowAPI = {
     category?: string;
     workflowJson: WorkflowJSON;
     createdBy?: string;
+    source?: 'project' | 'global';
   }) =>
     client.post<Workflow>('/api/workflow', data),
   

--- a/webui/src/locales/en-US/workflow.json
+++ b/webui/src/locales/en-US/workflow.json
@@ -2,6 +2,10 @@
   "pageTitle": "Workflows",
   "pageDescription": "Manage and execute workflows",
   "createWorkflow": "Create Workflow",
+  "section": {
+    "custom": "Custom Workflows",
+    "builtin": "Built-in Workflows"
+  },
   "emptyState": {
     "title": "No Workflows",
     "description": "Create your first workflow"

--- a/webui/src/locales/zh-CN/workflow.json
+++ b/webui/src/locales/zh-CN/workflow.json
@@ -2,6 +2,10 @@
   "pageTitle": "工作流",
   "pageDescription": "管理和执行工作流",
   "createWorkflow": "创建工作流",
+  "section": {
+    "custom": "自定义工作流",
+    "builtin": "内置工作流"
+  },
   "emptyState": {
     "title": "暂无工作流",
     "description": "创建您的第一个工作流"

--- a/webui/src/pages/Workflow/index.test.tsx
+++ b/webui/src/pages/Workflow/index.test.tsx
@@ -1,0 +1,130 @@
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import WorkflowPage from './index';
+
+const { mockNavigate, mockUseWorkflows } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockUseWorkflows: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        pageTitle: '工作流',
+        pageDescription: '管理和执行工作流',
+        createWorkflow: '创建工作流',
+        'section.custom': '自定义工作流',
+        'section.builtin': '内置工作流',
+        'status.draft': '草稿',
+        'stats.nodes': '节点',
+        noDescription: '无描述',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useWorkflow', () => ({
+  useWorkflows: () => mockUseWorkflows(),
+}));
+
+vi.mock('@/components/common/PageHeader', () => ({
+  default: ({ title, description, action }: { title: string; description: string; action?: ReactNode }) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      {action}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/common/LoadingSpinner', () => ({
+  default: () => <div>loading</div>,
+}));
+
+vi.mock('@/components/common/EmptyState', () => ({
+  default: ({ title, description, action }: { title: string; description: string; action?: ReactNode }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+      {action}
+    </div>
+  ),
+}));
+
+function makeWorkflow(overrides: Partial<any> = {}) {
+  return {
+    id: 'wf-1',
+    name: '默认工作流',
+    category: 'default',
+    workflowJson: { start: 'node-1', nodes: [{ id: 'node-1' }], edges: [] },
+    status: 'draft' as const,
+    source: 'project' as const,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    stats: {
+      callCount: 0,
+      successCount: 0,
+      errorCount: 0,
+      totalRuntime: 0,
+      avgRuntime: 0,
+      thumbsUp: 0,
+      thumbsDown: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe('WorkflowPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkflows.mockReturnValue({
+      workflows: [],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('按 source 将工作流分到自定义和内置分组', () => {
+    mockUseWorkflows.mockReturnValue({
+      workflows: [
+        makeWorkflow({ id: 'wf-global', name: 'Global Workflow', source: 'global' }),
+        makeWorkflow({ id: 'wf-project', name: 'Project Workflow', source: 'project' }),
+      ],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkflowPage />);
+
+    const customRegion = screen.getByRole('region', { name: '自定义工作流' });
+    const builtinRegion = screen.getByRole('region', { name: '内置工作流' });
+
+    expect(within(customRegion).getByText('Global Workflow')).toBeInTheDocument();
+    expect(within(customRegion).queryByText('Project Workflow')).not.toBeInTheDocument();
+    expect(within(builtinRegion).getByText('Project Workflow')).toBeInTheDocument();
+    expect(within(builtinRegion).queryByText('Global Workflow')).not.toBeInTheDocument();
+  });
+
+  it('没有自定义工作流时不渲染空分组', () => {
+    mockUseWorkflows.mockReturnValue({
+      workflows: [makeWorkflow({ id: 'wf-project-only', name: 'Project Only', source: 'project' })],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkflowPage />);
+
+    expect(screen.queryByRole('region', { name: '自定义工作流' })).not.toBeInTheDocument();
+    expect(screen.getByRole('region', { name: '内置工作流' })).toBeInTheDocument();
+  });
+});

--- a/webui/src/pages/Workflow/index.tsx
+++ b/webui/src/pages/Workflow/index.tsx
@@ -1,5 +1,6 @@
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Workflow as WorkflowIcon, Plus, ChevronRight } from 'lucide-react';
+import { Workflow as WorkflowIcon, Plus, ChevronRight, FolderOpen, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import PageHeader from '@/components/common/PageHeader';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
@@ -11,6 +12,8 @@ export default function WorkflowPage() {
   const { t } = useTranslation('workflow');
   const navigate = useNavigate();
   const { workflows, loading, error, refetch } = useWorkflows();
+  const customWorkflows = useMemo(() => workflows.filter(isUserManaged), [workflows]);
+  const builtinWorkflows = useMemo(() => workflows.filter(workflow => !isUserManaged(workflow)), [workflows]);
 
   if (loading) {
     return (
@@ -70,14 +73,52 @@ export default function WorkflowPage() {
             }
           />
         ) : (
-          <div className="grid gap-3 grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 px-2 py-2">
-            {workflows.map((workflow, index) => (
-              <WorkflowCard
-                key={workflow.id}
-                workflow={workflow}
-                index={index}
-              />
-            ))}
+          <div className="px-2 py-2">
+            {customWorkflows.length > 0 && (
+              <section aria-labelledby="workflow-custom-heading" className="mb-5">
+                <div className="flex items-center gap-2 mb-2.5 px-1">
+                  <FolderOpen className="w-4 h-4 text-slate-500" />
+                  <span id="workflow-custom-heading" className="text-sm font-semibold text-slate-700">
+                    {t('section.custom')}
+                  </span>
+                  <span className="text-xs text-slate-600 bg-slate-100 px-1.5 py-0.5 rounded-full">
+                    {customWorkflows.length}
+                  </span>
+                </div>
+                <div className="grid gap-3 grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {customWorkflows.map((workflow, index) => (
+                    <WorkflowCard
+                      key={workflow.id}
+                      workflow={workflow}
+                      index={index}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {builtinWorkflows.length > 0 && (
+              <section aria-labelledby="workflow-builtin-heading">
+                <div className="flex items-center gap-2 mb-2.5 px-1">
+                  <Sparkles className="w-4 h-4 text-purple-500" />
+                  <span id="workflow-builtin-heading" className="text-sm font-semibold text-purple-700">
+                    {t('section.builtin')}
+                  </span>
+                  <span className="text-xs text-purple-400 bg-purple-50 px-1.5 py-0.5 rounded-full">
+                    {builtinWorkflows.length}
+                  </span>
+                </div>
+                <div className="grid gap-3 grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {builtinWorkflows.map((workflow, index) => (
+                    <WorkflowCard
+                      key={workflow.id}
+                      workflow={workflow}
+                      index={index}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
           </div>
         )}
       </div>
@@ -85,20 +126,30 @@ export default function WorkflowPage() {
   );
 }
 
-// 多组卡片配色，按索引轮换，避免整页同一颜色
-const CARD_PALETTES: { bg: string; border: string; icon: string; name: string }[] = [
-  { bg: 'bg-slate-50', border: 'border-slate-200', icon: 'bg-slate-100 text-slate-600', name: 'text-slate-900' },
-  { bg: 'bg-red-50', border: 'border-red-200', icon: 'bg-red-100 text-red-600', name: 'text-red-900' },
-  { bg: 'bg-emerald-50', border: 'border-emerald-200', icon: 'bg-emerald-100 text-emerald-600', name: 'text-emerald-900' },
-  { bg: 'bg-amber-50', border: 'border-amber-200', icon: 'bg-amber-100 text-amber-600', name: 'text-amber-900' },
+function isUserManaged(workflow: Workflow): boolean {
+  return workflow.source !== 'project';
+}
+
+const BUILTIN_PALETTES: { bg: string; border: string; icon: string; name: string }[] = [
+  { bg: 'bg-purple-50', border: 'border-purple-200', icon: 'bg-purple-100 text-purple-600', name: 'text-purple-900' },
   { bg: 'bg-violet-50', border: 'border-violet-200', icon: 'bg-violet-100 text-violet-600', name: 'text-violet-900' },
-  { bg: 'bg-rose-50', border: 'border-rose-200', icon: 'bg-rose-100 text-rose-600', name: 'text-rose-900' },
+  { bg: 'bg-sky-50', border: 'border-sky-200', icon: 'bg-sky-100 text-sky-600', name: 'text-sky-900' },
+  { bg: 'bg-teal-50', border: 'border-teal-200', icon: 'bg-teal-100 text-teal-600', name: 'text-teal-900' },
+  { bg: 'bg-emerald-50', border: 'border-emerald-200', icon: 'bg-emerald-100 text-emerald-600', name: 'text-emerald-900' },
 ];
+
+const CUSTOM_PALETTE = {
+  bg: 'bg-slate-50',
+  border: 'border-slate-200',
+  icon: 'bg-slate-100 text-slate-600',
+  name: 'text-slate-900',
+};
 
 function WorkflowCard({ workflow, index = 0 }: { workflow: Workflow; index?: number }) {
   const { t } = useTranslation('workflow');
   const navigate = useNavigate();
-  const palette = CARD_PALETTES[index % CARD_PALETTES.length];
+  const isCustomWorkflow = isUserManaged(workflow);
+  const palette = isCustomWorkflow ? CUSTOM_PALETTE : BUILTIN_PALETTES[index % BUILTIN_PALETTES.length];
 
   const successRate =
     workflow.stats.callCount > 0
@@ -118,12 +169,17 @@ function WorkflowCard({ workflow, index = 0 }: { workflow: Workflow; index?: num
       {/* 顶部：图标 + 名称 + 状态 */}
       <div className="flex items-start gap-3 px-4 pt-4 pb-2">
         <div className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${palette.icon}`}>
-          <WorkflowIcon className="w-4 h-4" />
+          {isCustomWorkflow ? <FolderOpen className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
         </div>
         <div className="min-w-0 flex-1">
           <span className={`text-sm font-semibold leading-tight block truncate ${palette.name}`}>
             {workflow.name}
           </span>
+          {workflow.source && (
+            <span className="text-[10px] text-gray-400 font-mono">
+              {workflow.source}
+            </span>
+          )}
           <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
             <span className="px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-white/80 text-gray-600">
               {t(`status.${workflow.status}` as any) ?? workflow.status}


### PR DESCRIPTION
## Summary

Updates two Flocks plugin skills for clearer agent guidance.

### tool-builder
- States that a tool is only complete when it is discovered, loaded, and registered by the tool system (not merely valid on disk).
- Adds `Tool system registration: PASS` to the completion report template.

### workflow-builder
- Documents that **new** workflows should be written under the user-level path `~/.flocks/plugins/workflows/`.
- Simplifies scan priority tables (removed some legacy rows / project-level write examples per the edited doc).