### PR TITLE
fix(storage): unify sqlite WAL connection configuration

### DIFF
--- a/flocks/auth/service.py
+++ b/flocks/auth/service.py
@@ -82,7 +82,7 @@ class AuthService:
         db_path = Storage.get_db_path()
         if cls._initialized and cls._initialized_db_path == str(db_path) and db_path.exists():
             return
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             await db.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS users (
@@ -162,7 +162,7 @@ class AuthService:
             return True
         await cls.init()
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             async with db.execute("SELECT COUNT(1) FROM users") as cursor:
                 row = await cursor.fetchone()
                 result = bool(row and row[0] > 0)
@@ -211,7 +211,7 @@ class AuthService:
         now = _iso_now()
         password_hash = cls._hash_password(password)
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             await db.execute(
                 """
                 INSERT INTO users (
@@ -239,7 +239,7 @@ class AuthService:
     async def get_user_by_id(cls, user_id: str) -> Optional[LocalUser]:
         await cls.init()
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             async with db.execute(
                 """
                 SELECT id, username, role, status, must_reset_password,
@@ -266,7 +266,7 @@ class AuthService:
     async def get_user_by_username(cls, username: str) -> Optional[Tuple[LocalUser, str, Optional[str]]]:
         await cls.init()
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             async with db.execute(
                 """
                 SELECT id, username, role, status, must_reset_password, created_at, updated_at, last_login_at,
@@ -295,7 +295,7 @@ class AuthService:
         await cls.init()
         db_path = Storage.get_db_path()
         users: List[LocalUser] = []
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             async with db.execute(
                 """
                 SELECT id, username, role, status, must_reset_password, created_at, updated_at, last_login_at
@@ -326,7 +326,7 @@ class AuthService:
         now = _iso_now()
         expires_at = (_utc_now() + timedelta(days=cls._session_ttl_days)).isoformat()
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             await db.execute(
                 """
                 INSERT INTO user_sessions(session_id, user_id, expires_at, created_at, updated_at)
@@ -341,7 +341,7 @@ class AuthService:
     async def get_user_by_session_id(cls, session_id: str) -> Optional[LocalUser]:
         await cls.init()
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             async with db.execute(
                 """
                 SELECT u.id, u.username, u.role, u.status, u.must_reset_password, u.created_at, u.updated_at, u.last_login_at,
@@ -377,7 +377,7 @@ class AuthService:
     async def revoke_session(cls, session_id: str) -> None:
         await cls.init()
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             await db.execute("DELETE FROM user_sessions WHERE session_id = ?", (session_id,))
             await db.commit()
 
@@ -407,7 +407,7 @@ class AuthService:
         session_id = await cls._create_session(user.id)
         now = _iso_now()
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             await db.execute("UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?", (now, now, user.id))
             await db.commit()
 
@@ -453,7 +453,7 @@ class AuthService:
         now = _iso_now()
         pwd_hash = cls._hash_password(new_password)
         db_path = Storage.get_db_path()
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             cursor = await db.execute(
                 """
                 UPDATE users

--- a/flocks/channel/inbound/session_binding.py
+++ b/flocks/channel/inbound/session_binding.py
@@ -100,11 +100,12 @@ async def _get_db() -> aiosqlite.Connection:
         db_path = Storage.get_db_path()
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
-        _db_conn = await aiosqlite.connect(str(db_path))
+        _db_conn = await aiosqlite.connect(
+            str(db_path),
+            timeout=Storage._sqlite_timeout_s,
+        )
         _db_conn.row_factory = aiosqlite.Row
-
-        await _db_conn.execute("PRAGMA journal_mode=WAL")
-        await _db_conn.execute("PRAGMA busy_timeout=5000")
+        await Storage.configure_connection(_db_conn)
         await _db_conn.executescript(_DDL)
         await _migrate_legacy_binding_agent_ids(_db_conn)
         _db_ready = True

--- a/flocks/memory/sync/indexer.py
+++ b/flocks/memory/sync/indexer.py
@@ -222,7 +222,7 @@ class MemoryIndexer:
         indexed = {}
         
         try:
-            async with aiosqlite.connect(Storage.get_db_path()) as db:
+            async with Storage.connect(Storage.get_db_path()) as db:
                 cursor = await db.execute("""
                     SELECT path, hash, mtime, size
                     FROM memory_files
@@ -449,7 +449,7 @@ class MemoryIndexer:
         import aiosqlite
         
         try:
-            async with aiosqlite.connect(Storage.get_db_path()) as db:
+            async with Storage.connect(Storage.get_db_path()) as db:
                 await db.execute(
                     "DELETE FROM memory_chunks WHERE project_id = ? AND path = ?",
                     (self.project_id, path),
@@ -465,7 +465,7 @@ class MemoryIndexer:
         now = datetime.now().timestamp()
         
         try:
-            async with aiosqlite.connect(Storage.get_db_path()) as db:
+            async with Storage.connect(Storage.get_db_path()) as db:
                 await db.execute("""
                     INSERT OR REPLACE INTO memory_files
                     (path, project_id, source, hash, mtime, size, indexed_at)
@@ -496,7 +496,7 @@ class MemoryIndexer:
         import aiosqlite
         
         try:
-            async with aiosqlite.connect(Storage.get_db_path()) as db:
+            async with Storage.connect(Storage.get_db_path()) as db:
                 cursor = await db.execute("""
                     SELECT path FROM memory_files WHERE project_id = ?
                 """, (self.project_id,))

--- a/flocks/provider/usage_service.py
+++ b/flocks/provider/usage_service.py
@@ -270,7 +270,7 @@ async def _get_existing_usage_record(
 async def usage_record_exists(*, session_id: str, message_id: str) -> bool:
     """Check whether a usage row already exists for a message."""
     await Storage._ensure_init()
-    async with aiosqlite.connect(Storage._db_path) as db:
+    async with Storage.connect(Storage._db_path) as db:
         async with db.execute(
             "SELECT 1 FROM usage_records WHERE session_id = ? AND message_id = ? LIMIT 1",
             (session_id, message_id),
@@ -282,7 +282,7 @@ async def usage_record_exists(*, session_id: str, message_id: str) -> bool:
 async def _get_recorded_message_ids(session_id: str) -> set[str]:
     """Return all assistant message ids already present in usage_records."""
     await Storage._ensure_init()
-    async with aiosqlite.connect(Storage._db_path) as db:
+    async with Storage.connect(Storage._db_path) as db:
         async with db.execute(
             "SELECT message_id FROM usage_records WHERE session_id = ? AND message_id IS NOT NULL",
             (session_id,),
@@ -334,7 +334,7 @@ async def record_usage(req: RecordUsageRequest) -> UsageRecord:
         total_cost = 0.0
         currency = "USD"
 
-    async with aiosqlite.connect(Storage._db_path) as db:
+    async with Storage.connect(Storage._db_path) as db:
         db.row_factory = aiosqlite.Row
         existing = await _get_existing_usage_record(
             db,
@@ -419,7 +419,7 @@ async def get_usage_records(
         model_id=model_id,
         session_ids=session_ids,
     )
-    async with aiosqlite.connect(Storage._db_path) as db:
+    async with Storage.connect(Storage._db_path) as db:
         db.row_factory = aiosqlite.Row
         async with db.execute(
             f"""SELECT id, provider_id, model_id, credential_id, session_id, message_id,
@@ -453,7 +453,7 @@ async def get_usage_stats(
         session_ids=session_ids,
     )
 
-    async with aiosqlite.connect(Storage._db_path) as db:
+    async with Storage.connect(Storage._db_path) as db:
         db.row_factory = aiosqlite.Row
 
         async with db.execute(

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -4,8 +4,10 @@ Storage module for persistent data management
 Provides SQLite-based storage similar to Flocks's Storage namespace
 """
 
+from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
+import sqlite3
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Type, TypeVar
 import json
 import aiosqlite
 from datetime import datetime
@@ -43,6 +45,9 @@ class Storage:
     _db_path: Optional[Path] = None
     _initialized = False
     _extension_ddls: List[str] = []
+    _sqlite_timeout_s = 5.0
+    _sqlite_busy_timeout_ms = 5000
+    _sqlite_journal_mode = "WAL"
 
     @classmethod
     def _invalidate_runtime_caches(cls) -> None:
@@ -70,6 +75,48 @@ class Storage:
             return cls._db_path
         data_dir = Config.get_data_path()
         return data_dir / "flocks.db"
+
+    @classmethod
+    async def configure_connection(
+        cls, conn: aiosqlite.Connection
+    ) -> aiosqlite.Connection:
+        """Apply the runtime SQLite contract to an async connection."""
+        await conn.execute(f"PRAGMA journal_mode={cls._sqlite_journal_mode}")
+        await conn.execute(f"PRAGMA busy_timeout={cls._sqlite_busy_timeout_ms}")
+        await conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    @classmethod
+    def configure_sync_connection(cls, conn: sqlite3.Connection) -> sqlite3.Connection:
+        """Apply the runtime SQLite contract to a sync connection."""
+        conn.execute(f"PRAGMA journal_mode={cls._sqlite_journal_mode}")
+        conn.execute(f"PRAGMA busy_timeout={cls._sqlite_busy_timeout_ms}")
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    @classmethod
+    @asynccontextmanager
+    async def connect(
+        cls, db_path: Optional[Path] = None
+    ) -> AsyncIterator[aiosqlite.Connection]:
+        """Open a configured async SQLite connection for the active storage DB."""
+        target = Path(db_path) if db_path is not None else cls.get_db_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        conn = await aiosqlite.connect(target, timeout=cls._sqlite_timeout_s)
+        try:
+            await cls.configure_connection(conn)
+            yield conn
+        finally:
+            await conn.close()
+
+    @classmethod
+    def connect_sync(cls, db_path: Optional[Path] = None) -> sqlite3.Connection:
+        """Open a configured sync SQLite connection for the active storage DB."""
+        target = Path(db_path) if db_path is not None else cls.get_db_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(target, timeout=cls._sqlite_timeout_s)
+        conn.row_factory = sqlite3.Row
+        return cls.configure_sync_connection(conn)
 
     @classmethod
     def register_ddl(cls, ddl: str) -> None:
@@ -124,7 +171,7 @@ class Storage:
         cls._invalidate_runtime_caches()
         
         # Create tables
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             await db.execute("""
                 CREATE TABLE IF NOT EXISTS storage (
                     key TEXT PRIMARY KEY,
@@ -150,8 +197,9 @@ class Storage:
         # Run extension DDLs registered before init
         for ddl in cls._extension_ddls:
             try:
-                async with aiosqlite.connect(cls._db_path) as db:
+                async with cls.connect(cls._db_path) as db:
                     await db.executescript(ddl)
+                    await db.commit()
             except Exception as e:
                 cls._log.warn("storage.extension_ddl.failed", {"error": str(e)})
 
@@ -166,7 +214,7 @@ class Storage:
         (credentials, model settings, default models, custom providers)
         is stored in flocks.json / .secret.json.
         """
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             await db.executescript("""
                 -- Usage records (dynamic data — the only model-management table in SQLite)
                 CREATE TABLE IF NOT EXISTS usage_records (
@@ -249,7 +297,7 @@ class Storage:
         from datetime import UTC
         now = datetime.now(UTC).isoformat()
         
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             await db.execute("""
                 INSERT OR REPLACE INTO storage (key, value, type, created_at, updated_at)
                 VALUES (?, ?, ?, 
@@ -274,7 +322,7 @@ class Storage:
         """
         await cls._ensure_init()
         
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             async with db.execute(
                 "SELECT value, type FROM storage WHERE key = ?", (key,)
             ) as cursor:
@@ -303,7 +351,7 @@ class Storage:
         """
         await cls._ensure_init()
         
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             cursor = await db.execute("DELETE FROM storage WHERE key = ?", (key,))
             await db.commit()
             deleted = cursor.rowcount > 0
@@ -326,7 +374,7 @@ class Storage:
         """
         await cls._ensure_init()
         
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             if prefix:
                 query = "SELECT key FROM storage WHERE key LIKE ?"
                 params = (f"{prefix}%",)
@@ -360,7 +408,7 @@ class Storage:
         """
         await cls._ensure_init()
 
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             if prefix:
                 query = "SELECT key, value FROM storage WHERE key LIKE ?"
                 params = (f"{prefix}%",)
@@ -393,7 +441,7 @@ class Storage:
         """
         await cls._ensure_init()
         
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             async with db.execute(
                 "SELECT 1 FROM storage WHERE key = ?", (key,)
             ) as cursor:
@@ -414,7 +462,7 @@ class Storage:
         """
         await cls._ensure_init()
         
-        async with aiosqlite.connect(cls._db_path) as db:
+        async with cls.connect(cls._db_path) as db:
             if prefix:
                 query = "DELETE FROM storage WHERE key LIKE ?"
                 params = (f"{prefix}%",)

--- a/flocks/storage/vector.py
+++ b/flocks/storage/vector.py
@@ -12,6 +12,7 @@ import json
 import math
 from datetime import datetime
 
+from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 
 log = Log.create(service="storage.vector")
@@ -99,7 +100,7 @@ async def ensure_vector_tables(db_path: Path) -> Dict[str, Any]:
     }
     
     try:
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             # Create vector tables
             await db.executescript(VECTOR_SCHEMA_SQL)
             await db.commit()
@@ -188,7 +189,7 @@ async def vector_search(
     results = []
     
     try:
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             # Build query
             query = """
                 SELECT id, path, source, start_line, end_line, text, embedding
@@ -298,7 +299,7 @@ async def fts_search(
     results = []
     
     try:
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             # Build FTS query
             fts_query = build_fts_query(query)
             if not fts_query:
@@ -370,7 +371,7 @@ async def insert_chunks(
         Number of chunks inserted
     """
     try:
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             now = datetime.now().timestamp()
             
             # Insert into chunks table
@@ -442,7 +443,7 @@ async def get_embedding_from_cache(
         Tuple of (embedding, dims) or None if not found
     """
     try:
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             cursor = await db.execute("""
                 SELECT embedding, dims
                 FROM memory_embedding_cache
@@ -483,7 +484,7 @@ async def put_embedding_to_cache(
     Put embedding to cache
     """
     try:
-        async with aiosqlite.connect(db_path) as db:
+        async with Storage.connect(db_path) as db:
             now = datetime.now().timestamp()
             await db.execute("""
                 INSERT OR REPLACE INTO memory_embedding_cache

--- a/flocks/task/manager.py
+++ b/flocks/task/manager.py
@@ -813,9 +813,7 @@ class TaskManager:
 
     @staticmethod
     def _with_db_connection() -> sqlite3.Connection:
-        conn = sqlite3.connect(Storage.get_db_path())
-        conn.row_factory = sqlite3.Row
-        return conn
+        return Storage.connect_sync()
 
     @classmethod
     def _legacy_tables_exist(cls) -> bool:

--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -32,8 +32,11 @@ class TaskStore:
         if cls._initialized:
             return
         await Storage._ensure_init()
-        cls._conn = await aiosqlite.connect(Storage._db_path)
-        await cls._conn.execute("PRAGMA foreign_keys = ON")
+        cls._conn = await aiosqlite.connect(
+            Storage._db_path,
+            timeout=Storage._sqlite_timeout_s,
+        )
+        await Storage.configure_connection(cls._conn)
         await cls._conn.executescript(_TASKS_DDL)
         for stmt in _INDEX_STMTS:
             await cls._conn.execute(stmt)

--- a/tests/server/concurrency/conftest.py
+++ b/tests/server/concurrency/conftest.py
@@ -16,8 +16,32 @@ from httpx import AsyncClient, ASGITransport
 async def client() -> AsyncGenerator[AsyncClient, None]:
     from flocks.server.app import app
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+    headers = {"Authorization": "Bearer abc123", "User-Agent": "curl/8.0"}
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers=headers,
+    ) as ac:
         yield ac
+
+
+@pytest.fixture(autouse=True)
+def _concurrency_test_api_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a valid API token for concurrency tests."""
+    from flocks.server import auth as auth_module
+
+    class SecretManagerStub:
+        def __init__(self, values: dict[str, str]):
+            self._values = values
+
+        def get(self, key: str):
+            return self._values.get(key)
+
+    monkeypatch.setattr(
+        auth_module,
+        "get_secret_manager",
+        lambda: SecretManagerStub({auth_module.API_TOKEN_SECRET_ID: "abc123"}),
+    )
 
 
 @pytest.fixture

--- a/tests/storage/test_sqlite_connection_config.py
+++ b/tests/storage/test_sqlite_connection_config.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from flocks.config.config import Config
+from flocks.storage.storage import Storage
+from flocks.task.manager import TaskManager
+
+
+@pytest.fixture(autouse=True)
+async def isolated_storage(tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch):
+    data_dir = tmp_path / "flocks_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("FLOCKS_DATA_DIR", str(data_dir))
+
+    Config._global_config = None
+    Config._cached_config = None
+    Storage._initialized = False
+    Storage._db_path = None
+
+    yield
+
+    Storage._initialized = False
+    Storage._db_path = None
+    Config._global_config = None
+    Config._cached_config = None
+
+
+@pytest.mark.asyncio
+async def test_storage_init_enables_wal_for_fresh_database() -> None:
+    await Storage.init()
+
+    async with aiosqlite.connect(Storage.get_db_path()) as db:
+        async with db.execute("PRAGMA journal_mode") as cursor:
+            journal_mode = (await cursor.fetchone())[0]
+
+    assert journal_mode == "wal"
+
+
+@pytest.mark.asyncio
+async def test_storage_connect_applies_runtime_sqlite_pragmas() -> None:
+    await Storage.init()
+
+    async with Storage.connect() as db:
+        async with db.execute("PRAGMA busy_timeout") as cursor:
+            busy_timeout = (await cursor.fetchone())[0]
+        async with db.execute("PRAGMA foreign_keys") as cursor:
+            foreign_keys = (await cursor.fetchone())[0]
+
+    assert busy_timeout == Storage._sqlite_busy_timeout_ms
+    assert foreign_keys == 1
+
+
+def test_storage_connect_sync_applies_runtime_sqlite_pragmas() -> None:
+    import asyncio
+
+    asyncio.run(Storage.init())
+
+    with Storage.connect_sync() as db:
+        busy_timeout = db.execute("PRAGMA busy_timeout").fetchone()[0]
+        foreign_keys = db.execute("PRAGMA foreign_keys").fetchone()[0]
+
+    assert busy_timeout == Storage._sqlite_busy_timeout_ms
+    assert foreign_keys == 1
+
+
+@pytest.mark.asyncio
+async def test_task_manager_sync_connection_uses_storage_sqlite_contract() -> None:
+    await Storage.init()
+
+    with TaskManager._with_db_connection() as db:
+        row = db.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'storage'"
+        ).fetchone()
+        busy_timeout = db.execute("PRAGMA busy_timeout").fetchone()[0]
+        foreign_keys = db.execute("PRAGMA foreign_keys").fetchone()[0]
+
+    assert row is not None
+    assert busy_timeout == Storage._sqlite_busy_timeout_ms
+    assert foreign_keys == 1

--- a/tests/storage/test_sqlite_mixed_access.py
+++ b/tests/storage/test_sqlite_mixed_access.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from flocks.config.config import Config
+from flocks.provider.usage_service import RecordUsageRequest, get_usage_records, record_usage
+from flocks.storage.storage import Storage
+from flocks.task.models import TaskExecution, TaskScheduler, TaskStatus
+from flocks.task.store import TaskStore
+
+
+@pytest.fixture(autouse=True)
+async def isolated_storage_and_task_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    data_dir = tmp_path / "flocks_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("FLOCKS_DATA_DIR", str(data_dir))
+
+    Config._global_config = None
+    Config._cached_config = None
+    Storage._initialized = False
+    Storage._db_path = None
+    TaskStore._initialized = False
+    TaskStore._conn = None
+
+    await Storage.init()
+    await TaskStore.init()
+
+    yield
+
+    await TaskStore.close()
+    Config._global_config = None
+    Config._cached_config = None
+    Storage._initialized = False
+    Storage._db_path = None
+    TaskStore._initialized = False
+    TaskStore._conn = None
+
+
+@pytest.mark.asyncio
+async def test_mixed_storage_task_and_usage_access_share_consistent_sqlite_config() -> None:
+    scheduler = TaskScheduler(title="sqlite-mixed-access")
+    await TaskStore.create_scheduler(scheduler)
+
+    async def write_storage(idx: int) -> None:
+        await Storage.set(f"mixed:key:{idx}", {"value": idx})
+
+    async def write_usage(idx: int) -> None:
+        await record_usage(
+            RecordUsageRequest(
+                provider_id="test-provider",
+                model_id="test-model",
+                session_id=f"session-{idx}",
+                message_id=f"message-{idx}",
+                input_tokens=idx + 1,
+                output_tokens=idx + 2,
+            )
+        )
+
+    async def write_task_execution(idx: int) -> None:
+        execution = TaskExecution(
+            scheduler_id=scheduler.id,
+            title=f"execution-{idx}",
+            status=TaskStatus.QUEUED,
+        )
+        await TaskStore.create_execution(execution)
+        await TaskStore.enqueue_execution_ref(execution.id)
+
+    await asyncio.gather(
+        *[
+            asyncio.gather(
+                write_storage(idx),
+                write_usage(idx),
+                write_task_execution(idx),
+            )
+            for idx in range(5)
+        ]
+    )
+
+    keys = await Storage.list_keys(prefix="mixed:key:")
+    usage_records = await get_usage_records()
+    executions, total = await TaskStore.list_executions(scheduler_id=scheduler.id, limit=20)
+
+    assert len(keys) == 5
+    assert len(usage_records) == 5
+    assert total == 5
+    assert len(executions) == 5


### PR DESCRIPTION
## Summary
- centralize SQLite connection configuration in `Storage` so new `flocks.db` instances consistently enable WAL, busy timeout, and foreign key enforcement
- migrate task, auth, usage, memory, vector, channel binding, and sync task-manager access paths to the shared connection contract
- add regression coverage for SQLite pragmas, mixed module access, and the server concurrency fixture used by the targeted suite

## Test plan
- [x] `uv run pytest tests/storage/test_storage.py tests/storage/test_sqlite_connection_config.py tests/storage/test_sqlite_mixed_access.py tests/task/test_task.py tests/integration/test_task_queue_integration.py tests/provider/test_model_management_p2p3.py tests/server/concurrency/test_concurrency.py`

Made with [Cursor](https://cursor.com)