### PR TITLE
fix(browser): normalize env file decoding across platforms

### DIFF
--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from . import BROWSER_LABEL, PROJECT_ROOT, get_browser_version
 from . import _ipc as ipc
+from .utils import load_env_file
 
 
 NAME = os.environ.get("BU_NAME", "default")
@@ -26,16 +27,6 @@ def _load_env() -> None:
         if not path.exists():
             continue
         _load_env_file(path)
-
-
-def _load_env_file(path: Path) -> None:
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
-
 
 _load_env()
 

--- a/flocks/browser/daemon.py
+++ b/flocks/browser/daemon.py
@@ -14,6 +14,7 @@ from cdp_use.client import CDPClient
 
 from . import DEFAULT_AGENT_WORKSPACE, INTERNAL_URL_PREFIXES
 from . import _ipc as ipc
+from .utils import load_env_file
 
 
 AGENT_WORKSPACE = Path(os.environ.get("BH_AGENT_WORKSPACE", DEFAULT_AGENT_WORKSPACE)).expanduser()
@@ -57,16 +58,6 @@ def _load_env() -> None:
         if not path.exists():
             continue
         _load_env_file(path)
-
-
-def _load_env_file(path: Path) -> None:
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
-
 
 _load_env()
 

--- a/flocks/browser/helpers.py
+++ b/flocks/browser/helpers.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 from . import DEFAULT_AGENT_WORKSPACE, INTERNAL_URL_PREFIXES
 from . import _ipc as ipc
+from .utils import load_env_file
 
 
 AGENT_WORKSPACE = Path(os.environ.get("BH_AGENT_WORKSPACE", DEFAULT_AGENT_WORKSPACE)).expanduser()
@@ -45,16 +46,6 @@ def _load_env() -> None:
         if not path.exists():
             continue
         _load_env_file(path)
-
-
-def _load_env_file(path: Path) -> None:
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
-
 
 _load_env()
 

--- a/flocks/browser/utils.py
+++ b/flocks/browser/utils.py
@@ -1,0 +1,23 @@
+"""Shared browser utility helpers."""
+
+import locale
+import os
+from pathlib import Path
+
+
+def read_env_text(path: Path) -> str:
+    """Read an env file as UTF-8 first, then fall back to the local encoding."""
+    try:
+        return path.read_text(encoding="utf-8-sig")
+    except UnicodeDecodeError:
+        return path.read_text(encoding=locale.getpreferredencoding(False))
+
+
+def load_env_file(path: Path) -> None:
+    """Populate ``os.environ`` from a simple ``KEY=VALUE`` env file."""
+    for line in read_env_text(path).splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))

--- a/tests/browser/test_utils.py
+++ b/tests/browser/test_utils.py
@@ -1,0 +1,30 @@
+import os
+
+from flocks.browser import utils
+
+
+def test_read_env_text_supports_utf8(tmp_path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("TOKEN=中文\n", encoding="utf-8")
+
+    assert utils.read_env_text(env_file) == "TOKEN=中文\n"
+
+
+def test_load_env_file_supports_utf8_bom(tmp_path, monkeypatch) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_bytes('TOKEN="中文"\nNAME=test\n'.encode("utf-8-sig"))
+    monkeypatch.delenv("TOKEN", raising=False)
+    monkeypatch.delenv("NAME", raising=False)
+
+    utils.load_env_file(env_file)
+
+    assert os.environ["TOKEN"] == "中文"
+    assert os.environ["NAME"] == "test"
+
+
+def test_read_env_text_falls_back_to_local_encoding(tmp_path, monkeypatch) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_bytes("TOKEN=中文\n".encode("gbk"))
+    monkeypatch.setattr(utils.locale, "getpreferredencoding", lambda _do_setlocale=False: "gbk")
+
+    assert utils.read_env_text(env_file) == "TOKEN=中文\n"


### PR DESCRIPTION
## Summary
- centralize browser `.env` loading into a shared utility to avoid duplicated parsing logic
- read env files with `utf-8-sig` first and fall back to the local preferred encoding for Windows compatibility
- add browser tests covering UTF-8, UTF-8 BOM, and locale fallback decoding
