### PR TITLE
feat(server,webui): phased startup, route timing, session/tools UX

### DIFF
--- a/.flocks/plugins/skills/browser-use/SKILL.md
+++ b/.flocks/plugins/skills/browser-use/SKILL.md
@@ -68,11 +68,7 @@ browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后
 说明当前环境不适合 `CDP 直连`。此时要：
 
 1. 明确告诉用户是哪一项不满足，提示需要做什么操作才能达到要求
-2. 切换到 `agent-browser` 模式
-3. 立即阅读：
-   - `references/agent-browser.md`
-
-不要继续尝试 CDP。
+2. 提示用户切换到 `agent-browser` 模式
 
 ## 执行规则
 

--- a/flocks/mcp/client.py
+++ b/flocks/mcp/client.py
@@ -115,7 +115,6 @@ class McpClient:
         
         self.session: Optional[ClientSession] = None
         self._streams = None
-        self._streams_context = None
         self._connected = False
         self._transport_type: Optional[str] = None
         self._command_queue: asyncio.Queue[_ClientCommand] | None = None
@@ -182,7 +181,6 @@ class McpClient:
             self._connected = False
             self.session = None
             self._streams = None
-            self._streams_context = None
             self._transport_type = None
             await self._fail_pending_commands(RuntimeError(f"Client not connected: {self.name}"))
 
@@ -224,7 +222,6 @@ class McpClient:
         """Reset local state after disconnects or failed startups."""
         self.session = None
         self._streams = None
-        self._streams_context = None
         self._connected = False
         self._transport_type = None
         self._command_queue = None
@@ -368,7 +365,6 @@ class McpClient:
     ) -> None:
         """Run one remote transport from startup until disconnect."""
         async with transport_factory(full_url, headers) as streams:
-            self._streams_context = transport_name
             self._streams = streams
             await self._run_connected_session(transport_name, streams, startup_future)
 
@@ -594,37 +590,36 @@ class McpClient:
             "args": args,
         })
 
-        stderr_file = tempfile.TemporaryFile(mode="w+")
-        try:
-            async with self._create_stdio_streams(server_params, stderr_file) as streams:
-                self._streams_context = "stdio"
-                self._streams = streams
-                await self._run_connected_session("stdio", streams, startup_future)
-        except asyncio.TimeoutError as exc:
-            stderr_output = self._read_stderr(stderr_file)
-            log.error("mcp.client.timeout", {
-                "server": self.name,
-                "transport": "stdio",
-                "stderr": stderr_output,
-            })
-            detail = f"Connection timeout (stdio): {self.name}"
-            if stderr_output:
-                detail += f"\nServer stderr:\n{stderr_output}"
-            raise RuntimeError(detail) from exc
-        except Exception as exc:
-            stderr_output = self._read_stderr(stderr_file)
-            root_cause = _extract_root_cause(exc)
-            log.error("mcp.client.stdio_failed", {
-                "server": self.name,
-                "error": root_cause,
-                "stderr": stderr_output,
-            })
-            detail = f"Stdio connection failed: {self.name}: {root_cause}"
-            if stderr_output:
-                detail += f"\nServer stderr:\n{stderr_output}"
-            raise RuntimeError(detail)
-        finally:
-            stderr_file.close()
+        # Keep stderr capture lifetime explicit: the file must outlive the stdio
+        # transport context, but should close immediately once the attempt ends.
+        with tempfile.TemporaryFile(mode="w+") as stderr_file:
+            try:
+                async with self._create_stdio_streams(server_params, stderr_file) as streams:
+                    self._streams = streams
+                    await self._run_connected_session("stdio", streams, startup_future)
+            except asyncio.TimeoutError as exc:
+                stderr_output = self._read_stderr(stderr_file)
+                log.error("mcp.client.timeout", {
+                    "server": self.name,
+                    "transport": "stdio",
+                    "stderr": stderr_output,
+                })
+                detail = f"Connection timeout (stdio): {self.name}"
+                if stderr_output:
+                    detail += f"\nServer stderr:\n{stderr_output}"
+                raise RuntimeError(detail) from exc
+            except Exception as exc:
+                stderr_output = self._read_stderr(stderr_file)
+                root_cause = _extract_root_cause(exc)
+                log.error("mcp.client.stdio_failed", {
+                    "server": self.name,
+                    "error": root_cause,
+                    "stderr": stderr_output,
+                })
+                detail = f"Stdio connection failed: {self.name}: {root_cause}"
+                if stderr_output:
+                    detail += f"\nServer stderr:\n{stderr_output}"
+                raise RuntimeError(detail)
     
     async def disconnect(self) -> None:
         """Disconnect from server"""

--- a/flocks/mcp/client.py
+++ b/flocks/mcp/client.py
@@ -48,6 +48,15 @@ def _extract_root_cause(exc: BaseException) -> str:
     return str(exc)
 
 
+def _normalize_timeout(timeout: object) -> float:
+    """Normalize optional timeout inputs to a positive float."""
+    try:
+        value = float(timeout)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 30.0
+    return value if value > 0 else 30.0
+
+
 @dataclass(slots=True)
 class _ClientCommand:
     """A serialized request executed by the MCP owner task."""
@@ -102,7 +111,7 @@ class McpClient:
         self.env = env
         self.auth_config = auth_config
         self.transport = transport
-        self.timeout = timeout
+        self.timeout = _normalize_timeout(timeout)
         
         self.session: Optional[ClientSession] = None
         self._streams = None

--- a/flocks/mcp/client.py
+++ b/flocks/mcp/client.py
@@ -1,21 +1,26 @@
 """
 MCP Client Wrapper
 
-Client implementation based on official MCP SDK, supporting Streamable HTTP and SSE transports
+Client implementation based on official MCP SDK, supporting Streamable HTTP and SSE transports.
 """
 
 import asyncio
+import contextlib
 import os
 import tempfile
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Dict, Any, List, Literal
-from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
-from mcp.client.sse import sse_client
-from mcp.client.stdio import stdio_client, StdioServerParameters
+from typing import Any, Dict, List, Literal, Optional
 
-from flocks.mcp.types import McpToolDef, McpResource
-from flocks.mcp.utils import build_mcp_headers, build_mcp_url, resolve_env_var
+import httpx
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamable_http_client
+
+from flocks.mcp.types import McpResource, McpToolDef
+from flocks.mcp.utils import build_mcp_headers, build_mcp_url
 from flocks.utils.log import Log
 
 log = Log.create(service="mcp.client")
@@ -41,6 +46,15 @@ def _extract_root_cause(exc: BaseException) -> str:
             url = url.split('?')[0] + '?...'
         return f"HTTP {status} from {url}"
     return str(exc)
+
+
+@dataclass(slots=True)
+class _ClientCommand:
+    """A serialized request executed by the MCP owner task."""
+
+    action: Literal["list_tools", "call_tool", "list_resources", "read_resource", "disconnect"]
+    payload: Dict[str, Any] = field(default_factory=dict)
+    response: asyncio.Future[Any] | None = None
 
 
 class McpClient:
@@ -95,6 +109,9 @@ class McpClient:
         self._streams_context = None
         self._connected = False
         self._transport_type: Optional[str] = None
