### PR TITLE
feat(updater): Windows webui npm fallback and Session ownerUsername

### DIFF
--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -386,6 +386,14 @@ def _build_frontend_subprocess_env(*, npm_registry: str | None = None) -> dict[s
     )
 
 
+def _reset_staged_frontend_workspace(staged_webui_dir: Path) -> None:
+    """Remove transient frontend build artifacts before retrying another npm candidate."""
+    for name in ("node_modules", "dist"):
+        target = staged_webui_dir / name
+        if target.exists():
+            _safe_remove(target)
+
+
 def _dependency_sync_timeout_seconds() -> int:
     """Return the timeout budget for ``uv sync`` during self-update."""
     if sys.platform == "win32":
@@ -2020,20 +2028,22 @@ async def perform_update(
                     )
                     if is_last_attempt:
                         break
+                    _reset_staged_frontend_workspace(staged_webui_dir)
                     _record_update_journal(
                         "WARN "
-                        f"{final_frontend_error} Retrying staged frontend rebuild with fallback npm/node "
-                        f"after {attempt_source} attempt."
+                        f"{final_frontend_error} Cleaned staged frontend workspace and retrying with fallback "
+                        f"npm/node after {attempt_source} attempt."
                     )
                     continue
                 if code != 0:
                     final_frontend_error = f"Frontend dependency install failed ({install_label}): {err}"
                     if is_last_attempt:
                         break
+                    _reset_staged_frontend_workspace(staged_webui_dir)
                     _record_update_journal(
                         "WARN "
-                        f"{final_frontend_error} Retrying staged frontend rebuild with fallback npm/node "
-                        f"after {attempt_source} attempt."
+                        f"{final_frontend_error} Cleaned staged frontend workspace and retrying with fallback "
+                        f"npm/node after {attempt_source} attempt."
                     )
                     continue
 
@@ -2051,20 +2061,22 @@ async def perform_update(
                     )
                     if is_last_attempt:
                         break
+                    _reset_staged_frontend_workspace(staged_webui_dir)
                     _record_update_journal(
                         "WARN "
-                        f"{final_frontend_error} Retrying staged frontend rebuild with fallback npm/node "
-                        f"after {attempt_source} attempt."
+                        f"{final_frontend_error} Cleaned staged frontend workspace and retrying with fallback "
+                        f"npm/node after {attempt_source} attempt."
                     )
                     continue
                 if code != 0:
                     final_frontend_error = f"Frontend build failed: {err}"
                     if is_last_attempt:
                         break
+                    _reset_staged_frontend_workspace(staged_webui_dir)
                     _record_update_journal(
                         "WARN "
-                        f"{final_frontend_error} Retrying staged frontend rebuild with fallback npm/node "
-                        f"after {attempt_source} attempt."
+                        f"{final_frontend_error} Cleaned staged frontend workspace and retrying with fallback "
+                        f"npm/node after {attempt_source} attempt."
                     )
                     continue
 
@@ -2653,25 +2665,38 @@ def _resolve_frontend_npm_candidates(*, npm_registry: str | None = None) -> list
         )
 
     system_npm = _resolve_system_npm_executable()
-    if system_npm is not None:
+    if system_npm is not None and sys.platform == "win32":
         if sys.platform == "win32":
             normalized_system_npm = system_npm.replace("/", "\\").lower()
             duplicate = any(
                 candidate.npm.replace("/", "\\").lower() == normalized_system_npm
                 for candidate in candidates
             )
-        else:
-            duplicate = any(candidate.npm == system_npm for candidate in candidates)
         if not duplicate:
             candidates.append(
                 _FrontendNpmCandidate(
                     npm=system_npm,
                     env=_build_frontend_subprocess_env_for_node_dir(
-                        None if sys.platform == "win32" else _bundled_node_install_dir(),
+                        None,
                         npm_registry=npm_registry,
                     ),
-                    source="system" if sys.platform == "win32" else "default",
+                    source="system",
                 )
             )
+
+    if candidates:
+        return candidates
+
+    if system_npm is not None:
+        candidates.append(
+            _FrontendNpmCandidate(
+                npm=system_npm,
+                env=_build_frontend_subprocess_env_for_node_dir(
+                    None,
+                    npm_registry=npm_registry,
+                ),
+                source="default",
+            )
+        )
 
     return candidates

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -84,6 +84,15 @@ class UpdateMirrorProfile:
     pip_index_url: str | None = None
 
 
