### PR TITLE
chore: bump package version to v2026.5.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.5.9"
+version = "v2026.5.12"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.5.9"
+version = "2026.5.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Bump project version from `v2026.5.9` to `v2026.5.12` in `pyproject.toml` and sync `uv.lock`.

## Changes

- `pyproject.toml`: `version = "v2026.5.12"`
- `uv.lock`: flocks package version aligned to `2026.5.12`