+        self._command_queue: asyncio.Queue[_ClientCommand] | None = None
+        self._owner_task: asyncio.Task[None] | None = None
+        self._owner_error: BaseException | None = None
     
     async def connect(self) -> None:
         """
@@ -107,18 +124,107 @@ class McpClient:
         if self._connected:
             log.warn("mcp.client.already_connected", {"server": self.name})
             return
-        
-        if self.server_type in ("remote", "sse"):
-            # Both "remote" and "sse" use auto-detection:
-            # try Streamable HTTP first, fall back to SSE.
-            # This handles servers that only support one transport.
-            await self._connect_remote()
-        elif self.server_type in ("local", "stdio"):
-            await self._connect_local()
-        else:
-            raise ValueError(f"Unknown server type: {self.server_type}")
-    
-    async def _connect_remote(self) -> None:
+
+        if self._owner_task and not self._owner_task.done():
+            log.warn("mcp.client.connect_in_progress", {"server": self.name})
+            return
+
+        loop = asyncio.get_running_loop()
+        startup_future: asyncio.Future[None] = loop.create_future()
+        self._owner_error = None
+        self._command_queue = asyncio.Queue()
+
+        owner_task = asyncio.create_task(
+            self._run_connection_owner(startup_future),
+            name=f"mcp-owner:{self.name}",
+        )
+        owner_task.add_done_callback(self._handle_owner_task_done)
+        self._owner_task = owner_task
+
+        try:
+            await asyncio.wait_for(startup_future, timeout=self.timeout + 1.0)
+        except Exception:
+            await self._cancel_owner_task()
+            self._reset_runtime_state()
+            raise
+
+    async def _run_connection_owner(self, startup_future: asyncio.Future[None]) -> None:
+        """Own the entire MCP session lifecycle inside one asyncio task."""
+        try:
+            if self.server_type in ("remote", "sse"):
+                await self._connect_remote(startup_future)
+            elif self.server_type in ("local", "stdio"):
+                await self._connect_local(startup_future)
+            else:
+                raise ValueError(f"Unknown server type: {self.server_type}")
+        except Exception as exc:
+            if not startup_future.done():
+                startup_future.set_exception(exc)
+            else:
+                await self._fail_pending_commands(
+                    RuntimeError(f"Connection lost: {self.name}: {_extract_root_cause(exc)}")
+                )
+            raise
+        finally:
+            if not startup_future.done():
+                startup_future.set_exception(
+                    RuntimeError(f"Connection closed before initialization: {self.name}")
+                )
+            self._connected = False
+            self.session = None
+            self._streams = None
+            self._streams_context = None
+            self._transport_type = None
+            await self._fail_pending_commands(RuntimeError(f"Client not connected: {self.name}"))
+
+    def _handle_owner_task_done(self, task: asyncio.Task[None]) -> None:
+        """Retrieve background task exceptions so asyncio does not emit warnings."""
+        try:
+            owner_error = task.exception()
+        except asyncio.CancelledError:
+            owner_error = None
+
+        self._owner_error = owner_error
+        if self._owner_task is task:
+            self._owner_task = None
+
+        if owner_error is not None:
+            log.error("mcp.client.owner_task_error", {
+                "server": self.name,
+                "error": _extract_root_cause(owner_error),
+            })
+
+    async def _cancel_owner_task(self) -> None:
+        """Cancel and await the owner task if it is still running."""
+        owner_task = self._owner_task
+        if owner_task is None:
+            return
+        if not owner_task.done():
+            owner_task.cancel()
+        try:
+            await owner_task
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            # Connection startup may already have failed; preserve the error so
+            # callers can finish cleanup and still surface the root cause.
+            if self._owner_error is None:
+                self._owner_error = exc
+
+    def _reset_runtime_state(self, clear_owner_error: bool = False) -> None:
+        """Reset local state after disconnects or failed startups."""
+        self.session = None
+        self._streams = None
+        self._streams_context = None
+        self._connected = False
+        self._transport_type = None
+        self._command_queue = None
+        if self._owner_task is not None and self._owner_task.done():
+            self._owner_task = None
+        if clear_owner_error:
+            self._owner_error = None
+
+    async def _connect_remote(self, startup_future: asyncio.Future[None]) -> None:
         """Connect to a remote server using the configured transport strategy."""
         full_url = build_mcp_url(self.url, self.auth_config)
         request_headers = build_mcp_headers(self.headers, self.auth_config)
@@ -129,7 +235,7 @@ class McpClient:
                 "type": "remote",
                 "strategy": "streamable_http_only",
             })
-            await self._connect_streamable_http_only(full_url, request_headers)
+            await self._connect_streamable_http_only(full_url, request_headers, startup_future)
             return
 
         if self.transport == "sse":
@@ -138,7 +244,7 @@ class McpClient:
                 "type": "remote",
                 "strategy": "sse_only",
             })
-            await self._connect_sse_only(full_url, request_headers)
+            await self._connect_sse_only(full_url, request_headers, startup_future)
             return
 
         log.info("mcp.client.connecting", {
@@ -146,163 +252,262 @@ class McpClient:
             "type": "remote",
             "strategy": "streamable_http_then_sse",
         })
-        await self._connect_auto(full_url, request_headers)
+        await self._connect_auto(full_url, request_headers, startup_future)
 
     async def _connect_streamable_http_only(
-        self, full_url: str, headers: Optional[Dict[str, str]]
+        self,
+        full_url: str,
+        headers: Optional[Dict[str, str]],
+        startup_future: asyncio.Future[None],
     ) -> None:
         """Connect using only Streamable HTTP."""
         try:
-            await self._do_connect_streamable_http(full_url, headers)
-            self._transport_type = "streamable_http"
-        except asyncio.TimeoutError:
-            await self._cleanup_connection()
+            await self._run_remote_transport(
+                transport_name="streamable_http",
+                full_url=full_url,
+                headers=headers,
+                startup_future=startup_future,
+                transport_factory=self._create_streamable_http_streams,
+            )
+        except asyncio.TimeoutError as exc:
             log.error("mcp.client.timeout", {
                 "server": self.name,
                 "transport": "streamable_http",
             })
-            raise RuntimeError(f"Connection timeout: {self.name}")
-        except Exception as e:
-            root_cause = _extract_root_cause(e)
-            await self._cleanup_connection()
-            raise RuntimeError(f"Connection failed: {self.name}: {root_cause}")
+            raise RuntimeError(f"Connection timeout: {self.name}") from exc
+        except Exception as exc:
+            raise RuntimeError(f"Connection failed: {self.name}: {_extract_root_cause(exc)}") from exc
 
     async def _connect_sse_only(
-        self, full_url: str, headers: Optional[Dict[str, str]]
+        self,
+        full_url: str,
+        headers: Optional[Dict[str, str]],
+        startup_future: asyncio.Future[None],
     ) -> None:
         """Connect using only SSE."""
         try:
-            await self._do_connect_sse(full_url, headers)
-            self._transport_type = "sse"
-        except asyncio.TimeoutError:
-            await self._cleanup_connection()
+            await self._run_remote_transport(
+                transport_name="sse",
+                full_url=full_url,
+                headers=headers,
+                startup_future=startup_future,
+                transport_factory=self._create_sse_streams,
+            )
+        except asyncio.TimeoutError as exc:
             log.error("mcp.client.timeout", {
                 "server": self.name,
                 "transport": "sse",
             })
-            raise RuntimeError(f"Connection timeout: {self.name}")
-        except Exception as e:
-            root_cause = _extract_root_cause(e)
-            await self._cleanup_connection()
-            raise RuntimeError(f"Connection failed: {self.name}: {root_cause}")
+            raise RuntimeError(f"Connection timeout: {self.name}") from exc
+        except Exception as exc:
+            raise RuntimeError(f"Connection failed: {self.name}: {_extract_root_cause(exc)}") from exc
 
     async def _connect_auto(
-        self, full_url: str, headers: Optional[Dict[str, str]]
+        self,
+        full_url: str,
+        headers: Optional[Dict[str, str]],
+        startup_future: asyncio.Future[None],
     ) -> None:
         """Connect using auto-detection: HTTP first, then SSE."""
         try:
-            await self._do_connect_streamable_http(full_url, headers)
-            self._transport_type = "streamable_http"
+            await self._run_remote_transport(
+                transport_name="streamable_http",
+                full_url=full_url,
+                headers=headers,
+                startup_future=startup_future,
+                transport_factory=self._create_streamable_http_streams,
+            )
             return
-        except asyncio.TimeoutError:
-            await self._cleanup_connection()
+        except asyncio.TimeoutError as exc:
             log.error("mcp.client.timeout", {
                 "server": self.name,
                 "transport": "streamable_http",
             })
-            raise RuntimeError(f"Connection timeout: {self.name}")
-        except Exception as e:
+            raise RuntimeError(f"Connection timeout: {self.name}") from exc
+        except Exception as exc:
+            if startup_future.done():
+                raise
             log.info("mcp.client.streamable_http_failed", {
                 "server": self.name,
-                "error": str(e),
+                "error": _extract_root_cause(exc),
                 "fallback": "sse",
             })
-            await self._cleanup_connection()
 
         try:
-            await self._do_connect_sse(full_url, headers)
-            self._transport_type = "sse"
-            return
-        except Exception as e:
-            root_cause = _extract_root_cause(e)
+            await self._run_remote_transport(
+                transport_name="sse",
+                full_url=full_url,
+                headers=headers,
+                startup_future=startup_future,
+                transport_factory=self._create_sse_streams,
+            )
+        except Exception as exc:
+            root_cause = _extract_root_cause(exc)
             log.error("mcp.client.all_transports_failed", {
                 "server": self.name,
                 "error": root_cause,
             })
-            await self._cleanup_connection()
-            raise RuntimeError(f"Connection failed: {self.name}: {root_cause}")
-    
-    async def _do_connect_streamable_http(
-        self, full_url: str, headers: Optional[Dict[str, str]] = None
+            raise RuntimeError(f"Connection failed: {self.name}: {root_cause}") from exc
+
+    async def _run_remote_transport(
+        self,
+        transport_name: Literal["streamable_http", "sse"],
+        full_url: str,
+        headers: Optional[Dict[str, str]],
+        startup_future: asyncio.Future[None],
+        transport_factory,
     ) -> None:
-        """Perform Streamable HTTP connection.
-        
-        Raises:
-            asyncio.TimeoutError: If connection or initialization times out
-            Exception: Any other connection error
-        """
-        self._streams_context = streamablehttp_client(
-            full_url,
-            headers=headers,
-            timeout=self.timeout,
-        )
-        self._streams = await self._streams_context.__aenter__()
-        read_stream, write_stream, _ = self._streams
-        
-        self.session = ClientSession(read_stream, write_stream)
-        await self.session.__aenter__()
-        init_result = await asyncio.wait_for(
-            self.session.initialize(),
-            timeout=self.timeout
-        )
-        
-        self._connected = True
-        log.info("mcp.client.connected", {
-            "server": self.name,
-            "transport": "streamable_http",
-            "protocol_version": getattr(init_result, 'protocolVersion', 'unknown'),
-            "server_info": getattr(init_result, 'serverInfo', {})
-        })
-    
-    async def _do_connect_sse(
-        self, full_url: str, headers: Optional[Dict[str, str]] = None
+        """Run one remote transport from startup until disconnect."""
+        async with transport_factory(full_url, headers) as streams:
+            self._streams_context = transport_name
+            self._streams = streams
+            await self._run_connected_session(transport_name, streams, startup_future)
+
+    @asynccontextmanager
+    async def _create_streamable_http_streams(
+        self,
+        full_url: str,
+        headers: Optional[Dict[str, str]],
+    ):
+        """Create a modern Streamable HTTP transport context."""
+        timeout = httpx.Timeout(self.timeout, read=60 * 5)
+        async with httpx.AsyncClient(headers=headers, timeout=timeout) as http_client:
+            async with streamable_http_client(full_url, http_client=http_client) as streams:
+                yield streams
+
+    @asynccontextmanager
+    async def _create_sse_streams(
+        self,
+        full_url: str,
+        headers: Optional[Dict[str, str]],
+    ):
+        """Create an SSE transport context."""
+        async with sse_client(full_url, headers=headers, timeout=self.timeout) as streams:
+            yield streams
+
+    async def _run_connected_session(
+        self,
+        transport_name: Literal["streamable_http", "sse", "stdio"],
+        streams,
+        startup_future: asyncio.Future[None],
     ) -> None:
-        """Perform SSE connection.
-        
-        Raises:
-            asyncio.TimeoutError: If connection or initialization times out
-            Exception: Any other connection error
-        """
-        self._streams_context = sse_client(
-            full_url,
-            headers=headers,
-            timeout=self.timeout,
-        )
-        self._streams = await self._streams_context.__aenter__()
-        read_stream, write_stream = self._streams
-        
-        self.session = ClientSession(read_stream, write_stream)
-        await self.session.__aenter__()
-        init_result = await asyncio.wait_for(
-            self.session.initialize(),
-            timeout=self.timeout
-        )
-        
-        self._connected = True
-        log.info("mcp.client.connected", {
-            "server": self.name,
-            "transport": "sse",
-            "protocol_version": getattr(init_result, 'protocolVersion', 'unknown'),
-            "server_info": getattr(init_result, 'serverInfo', {})
-        })
-    
-    async def _cleanup_connection(self) -> None:
-        """Clean up connection resources after a failed attempt"""
-        if self.session:
+        """Initialize the MCP session and then serve queued commands."""
+        if len(streams) == 3:
+            read_stream, write_stream, _ = streams
+        else:
+            read_stream, write_stream = streams
+
+        async with ClientSession(read_stream, write_stream) as session:
+            self.session = session
+            init_result = await asyncio.wait_for(session.initialize(), timeout=self.timeout)
+            self._connected = True
+            self._transport_type = transport_name
+            if not startup_future.done():
+                startup_future.set_result(None)
+            log.info("mcp.client.connected", {
+                "server": self.name,
+                "transport": transport_name,
+                "protocol_version": getattr(init_result, "protocolVersion", "unknown"),
+                "server_info": getattr(init_result, "serverInfo", {}),
+            })
+            await self._serve_commands(session)
+
+    async def _serve_commands(self, session: ClientSession) -> None:
+        """Process serialized commands until disconnect is requested."""
+        if self._command_queue is None:
+            raise RuntimeError(f"Command queue not initialized: {self.name}")
+
+        while True:
+            command = await self._command_queue.get()
+            if command.action == "disconnect":
+                if command.response is not None and not command.response.done():
+                    command.response.set_result(None)
+                return
+
             try:
-                await self.session.__aexit__(None, None, None)
-            except Exception:
-                pass
-        if self._streams_context:
+                result = await self._execute_command(session, command)
+            except Exception as exc:
+                if command.response is not None and not command.response.done():
+                    command.response.set_exception(exc)
+            else:
+                if command.response is not None and not command.response.done():
+                    command.response.set_result(result)
+
+    async def _execute_command(self, session: ClientSession, command: _ClientCommand) -> Any:
+        """Execute one queued MCP command inside the owner task."""
+        if command.action == "list_tools":
+            result = await asyncio.wait_for(session.list_tools(), timeout=self.timeout)
+            tools = [McpToolDef.from_sdk(tool) for tool in result.tools]
+            log.debug("mcp.client.tools_listed", {
+                "server": self.name,
+                "count": len(tools),
+            })
+            return tools
+
+        if command.action == "call_tool":
+            tool_name = command.payload["name"]
             try:
-                await self._streams_context.__aexit__(None, None, None)
-            except Exception:
-                pass
-        self.session = None
-        self._streams = None
-        self._streams_context = None
-        self._connected = False
-        self._transport_type = None
+                result = await asyncio.wait_for(
+                    session.call_tool(name=tool_name, arguments=command.payload["arguments"]),
+                    timeout=self.timeout,
+                )
+            except asyncio.TimeoutError as exc:
+                log.error("mcp.client.call_timeout", {
+                    "server": self.name,
+                    "tool": tool_name,
+                })
+                from concurrent.futures import TimeoutError as _FuturesTimeoutError
+
+                raise _FuturesTimeoutError(f"MCP工具调用超时 ({self.timeout}s): {tool_name}") from exc
+
+            log.debug("mcp.client.tool_called", {
+                "server": self.name,
+                "tool": tool_name,
+            })
+            return result
+
+        if command.action == "list_resources":
+            result = await asyncio.wait_for(session.list_resources(), timeout=self.timeout)
+            resources = [
+                McpResource(
+                    name=resource.name,
+                    uri=resource.uri,
+                    description=getattr(resource, "description", None),
+                    mime_type=getattr(resource, "mimeType", None),
+                    server=self.name,
+                )
+                for resource in result.resources
+            ]
+            log.debug("mcp.client.resources_listed", {
+                "server": self.name,
+                "count": len(resources),
+            })
+            return resources
+
+        if command.action == "read_resource":
+            uri = command.payload["uri"]
+            result = await asyncio.wait_for(session.read_resource(uri=uri), timeout=self.timeout)
+            log.debug("mcp.client.resource_read", {
+                "server": self.name,
+                "uri": uri,
+            })
+            return result
+
+        raise ValueError(f"Unknown MCP command: {command.action}")
+
+    async def _fail_pending_commands(self, error: Exception) -> None:
+        """Fail any queued commands when the owner task exits."""
+        if self._command_queue is None:
+            return
+
+        while True:
+            try:
+                command = self._command_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+
+            if command.response is not None and not command.response.done():
+                command.response.set_exception(error)
     
     @staticmethod
     def _read_stderr(stderr_file) -> str:
@@ -325,7 +530,13 @@ class McpClient:
         prefix.mkdir(parents=True, exist_ok=True)
         return str(prefix)
 
-    async def _connect_local(self) -> None:
+    @asynccontextmanager
+    async def _create_stdio_streams(self, server_params: StdioServerParameters, stderr_file):
+        """Create stdio transport streams."""
+        async with stdio_client(server_params, errlog=stderr_file) as streams:
+            yield streams
+
+    async def _connect_local(self, startup_future: asyncio.Future[None]) -> None:
         """Connect to local server via Stdio transport."""
         if not self.command:
             raise ValueError(f"No command specified for local server: {self.name}")
@@ -376,28 +587,12 @@ class McpClient:
 
         stderr_file = tempfile.TemporaryFile(mode="w+")
         try:
-            self._streams_context = stdio_client(server_params, errlog=stderr_file)
-            self._streams = await self._streams_context.__aenter__()
-            read_stream, write_stream = self._streams
-
-            self.session = ClientSession(read_stream, write_stream)
-            await self.session.__aenter__()
-            init_result = await asyncio.wait_for(
-                self.session.initialize(),
-                timeout=self.timeout,
-            )
-
-            self._connected = True
-            self._transport_type = "stdio"
-            log.info("mcp.client.connected", {
-                "server": self.name,
-                "transport": "stdio",
-                "protocol_version": getattr(init_result, 'protocolVersion', 'unknown'),
-                "server_info": getattr(init_result, 'serverInfo', {}),
-            })
-        except asyncio.TimeoutError:
+            async with self._create_stdio_streams(server_params, stderr_file) as streams:
+                self._streams_context = "stdio"
+                self._streams = streams
+                await self._run_connected_session("stdio", streams, startup_future)
+        except asyncio.TimeoutError as exc:
             stderr_output = self._read_stderr(stderr_file)
-            await self._cleanup_connection()
             log.error("mcp.client.timeout", {
                 "server": self.name,
                 "transport": "stdio",
@@ -406,11 +601,10 @@ class McpClient:
             detail = f"Connection timeout (stdio): {self.name}"
             if stderr_output:
                 detail += f"\nServer stderr:\n{stderr_output}"
-            raise RuntimeError(detail)
-        except Exception as e:
+            raise RuntimeError(detail) from exc
+        except Exception as exc:
             stderr_output = self._read_stderr(stderr_file)
-            root_cause = _extract_root_cause(e)
-            await self._cleanup_connection()
+            root_cause = _extract_root_cause(exc)
             log.error("mcp.client.stdio_failed", {
                 "server": self.name,
                 "error": root_cause,
@@ -425,39 +619,30 @@ class McpClient:
     
     async def disconnect(self) -> None:
         """Disconnect from server"""
-        if not self._connected:
+        owner_task = self._owner_task
+        if owner_task is None and not self._connected:
             return
-        
+
         try:
-            # Close session first
-            if self.session:
-                try:
-                    await self.session.__aexit__(None, None, None)
-                except Exception as e:
-                    log.warn("mcp.client.session_close_error", {
-                        "server": self.name,
-                        "error": str(e)
-                    })
-            
-            # Then close streams
-            if self._streams_context:
-                try:
-                    await self._streams_context.__aexit__(None, None, None)
-                except Exception as e:
-                    log.warn("mcp.client.streams_close_error", {
-                        "server": self.name,
-                        "error": str(e)
-                    })
-        except Exception as e:
+            if owner_task is not None and not owner_task.done() and self._command_queue is not None:
+                response = asyncio.get_running_loop().create_future()
+                await self._command_queue.put(_ClientCommand(action="disconnect", response=response))
+                await response
+            elif owner_task is not None and not owner_task.done():
+                owner_task.cancel()
+
+            if owner_task is not None:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await owner_task
+        except Exception as exc:
             log.error("mcp.client.disconnect_error", {
                 "server": self.name,
-                "error": str(e)
+                "error": str(exc),
             })
         finally:
-            self._connected = False
-            self.session = None
-            self._streams = None
-            self._streams_context = None
+            self._reset_runtime_state(clear_owner_error=True)
+            if self._owner_task is owner_task:
+                self._owner_task = None
             log.info("mcp.client.disconnected", {"server": self.name})
     
     async def list_tools(self) -> List[McpToolDef]:
@@ -470,24 +655,13 @@ class McpClient:
         Raises:
             RuntimeError: If not connected
         """
