### PR TITLE
feat(config): canonicalize verify_ssl and relax TDP connectivity probe

### DIFF
--- a/.flocks/plugins/tools/api/tdp_v3_3_10/_test.yaml
+++ b/.flocks/plugins/tools/api/tdp_v3_3_10/_test.yaml
@@ -2,12 +2,13 @@ schema_version: 1
 provider: tdp_api
 
 # Service-level connectivity probe.
-# `system_status` with `action: all` is a lightweight multi-endpoint health
-# check; it verifies HMAC-SHA256 signing and basic platform reachability.
+# Use a single lightweight read-only overview endpoint here instead of the
+# stricter multi-endpoint system-status aggregate. This keeps the connectivity
+# check lenient while still verifying signing and basic reachability.
 connectivity:
-  tool: tdp_system_status
+  tool: tdp_dashboard_status
   params:
-    action: all
+    action: status
 
 # Tool-level test samples shown in the WebUI ToolDetailDrawer drop-down.
 # `label` is the default (English) display string; `label_cn` is the

--- a/.flocks/plugins/tools/api/tdp_v3_3_10/_test.yaml
+++ b/.flocks/plugins/tools/api/tdp_v3_3_10/_test.yaml
@@ -2,13 +2,13 @@ schema_version: 1
 provider: tdp_api
 
 # Service-level connectivity probe.
-# Use a single lightweight read-only overview endpoint here instead of the
-# stricter multi-endpoint system-status aggregate. This keeps the connectivity
-# check lenient while still verifying signing and basic reachability.
+# Use a single lightweight system-status endpoint here instead of the stricter
+# multi-endpoint aggregate. This keeps the connectivity check focused on basic
+# service health without coupling it to every subsystem state.
 connectivity:
-  tool: tdp_dashboard_status
+  tool: tdp_system_status
   params:
-    action: status
+    action: service
 
 # Tool-level test samples shown in the WebUI ToolDetailDrawer drop-down.
 # `label` is the default (English) display string; `label_cn` is the

--- a/flocks/config/api_versioning.py
+++ b/flocks/config/api_versioning.py
@@ -287,7 +287,9 @@ def migrate_api_services(*, backup: bool = True) -> Dict[str, str]:
 
     for desc in pending:
         # Deep-copy via JSON round-trip; api_services blocks are pure JSON.
