### PR TITLE
fix(browser): restore env loader calls during import

### DIFF
--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -26,7 +26,7 @@ def _load_env() -> None:
     for path in env_paths:
         if not path.exists():
             continue
-        _load_env_file(path)
+        load_env_file(path)
 
 _load_env()
 

--- a/flocks/browser/daemon.py
+++ b/flocks/browser/daemon.py
@@ -57,7 +57,7 @@ def _load_env() -> None:
     for path in (Path(__file__).resolve().parents[2] / ".env", AGENT_WORKSPACE / ".env"):
         if not path.exists():
             continue
-        _load_env_file(path)
+        load_env_file(path)
 
 _load_env()
 

--- a/flocks/browser/helpers.py
+++ b/flocks/browser/helpers.py
@@ -45,7 +45,7 @@ def _load_env() -> None:
     for path in (Path(__file__).resolve().parents[2] / ".env", AGENT_WORKSPACE / ".env"):
         if not path.exists():
             continue
-        _load_env_file(path)
+        load_env_file(path)
 
 _load_env()
 

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -37,6 +37,24 @@ def test_handshake_403_needs_chrome_remote_debugging_prompt() -> None:
     assert admin._needs_chrome_remote_debugging_prompt(msg)
 
 
+def test_load_env_uses_shared_loader_for_existing_files(tmp_path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_env = tmp_path / ".env"
+    workspace_env = workspace / ".env"
+    repo_env.write_text("TOKEN=repo\n", encoding="utf-8")
+    workspace_env.write_text("TOKEN=workspace\n", encoding="utf-8")
+    loaded_paths = []
+
+    monkeypatch.setattr(admin, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setenv("BH_AGENT_WORKSPACE", str(workspace))
+    monkeypatch.setattr(admin, "load_env_file", lambda path: loaded_paths.append(path))
+
+    admin._load_env()
+
+    assert loaded_paths == [repo_env, workspace_env]
+
+
 def test_stale_websocket_does_not_open_chrome_inspect() -> None:
     msg = "no close frame received or sent"
     assert not admin._needs_chrome_remote_debugging_prompt(msg)

--- a/tests/browser/test_daemon.py
+++ b/tests/browser/test_daemon.py
@@ -7,3 +7,31 @@ def test_is_real_page_filters_edge_internal_pages() -> None:
 
 def test_is_real_page_accepts_normal_https_pages() -> None:
     assert daemon.is_real_page({"type": "page", "url": "https://example.com"})
+
+
+def test_load_env_uses_shared_loader_for_existing_files(tmp_path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    repo_env = repo_root / ".env"
+    workspace_env = workspace / ".env"
+    repo_env.write_text("TOKEN=repo\n", encoding="utf-8")
+    workspace_env.write_text("TOKEN=workspace\n", encoding="utf-8")
+    loaded_paths = []
+
+    class _FakeModulePath:
+        def resolve(self):
+            return self
+
+        @property
+        def parents(self):
+            return [None, None, repo_root]
+
+    monkeypatch.setattr(daemon, "AGENT_WORKSPACE", workspace)
+    monkeypatch.setattr(daemon, "Path", lambda _value: _FakeModulePath())
+    monkeypatch.setattr(daemon, "load_env_file", lambda path: loaded_paths.append(path))
+
+    daemon._load_env()
+
+    assert loaded_paths == [repo_env, workspace_env]

--- a/tests/browser/test_helpers.py
+++ b/tests/browser/test_helpers.py
@@ -31,6 +31,34 @@ def test_max_dim_default_is_no_resize(fake_png) -> None:
     assert _run(fake_png, 4592, 2286) == (4592, 2286)
 
 
+def test_load_env_uses_shared_loader_for_existing_files(tmp_path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    repo_env = repo_root / ".env"
+    workspace_env = workspace / ".env"
+    repo_env.write_text("TOKEN=repo\n", encoding="utf-8")
+    workspace_env.write_text("TOKEN=workspace\n", encoding="utf-8")
+    loaded_paths = []
+
+    class _FakeModulePath:
+        def resolve(self):
+            return self
+
+        @property
+        def parents(self):
+            return [None, None, repo_root]
+
+    monkeypatch.setattr(helpers, "AGENT_WORKSPACE", workspace)
+    monkeypatch.setattr(helpers, "Path", lambda _value: _FakeModulePath())
+    monkeypatch.setattr(helpers, "load_env_file", lambda path: loaded_paths.append(path))
+
+    helpers._load_env()
+
+    assert loaded_paths == [repo_env, workspace_env]
+
+
 def test_page_info_raises_clear_error_on_js_exception() -> None:
     def fake_send(req):
         return {}


### PR DESCRIPTION
## Summary
- fix browser env initialization to call the shared `load_env_file` helper during module import
- update `admin.py`, `daemon.py`, and `helpers.py` so CLI startup no longer fails with `NameError`
- add regression tests covering env loader usage across the three browser modules