-        if not self._connected or not self.session:
-            raise RuntimeError(f"Client not connected: {self.name}")
-        
         try:
-            result = await asyncio.wait_for(
-                self.session.list_tools(),
-                timeout=self.timeout
-            )
-            tools = [McpToolDef.from_sdk(tool) for tool in result.tools]
-            log.debug("mcp.client.tools_listed", {
-                "server": self.name,
-                "count": len(tools)
-            })
-            return tools
-        except Exception as e:
+            result = await self._submit_command("list_tools")
+            return result
+        except Exception as exc:
             log.error("mcp.client.list_tools_error", {
                 "server": self.name,
-                "error": str(e)
+                "error": str(exc),
             })
             raise
     
@@ -505,31 +679,13 @@ class McpClient:
         Raises:
             RuntimeError: If not connected
         """
-        if not self._connected or not self.session:
-            raise RuntimeError(f"Client not connected: {self.name}")
-        
         try:
-            result = await asyncio.wait_for(
-                self.session.call_tool(name=name, arguments=arguments),
-                timeout=self.timeout
-            )
-            log.debug("mcp.client.tool_called", {
-                "server": self.name,
-                "tool": name
-            })
-            return result
-        except asyncio.TimeoutError:
-            log.error("mcp.client.call_timeout", {
-                "server": self.name,
-                "tool": name
-            })
-            from concurrent.futures import TimeoutError as _FuturesTimeoutError
-            raise _FuturesTimeoutError(f"MCP工具调用超时 ({self.timeout}s): {name}")
-        except Exception as e:
+            return await self._submit_command("call_tool", name=name, arguments=arguments)
+        except Exception as exc:
             log.error("mcp.client.call_error", {
                 "server": self.name,
                 "tool": name,
-                "error": str(e)
+                "error": str(exc),
             })
             raise
     
@@ -543,32 +699,13 @@ class McpClient:
         Raises:
             RuntimeError: If not connected
         """
-        if not self._connected or not self.session:
-            raise RuntimeError(f"Client not connected: {self.name}")
-        
         try:
-            result = await asyncio.wait_for(
-                self.session.list_resources(),
-                timeout=self.timeout
-            )
-            resources = []
-            for r in result.resources:
-                resources.append(McpResource(
-                    name=r.name,
-                    uri=r.uri,
-                    description=getattr(r, 'description', None),
-                    mime_type=getattr(r, 'mimeType', None),
-                    server=self.name
-                ))
-            log.debug("mcp.client.resources_listed", {
-                "server": self.name,
-                "count": len(resources)
-            })
-            return resources
-        except Exception as e:
+            result = await self._submit_command("list_resources")
+            return result
+        except Exception as exc:
             log.error("mcp.client.list_resources_error", {
                 "server": self.name,
-                "error": str(e)
+                "error": str(exc),
             })
             raise
     
@@ -585,26 +722,42 @@ class McpClient:
         Raises:
             RuntimeError: If not connected
         """
-        if not self._connected or not self.session:
-            raise RuntimeError(f"Client not connected: {self.name}")
-        
         try:
-            result = await asyncio.wait_for(
-                self.session.read_resource(uri=uri),
-                timeout=self.timeout
-            )
-            log.debug("mcp.client.resource_read", {
-                "server": self.name,
-                "uri": uri
-            })
-            return result
-        except Exception as e:
+            return await self._submit_command("read_resource", uri=uri)
+        except Exception as exc:
             log.error("mcp.client.read_resource_error", {
                 "server": self.name,
                 "uri": uri,
-                "error": str(e)
+                "error": str(exc),
             })
             raise
+
+    async def _submit_command(self, action: str, **payload: Any) -> Any:
+        """Send a serialized command to the owner task."""
+        if not self._connected or self._command_queue is None:
+            if self._owner_error is not None:
+                raise RuntimeError(
+                    f"Client not connected: {self.name}: {_extract_root_cause(self._owner_error)}"
+                ) from self._owner_error
+            raise RuntimeError(f"Client not connected: {self.name}")
+
+        owner_task = self._owner_task
+        if owner_task is None:
+            if self._owner_error is not None:
+                raise RuntimeError(
+                    f"Client not connected: {self.name}: {_extract_root_cause(self._owner_error)}"
+                ) from self._owner_error
+            raise RuntimeError(f"Client not connected: {self.name}")
+
+        response = asyncio.get_running_loop().create_future()
+        command = _ClientCommand(action=action, payload=payload, response=response)
+        await self._command_queue.put(command)
+
+        if owner_task.done() and not response.done():
+            owner_error = self._owner_error or RuntimeError(f"Client not connected: {self.name}")
+            response.set_exception(owner_error)
+
+        return await response
     
     @property
     def is_connected(self) -> bool:

--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -5,10 +5,12 @@ Main HTTP API server for AI-Native SecOps Platform
 """
 
 import asyncio
+import inspect
 import os
 import time
+from types import SimpleNamespace
 from pathlib import Path
-from typing import Optional
+from typing import Any, Callable, Optional
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -43,6 +45,60 @@ except Exception as e:
 
 
 # Lifespan context manager for startup/shutdown