-        services[desc.storage_key] = json.loads(json.dumps(services[desc.service_id]))
+        copied = json.loads(json.dumps(services[desc.service_id]))
+        from flocks.config.config_writer import ConfigWriter
+        services[desc.storage_key] = ConfigWriter._normalize_api_service_config(copied)
         actions[desc.storage_key] = "copied"
         log.info("versioning.migrated", {
             "service_id": desc.service_id,

--- a/flocks/config/config_writer.py
+++ b/flocks/config/config_writer.py
@@ -469,6 +469,22 @@ class ConfigWriter:
     # API Services CRUD  (api_services section)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _normalize_api_service_config(service_config: Dict[str, Any]) -> Dict[str, Any]:
+        """Canonicalize API service config keys before persisting.
+
+        ``verify_ssl`` is the canonical field. ``ssl_verify`` remains a
+        read-time compatibility alias, but writers should never persist both
+        fields at once or keep writing the legacy alias forward.
+        """
+        normalized = dict(service_config)
+        if "verify_ssl" in normalized:
+            normalized.pop("ssl_verify", None)
+            return normalized
+        if "ssl_verify" in normalized:
+            normalized["verify_ssl"] = normalized.pop("ssl_verify")
+        return normalized
+
     @classmethod
     def get_api_service_raw(cls, service_id: str) -> Optional[Dict[str, Any]]:
         """Read a single ``api_services`` entry (raw, secrets unresolved).
@@ -513,7 +529,7 @@ class ConfigWriter:
         """
         data = cls._read_raw()
         services = data.setdefault("api_services", {})
-        services[service_id] = service_config
+        services[service_id] = cls._normalize_api_service_config(service_config)
         cls._write_raw(data)
         log.info("config_writer.api_service_set", {"service_id": service_id})
 

--- a/tests/config/test_api_versioning.py
+++ b/tests/config/test_api_versioning.py
@@ -302,6 +302,27 @@ class TestMigration:
         assert services["tdp_api_v3_3_10"]["base_url"] == "https://tdp.example"
         assert services["tdp_api_v3_3_10"]["apiKey"] == "{secret:tdp_key}"
 
+    def test_migration_canonicalizes_legacy_ssl_verify_alias(self, isolated_env, api_root):
+        _, user_config = isolated_env
+        _write_provider_yaml(api_root / "tdp_v3_3_10", service_id="tdp_api", version="3.3.10")
+        config_path = _write_flocks_json(user_config, {
+            "api_services": {
+                "tdp_api": {
+                    "enabled": True,
+                    "base_url": "https://tdp.example",
+                    "ssl_verify": True,
+                },
+            },
+        })
+
+        actions = migrate_api_services()
+
+        assert actions == {"tdp_api_v3_3_10": "copied"}
+        services = json.loads(config_path.read_text(encoding="utf-8"))["api_services"]
+        assert services["tdp_api"]["ssl_verify"] is True
+        assert services["tdp_api_v3_3_10"]["verify_ssl"] is True
+        assert "ssl_verify" not in services["tdp_api_v3_3_10"]
+
     def test_idempotent_when_storage_key_exists(self, isolated_env, api_root):
         _, user_config = isolated_env
         _write_provider_yaml(api_root / "tdp_v3_3_10", service_id="tdp_api", version="3.3.10")
@@ -504,6 +525,41 @@ class TestConfigWriterFallback:
 
         captured = capsys.readouterr()
         assert "api_service.write.shadowed_legacy" not in captured.err
+
+    def test_set_api_service_promotes_ssl_verify_alias_to_verify_ssl(self, isolated_env, api_root):
+        _, user_config = isolated_env
+        from flocks.config.config_writer import ConfigWriter
+
+        _write_provider_yaml(api_root / "tdp_v3_3_10", service_id="tdp_api", version="3.3.10")
+        _write_flocks_json(user_config, {"api_services": {}})
+        versioning._reset_descriptor_cache()
+
+        ConfigWriter.set_api_service("tdp_api_v3_3_10", {
+            "base_url": "https://tdp.example",
+            "ssl_verify": False,
+        })
+
+        services = json.loads((user_config / "flocks.json").read_text(encoding="utf-8"))["api_services"]
+        assert services["tdp_api_v3_3_10"]["verify_ssl"] is False
+        assert "ssl_verify" not in services["tdp_api_v3_3_10"]
+
+    def test_set_api_service_drops_alias_when_verify_ssl_already_present(self, isolated_env, api_root):
+        _, user_config = isolated_env
+        from flocks.config.config_writer import ConfigWriter
+
+        _write_provider_yaml(api_root / "tdp_v3_3_10", service_id="tdp_api", version="3.3.10")
+        _write_flocks_json(user_config, {"api_services": {}})
+        versioning._reset_descriptor_cache()
+
+        ConfigWriter.set_api_service("tdp_api_v3_3_10", {
+            "base_url": "https://tdp.example",
+            "ssl_verify": True,
+            "verify_ssl": False,
+        })
+
+        services = json.loads((user_config / "flocks.json").read_text(encoding="utf-8"))["api_services"]
+        assert services["tdp_api_v3_3_10"]["verify_ssl"] is False
+        assert "ssl_verify" not in services["tdp_api_v3_3_10"]
 
     def test_get_api_service_raw_handles_null_api_services(self, isolated_env, api_root):
         """``"api_services": null`` in flocks.json must not crash the reader."""

--- a/tests/provider/test_test_credentials.py
+++ b/tests/provider/test_test_credentials.py
@@ -363,6 +363,54 @@ class TestTestCredentialsToolExecution:
             mock_tr.execute.assert_awaited_once_with(tool_name="qingteng_login")
 
     @pytest.mark.asyncio
+    async def test_declared_manifest_probe_is_used_before_heuristic_tool_selection(self):
+        """A declared connectivity probe should bypass heuristic tool sorting."""
+        from flocks.server.routes.provider import test_provider_credentials
+        from flocks.tool.probe_loader import ConnectivitySpec
+
+        heuristic_tool = _make_tool_info("tdp_assets_domain_list")
+
+        mock_secrets = MagicMock()
+        mock_secrets.get.return_value = "valid-creds"
+
+        with (
+            patch(_PATCH_SECRET_MGR, return_value=mock_secrets),
+            patch(_PATCH_PROVIDER) as mock_provider_cls,
+            patch(_PATCH_TOOL_REGISTRY) as mock_tr,
+            patch(_PATCH_TOOL_SOURCE, return_value=("api", "tdp_api_v3_3_10")),
+            patch(
+                "flocks.tool.probe_loader.get_connectivity_spec",
+                return_value=ConnectivitySpec(
+                    tool="tdp_dashboard_status",
+                    params={"action": "status"},
+                ),
+            ),
+        ):
+            mock_provider_cls._ensure_initialized = MagicMock()
+            mock_provider_cls.apply_config = AsyncMock()
+            mock_provider_cls.get.return_value = None
+
+            mock_tr.init = MagicMock()
+            mock_tr.list_tools.return_value = [heuristic_tool]
+            mock_tr._dynamic_tools_by_module = {
+                "flocks.tool.generated.tdp_api": ["tdp_assets_domain_list"],
+            }
+            mock_tr.execute = AsyncMock(return_value=ToolResult(
+                success=True,
+                output={"status": "ok"},
+            ))
+
+            result = await test_provider_credentials("tdp_api_v3_3_10")
+
+            assert result["success"] is True, result
+            assert result["tool_tested"] == "tdp_dashboard_status"
+            assert result["probe_source"] == "manifest"
+            mock_tr.execute.assert_awaited_once_with(
+                tool_name="tdp_dashboard_status",
+                action="status",
+            )
+
+    @pytest.mark.asyncio
     async def test_login_probe_does_not_overmatch_business_tools(self):
         """`_is_login_probe` must only match dedicated probes — not arbitrary
         business tools whose names happen to contain ``login`` (e.g. TDP's

--- a/tests/provider/test_test_credentials.py
+++ b/tests/provider/test_test_credentials.py
@@ -381,8 +381,8 @@ class TestTestCredentialsToolExecution:
             patch(
                 "flocks.tool.probe_loader.get_connectivity_spec",
                 return_value=ConnectivitySpec(
-                    tool="tdp_dashboard_status",
-                    params={"action": "status"},
+                    tool="tdp_system_status",
+                    params={"action": "service"},
                 ),
             ),
         ):
@@ -403,11 +403,11 @@ class TestTestCredentialsToolExecution:
             result = await test_provider_credentials("tdp_api_v3_3_10")
 
             assert result["success"] is True, result
-            assert result["tool_tested"] == "tdp_dashboard_status"
+            assert result["tool_tested"] == "tdp_system_status"
             assert result["probe_source"] == "manifest"
             mock_tr.execute.assert_awaited_once_with(
-                tool_name="tdp_dashboard_status",
-                action="status",
+                tool_name="tdp_system_status",
+                action="service",
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Canonicalize API service TLS config on write: persist `verify_ssl` and drop legacy `ssl_verify` alias (including when both appear).
- Run the same normalization when `migrate_api_services` copies a service to a versioned storage key.
- TDP provider manifest: use `tdp_dashboard_status` with `action: status` for connectivity instead of the stricter multi-endpoint `tdp_system_status` aggregate.