+@dataclass(frozen=True)
+class _FrontendNpmCandidate:
+    """A single npm launcher candidate for staged frontend rebuilds."""
+
+    npm: str
+    env: dict[str, str] | None
+    source: str
+
+
 # ------------------------------------------------------------------ #
 # Install root
 # ------------------------------------------------------------------ #
@@ -349,13 +358,16 @@ def _build_uv_sync_env() -> dict[str, str] | None:
     return {"PATH": os.pathsep.join([current_path] + missing)}
 
 
-def _build_frontend_subprocess_env(*, npm_registry: str | None = None) -> dict[str, str] | None:
+def _build_frontend_subprocess_env_for_node_dir(
+    node_dir: Path | None,
+    *,
+    npm_registry: str | None = None,
+) -> dict[str, str] | None:
     """Build supplemental env vars for frontend npm commands."""
     env: dict[str, str] = {}
     if npm_registry:
         env["npm_config_registry"] = npm_registry
 
-    node_dir = _bundled_node_install_dir()
     if node_dir is not None:
         node_bin = str(node_dir if sys.platform == "win32" else node_dir / "bin")
         current_path = os.environ.get("PATH", "")
@@ -364,6 +376,14 @@ def _build_frontend_subprocess_env(*, npm_registry: str | None = None) -> dict[s
             env["PATH"] = node_bin if not current_path else node_bin + os.pathsep + current_path
 
     return env or None
+
+
+def _build_frontend_subprocess_env(*, npm_registry: str | None = None) -> dict[str, str] | None:
+    """Build supplemental env vars for frontend npm commands."""
+    return _build_frontend_subprocess_env_for_node_dir(
+        _bundled_node_install_dir(),
+        npm_registry=npm_registry,
+    )
 
 
 def _dependency_sync_timeout_seconds() -> int:
@@ -1974,71 +1994,89 @@ async def perform_update(
     # ------------------------------------------------------------------ #
     staged_webui_dir = content_root / "webui"
     if staged_webui_dir.is_dir() and (staged_webui_dir / "package.json").exists():
-        npm = _resolve_npm_executable()
-        if npm:
-            yield UpdateProgress(stage="building", message="Installing frontend dependencies...")
-            npm_env = _build_frontend_subprocess_env(npm_registry=profile.npm_registry)
+        npm_candidates = _resolve_frontend_npm_candidates(npm_registry=profile.npm_registry)
+        if npm_candidates:
             install_subcommand = "ci" if (staged_webui_dir / "package-lock.json").exists() else "install"
-            install_cmd = [npm, install_subcommand]
             install_label = f"npm {install_subcommand}"
-            try:
-                code, _, err = await _run_async(
-                    install_cmd,
-                    cwd=staged_webui_dir,
-                    timeout=_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS,
-                    env=npm_env,
-                )
-            except subprocess.TimeoutExpired:
-                shutil.rmtree(tmp_dir, ignore_errors=True)
-                _fe_dep_timeout = (
-                    "Frontend dependency install timed out after "
-                    f"{_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS}s while running {install_label}."
-                )
-                _record_update_journal(f"ERROR {_fe_dep_timeout}")
-                yield UpdateProgress(
-                    stage="error",
-                    message=_fe_dep_timeout,
-                    success=False,
-                )
-                return
-            if code != 0:
-                shutil.rmtree(tmp_dir, ignore_errors=True)
-                _fe_dep = f"Frontend dependency install failed ({install_label}): {err}"
-                _record_update_journal(f"ERROR {_fe_dep}")
-                yield UpdateProgress(
-                    stage="error",
-                    message=_fe_dep,
-                    success=False,
-                )
-                return
+            final_frontend_error: str | None = None
 
-            yield UpdateProgress(stage="building", message="Building frontend...")
-            try:
-                code, _, err = await _run_async(
-                    [npm, "run", "build"],
-                    cwd=staged_webui_dir,
-                    timeout=_FRONTEND_BUILD_TIMEOUT_SECONDS,
-                    env=npm_env,
-                )
-            except subprocess.TimeoutExpired:
+            for index, candidate in enumerate(npm_candidates):
+                attempt_source = candidate.source
+                is_last_attempt = index == len(npm_candidates) - 1
+
+                yield UpdateProgress(stage="building", message="Installing frontend dependencies...")
+                install_cmd = [candidate.npm, install_subcommand]
+                try:
+                    code, _, err = await _run_async(
+                        install_cmd,
+                        cwd=staged_webui_dir,
+                        timeout=_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS,
+                        env=candidate.env,
+                    )
+                except subprocess.TimeoutExpired:
+                    final_frontend_error = (
+                        "Frontend dependency install timed out after "
+                        f"{_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS}s while running {install_label}."
+                    )
+                    if is_last_attempt:
+                        break
+                    _record_update_journal(
+                        "WARN "
+                        f"{final_frontend_error} Retrying staged frontend rebuild with fallback npm/node "
+                        f"after {attempt_source} attempt."
+                    )
+                    continue
+                if code != 0:
+                    final_frontend_error = f"Frontend dependency install failed ({install_label}): {err}"
+                    if is_last_attempt:
+                        break
+                    _record_update_journal(
+                        "WARN "
+                        f"{final_frontend_error} Retrying staged frontend rebuild with fallback npm/node "
+                        f"after {attempt_source} attempt."
+                    )
+                    continue
+
+                yield UpdateProgress(stage="building", message="Building frontend...")
+                try:
+                    code, _, err = await _run_async(
+                        [candidate.npm, "run", "build"],
+                        cwd=staged_webui_dir,
+                        timeout=_FRONTEND_BUILD_TIMEOUT_SECONDS,
+                        env=candidate.env,
+                    )
+                except subprocess.TimeoutExpired:
+                    final_frontend_error = (
+                        f"Frontend build timed out after {_FRONTEND_BUILD_TIMEOUT_SECONDS}s while running npm run build."
+                    )
+                    if is_last_attempt:
+                        break
+                    _record_update_journal(
+                        "WARN "
+                        f"{final_frontend_error} Retrying staged frontend rebuild with fallback npm/node "
+                        f"after {attempt_source} attempt."
+                    )
+                    continue
+                if code != 0:
+                    final_frontend_error = f"Frontend build failed: {err}"
+                    if is_last_attempt:
+                        break
+                    _record_update_journal(
+                        "WARN "
+                        f"{final_frontend_error} Retrying staged frontend rebuild with fallback npm/node "
+                        f"after {attempt_source} attempt."
+                    )
+                    continue
+
+                final_frontend_error = None
+                break
+
+            if final_frontend_error is not None:
                 shutil.rmtree(tmp_dir, ignore_errors=True)
-                _fe_build_timeout = (
-                    f"Frontend build timed out after {_FRONTEND_BUILD_TIMEOUT_SECONDS}s while running npm run build."
-                )
-                _record_update_journal(f"ERROR {_fe_build_timeout}")
+                _record_update_journal(f"ERROR {final_frontend_error}")
                 yield UpdateProgress(
                     stage="error",
-                    message=_fe_build_timeout,
-                    success=False,
-                )
-                return
-            if code != 0:
-                shutil.rmtree(tmp_dir, ignore_errors=True)
-                _fe_build = f"Frontend build failed: {err}"
-                _record_update_journal(f"ERROR {_fe_build}")
-                yield UpdateProgress(
-                    stage="error",
-                    message=_fe_build,
+                    message=final_frontend_error,
                     success=False,
                 )
                 return
@@ -2566,17 +2604,74 @@ def _find_executable(name: str) -> str | None:
 
 def _resolve_npm_executable() -> str | None:
     """Resolve npm from bundled Node first, then standard executable probing."""
-    node_dir = _bundled_node_install_dir()
-    if node_dir is not None:
-        candidates = (
-            [node_dir / "npm.cmd", node_dir / "npm", node_dir / "bin" / "npm"]
-            if sys.platform == "win32"
-            else [node_dir / "bin" / "npm", node_dir / "npm"]
-        )
-        for candidate in candidates:
-            if candidate.exists():
-                return str(candidate)
+    candidates = _resolve_frontend_npm_candidates()
+    if candidates:
+        return candidates[0].npm
+    return None
 
+
+def _resolve_bundled_npm_executable() -> tuple[str, Path] | None:
+    """Resolve npm from the bundled Node.js install, if available."""
+    node_dir = _bundled_node_install_dir()
+    if node_dir is None:
+        return None
+
+    candidates = (
+        [node_dir / "npm.cmd", node_dir / "npm", node_dir / "bin" / "npm"]
+        if sys.platform == "win32"
+        else [node_dir / "bin" / "npm", node_dir / "npm"]
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate), node_dir
+    return None
+
+
+def _resolve_system_npm_executable() -> str | None:
+    """Resolve npm without relying on the bundled Node.js install."""
     if sys.platform == "win32":
         return _find_executable("npm.cmd") or _find_executable("npm")
     return _find_executable("npm") or _find_executable("npm.cmd")
+
+
+def _resolve_frontend_npm_candidates(*, npm_registry: str | None = None) -> list[_FrontendNpmCandidate]:
+    """Resolve npm candidates for staged frontend rebuilds."""
+    candidates: list[_FrontendNpmCandidate] = []
+
+    bundled = _resolve_bundled_npm_executable()
+    if bundled is not None:
+        bundled_npm, node_dir = bundled
+        candidates.append(
+            _FrontendNpmCandidate(
+                npm=bundled_npm,
+                env=_build_frontend_subprocess_env_for_node_dir(
+                    node_dir,
+                    npm_registry=npm_registry,
+                ),
+                source="bundled",
+            )
+        )
+
+    system_npm = _resolve_system_npm_executable()
+    if system_npm is not None:
+        if sys.platform == "win32":
+            normalized_system_npm = system_npm.replace("/", "\\").lower()
+            duplicate = any(
+                candidate.npm.replace("/", "\\").lower() == normalized_system_npm
+                for candidate in candidates
+            )
+        else:
+            duplicate = any(candidate.npm == system_npm for candidate in candidates)
+        if not duplicate:
+            candidates.append(
+                _FrontendNpmCandidate(
+                    npm=system_npm,
+                    env=_build_frontend_subprocess_env_for_node_dir(
+                        None if sys.platform == "win32" else _bundled_node_install_dir(),
+                        npm_registry=npm_registry,
+                    ),
+                    source="system" if sys.platform == "win32" else "default",
+                )
+            )
+
+    return candidates

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -252,6 +252,30 @@ def test_resolve_frontend_npm_candidates_adds_system_fallback_on_windows(
     }
 
 
+def test_resolve_frontend_npm_candidates_keeps_single_candidate_off_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    node_home = tmp_path / "tools" / "node"
+    node_bin = node_home / "bin"
+    node_bin.mkdir(parents=True)
+    (node_bin / "node").write_text("", encoding="utf-8")
+    bundled_npm = node_bin / "npm"
+    bundled_npm.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+    monkeypatch.setenv("FLOCKS_NODE_HOME", str(node_home))
+    monkeypatch.delenv("FLOCKS_INSTALL_ROOT", raising=False)
+    monkeypatch.setattr(updater, "_find_executable", lambda name: f"/usr/bin/{name}")
+
+    candidates = updater._resolve_frontend_npm_candidates(
+        npm_registry="https://registry.npmmirror.com/"
+    )
+
+    assert [candidate.npm for candidate in candidates] == [str(bundled_npm)]
+    assert candidates[0].source == "bundled"
+
+
 def test_find_executable_ignores_wsl_mnt_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1684,8 +1708,6 @@ async def test_perform_update_retries_windows_frontend_with_system_npm_after_bun
     staged_webui = staged_root / "webui"
     staged_webui.mkdir(parents=True)
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
-    (staged_webui / "dist").mkdir()
-    (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
 
     node_home = tmp_path / "tools" / "node"
     node_home.mkdir(parents=True)
@@ -1714,12 +1736,23 @@ async def test_perform_update_retries_windows_frontend_with_system_npm_after_bun
     async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
         run_calls.append((list(cmd), timeout, env))
         if cmd == [str(bundled_npm), "install"]:
+            bundled_modules = staged_webui / "node_modules" / "@esbuild"
+            bundled_modules.mkdir(parents=True, exist_ok=True)
+            (bundled_modules / "bundled.txt").write_text("bundled", encoding="utf-8")
             return 0, "", ""
         if cmd == [str(bundled_npm), "run", "build"]:
+            stale_dist = staged_webui / "dist"
+            stale_dist.mkdir(exist_ok=True)
+            (stale_dist / "stale.txt").write_text("stale", encoding="utf-8")
             return 1, "", "bundled build failed"
         if cmd == [system_npm, "install"]:
+            assert not (staged_webui / "node_modules").exists()
+            assert not (staged_webui / "dist").exists()
             return 0, "", ""
         if cmd == [system_npm, "run", "build"]:
+            dist_dir = staged_webui / "dist"
+            dist_dir.mkdir(exist_ok=True)
+            (dist_dir / "index.html").write_text("<html></html>", encoding="utf-8")
             return 0, "", ""
         if "sync" in cmd:
             return 0, "", ""
@@ -1789,8 +1822,6 @@ async def test_perform_update_retries_windows_frontend_with_full_timeout_after_b
     staged_webui.mkdir(parents=True)
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
     (staged_webui / "package-lock.json").write_text("{}", encoding="utf-8")
-    (staged_webui / "dist").mkdir()
-    (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
 
     node_home = tmp_path / "tools" / "node"
     node_home.mkdir(parents=True)
@@ -1819,10 +1850,18 @@ async def test_perform_update_retries_windows_frontend_with_full_timeout_after_b
     async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
         run_calls.append((list(cmd), timeout, env))
         if cmd == [str(bundled_npm), "ci"]:
+            bundled_modules = staged_webui / "node_modules" / "@esbuild"
+            bundled_modules.mkdir(parents=True, exist_ok=True)
+            (bundled_modules / "bundled.txt").write_text("bundled", encoding="utf-8")
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
         if cmd == [system_npm, "ci"]:
+            assert not (staged_webui / "node_modules").exists()
+            assert not (staged_webui / "dist").exists()
             return 0, "", ""
         if cmd == [system_npm, "run", "build"]:
+            dist_dir = staged_webui / "dist"
+            dist_dir.mkdir(exist_ok=True)
+            (dist_dir / "index.html").write_text("<html></html>", encoding="utf-8")
             return 0, "", ""
         if "sync" in cmd:
             return 0, "", ""

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -215,6 +215,43 @@ def test_resolve_npm_executable_falls_back_to_find_executable(
     assert updater._resolve_npm_executable() == r"C:\Program Files\nodejs\npm.cmd"
 
 
+def test_resolve_frontend_npm_candidates_adds_system_fallback_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    node_home = tmp_path / "tools" / "node"
+    node_home.mkdir(parents=True)
+    (node_home / "node.exe").write_text("", encoding="utf-8")
+    bundled_npm = node_home / "npm.cmd"
+    bundled_npm.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setenv("FLOCKS_NODE_HOME", str(node_home))
+    monkeypatch.delenv("FLOCKS_INSTALL_ROOT", raising=False)
+    monkeypatch.setenv("PATH", r"C:\Windows\System32")
+
+    def fake_find(name: str) -> str | None:
+        if name == "npm.cmd":
+            return r"C:\Program Files\nodejs\npm.cmd"
+        return None
+
+    monkeypatch.setattr(updater, "_find_executable", fake_find)
+
+    candidates = updater._resolve_frontend_npm_candidates(
+        npm_registry="https://registry.npmmirror.com/"
+    )
+
+    assert [candidate.npm for candidate in candidates] == [
+        str(bundled_npm),
+        r"C:\Program Files\nodejs\npm.cmd",
+    ]
+    assert candidates[0].env is not None
+    assert candidates[0].env["PATH"].split(os.pathsep)[0] == str(node_home)
+    assert candidates[1].env == {
+        "npm_config_registry": "https://registry.npmmirror.com/"
+    }
+
+
 def test_find_executable_ignores_wsl_mnt_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1609,7 +1646,6 @@ async def test_perform_update_prefers_bundled_npm_for_windows_frontend_rebuild(
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
     monkeypatch.setattr(updater, "_extract_archive", lambda *_args, **_kwargs: staged_root)
     monkeypatch.setattr(updater, "_run_async", fake_run_async)
-    monkeypatch.setattr(updater, "_resolve_npm_executable", lambda: str(bundled_npm))
     monkeypatch.setattr(updater, "_find_executable", lambda name: r"C:\Users\flocks\AppData\Local\Programs\Flocks\tools\uv\uv.exe" if name == "uv" else None)
     monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
     monkeypatch.setattr(updater, "_validate_windows_restart_runtime", fake_validate_windows_restart_runtime)
@@ -1635,6 +1671,202 @@ async def test_perform_update_prefers_bundled_npm_for_windows_frontend_rebuild(
     assert build_env["npm_config_registry"] == "https://registry.npmmirror.com/"
     assert install_env["PATH"].split(os.pathsep)[0] == str(node_home)
     assert build_env["PATH"].split(os.pathsep)[0] == str(node_home)
+
+
+@pytest.mark.asyncio
+async def test_perform_update_retries_windows_frontend_with_system_npm_after_bundled_build_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "flocks.zip"
+    archive_path.write_text("archive", encoding="utf-8")
+    staged_root = tmp_path / "staged"
+    staged_webui = staged_root / "webui"
+    staged_webui.mkdir(parents=True)
+    (staged_webui / "package.json").write_text("{}", encoding="utf-8")
+    (staged_webui / "dist").mkdir()
+    (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    node_home = tmp_path / "tools" / "node"
+    node_home.mkdir(parents=True)
+    (node_home / "node.exe").write_text("", encoding="utf-8")
+    bundled_npm = node_home / "npm.cmd"
+    bundled_npm.write_text("", encoding="utf-8")
+    system_npm = r"C:\Program Files\nodejs\npm.cmd"
+
+    run_calls: list[tuple[list[str], int | None, dict[str, str] | None]] = []
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            archive_format="zip",
+            sources=["github"],
+            repo="AgentFlocks/Flocks",
+            token=None,
+            gitee_token=None,
+            backup_retain_count=3,
+            base_url=None,
+            gitee_repo=None,
+        )
+
+    async def fake_download_with_fallback(**_kwargs):
+        return archive_path
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        run_calls.append((list(cmd), timeout, env))
+        if cmd == [str(bundled_npm), "install"]:
+            return 0, "", ""
+        if cmd == [str(bundled_npm), "run", "build"]:
+            return 1, "", "bundled build failed"
+        if cmd == [system_npm, "install"]:
+            return 0, "", ""
+        if cmd == [system_npm, "run", "build"]:
+            return 0, "", ""
+        if "sync" in cmd:
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    async def fake_validate_windows_restart_runtime(*_args, **_kwargs):
+        return None
+
+    def fake_find(name: str) -> str | None:
+        if name == "npm.cmd":
+            return system_npm
+        if name == "uv":
+            return r"C:\Users\flocks\AppData\Local\Programs\Flocks\tools\uv\uv.exe"
+        return None
+
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
+    monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
+    monkeypatch.setattr(updater, "_extract_archive", lambda *_args, **_kwargs: staged_root)
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(updater, "_find_executable", fake_find)
+    monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
+    monkeypatch.setattr(updater, "_validate_windows_restart_runtime", fake_validate_windows_restart_runtime)
+    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setenv("FLOCKS_NODE_HOME", str(node_home))
+    monkeypatch.delenv("FLOCKS_INSTALL_ROOT", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    progresses = [step async for step in updater.perform_update("2026.4.1", restart=False, locale="zh-CN")]
+
+    assert progresses[-1].stage == "done"
+    frontend_calls = [
+        call for call in run_calls if call[0][0] in {str(bundled_npm), system_npm}
+    ]
+    assert [call[0] for call in frontend_calls] == [
+        [str(bundled_npm), "install"],
+        [str(bundled_npm), "run", "build"],
+        [system_npm, "install"],
+        [system_npm, "run", "build"],
+    ]
+    assert [call[1] for call in frontend_calls] == [300, 300, 300, 300]
+    bundled_install_env = frontend_calls[0][2]
+    bundled_build_env = frontend_calls[1][2]
+    system_install_env = frontend_calls[2][2]
+    system_build_env = frontend_calls[3][2]
+    assert bundled_install_env is not None
+    assert bundled_build_env is not None
+    assert bundled_install_env["PATH"].split(os.pathsep)[0] == str(node_home)
+    assert bundled_build_env["PATH"].split(os.pathsep)[0] == str(node_home)
+    assert system_install_env == {"npm_config_registry": "https://registry.npmmirror.com/"}
+    assert system_build_env == {"npm_config_registry": "https://registry.npmmirror.com/"}
+
+
+@pytest.mark.asyncio
+async def test_perform_update_retries_windows_frontend_with_full_timeout_after_bundled_install_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "flocks.zip"
+    archive_path.write_text("archive", encoding="utf-8")
+    staged_root = tmp_path / "staged"
+    staged_webui = staged_root / "webui"
+    staged_webui.mkdir(parents=True)
+    (staged_webui / "package.json").write_text("{}", encoding="utf-8")
+    (staged_webui / "package-lock.json").write_text("{}", encoding="utf-8")
+    (staged_webui / "dist").mkdir()
+    (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    node_home = tmp_path / "tools" / "node"
+    node_home.mkdir(parents=True)
+    (node_home / "node.exe").write_text("", encoding="utf-8")
+    bundled_npm = node_home / "npm.cmd"
+    bundled_npm.write_text("", encoding="utf-8")
+    system_npm = r"C:\Program Files\nodejs\npm.cmd"
+
+    run_calls: list[tuple[list[str], int | None, dict[str, str] | None]] = []
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            archive_format="zip",
+            sources=["github"],
+            repo="AgentFlocks/Flocks",
+            token=None,
+            gitee_token=None,
+            backup_retain_count=3,
+            base_url=None,
+            gitee_repo=None,
+        )
+
+    async def fake_download_with_fallback(**_kwargs):
+        return archive_path
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        run_calls.append((list(cmd), timeout, env))
+        if cmd == [str(bundled_npm), "ci"]:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+        if cmd == [system_npm, "ci"]:
+            return 0, "", ""
+        if cmd == [system_npm, "run", "build"]:
+            return 0, "", ""
+        if "sync" in cmd:
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    async def fake_validate_windows_restart_runtime(*_args, **_kwargs):
+        return None
+
+    def fake_find(name: str) -> str | None:
+        if name == "npm.cmd":
+            return system_npm
+        if name == "uv":
+            return r"C:\Users\flocks\AppData\Local\Programs\Flocks\tools\uv\uv.exe"
+        return None
+
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
+    monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
+    monkeypatch.setattr(updater, "_extract_archive", lambda *_args, **_kwargs: staged_root)
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(updater, "_find_executable", fake_find)
+    monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
+    monkeypatch.setattr(updater, "_validate_windows_restart_runtime", fake_validate_windows_restart_runtime)
+    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setenv("FLOCKS_NODE_HOME", str(node_home))
+    monkeypatch.delenv("FLOCKS_INSTALL_ROOT", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    progresses = [step async for step in updater.perform_update("2026.4.1", restart=False, locale="zh-CN")]
+
+    assert progresses[-1].stage == "done"
+    frontend_calls = [
+        call for call in run_calls if call[0][0] in {str(bundled_npm), system_npm}
+    ]
+    assert [call[0] for call in frontend_calls] == [
+        [str(bundled_npm), "ci"],
+        [system_npm, "ci"],
+        [system_npm, "run", "build"],
+    ]
+    assert [call[1] for call in frontend_calls] == [300, 300, 300]
 
 
 @pytest.mark.asyncio

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -18,6 +18,7 @@ export interface Session {
   /** Session category: 'user' | 'workflow' | 'task' | 'entity-config' | ... */
   category?: string;
   ownerUserID?: string;
+  ownerUsername?: string;
   canDelete?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Windows updater: retry staged webui `npm install`/`ci` and `run build` with system `npm.cmd` when bundled Node npm fails or hits timeout, with appropriate timeouts and env.
- Webui: add optional `ownerUsername` on `Session` in TypeScript types.
- Tests: new async updater tests covering bundled-build failure and bundled-install timeout retry paths.