+async def _maybe_await(result: Any) -> Any:
+    """Await values that are awaitable and return plain values unchanged."""
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+async def _run_startup_phase(
+    log,
+    phase: str,
+    fn: Callable[[], Any],
+) -> Any:
+    """Execute one startup phase and emit structured timing logs."""
+    started_at = time.perf_counter()
+    try:
+        result = await _maybe_await(fn())
+    except Exception as exc:
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        log.warning("server.startup.phase", {
+            "phase": phase,
+            "status": "failed",
+            "duration_ms": duration_ms,
+            "error": str(exc),
+        })
+        raise
+
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    log.info("server.startup.phase", {
+        "phase": phase,
+        "status": "completed",
+        "duration_ms": duration_ms,
+    })
+    return result
+
+
+def _schedule_startup_phase(
+    app: FastAPI,
+    log,
+    phase: str,
+    fn: Callable[[], Any],
+) -> None:
+    """Run a non-critical startup phase in the background after app is ready."""
+
+    async def _runner() -> None:
+        try:
+            await _run_startup_phase(log, phase, fn)
+        except Exception:
+            # _run_startup_phase already logged the failure.
+            return
+
+    task = asyncio.create_task(_runner(), name=f"startup:{phase}")
+    app.state.startup_background_tasks.append(task)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Handle application lifecycle"""
@@ -51,13 +107,21 @@ async def lifespan(app: FastAPI):
         await Log.init(print=False, dev=False, level=LogLevel.INFO)
 
     log = Log.create(service="server")
+    if not hasattr(app, "state") or app.state is None:
+        app.state = SimpleNamespace()
+    app.state.startup_background_tasks = []
+    startup_started_at = time.perf_counter()
 
     # Startup
     log.info("server.startup", {"version": "0.2.0"})
     try:
         from flocks.updater.updater import cleanup_replaced_files
 
-        await asyncio.to_thread(cleanup_replaced_files)
+        await _run_startup_phase(
+            log,
+            "updater.cleanup_leftovers",
+            lambda: asyncio.to_thread(cleanup_replaced_files),
+        )
         log.info("updater.leftovers.cleaned")
     except Exception as e:
         log.warning("updater.leftovers.cleanup_failed", {"error": str(e)})
@@ -65,13 +129,21 @@ async def lifespan(app: FastAPI):
     try:
         from flocks.updater.updater import _get_repo_root, _refresh_global_cli_entry
 
-        await asyncio.to_thread(_refresh_global_cli_entry, _get_repo_root())
+        await _run_startup_phase(
+            log,
+            "cli.refresh_global_entry",
+            lambda: asyncio.to_thread(_refresh_global_cli_entry, _get_repo_root()),
+        )
         log.info("cli.global_entry.refreshed")
     except Exception as e:
         log.warning("cli.global_entry.refresh_failed", {"error": str(e)})
 
     try:
-        init_observability()
+        await _run_startup_phase(
+            log,
+            "observability.init",
+            init_observability,
+        )
         log.info("observability.initialized")
     except Exception as e:
         log.warning("observability.init_failed", {"error": str(e)})
@@ -79,7 +151,11 @@ async def lifespan(app: FastAPI):
     # Ensure config files exist (copy from examples if needed)
     try:
         from flocks.config.config_writer import ensure_config_files
-        ensure_config_files()
+        await _run_startup_phase(
+            log,
+            "config.ensure_files",
+            ensure_config_files,
+        )
         log.info("config.files.checked")
     except Exception as e:
         log.warning("config.files.check_failed", {"error": str(e)})
@@ -89,7 +165,11 @@ async def lifespan(app: FastAPI):
     # ``<service_id>_v<version>`` once the plugin declares a version.
     try:
         from flocks.config.api_versioning import migrate_api_services
-        actions = migrate_api_services()
+        actions = await _run_startup_phase(
+            log,
+            "config.migrate_api_services",
+            migrate_api_services,
+        )
         copied = [k for k, v in actions.items() if v == "copied"]
         if copied:
             log.info("config.api_services.migrated", {"copied": copied})
@@ -97,31 +177,42 @@ async def lifespan(app: FastAPI):
         log.warning("config.api_services.migrate_failed", {"error": str(e)})
     
     # Initialize storage
-    await Storage.init()
+    await _run_startup_phase(log, "storage.init", Storage.init)
     log.info("storage.initialized")
 
     # Initialize local auth/account tables
-    await AuthService.init()
+    await _run_startup_phase(log, "auth.init", AuthService.init)
     log.info("auth.initialized")
 
     # Best-effort migration: old sessions default to admin ownership.
     # The migration itself is idempotent (guarded by a persisted marker),
     # but we still skip loading users when the marker is already set
     # to avoid unnecessary DB + session scans on every startup.
-    try:
+    async def _migrate_legacy_sessions_to_admin() -> None:
         marker = await Storage.get("auth:migration:legacy_session_owner_to_admin", dict)
-        if not (marker and marker.get("done")):
-            if await AuthService.has_users():
-                users = await AuthService.list_users()
-                admin = next((u for u in users if u.role == "admin"), None)
-                if admin:
-                    await AuthService.migrate_legacy_sessions_to_admin(admin.id)
-    except Exception as e:
-        log.warning("auth.legacy_sessions.migration_failed", {"error": str(e)})
+        if marker and marker.get("done"):
+            return
+        if not await AuthService.has_users():
+            return
+        users = await AuthService.list_users()
+        admin = next((u for u in users if u.role == "admin"), None)
+        if admin:
+            await AuthService.migrate_legacy_sessions_to_admin(admin.id)
+
+    _schedule_startup_phase(
+        app,
+        log,
+        "auth.migrate_legacy_session_owner",
+        _migrate_legacy_sessions_to_admin,
+    )
     
     # Setup question handler for real user interaction
     from flocks.tool.question_handler import setup_api_question_handler
-    setup_api_question_handler()
+    await _run_startup_phase(
+        log,
+        "question_handler.setup",
+        setup_api_question_handler,
+    )
     log.info("question_handler.initialized")
     
     # Register built-in hooks if memory is enabled
@@ -129,7 +220,11 @@ async def lifespan(app: FastAPI):
         config = await Config.get()
         if config.memory.enabled:
             from flocks.hooks.builtin import register_builtin_hooks
-            register_builtin_hooks()
+            await _run_startup_phase(
+                log,
+                "hooks.register_builtin",
+                register_builtin_hooks,
+            )
             log.info("hooks.registered")
     except Exception as e:
         # Hook registration failure should not stop server startup
@@ -138,25 +233,47 @@ async def lifespan(app: FastAPI):
     # Migrate env-var credentials to .secret.json (idempotent)
     try:
         from flocks.provider.credential import migrate_env_credentials
-        migrated = migrate_env_credentials()
-        if migrated > 0:
-            log.info("credential.env_migration.done", {"migrated": migrated})
+
+        def _migrate_env_credentials_phase() -> None:
+            migrated = migrate_env_credentials()
+            if migrated > 0:
+                log.info("credential.env_migration.done", {"migrated": migrated})
+
+        _schedule_startup_phase(
+            app,
+            log,
+            "credential.migrate_env_credentials",
+            _migrate_env_credentials_phase,
+        )
     except Exception as e:
         log.warning("credential.env_migration.failed", {"error": str(e)})
 
     # Sync new catalog models into flocks.json for existing providers (idempotent)
     try:
         from flocks.provider.model_catalog import sync_catalog_models_to_config
-        synced = sync_catalog_models_to_config()
-        if synced > 0:
-            log.info("catalog.model_sync.done", {"models_added": synced})
+
+        def _sync_catalog_models_phase() -> None:
+            synced = sync_catalog_models_to_config()
+            if synced > 0:
+                log.info("catalog.model_sync.done", {"models_added": synced})
+
+        _schedule_startup_phase(
+            app,
+            log,
+            "catalog.sync_models_to_config",
+            _sync_catalog_models_phase,
+        )
     except Exception as e:
         log.warning("catalog.model_sync.failed", {"error": str(e)})
 
     # Load custom providers from flocks.json into runtime
     try:
         from flocks.server.routes.custom_provider import load_custom_providers_on_startup
-        await load_custom_providers_on_startup()
+        await _run_startup_phase(
+            log,
+            "custom_providers.load",
+            load_custom_providers_on_startup,
+        )
         log.info("custom_providers.loaded")
     except Exception as e:
         log.warning("custom_providers.load.failed", {"error": str(e)})
@@ -165,23 +282,31 @@ async def lifespan(app: FastAPI):
     # after a service restart, without requiring manual UI reconnection.
     try:
         from flocks.mcp import MCP
-        await MCP.init()
-        log.info("mcp.initialized")
+
+        _schedule_startup_phase(app, log, "mcp.init", MCP.init)
     except Exception as e:
         log.warning("mcp.init_failed", {"error": str(e)})
 
     # Sync workflows from .flocks/workflow/ filesystem into Storage
     try:
         from flocks.server.routes.workflow import sync_workflows_from_filesystem
-        imported = await sync_workflows_from_filesystem()
-        log.info("workflow.sync.done", {"imported": imported})
+
+        async def _sync_workflows_phase() -> None:
+            imported = await sync_workflows_from_filesystem()
+            log.info("workflow.sync.done", {"imported": imported})
+
+        _schedule_startup_phase(app, log, "workflow.sync_filesystem", _sync_workflows_phase)
     except Exception as e:
         log.warning("workflow.sync.failed", {"error": str(e)})
 
     # Start Task Center (scheduler + queue executor)
     try:
         from flocks.task.manager import TaskManager
-        await TaskManager.start()
+        await _run_startup_phase(
+            log,
+            "task_manager.start",
+            TaskManager.start,
+        )
         log.info("task_manager.started")
     except Exception as e:
         from flocks.task.manager import TaskManager
@@ -191,53 +316,90 @@ async def lifespan(app: FastAPI):
     # Seed built-in scheduled tasks from .flocks/plugins/tasks/*.json (idempotent)
     try:
         from flocks.task.plugin import seed_tasks_from_plugin
-        seeded = await seed_tasks_from_plugin()
-        if seeded:
-            log.info("task.plugin.seeded", {"count": seeded})
+
+        async def _seed_tasks_phase() -> None:
+            seeded = await seed_tasks_from_plugin()
+            if seeded:
+                log.info("task.plugin.seeded", {"count": seeded})
+
+        _schedule_startup_phase(app, log, "task.seed_plugin_specs", _seed_tasks_phase)
     except Exception as e:
         log.warning("task.plugin.seed_failed", {"error": str(e)})
 
     # Start Skill file watcher (auto-invalidate cache on SKILL.md changes)
     try:
         from flocks.skill.skill import Skill
-        Skill.start_watcher()
-        log.info("skill.watcher.initialized")
+
+        def _start_skill_watcher() -> None:
+            Skill.start_watcher()
+            log.info("skill.watcher.initialized")
+
+        _schedule_startup_phase(app, log, "skill.watcher.start", _start_skill_watcher)
     except Exception as e:
         log.warning("skill.watcher.init_failed", {"error": str(e)})
 
     # Start Agent file watcher (auto-invalidate cache on plugin agent changes)
     try:
         from flocks.agent.registry import Agent
-        Agent.start_watcher()
-        log.info("agent.watcher.initialized")
+
+        def _start_agent_watcher() -> None:
+            Agent.start_watcher()
+            log.info("agent.watcher.initialized")
+
+        _schedule_startup_phase(app, log, "agent.watcher.start", _start_agent_watcher)
     except Exception as e:
         log.warning("agent.watcher.init_failed", {"error": str(e)})
 
     # Start Tool file watcher (auto-reload plugin tools on file changes)
     try:
         from flocks.tool.registry import ToolRegistry
-        ToolRegistry.start_watcher()
-        log.info("tool.watcher.initialized")
+
+        def _start_tool_watcher() -> None:
+            ToolRegistry.start_watcher()
+            log.info("tool.watcher.initialized")
+
+        _schedule_startup_phase(app, log, "tool.watcher.start", _start_tool_watcher)
     except Exception as e:
         log.warning("tool.watcher.init_failed", {"error": str(e)})
 
     # Start Channel Gateway (connect enabled IM channels)
     try:
         from flocks.channel.gateway.manager import default_manager
-        await default_manager.start_all()
-        log.info("channel.gateway.started")
+
+        async def _start_channel_gateway() -> None:
+            await default_manager.start_all()
+            log.info("channel.gateway.started")
+
+        _schedule_startup_phase(app, log, "channel.gateway.start", _start_channel_gateway)
     except Exception as e:
         log.warning("channel.gateway.start_failed", {"error": str(e)})
 
     try:
         from flocks.updater.updater import recover_upgrade_state
 
-        await asyncio.to_thread(recover_upgrade_state)
+        await _run_startup_phase(
+            log,
+            "updater.recover_upgrade_state",
+            lambda: asyncio.to_thread(recover_upgrade_state),
+        )
         log.info("updater.recovery.checked")
     except Exception as e:
         log.warning("updater.recovery.failed", {"error": str(e)})
 
+    blocking_startup_ms = int((time.perf_counter() - startup_started_at) * 1000)
+    log.info("server.startup.ready", {
+        "blocking_duration_ms": blocking_startup_ms,
+        "background_tasks": len(app.state.startup_background_tasks),
+    })
+
     yield
+
+    background_tasks = list(getattr(app.state, "startup_background_tasks", []))
+    for task in background_tasks:
+        if not task.done():
+            task.cancel()
+    if background_tasks:
+        await asyncio.gather(*background_tasks, return_exceptions=True)
 
     # --- Graceful shutdown: notify SSE clients FIRST ---
     try:

--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -401,7 +401,8 @@ async def lifespan(app: FastAPI):
     if background_tasks:
         await asyncio.gather(*background_tasks, return_exceptions=True)
 
-    # --- Graceful shutdown: notify SSE clients FIRST ---
+    # Notify SSE clients before stopping sessions, MCP transports, and other
+    # long-lived runtime services so browser listeners see the shutdown event.
     try:
         from flocks.server.routes.event import EventBroadcaster
         broadcaster = EventBroadcaster.get()

--- a/flocks/server/routes/_timing.py
+++ b/flocks/server/routes/_timing.py
@@ -1,0 +1,28 @@
+"""Helpers for route timing logs."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from flocks.utils.log import Logger
+
+DEFAULT_SLOW_ROUTE_LOG_THRESHOLD_MS = 300
+
+
+def log_route_timing(
+    logger: Logger,
+    event: str,
+    *,
+    started_at: float,
+    extra: dict[str, Any] | None = None,
+    slow_threshold_ms: int = DEFAULT_SLOW_ROUTE_LOG_THRESHOLD_MS,
+) -> int:
+    """Log route timings at INFO only when a request is slow enough."""
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    payload = {"duration_ms": duration_ms, **(extra or {})}
+    if duration_ms >= slow_threshold_ms:
+        logger.info(event, payload)
+    else:
+        logger.debug(event, payload)
+    return duration_ms

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -15,6 +15,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, ConfigDict
 
 from flocks.auth.context import get_current_auth_user
+from flocks.server.routes._timing import log_route_timing
 from flocks.session.session import Session, SessionInfo as SessionModel
 from flocks.session.policy import SessionPolicy
 from flocks.utils.log import Log
@@ -237,8 +238,7 @@ async def list_sessions(
             break
     
     response = [_session_to_response(s) for s in filtered]
-    log.info("session.list.complete", {
-        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+    log_route_timing(log, "session.list.complete", started_at=started_at, extra={
         "count": len(response),
         "roots": roots,
         "limit": limit,

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -206,6 +206,7 @@ async def list_sessions(
     category: Optional[str] = Query(None, description="Filter by category: user or task"),
 ) -> List[SessionResponse]:
     """List all sessions with optional filters"""
+    started_at = time.perf_counter()
     _current_user = require_user(request)
     all_sessions = await Session.list_all()
     
@@ -235,7 +236,16 @@ async def list_sessions(
         if limit is not None and len(filtered) >= limit:
             break
     
-    return [_session_to_response(s) for s in filtered]
+    response = [_session_to_response(s) for s in filtered]
+    log.info("session.list.complete", {
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "count": len(response),
+        "roots": roots,
+        "limit": limit,
+        "search": bool(search),
+        "category": category,
+    })
+    return response
 
 
 @router.post(

--- a/flocks/server/routes/task_entities.py
+++ b/flocks/server/routes/task_entities.py
@@ -1,13 +1,16 @@
 """Execution-centric task scheduler/execution routes."""
 
 from enum import Enum
+import time
 from typing import List, Optional, Type
 
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
+from flocks.utils.log import Log
 
 
 router = APIRouter()
+log = Log.create(service="task-routes")
 
 
 class SchedulerCreateRequest(BaseModel):
@@ -143,21 +146,43 @@ def _parse_task_type(task_type: str) -> str:
 async def get_task_system_notice():
     from flocks.task.manager import TaskManager
 
-    return await TaskManager.get_task_page_notice()
+    started_at = time.perf_counter()
+    notice = await TaskManager.get_task_page_notice()
+    log.info("task.notice.complete", {
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "has_notice": bool(notice),
+    })
+    return notice
 
 
 @router.get("/task-system/dashboard")
 async def task_dashboard():
     from flocks.task.manager import TaskManager
 
-    return await TaskManager.dashboard()
+    started_at = time.perf_counter()
+    payload = await TaskManager.dashboard()
+    log.info("task.dashboard.complete", {
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "running": payload.get("running"),
+        "queued": payload.get("queued"),
+        "scheduled_active": payload.get("scheduled_active"),
+    })
+    return payload
 
 
 @router.get("/task-system/queue/status")
 async def task_queue_status():
     from flocks.task.manager import TaskManager
 
-    return await TaskManager.queue_status()
+    started_at = time.perf_counter()
+    payload = await TaskManager.queue_status()
+    log.info("task.queue_status.complete", {
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "queued": payload.get("queued"),
+        "running": payload.get("running"),
+        "paused": payload.get("paused"),
+    })
+    return payload
 
 
 @router.post("/task-system/queue/pause")

--- a/flocks/server/routes/task_entities.py
+++ b/flocks/server/routes/task_entities.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Type
 
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
+from flocks.server.routes._timing import log_route_timing
 from flocks.utils.log import Log
 
 
@@ -148,8 +149,7 @@ async def get_task_system_notice():
 
     started_at = time.perf_counter()
     notice = await TaskManager.get_task_page_notice()
-    log.info("task.notice.complete", {
-        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+    log_route_timing(log, "task.notice.complete", started_at=started_at, extra={
         "has_notice": bool(notice),
     })
     return notice
@@ -161,8 +161,7 @@ async def task_dashboard():
 
     started_at = time.perf_counter()
     payload = await TaskManager.dashboard()
-    log.info("task.dashboard.complete", {
-        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+    log_route_timing(log, "task.dashboard.complete", started_at=started_at, extra={
         "running": payload.get("running"),
         "queued": payload.get("queued"),
         "scheduled_active": payload.get("scheduled_active"),
@@ -176,8 +175,7 @@ async def task_queue_status():
 
     started_at = time.perf_counter()
     payload = await TaskManager.queue_status()
-    log.info("task.queue_status.complete", {
-        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+    log_route_timing(log, "task.queue_status.complete", started_at=started_at, extra={
         "queued": payload.get("queued"),
         "running": payload.get("running"),
         "paused": payload.get("paused"),

--- a/flocks/server/routes/tool.py
+++ b/flocks/server/routes/tool.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from flocks.server.auth import require_admin
+from flocks.server.routes._timing import log_route_timing
 from flocks.utils.log import Log
 from flocks.config.config_writer import ConfigWriter
 from flocks.permission.next import DeniedError, PermissionNext
@@ -461,8 +462,7 @@ async def list_tools(
     if source:
         result = [t for t in result if t.source == source]
 
-    log.info("tools.list.complete", {
-        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+    log_route_timing(log, "tools.list.complete", started_at=started_at, extra={
         "count": len(result),
         "category": category,
         "source": source,
@@ -792,10 +792,9 @@ async def refresh_tools(_admin: object = Depends(require_admin)):
         errors.append(f"plugin: {e}")
 
     tool_count = len(ToolRegistry.all_tool_ids())
-    log.info("tools.refresh.done", {
+    log_route_timing(log, "tools.refresh.done", started_at=started_at, extra={
         "tool_count": tool_count,
         "errors": len(errors),
-        "duration_ms": int((time.perf_counter() - started_at) * 1000),
     })
 
     if errors:

--- a/flocks/server/routes/tool.py
+++ b/flocks/server/routes/tool.py
@@ -3,6 +3,7 @@ Tool routes - API endpoints for tool management and execution
 """
 
 import asyncio
+import time
 from typing import List, Optional, Dict, Any
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -439,6 +440,7 @@ async def list_tools(
         List of tool information
     """
     # Initialize registry if needed
+    started_at = time.perf_counter()
     ToolRegistry.init()
     
     # Parse category filter
@@ -458,7 +460,13 @@ async def list_tools(
     # Apply source filter if specified
     if source:
         result = [t for t in result if t.source == source]
-    
+
+    log.info("tools.list.complete", {
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+        "count": len(result),
+        "category": category,
+        "source": source,
+    })
     return result
 
 
@@ -764,6 +772,7 @@ async def refresh_tools(_admin: object = Depends(require_admin)):
 
     This is the batch counterpart to the single-tool ``/{name}/reload`` endpoint.
     """
+    started_at = time.perf_counter()
     ToolRegistry.init()
 
     errors: list[str] = []
@@ -783,7 +792,11 @@ async def refresh_tools(_admin: object = Depends(require_admin)):
         errors.append(f"plugin: {e}")
 
     tool_count = len(ToolRegistry.all_tool_ids())
-    log.info("tools.refresh.done", {"tool_count": tool_count, "errors": len(errors)})
+    log.info("tools.refresh.done", {
+        "tool_count": tool_count,
+        "errors": len(errors),
+        "duration_ms": int((time.perf_counter() - started_at) * 1000),
+    })
 
     if errors:
         return RefreshResponse(

--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -364,6 +364,17 @@ def _list_workflows_from_fs() -> List[Dict[str, Any]]:
     return list(by_id.values())
 
 
+async def sync_workflows_from_filesystem() -> int:
+    """Best-effort startup sync for filesystem-backed workflows.
+
+    The filesystem is the source of truth for workflow definitions. Startup only
+    needs to migrate any legacy Storage-only records to disk and report how many
+    workflows are currently discoverable from the configured workflow roots.
+    """
+    await _migrate_storage_to_filesystem()
+    return len(_list_workflows_from_fs())
+
+
 async def _migrate_storage_to_filesystem() -> None:
     """One-time migration: move Storage-only workflow definitions to the filesystem.
 

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -1,7 +1,11 @@
+import asyncio
+from contextlib import asynccontextmanager
+from types import MethodType
 from unittest.mock import AsyncMock
 
 import pytest
 
+import flocks.mcp.client as mcp_client_module
 from flocks.mcp.client import McpClient
 
 
@@ -117,3 +121,58 @@ class TestMcpClientTransportSelection:
         await client.connect()
 
         fake_owner.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connect_local_closes_stderr_file_on_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        class _FakeTempFile:
+            def __init__(self) -> None:
+                self.closed = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                self.close()
+                return False
+
+            def seek(self, _offset: int) -> None:
+                return None
+
+            def read(self, _size: int = -1) -> str:
+                return "stdio stderr"
+
+            def close(self) -> None:
+                self.closed = True
+
+        fake_stderr = _FakeTempFile()
+        client = McpClient(
+            name="demo",
+            server_type="stdio",
+            command=["python", "-m", "demo"],
+        )
+
+        @asynccontextmanager
+        async def broken_stdio(self, _server_params, stderr_file):
+            assert stderr_file is fake_stderr
+            raise RuntimeError("spawn failed")
+            yield
+
+        monkeypatch.setattr(
+            mcp_client_module.tempfile,
+            "TemporaryFile",
+            lambda mode="w+": fake_stderr,
+        )
+        monkeypatch.setattr(
+            client,
+            "_create_stdio_streams",
+            MethodType(broken_stdio, client),
+        )
+
+        startup_future = asyncio.get_running_loop().create_future()
+        with pytest.raises(RuntimeError, match="Stdio connection failed"):
+            await client._connect_local(startup_future)
+
+        assert fake_stderr.closed is True

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -51,6 +51,29 @@ class TestMcpClientTransportSelection:
         assert calls == ["local"]
 
     @pytest.mark.asyncio
+    async def test_timeout_none_defaults_to_safe_float(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        observed: list[float] = []
+
+        async def fake_remote(startup_future):
+            observed.append(client.timeout)
+            startup_future.set_result(None)
+
+        client = McpClient(
+            name="demo",
+            server_type="remote",
+            url="https://example.com/mcp",
+            timeout=None,
+        )
+        monkeypatch.setattr(client, "_connect_remote", fake_remote)
+
+        await client.connect()
+
+        assert observed == [30.0]
+
+    @pytest.mark.asyncio
     async def test_unknown_type_raises_value_error(self):
         client = McpClient(
             name="demo",

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
 from flocks.mcp.client import McpClient
@@ -5,78 +7,90 @@ from flocks.mcp.client import McpClient
 
 class TestMcpClientTransportSelection:
     @pytest.mark.asyncio
-    async def test_connect_uses_sse_only_when_transport_is_sse(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_connect_routes_remote_servers_to_remote_owner(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         calls: list[str] = []
 
-        async def fake_http(*args, **kwargs):
-            calls.append("http")
-
-        async def fake_sse(*args, **kwargs):
-            calls.append("sse")
-
-        client = McpClient(
-            name="demo",
-            server_type="remote",
-            url="https://example.com/sse",
-            transport="sse",
-        )
-        monkeypatch.setattr(client, "_do_connect_streamable_http", fake_http)
-        monkeypatch.setattr(client, "_do_connect_sse", fake_sse)
-
-        await client.connect()
-
-        assert calls == ["sse"]
-        assert client._transport_type == "sse"
-
-    @pytest.mark.asyncio
-    async def test_connect_uses_http_only_when_transport_is_http(self, monkeypatch: pytest.MonkeyPatch):
-        calls: list[str] = []
-
-        async def fake_http(*args, **kwargs):
-            calls.append("http")
-
-        async def fake_sse(*args, **kwargs):
-            calls.append("sse")
+        async def fake_remote(startup_future):
+            calls.append("remote")
+            startup_future.set_result(None)
 
         client = McpClient(
             name="demo",
             server_type="remote",
             url="https://example.com/mcp",
-            transport="http",
         )
-        monkeypatch.setattr(client, "_do_connect_streamable_http", fake_http)
-        monkeypatch.setattr(client, "_do_connect_sse", fake_sse)
+        monkeypatch.setattr(client, "_connect_remote", fake_remote)
 
         await client.connect()
 
-        assert calls == ["http"]
-        assert client._transport_type == "streamable_http"
+        assert calls == ["remote"]
 
     @pytest.mark.asyncio
-    async def test_connect_auto_falls_back_to_sse_after_http_failure(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_connect_routes_stdio_servers_to_local_owner(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         calls: list[str] = []
 
-        async def fake_http(*args, **kwargs):
-            calls.append("http")
-            raise RuntimeError("HTTP 405")
+        async def fake_local(startup_future):
+            calls.append("local")
+            startup_future.set_result(None)
 
-        async def fake_sse(*args, **kwargs):
-            calls.append("sse")
+        client = McpClient(
+            name="demo",
+            server_type="stdio",
+            command=["python", "-m", "demo"],
+        )
+        monkeypatch.setattr(client, "_connect_local", fake_local)
 
-        async def fake_cleanup():
-            return None
+        await client.connect()
 
+        assert calls == ["local"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_type_raises_value_error(self):
+        client = McpClient(
+            name="demo",
+            server_type="websocket",
+            url="wss://example.com",
+        )
+
+        with pytest.raises(ValueError, match="Unknown server type: websocket"):
+            await client.connect()
+
+    @pytest.mark.asyncio
+    async def test_failed_connect_cleans_up_owner_runtime_state(self):
+        client = McpClient(
+            name="demo",
+            server_type="websocket",
+            url="wss://example.com",
+        )
+
+        with pytest.raises(ValueError, match="Unknown server type: websocket"):
+            await client.connect()
+
+        assert client._connected is False
+        assert client._command_queue is None
+        assert client._owner_task is None
+        assert isinstance(client._owner_error, ValueError)
+
+    @pytest.mark.asyncio
+    async def test_already_connected_skips_new_owner_task(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         client = McpClient(
             name="demo",
             server_type="remote",
             url="https://example.com/mcp",
-            transport="auto",
         )
-        monkeypatch.setattr(client, "_do_connect_streamable_http", fake_http)
-        monkeypatch.setattr(client, "_do_connect_sse", fake_sse)
-        monkeypatch.setattr(client, "_cleanup_connection", fake_cleanup)
+        client._connected = True
+        fake_owner = AsyncMock()
+        monkeypatch.setattr(client, "_run_connection_owner", fake_owner)
 
         await client.connect()
 
-        assert calls == ["http", "sse"]
-        assert client._transport_type == "sse"
+        fake_owner.assert_not_called()

--- a/tests/mcp/test_mcp_client_sse.py
+++ b/tests/mcp/test_mcp_client_sse.py
@@ -1,220 +1,243 @@
-"""
-Tests for MCP Client SSE transport support
-
-Verifies that McpClient correctly handles:
-- remote / sse server type (auto-detect: Streamable HTTP -> SSE fallback)
-- Timeout does NOT fall back (avoids double wait)
-- Unknown server types (raises ValueError)
-- Error message extraction from ExceptionGroups
-"""
+"""Tests for MCP client remote transport lifecycle and fallback behavior."""
 
 import asyncio
+from contextlib import asynccontextmanager
+from types import MethodType, SimpleNamespace
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+
+import flocks.mcp.client as mcp_client_module
 from flocks.mcp.client import McpClient, _extract_root_cause
 
 
-class TestMcpClientServerTypes:
-    """Test McpClient server type routing"""
+def _make_session_class(
+    *,
+    events: dict[str, object] | None = None,
+    tool_result: object | None = None,
+    tools: list[object] | None = None,
+    resources: list[object] | None = None,
+):
+    class FakeSession:
+        def __init__(self, read_stream, write_stream):
+            self.read_stream = read_stream
+            self.write_stream = write_stream
 
-    def test_init_sse_type(self):
-        """SSE type should be accepted"""
-        client = McpClient(
-            name="test-sse",
-            server_type="sse",
-            url="https://example.com/sse",
-        )
-        assert client.server_type == "sse"
-        assert client.url == "https://example.com/sse"
+        async def __aenter__(self):
+            if events is not None:
+                events["session_enter_task"] = asyncio.current_task()
+            return self
 
-    def test_init_remote_type(self):
-        """Remote type should be accepted"""
-        client = McpClient(
-            name="test-remote",
-            server_type="remote",
-            url="https://example.com/mcp",
-        )
-        assert client.server_type == "remote"
+        async def __aexit__(self, exc_type, exc, tb):
+            if events is not None:
+                events["session_exit_task"] = asyncio.current_task()
+            return False
 
-    @pytest.mark.asyncio
-    async def test_unknown_type_raises_value_error(self):
-        """Unknown server type should raise ValueError"""
-        client = McpClient(
-            name="test-bad",
-            server_type="websocket",
-            url="wss://example.com",
-        )
-        with pytest.raises(ValueError, match="Unknown server type: websocket"):
-            await client.connect()
+        async def initialize(self):
+            return SimpleNamespace(protocolVersion="2026-05-12", serverInfo={"name": "demo"})
 
-    @pytest.mark.asyncio
-    async def test_sse_type_uses_auto_detect(self):
-        """SSE type should use _connect_remote (auto-detect) same as remote"""
-        client = McpClient(
-            name="test",
-            server_type="sse",
-            url="https://example.com/sse",
-        )
-        client._connect_remote = AsyncMock()
-        await client.connect()
-        client._connect_remote.assert_called_once()
+        async def list_tools(self):
+            return SimpleNamespace(tools=tools or [])
 
-    @pytest.mark.asyncio
-    async def test_remote_type_calls_connect_remote(self):
-        """Remote type should call _connect_remote"""
-        client = McpClient(
-            name="test",
-            server_type="remote",
-            url="https://example.com/mcp",
-        )
-        client._connect_remote = AsyncMock()
-        await client.connect()
-        client._connect_remote.assert_called_once()
+        async def call_tool(self, name, arguments):
+            if events is not None:
+                events["call_tool_task"] = asyncio.current_task()
+            if isinstance(tool_result, Exception):
+                raise tool_result
+            if tool_result is not None:
+                return tool_result
+            return {"name": name, "arguments": arguments}
 
-    @pytest.mark.asyncio
-    async def test_stdio_type_calls_connect_local(self):
-        """Stdio type attempts connection (raises RuntimeError on failure)"""
-        client = McpClient(
-            name="test",
-            server_type="stdio",
-            url=None,
-            command=["python", "-m", "some_server"],
-        )
-        # Stdio connection will fail since 'some_server' doesn't exist
-        with pytest.raises((NotImplementedError, RuntimeError)):
-            await client.connect()
+        async def list_resources(self):
+            return SimpleNamespace(resources=resources or [])
 
-    @pytest.mark.asyncio
-    async def test_already_connected_skips(self):
-        """Already connected client should skip reconnection"""
-        client = McpClient(
-            name="test",
-            server_type="sse",
-            url="https://example.com/sse",
-        )
-        client._connected = True
-        client._connect_remote = AsyncMock()
-        await client.connect()
-        client._connect_remote.assert_not_called()
+        async def read_resource(self, uri):
+            return {"uri": uri}
+
+    return FakeSession
+
+
+def _make_remote_transport_factory(
+    label: str,
+    *,
+    streams: tuple[object, ...] | None = None,
+    error: Exception | None = None,
+    events: dict[str, object] | None = None,
+    captures: list[tuple[str, str, dict | None]] | None = None,
+):
+    if streams is None:
+        if label == "http":
+            streams = ("read", "write", lambda: None)
+        else:
+            streams = ("read", "write")
+
+    @asynccontextmanager
+    async def factory(self, url, headers):
+        if captures is not None:
+            captures.append((label, url, headers))
+        if error is not None:
+            raise error
+        if events is not None:
+            events[f"{label}_enter_task"] = asyncio.current_task()
+        try:
+            yield streams
+        finally:
+            if events is not None:
+                events[f"{label}_exit_task"] = asyncio.current_task()
+
+    return factory
+
+
+def _bind_method(monkeypatch: pytest.MonkeyPatch, client: McpClient, name: str, method) -> None:
+    monkeypatch.setattr(client, name, MethodType(method, client))
 
 
 class TestMcpClientRemoteFallback:
-    """Test remote type fallback from Streamable HTTP to SSE"""
-
     @pytest.mark.asyncio
-    async def test_remote_falls_back_to_sse(self):
-        """Remote type should fall back to SSE when Streamable HTTP fails"""
+    async def test_remote_falls_back_to_sse(self, monkeypatch: pytest.MonkeyPatch):
         client = McpClient(
             name="test-remote",
             server_type="remote",
             url="https://mcp.example.com/mcp",
             timeout=10.0,
         )
+        monkeypatch.setattr(mcp_client_module, "ClientSession", _make_session_class())
 
-        # Mock _do_connect_streamable_http to fail
-        client._do_connect_streamable_http = AsyncMock(
-            side_effect=RuntimeError("Streamable HTTP not supported")
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_streamable_http_streams",
+            _make_remote_transport_factory("http", error=RuntimeError("HTTP failed")),
         )
-        # Mock _do_connect_sse to succeed
-        async def mark_connected(url, headers=None):
-            client._connected = True
-        client._do_connect_sse = AsyncMock(side_effect=mark_connected)
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_sse_streams",
+            _make_remote_transport_factory("sse"),
+        )
 
         await client.connect()
 
-        client._do_connect_streamable_http.assert_called_once()
-        client._do_connect_sse.assert_called_once()
         assert client._transport_type == "sse"
+        await client.disconnect()
 
     @pytest.mark.asyncio
-    async def test_remote_streamable_http_success_no_sse(self):
-        """Remote type should not try SSE if Streamable HTTP succeeds"""
+    async def test_remote_streamable_http_success_no_sse(self, monkeypatch: pytest.MonkeyPatch):
         client = McpClient(
             name="test-remote",
             server_type="remote",
             url="https://mcp.example.com/mcp",
             timeout=10.0,
         )
+        captures: list[tuple[str, str, dict | None]] = []
+        monkeypatch.setattr(mcp_client_module, "ClientSession", _make_session_class())
 
-        async def mark_connected(url, headers=None):
-            client._connected = True
-        client._do_connect_streamable_http = AsyncMock(side_effect=mark_connected)
-        client._do_connect_sse = AsyncMock()
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_streamable_http_streams",
+            _make_remote_transport_factory("http", captures=captures),
+        )
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_sse_streams",
+            _make_remote_transport_factory("sse", captures=captures),
+        )
 
         await client.connect()
 
-        client._do_connect_streamable_http.assert_called_once()
-        client._do_connect_sse.assert_not_called()
         assert client._transport_type == "streamable_http"
+        assert [label for label, _, _ in captures] == ["http"]
+        await client.disconnect()
 
     @pytest.mark.asyncio
-    async def test_remote_both_fail_raises(self):
-        """Remote type should raise RuntimeError if both transports fail"""
+    async def test_remote_both_fail_raises(self, monkeypatch: pytest.MonkeyPatch):
         client = McpClient(
             name="test-remote",
             server_type="remote",
             url="https://mcp.example.com/mcp",
             timeout=10.0,
         )
+        monkeypatch.setattr(mcp_client_module, "ClientSession", _make_session_class())
 
-        client._do_connect_streamable_http = AsyncMock(
-            side_effect=RuntimeError("HTTP failed")
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_streamable_http_streams",
+            _make_remote_transport_factory("http", error=RuntimeError("HTTP failed")),
         )
-        client._do_connect_sse = AsyncMock(
-            side_effect=RuntimeError("SSE failed")
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_sse_streams",
+            _make_remote_transport_factory("sse", error=RuntimeError("SSE failed")),
         )
 
         with pytest.raises(RuntimeError, match="Connection failed.*SSE failed"):
             await client.connect()
 
     @pytest.mark.asyncio
-    async def test_sse_type_also_tries_streamable_http_first(self):
-        """SSE type uses same auto-detect strategy as remote (Streamable HTTP first)"""
+    async def test_sse_type_also_tries_streamable_http_first(self, monkeypatch: pytest.MonkeyPatch):
         client = McpClient(
             name="test-sse",
             server_type="sse",
             url="https://mcp.example.com/mcp",
             timeout=10.0,
         )
+        captures: list[tuple[str, str, dict | None]] = []
+        monkeypatch.setattr(mcp_client_module, "ClientSession", _make_session_class())
 
-        async def mark_connected(url, headers=None):
-            client._connected = True
-        client._do_connect_streamable_http = AsyncMock(side_effect=mark_connected)
-        client._do_connect_sse = AsyncMock()
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_streamable_http_streams",
+            _make_remote_transport_factory("http", captures=captures),
+        )
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_sse_streams",
+            _make_remote_transport_factory("sse", captures=captures),
+        )
 
         await client.connect()
 
-        # "sse" and "remote" share the same auto-detect logic
-        client._do_connect_streamable_http.assert_called_once()
-        client._do_connect_sse.assert_not_called()
         assert client._transport_type == "streamable_http"
+        assert [label for label, _, _ in captures] == ["http"]
+        await client.disconnect()
 
     @pytest.mark.asyncio
-    async def test_timeout_does_not_fall_back(self):
-        """Streamable HTTP timeout should NOT fall back to SSE (avoids double wait)"""
+    async def test_timeout_does_not_fall_back(self, monkeypatch: pytest.MonkeyPatch):
         client = McpClient(
             name="test-timeout",
             server_type="remote",
             url="https://mcp.example.com/mcp",
             timeout=10.0,
         )
+        captures: list[tuple[str, str, dict | None]] = []
+        monkeypatch.setattr(mcp_client_module, "ClientSession", _make_session_class())
 
-        client._do_connect_streamable_http = AsyncMock(
-            side_effect=asyncio.TimeoutError()
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_streamable_http_streams",
+            _make_remote_transport_factory("http", error=asyncio.TimeoutError()),
         )
-        client._do_connect_sse = AsyncMock()
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_sse_streams",
+            _make_remote_transport_factory("sse", captures=captures),
+        )
 
         with pytest.raises(RuntimeError, match="Connection timeout"):
             await client.connect()
 
-        # SSE should NOT have been attempted
-        client._do_connect_sse.assert_not_called()
+        assert captures == []
         assert client._transport_type is None
 
     @pytest.mark.asyncio
-    async def test_remote_passes_resolved_headers_to_transports(self):
-        """Remote connection should pass config and auth headers to SDK transports"""
+    async def test_remote_passes_resolved_headers_to_transports(self, monkeypatch: pytest.MonkeyPatch):
         client = McpClient(
             name="test-headers",
             server_type="remote",
@@ -228,15 +251,21 @@ class TestMcpClientRemoteFallback:
             },
             timeout=10.0,
         )
+        captures: list[tuple[str, str, dict | None]] = []
+        monkeypatch.setattr(mcp_client_module, "ClientSession", _make_session_class())
 
-        client._do_connect_streamable_http = AsyncMock(
-            side_effect=RuntimeError("HTTP failed")
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_streamable_http_streams",
+            _make_remote_transport_factory("http", captures=captures, error=RuntimeError("HTTP failed")),
         )
-
-        async def mark_connected(url, headers):
-            client._connected = True
-
-        client._do_connect_sse = AsyncMock(side_effect=mark_connected)
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_sse_streams",
+            _make_remote_transport_factory("sse", captures=captures),
+        )
 
         await client.connect()
 
@@ -244,46 +273,104 @@ class TestMcpClientRemoteFallback:
             "Api-Key": "token123",
             "Authorization": "Bearer abc",
         }
-        client._do_connect_streamable_http.assert_called_once_with(
-            "https://mcp.example.com/mcp",
-            expected_headers,
+        assert captures == [
+            ("http", "https://mcp.example.com/mcp", expected_headers),
+            ("sse", "https://mcp.example.com/mcp", expected_headers),
+        ]
+        await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_streams_and_session_in_owner_task(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        client = McpClient(
+            name="test-owner",
+            server_type="remote",
+            url="https://mcp.example.com/mcp",
         )
-        client._do_connect_sse.assert_called_once_with(
-            "https://mcp.example.com/mcp",
-            expected_headers,
+        events: dict[str, object] = {}
+        monkeypatch.setattr(mcp_client_module, "ClientSession", _make_session_class(events=events))
+
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_streamable_http_streams",
+            _make_remote_transport_factory("http", events=events),
         )
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_sse_streams",
+            _make_remote_transport_factory("sse", events=events),
+        )
+
+        await client.connect()
+        await client.disconnect()
+
+        assert events["http_enter_task"] is events["http_exit_task"]
+        assert events["session_enter_task"] is events["session_exit_task"]
+
+    @pytest.mark.asyncio
+    async def test_call_tool_runs_through_owner_task(self, monkeypatch: pytest.MonkeyPatch):
+        client = McpClient(
+            name="test-call",
+            server_type="remote",
+            url="https://mcp.example.com/mcp",
+        )
+        events: dict[str, object] = {}
+        monkeypatch.setattr(
+            mcp_client_module,
+            "ClientSession",
+            _make_session_class(events=events),
+        )
+
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_streamable_http_streams",
+            _make_remote_transport_factory("http"),
+        )
+        _bind_method(
+            monkeypatch,
+            client,
+            "_create_sse_streams",
+            _make_remote_transport_factory("sse"),
+        )
+
+        await client.connect()
+        result = await client.call_tool("demo_tool", {"value": 1})
+        await client.disconnect()
+
+        assert result == {"name": "demo_tool", "arguments": {"value": 1}}
+        assert events["call_tool_task"] is events["session_enter_task"]
 
 
 class TestExtractRootCause:
-    """Test _extract_root_cause helper function"""
-
     def test_simple_exception(self):
-        """Simple exception returns its message"""
         assert _extract_root_cause(RuntimeError("simple error")) == "simple error"
 
     def test_exception_group(self):
-        """ExceptionGroup should unwrap to the root cause"""
         inner = RuntimeError("real error")
         group = ExceptionGroup("group", [inner])
         assert _extract_root_cause(group) == "real error"
 
     def test_nested_exception_group(self):
-        """Nested ExceptionGroups should be fully unwrapped"""
         inner = ValueError("deep error")
         group1 = ExceptionGroup("inner group", [inner])
         group2 = ExceptionGroup("outer group", [group1])
         assert _extract_root_cause(group2) == "deep error"
 
     def test_http_status_error(self):
-        """HTTP status errors should show status code"""
-        # Simulate httpx.HTTPStatusError
         class MockResponse:
             status_code = 401
+
         class MockRequest:
             url = "https://example.com/mcp?apikey=secret123"
+
         exc = Exception("HTTP error")
         exc.response = MockResponse()
         exc.request = MockRequest()
         result = _extract_root_cause(exc)
         assert "401" in result
-        assert "secret" not in result  # URL should be masked
+        assert "secret" not in result

--- a/tests/server/routes/test_route_timing.py
+++ b/tests/server/routes/test_route_timing.py
@@ -1,0 +1,53 @@
+import pytest
+
+from flocks.server.routes import _timing as timing_module
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.debug_calls: list[tuple[str, dict]] = []
+        self.info_calls: list[tuple[str, dict]] = []
+
+    def debug(self, message, extra=None) -> None:
+        self.debug_calls.append((message, extra or {}))
+
+    def info(self, message, extra=None) -> None:
+        self.info_calls.append((message, extra or {}))
+
+
+def test_log_route_timing_uses_debug_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = _Recorder()
+    monkeypatch.setattr(timing_module.time, "perf_counter", lambda: 100.2)
+
+    duration_ms = timing_module.log_route_timing(
+        logger,
+        "session.list.complete",
+        started_at=100.0,
+        extra={"count": 2},
+        slow_threshold_ms=300,
+    )
+
+    assert 199 <= duration_ms <= 200
+    assert logger.info_calls == []
+    assert logger.debug_calls == [
+        ("session.list.complete", {"duration_ms": duration_ms, "count": 2}),
+    ]
+
+
+def test_log_route_timing_uses_info_at_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = _Recorder()
+    monkeypatch.setattr(timing_module.time, "perf_counter", lambda: 200.3)
+
+    duration_ms = timing_module.log_route_timing(
+        logger,
+        "task.dashboard.complete",
+        started_at=200.0,
+        extra={"running": 1},
+        slow_threshold_ms=300,
+    )
+
+    assert 299 <= duration_ms <= 300
+    assert logger.debug_calls == []
+    assert logger.info_calls == [
+        ("task.dashboard.complete", {"duration_ms": duration_ms, "running": 1}),
+    ]

--- a/tui/tsconfig.json
+++ b/tui/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/bun/tsconfig.json",
   "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
     "jsx": "preserve",
     "jsxImportSource": "@opentui/solid",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -521,7 +521,7 @@ export default function SessionChat({
 
   const hasUserMessage = useMemo(() => messages.some((m) => m.role === 'user'), [messages]);
 
-  const sseEnabled = live || isStreaming || !hideInput;
+  const sseEnabled = Boolean(sessionId) && (live || isStreaming || !hideInput);
 
   const handleSSEEvent = useCallback(
     (event: SSEChatEvent) => {

--- a/webui/src/hooks/useTasks.ts
+++ b/webui/src/hooks/useTasks.ts
@@ -22,10 +22,11 @@ export function useTaskSchedulers(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const tasksRef = useRef<TaskScheduler[]>([]);
+  const initializedRef = useRef(false);
 
   const fetchTasks = useCallback(async () => {
     try {
-      setLoading(true);
+      if (!initializedRef.current) setLoading(true);
       setError(null);
       const response = await taskAPI.listSchedulers(filters);
       const data = response.data;
@@ -39,6 +40,7 @@ export function useTaskSchedulers(
       setTotal(0);
     } finally {
       setLoading(false);
+      initializedRef.current = true;
     }
   }, [
     filters?.status,
@@ -87,10 +89,11 @@ export function useTaskExecutions(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const tasksRef = useRef<TaskExecution[]>([]);
+  const initializedRef = useRef(false);
 
   const fetchTasks = useCallback(async () => {
     try {
-      setLoading(true);
+      if (!initializedRef.current) setLoading(true);
       setError(null);
       const response = await taskAPI.listExecutions(filters);
       const data = response.data;
@@ -104,6 +107,7 @@ export function useTaskExecutions(
       setTotal(0);
     } finally {
       setLoading(false);
+      initializedRef.current = true;
     }
   }, [
     filters?.status,
@@ -173,10 +177,11 @@ export function useTaskDashboard(options?: { pollInterval?: number }) {
   const [counts, setCounts] = useState<DashboardCounts | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const initializedRef = useRef(false);
 
   const fetchDashboard = useCallback(async () => {
     try {
-      setLoading(true);
+      if (!initializedRef.current) setLoading(true);
       setError(null);
       const response = await taskAPI.dashboard();
       setCounts(response.data);
@@ -184,6 +189,7 @@ export function useTaskDashboard(options?: { pollInterval?: number }) {
       setError(err.message || 'Failed to fetch dashboard');
     } finally {
       setLoading(false);
+      initializedRef.current = true;
     }
   }, []);
 
@@ -232,10 +238,11 @@ export function useQueueStatus(options?: { pollInterval?: number }) {
   const [queueStatus, setQueueStatus] = useState<QueueStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const initializedRef = useRef(false);
 
   const fetchQueueStatus = useCallback(async () => {
     try {
-      setLoading(true);
+      if (!initializedRef.current) setLoading(true);
       setError(null);
       const response = await taskAPI.queueStatus();
       setQueueStatus(response.data);
@@ -243,6 +250,7 @@ export function useQueueStatus(options?: { pollInterval?: number }) {
       setError(err.message || 'Failed to fetch queue status');
     } finally {
       setLoading(false);
+      initializedRef.current = true;
     }
   }, []);
 
@@ -263,10 +271,11 @@ export function useTaskSystemNotice() {
   const [notice, setNotice] = useState<TaskSystemNotice | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const initializedRef = useRef(false);
 
   const fetchNotice = useCallback(async () => {
     try {
-      setLoading(true);
+      if (!initializedRef.current) setLoading(true);
       setError(null);
       const response = await taskAPI.getSystemNotice();
       setNotice(response.data ?? null);
@@ -274,6 +283,7 @@ export function useTaskSystemNotice() {
       setError(err.message || 'Failed to fetch system notice');
     } finally {
       setLoading(false);
+      initializedRef.current = true;
     }
   }, []);
 

--- a/webui/src/hooks/useTools.test.tsx
+++ b/webui/src/hooks/useTools.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTools } from './useTools';
+
+const { listMock, refreshMock } = vi.hoisted(() => ({
+  listMock: vi.fn(),
+  refreshMock: vi.fn(),
+}));
+
+vi.mock('@/api/tool', () => ({
+  toolAPI: {
+    list: listMock,
+    refresh: refreshMock,
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('useTools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the tool list before the background refresh completes', async () => {
+    const refreshDeferred = deferred<{ data: { status: string } }>();
+
+    listMock.mockResolvedValue({
+      data: [
+        {
+          name: 'tool-alpha',
+          description: 'alpha tool',
+          category: 'custom',
+          source: 'custom',
+          enabled: true,
+        },
+      ],
+    });
+    refreshMock.mockReturnValue(refreshDeferred.promise);
+
+    const { result } = renderHook(() => useTools());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.tools).toHaveLength(1);
+    expect(result.current.tools[0].name).toBe('tool-alpha');
+    expect(listMock).toHaveBeenCalledTimes(1);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+
+    refreshDeferred.resolve({ data: { status: 'success' } });
+
+    await waitFor(() => {
+      expect(listMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/webui/src/hooks/useTools.ts
+++ b/webui/src/hooks/useTools.ts
@@ -6,17 +6,19 @@ export function useTools() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const lastRefreshRef = useRef(0);
+  const initializedRef = useRef(false);
 
   const fetchTools = useCallback(async (showLoading = false) => {
     try {
-      if (showLoading) setLoading(true);
+      if (showLoading && !initializedRef.current) setLoading(true);
       setError(null);
       const response = await toolAPI.list();
       setTools(Array.isArray(response.data) ? response.data : []);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch tools');
     } finally {
-      if (showLoading) setLoading(false);
+      if (showLoading && !initializedRef.current) setLoading(false);
+      initializedRef.current = true;
     }
   }, []);
 
@@ -31,18 +33,34 @@ export function useTools() {
   }, [fetchTools]);
 
   useEffect(() => {
+    let cancelled = false;
+
     const init = async () => {
-      try { await toolAPI.refresh(); } catch { /* ignore */ }
-      lastRefreshRef.current = Date.now();
       await fetchTools(true);
+      if (cancelled) return;
+
+      try {
+        await toolAPI.refresh();
+        if (cancelled) return;
+        lastRefreshRef.current = Date.now();
+        await fetchTools(false);
+      } catch {
+        /* ignore */
+      }
     };
-    init();
+
+    void init();
 
     const onVisible = () => {
-      if (document.visibilityState === 'visible') refreshAndFetch();
+      if (document.visibilityState === 'visible') {
+        void refreshAndFetch();
+      }
     };
     document.addEventListener('visibilitychange', onVisible);
-    return () => document.removeEventListener('visibilitychange', onVisible);
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [fetchTools, refreshAndFetch]);
 
   return {

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -264,6 +264,12 @@ describe('SessionPage session actions menu', () => {
     expect(global.confirm).toHaveBeenCalledWith('confirmDelete');
   });
 
+  it('does not auto-select the first session on initial load', () => {
+    renderSessionPage();
+
+    expect(screen.getByTestId('session-chat')).toHaveTextContent('no-session');
+  });
+
   it('syncs selected session when query param changes after mount', async () => {
     const user = userEvent.setup();
 
@@ -294,9 +300,7 @@ describe('SessionPage session actions menu', () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('session-chat')).toHaveTextContent('session-1');
-    });
+    expect(screen.getByTestId('session-chat')).toHaveTextContent('no-session');
 
     await user.click(screen.getByRole('button', { name: 'go-session-2' }));
 

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -99,13 +99,6 @@ export default function SessionPage() {
     }
   }, [searchParams, selectedSessionId, setSearchParams]);
 
-  // Auto select first session
-  useEffect(() => {
-    if (!selectedSessionId && sessions.length > 0) {
-      setSelectedSessionId(sessions[0].id);
-    }
-  }, [sessions, selectedSessionId]);
-
   // Close agent dropdown on outside click
   useEffect(() => {
     if (!showAgentOptions) return;
@@ -617,7 +610,7 @@ export default function SessionPage() {
         <SessionChat
           key={selectedSessionId ?? 'empty-session'}
           sessionId={selectedSessionId}
-          live
+          live={Boolean(selectedSessionId)}
           display={{ compact: false, showActions: true, showTimestamp: false }}
           agentName={selectedAgent}
           className="flex-1 min-h-0"

--- a/webui/src/pages/Task/index.tsx
+++ b/webui/src/pages/Task/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { ListTodo, Plus, Clock, Calendar, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import PageHeader from '@/components/common/PageHeader';
-import { useTaskDashboard, useQueueStatus, useTaskSystemNotice } from '@/hooks/useTasks';
+import { useTaskDashboard, useTaskSystemNotice } from '@/hooks/useTasks';
 import { DashboardCounts } from '@/api/task';
 import { DashboardCards } from './components';
 import QueuedSection from './QueuedSection';
@@ -24,11 +24,9 @@ export default function TaskPage() {
   const [sectionRefreshKey, setSectionRefreshKey] = useState(0);
 
   const { counts, refetch: refetchDashboard } = useTaskDashboard({ pollInterval: 15000 });
-  const { refetch: refetchQueue } = useQueueStatus({ pollInterval: 10000 });
   const { notice } = useTaskSystemNotice();
   const refreshGlobal = () => {
     refetchDashboard();
-    refetchQueue();
   };
 
   const forceRemountSections = () => {


### PR DESCRIPTION
## Summary

- **Server startup**: Run lifecycle work in timed phases with structured logs; schedule non-critical steps (MCP init, workflow sync, watchers, channel gateway, etc.) in the background; await/cancel background tasks on shutdown; emit `server.startup.ready` with blocking duration.
- **MCP / transport**: Keep startup-only fallback behavior for remote MCP transports, use a `streamable_http_client` read timeout of `300s` so long-running responses can stay open without changing the configured connect/setup timeout, remove the stale `_streams_context` state, and make stdio stderr capture close explicitly on all exit paths.
- **API observability**: Add duration/count logs for session list, tools list/refresh, and task dashboard/notice/queue routes; keep high-frequency route timings at `DEBUG` unless they exceed the slow-request threshold.
- **Workflow**: Export `sync_workflows_from_filesystem` for startup use.
- **WebUI**: Remove auto-select of the first session, so `/sessions` now opens in an empty state until the user picks a session; only enable live chat/SSE when a session is selected; improve `useTools` init/refresh ordering and cancellation; reduce loading flicker in task/tools polling hooks; simplify Task page refresh (drop redundant queue status refetch).
- **TUI**: Replace `extends` in `tsconfig.json` with explicit compiler options.
- **Tests**: Add `useTools` tests; update Session page tests for no default session selection; add coverage for route-timing log thresholds and stdio stderr cleanup.