### PR TITLE
Updater: npm install then ci fallback; export build_updated_frontend

### DIFF
--- a/flocks/cli/commands/update.py
+++ b/flocks/cli/commands/update.py
@@ -35,7 +35,7 @@ def update_command(
 
 
 async def _update(check: bool, yes: bool, force: bool = False, region: str | None = None) -> None:
-    from flocks.updater import check_update, perform_update, detect_deploy_mode
+    from flocks.updater import build_updated_frontend, check_update, perform_update, detect_deploy_mode
 
     if not yes and not check and region is None:
         use_cn_mirror = typer.confirm("\n是否使用中国镜像进行升级？", default=False)
@@ -93,13 +93,22 @@ async def _update(check: bool, yes: bool, force: bool = False, region: str | Non
             console.print("[yellow]已取消[/yellow]")
             return
 
+    from flocks.cli.service_manager import ServiceError, stop_all
+
+    try:
+        stop_all(console)
+    except ServiceError as error:
+        console.print(f"[red]执行 flocks stop 失败：{error}[/red]")
+        raise typer.Exit(1)
+
+    append_upgrade_text_log(f"OK cli_update_stopped_services_before_upgrade version={version_to_apply}")
+    console.print("[green]✓ 已执行 flocks stop[/green]")
     console.print()
     stage_labels = {
         "fetching":    "下载最新源码包",
         "backing_up":  "备份当前版本",
         "applying":    f"应用 v{info.latest_version}",
         "syncing":     "同步依赖",
-        "building":    "构建前端",
         "restarting":  "重启服务",
         "done":        "完成",
     }
@@ -132,9 +141,6 @@ async def _update(check: bool, yes: bool, force: bool = False, region: str | Non
 
         if progress.stage == "done":
             _finish_active(success=True)
-            step += 1
-            console.print(f"[cyan][{step}/{total_steps}] 完成[/cyan]  ", end="")
-            console.print("[green]✓[/green]")
             continue
 
         if progress.stage not in seen_stages:
@@ -145,9 +151,23 @@ async def _update(check: bool, yes: bool, force: bool = False, region: str | Non
             console.print(f"[cyan][{step}/{total_steps}] {label}...[/cyan]  ", end="")
             active_stage = progress.stage
 
+    step += 1
+    console.print(f"[cyan][{step}/{total_steps}] 构建前端...[/cyan]  ", end="")
+    try:
+        await build_updated_frontend(region=region)
+    except Exception as error:
+        console.print("[red]✗[/red]")
+        console.print(f"\n[red]✗ 前端构建失败：{error}[/red]")
+        raise typer.Exit(1)
+    console.print("[green]✓[/green]")
+
+    step += 1
+    console.print(f"[cyan][{step}/{total_steps}] 完成[/cyan]  ", end="")
+    console.print("[green]✓[/green]")
+
     append_upgrade_text_log(f"OK cli_update_completed version={version_to_apply}")
     console.print(f"\n[green]✓ 升级完成 → v{version_to_apply}[/green]")
-    console.print("[dim]如有后台服务正在运行，请执行 [bold]flocks restart[/bold] 重启服务[/dim]")
+    console.print("[dim]如需恢复服务，请执行 [bold]flocks start[/bold][/dim]")
 
 
 def _print_version_table(info) -> None:

--- a/flocks/updater/__init__.py
+++ b/flocks/updater/__init__.py
@@ -9,6 +9,7 @@ and replaces source files — no git binary required at runtime.
 from flocks.updater.deploy import DeployMode, detect_deploy_mode
 from flocks.updater.models import VersionInfo, UpdateProgress, UpdateStage
 from flocks.updater.updater import (
+    build_updated_frontend,
     check_update,
     get_current_version,
     get_latest_release,
@@ -21,6 +22,7 @@ __all__ = [
     "VersionInfo",
     "UpdateProgress",
     "UpdateStage",
+    "build_updated_frontend",
     "check_update",
     "get_current_version",
     "get_latest_release",

--- a/flocks/updater/models.py
+++ b/flocks/updater/models.py
@@ -12,7 +12,6 @@ UpdateStage = Literal[
     "backing_up",
     "applying",
     "syncing",
-    "building",
     "restarting",
     "done",
     "error",

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -411,37 +411,48 @@ async def _build_frontend_workspace(
         )
         return "Frontend dependency install failed: npm was not found."
 
-    install_label = "npm install"
+    has_package_lock = (webui_dir / "package-lock.json").exists()
+    install_subcommands = ["install"]
+    if has_package_lock:
+        install_subcommands.append("ci")
     final_frontend_error: str | None = None
 
     for index, candidate in enumerate(npm_candidates):
         attempt_source = candidate.source
         is_last_attempt = index == len(npm_candidates) - 1
-        install_cmd = [candidate.npm, "install"]
-        try:
-            code, _, err = await _run_async(
-                install_cmd,
-                cwd=webui_dir,
-                timeout=_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS,
-                env=candidate.env,
-            )
-        except subprocess.TimeoutExpired:
-            final_frontend_error = (
-                "Frontend dependency install timed out after "
-                f"{_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS}s while running {install_label}."
-            )
-            if is_last_attempt:
-                break
-            _reset_frontend_workspace(webui_dir)
-            _record_update_journal(
-                "WARN "
-                f"{final_frontend_error} Cleaned frontend workspace and retrying with fallback "
-                f"npm/node after {attempt_source} attempt."
-            )
-            continue
+        install_succeeded = False
+        for install_attempt_index, install_subcommand in enumerate(install_subcommands):
+            install_label = f"npm {install_subcommand}"
+            install_cmd = [candidate.npm, install_subcommand]
+            try:
+                code, _, err = await _run_async(
+                    install_cmd,
+                    cwd=webui_dir,
+                    timeout=_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS,
+                    env=candidate.env,
+                )
+            except subprocess.TimeoutExpired:
+                final_frontend_error = (
+                    "Frontend dependency install timed out after "
+                    f"{_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS}s while running {install_label}."
+                )
+            else:
+                if code == 0:
+                    install_succeeded = True
+                    final_frontend_error = None
+                    break
+                final_frontend_error = f"Frontend dependency install failed ({install_label}): {err}"
 
-        if code != 0:
-            final_frontend_error = f"Frontend dependency install failed ({install_label}): {err}"
+            has_same_candidate_fallback = install_attempt_index < len(install_subcommands) - 1
+            if has_same_candidate_fallback:
+                next_install_label = f"npm {install_subcommands[install_attempt_index + 1]}"
+                _record_update_journal(
+                    "WARN "
+                    f"{final_frontend_error} Retrying {next_install_label} "
+                    f"with the same npm/node after {attempt_source} {install_label} attempt."
+                )
+
+        if not install_succeeded:
             if is_last_attempt:
                 break
             _reset_frontend_workspace(webui_dir)

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -23,6 +23,7 @@ import sys
 import tarfile
 import tempfile
 import time
+import tomllib
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -59,7 +60,7 @@ _PRESERVE_NAMES: set[str] = {
     "node_modules",
     "logs",
     ".env",
-    "flocks.json",
+    ".git",
     "__pycache__",
 }
 
@@ -86,7 +87,7 @@ class UpdateMirrorProfile:
 
 @dataclass(frozen=True)
 class _FrontendNpmCandidate:
-    """A single npm launcher candidate for staged frontend rebuilds."""
+    """A single npm launcher candidate for frontend rebuilds."""
 
     npm: str
     env: dict[str, str] | None
@@ -386,12 +387,150 @@ def _build_frontend_subprocess_env(*, npm_registry: str | None = None) -> dict[s
     )
 
 
-def _reset_staged_frontend_workspace(staged_webui_dir: Path) -> None:
+def _reset_frontend_workspace(webui_dir: Path) -> None:
     """Remove transient frontend build artifacts before retrying another npm candidate."""
     for name in ("node_modules", "dist"):
-        target = staged_webui_dir / name
+        target = webui_dir / name
         if target.exists():
             _safe_remove(target)
+
+
+async def _build_frontend_workspace(
+    webui_dir: Path,
+    *,
+    npm_registry: str | None = None,
+) -> str | None:
+    """Install dependencies and build the frontend in the active install tree."""
+    npm_candidates = _resolve_frontend_npm_candidates(npm_registry=npm_registry)
+    if not npm_candidates:
+        log.warning(
+            "updater.frontend.npm_not_found",
+            {
+                "hint": ("Cannot build frontend during restart because npm was not found"),
+            },
+        )
+        return "Frontend dependency install failed: npm was not found."
+
+    install_label = "npm install"
+    final_frontend_error: str | None = None
+
+    for index, candidate in enumerate(npm_candidates):
+        attempt_source = candidate.source
+        is_last_attempt = index == len(npm_candidates) - 1
+        install_cmd = [candidate.npm, "install"]
+        try:
+            code, _, err = await _run_async(
+                install_cmd,
+                cwd=webui_dir,
+                timeout=_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS,
+                env=candidate.env,
+            )
+        except subprocess.TimeoutExpired:
+            final_frontend_error = (
+                "Frontend dependency install timed out after "
+                f"{_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS}s while running {install_label}."
+            )
+            if is_last_attempt:
+                break
+            _reset_frontend_workspace(webui_dir)
+            _record_update_journal(
+                "WARN "
+                f"{final_frontend_error} Cleaned frontend workspace and retrying with fallback "
+                f"npm/node after {attempt_source} attempt."
+            )
+            continue
+
+        if code != 0:
+            final_frontend_error = f"Frontend dependency install failed ({install_label}): {err}"
+            if is_last_attempt:
+                break
+            _reset_frontend_workspace(webui_dir)
+            _record_update_journal(
+                "WARN "
+                f"{final_frontend_error} Cleaned frontend workspace and retrying with fallback "
+                f"npm/node after {attempt_source} attempt."
+            )
+            continue
+
+        try:
+            code, _, err = await _run_async(
+                [candidate.npm, "run", "build"],
+                cwd=webui_dir,
+                timeout=_FRONTEND_BUILD_TIMEOUT_SECONDS,
+                env=candidate.env,
+            )
+        except subprocess.TimeoutExpired:
+            final_frontend_error = (
+                f"Frontend build timed out after {_FRONTEND_BUILD_TIMEOUT_SECONDS}s while running npm run build."
+            )
+            if is_last_attempt:
+                break
+            _reset_frontend_workspace(webui_dir)
+            _record_update_journal(
+                "WARN "
+                f"{final_frontend_error} Cleaned frontend workspace and retrying with fallback "
+                f"npm/node after {attempt_source} attempt."
+            )
+            continue
+
+        if code != 0:
+            final_frontend_error = f"Frontend build failed: {err}"
+            if is_last_attempt:
+                break
+            _reset_frontend_workspace(webui_dir)
+            _record_update_journal(
+                "WARN "
+                f"{final_frontend_error} Cleaned frontend workspace and retrying with fallback "
+                f"npm/node after {attempt_source} attempt."
+            )
+            continue
+
+        final_frontend_error = None
+        break
+
+    if final_frontend_error is not None:
+        return final_frontend_error
+
+    dist_index = webui_dir / "dist" / "index.html"
+    if not dist_index.exists():
+        return "Frontend build output is missing after npm run build."
+
+    return None
+
+
+async def build_updated_frontend(
+    *,
+    locale: str | None = None,
+    region: str | None = None,
+) -> None:
+    """Build the active install tree frontend after a non-restarting update."""
+    ucfg = await _get_updater_config()
+    profile = _resolve_update_mirror_profile(
+        ucfg.sources,
+        region=region,
+        locale=locale,
+    )
+    install_root = _get_repo_root()
+    webui_dir = install_root / "webui"
+    if not webui_dir.is_dir() or not (webui_dir / "package.json").exists():
+        return
+
+    frontend_error = await _build_frontend_workspace(
+        webui_dir,
+        npm_registry=profile.npm_registry,
+    )
+    if frontend_error is not None:
+        raise RuntimeError(frontend_error)
+
+
+async def _await_ignoring_cancellation(awaitable):
+    """Finish a post-handover critical step even if the SSE client disconnects."""
+    task = asyncio.create_task(awaitable)
+    while True:
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            log.warning("updater.restart.critical_step_cancelled_ignored")
 
 
 def _dependency_sync_timeout_seconds() -> int:
@@ -1071,21 +1210,19 @@ def _backup_current_version(
     """
     Compress the current install directory into ~/.flocks/version/ .
     Returns the backup path on success, None on failure.
-    Heavy directories (.venv, node_modules, ...) are excluded.
+    Preserved runtime/user directories are excluded.
     """
     _BACKUP_DIR.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
     backup_name = f"flocks-{current_version}-{ts}"
     backup_path = _BACKUP_DIR / f"{backup_name}.tar.gz"
 
-    exclude = {".venv", "node_modules", "__pycache__", ".git", "logs"}
-
     def _filter(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
         parts = info.name.split("/")
         for index, part in enumerate(parts):
-            if part in exclude:
+            if part in _PRESERVE_NAMES:
                 return None
-            if part == "dist" and parts[max(index - 1, 0)] != "webui":
+            if part == "dist":
                 return None
         return info
 
@@ -1738,44 +1875,40 @@ def _replace_install_dir(
 _VERSION_MARKER_PATH = _BACKUP_DIR / ".current_version"
 
 
+def _read_version_marker() -> str:
+    """Read the persisted installed version marker."""
+    try:
+        if _VERSION_MARKER_PATH.is_file():
+            return _VERSION_MARKER_PATH.read_text(encoding="utf-8").strip().lstrip("v")
+    except Exception:
+        pass
+    return ""
+
+
+def _read_pyproject_version() -> str:
+    """Read the source version from the repository pyproject.toml."""
+    try:
+        pyproject_path = _get_repo_root() / "pyproject.toml"
+        if not pyproject_path.is_file():
+            return ""
+        payload = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+        version = str(payload.get("project", {}).get("version", "")).strip()
+        return version.lstrip("v")
+    except Exception:
+        pass
+    return ""
+
+
 def get_current_version() -> str:
     """
     Return the running version.
-    Priority:
-      1. Version marker at ~/.flocks/version/.current_version — always
-         accurate after a download-based upgrade since local git tags
-         are no longer updated.
-      2. git describe --tags (works when installed from a git checkout).
-         If found, also persist it to the marker for future lookups.
-      3. importlib.metadata / pyproject.toml via flocks.__version__.
+    Compare the persisted marker at ~/.flocks/version/.current_version
+    with the source version in pyproject.toml and return the higher one.
     """
-    try:
-        if _VERSION_MARKER_PATH.is_file():
-            ver = _VERSION_MARKER_PATH.read_text(encoding="utf-8").strip()
-            if ver:
-                return ver.lstrip("v")
-    except Exception:
-        pass
-
-    try:
-        result = subprocess.run(
-            ["git", "describe", "--tags", "--abbrev=0"],
-            cwd=_get_repo_root(),
-            capture_output=True,
-            text=False,
-            timeout=3,
-        )
-        stdout = _clean_process_output(result.stdout)
-        if result.returncode == 0 and stdout:
-            ver = stdout.lstrip("v")
-            _write_version_marker(ver)
-            return ver
-    except Exception:
-        pass
-
-    from flocks import __version__
-
-    return __version__
+    return _pick_best_tag([
+        _read_version_marker(),
+        _read_pyproject_version(),
+    ])
 
 
 def _write_version_marker(version: str) -> None:
@@ -1998,126 +2131,13 @@ async def perform_update(
         return
 
     # ------------------------------------------------------------------ #
-    # Step 3 – prepare staged frontend
+    # Step 3 – determine whether frontend handover is needed
     # ------------------------------------------------------------------ #
     staged_webui_dir = content_root / "webui"
-    if staged_webui_dir.is_dir() and (staged_webui_dir / "package.json").exists():
-        npm_candidates = _resolve_frontend_npm_candidates(npm_registry=profile.npm_registry)
-        if npm_candidates:
-            install_subcommand = "ci" if (staged_webui_dir / "package-lock.json").exists() else "install"
-            install_label = f"npm {install_subcommand}"
-            final_frontend_error: str | None = None
-
-            for index, candidate in enumerate(npm_candidates):
-                attempt_source = candidate.source
-                is_last_attempt = index == len(npm_candidates) - 1
-
-                yield UpdateProgress(stage="building", message="Installing frontend dependencies...")
-                install_cmd = [candidate.npm, install_subcommand]
-                try:
-                    code, _, err = await _run_async(
-                        install_cmd,
-                        cwd=staged_webui_dir,
-                        timeout=_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS,
-                        env=candidate.env,
-                    )
-                except subprocess.TimeoutExpired:
-                    final_frontend_error = (
-                        "Frontend dependency install timed out after "
-                        f"{_FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS}s while running {install_label}."
-                    )
-                    if is_last_attempt:
-                        break
-                    _reset_staged_frontend_workspace(staged_webui_dir)
-                    _record_update_journal(
-                        "WARN "
-                        f"{final_frontend_error} Cleaned staged frontend workspace and retrying with fallback "
-                        f"npm/node after {attempt_source} attempt."
-                    )
-                    continue
-                if code != 0:
-                    final_frontend_error = f"Frontend dependency install failed ({install_label}): {err}"
-                    if is_last_attempt:
-                        break
-                    _reset_staged_frontend_workspace(staged_webui_dir)
-                    _record_update_journal(
-                        "WARN "
-                        f"{final_frontend_error} Cleaned staged frontend workspace and retrying with fallback "
-                        f"npm/node after {attempt_source} attempt."
-                    )
-                    continue
-
-                yield UpdateProgress(stage="building", message="Building frontend...")
-                try:
-                    code, _, err = await _run_async(
-                        [candidate.npm, "run", "build"],
-                        cwd=staged_webui_dir,
-                        timeout=_FRONTEND_BUILD_TIMEOUT_SECONDS,
-                        env=candidate.env,
-                    )
-                except subprocess.TimeoutExpired:
-                    final_frontend_error = (
-                        f"Frontend build timed out after {_FRONTEND_BUILD_TIMEOUT_SECONDS}s while running npm run build."
-                    )
-                    if is_last_attempt:
-                        break
-                    _reset_staged_frontend_workspace(staged_webui_dir)
-                    _record_update_journal(
-                        "WARN "
-                        f"{final_frontend_error} Cleaned staged frontend workspace and retrying with fallback "
-                        f"npm/node after {attempt_source} attempt."
-                    )
-                    continue
-                if code != 0:
-                    final_frontend_error = f"Frontend build failed: {err}"
-                    if is_last_attempt:
-                        break
-                    _reset_staged_frontend_workspace(staged_webui_dir)
-                    _record_update_journal(
-                        "WARN "
-                        f"{final_frontend_error} Cleaned staged frontend workspace and retrying with fallback "
-                        f"npm/node after {attempt_source} attempt."
-                    )
-                    continue
-
-                final_frontend_error = None
-                break
-
-            if final_frontend_error is not None:
-                shutil.rmtree(tmp_dir, ignore_errors=True)
-                _record_update_journal(f"ERROR {final_frontend_error}")
-                yield UpdateProgress(
-                    stage="error",
-                    message=final_frontend_error,
-                    success=False,
-                )
-                return
-        else:
-            log.warning(
-                "updater.frontend.npm_not_found",
-                {
-                    "hint": ("Cannot prebuild frontend during upgrade because npm was not found"),
-                },
-            )
-        dist_index = staged_webui_dir / "dist" / "index.html"
-        if not dist_index.exists():
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            _fe_miss = "Frontend build output is missing; upgrade aborted before cutover."
-            _record_update_journal(f"ERROR {_fe_miss}")
-            yield UpdateProgress(
-                stage="error",
-                message=_fe_miss,
-                success=False,
-            )
-            return
-
-    # ------------------------------------------------------------------ #
-    # Step 4 – determine whether frontend handover is needed
-    # ------------------------------------------------------------------ #
     needs_handover = staged_webui_dir.is_dir() and (staged_webui_dir / "package.json").exists()
 
     # ------------------------------------------------------------------ #
-    # Step 5 – replace install tree
+    # Step 4 – replace install tree
     # (Frontend proxy is still alive so the SSE stream keeps flowing.)
     # ------------------------------------------------------------------ #
     yield UpdateProgress(
@@ -2128,6 +2148,9 @@ async def perform_update(
     async def _restore_after_apply_failure() -> None:
         nonlocal handover_active
         if backup_path is None:
+            if handover_active:
+                await asyncio.to_thread(rollback_upgrade_handover)
+                handover_active = False
             return
         if handover_active:
             await asyncio.to_thread(
@@ -2184,7 +2207,7 @@ async def perform_update(
             return
 
     # ------------------------------------------------------------------ #
-    # Step 6 – sync dependencies
+    # Step 5 – sync dependencies
     # ------------------------------------------------------------------ #
     yield UpdateProgress(stage="syncing", message="Syncing dependencies...")
 
@@ -2315,14 +2338,14 @@ async def perform_update(
         log.warning("updater.refresh_cli.failed", {"error": str(exc)})
 
     # ------------------------------------------------------------------ #
-    # Step 7 – restart in-place (skipped when restart=False, e.g. CLI)
+    # Step 6 – restart in-place (skipped when restart=False, e.g. CLI)
     # Send the "restarting" event while the proxy is still alive, then
-    # perform the handover (kill frontend + start temp page) right
-    # before os.execv so the SSE stream is not broken prematurely.
+    # perform the handover, rebuild the frontend in the active install tree,
+    # and finally restart the service.
     #
-    # CRITICAL: handover + execv run SYNCHRONOUSLY (no await) so that
-    # CancelledError from client disconnect cannot interrupt between
-    # killing the Vite proxy and calling os.execv.
+    # CRITICAL: once handover starts we ignore client-disconnect cancellation
+    # until the build/restart sequence finishes, so the temporary upgrade page
+    # is not left behind half-way through cutover.
     # ------------------------------------------------------------------ #
     if not restart:
         yield UpdateProgress(
@@ -2372,6 +2395,41 @@ async def perform_update(
             handover_active = True
         except Exception as exc:
             log.error("updater.handover.failed", {"error": str(exc)})
+            await _restore_after_apply_failure()
+            yield UpdateProgress(
+                stage="error",
+                message=f"Failed to prepare WebUI handover: {exc}",
+                success=False,
+            )
+            return
+
+    install_webui_dir = install_root / "webui"
+    if install_webui_dir.is_dir() and (install_webui_dir / "package.json").exists():
+        if not handover_active:
+            frontend_error = "Refusing to rebuild frontend before WebUI handover completes."
+            _record_update_journal(f"ERROR {frontend_error}")
+            await _restore_after_apply_failure()
+            yield UpdateProgress(
+                stage="error",
+                message=frontend_error,
+                success=False,
+            )
+            return
+        frontend_error = await _await_ignoring_cancellation(
+            _build_frontend_workspace(
+                install_webui_dir,
+                npm_registry=profile.npm_registry,
+            )
+        )
+        if frontend_error is not None:
+            _record_update_journal(f"ERROR {frontend_error}")
+            await _await_ignoring_cancellation(_restore_after_apply_failure())
+            yield UpdateProgress(
+                stage="error",
+                message=frontend_error,
+                success=False,
+            )
+            return
 
     if sys.platform == "win32":
         log.info("updater.restart.spawn", {"argv": restart_argv})
@@ -2647,7 +2705,7 @@ def _resolve_system_npm_executable() -> str | None:
 
 
 def _resolve_frontend_npm_candidates(*, npm_registry: str | None = None) -> list[_FrontendNpmCandidate]:
-    """Resolve npm candidates for staged frontend rebuilds."""
+    """Resolve npm candidates for frontend rebuilds."""
     candidates: list[_FrontendNpmCandidate] = []
 
     bundled = _resolve_bundled_npm_executable()

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -18,6 +18,12 @@ async def _noop_log_init(**_: object) -> None:
     return None
 
 
+def test_updater_package_exports_build_updated_frontend() -> None:
+    from flocks.updater import updater as updater_module
+
+    assert updater_pkg.build_updated_frontend is updater_module.build_updated_frontend
+
+
 def test_update_cli_accepts_force_option(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
     monkeypatch.setattr(cli_main.Log, "init", _noop_log_init)

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -1,10 +1,13 @@
 from io import StringIO
 
+import pytest
+import typer
 from rich.console import Console
 from typer.testing import CliRunner
 
 import flocks.cli.commands.update as update_cmd
 import flocks.cli.main as cli_main
+import flocks.cli.service_manager as service_manager
 import flocks.updater as updater_pkg
 from flocks.updater.models import UpdateProgress, VersionInfo
 
@@ -46,6 +49,8 @@ def test_update_prompts_for_cn_mirror_before_upgrade_confirmation(monkeypatch) -
     check_regions: list[str | None] = []
     confirm_prompts: list[str] = []
     captured: dict[str, object] = {}
+    stop_calls: list[str] = []
+    build_calls: list[str | None] = []
     answers = iter([True, True])
 
     async def fake_check_update(*, locale: str | None = None, region: str | None = None) -> VersionInfo:
@@ -86,10 +91,18 @@ def test_update_prompts_for_cn_mirror_before_upgrade_confirmation(monkeypatch) -
         confirm_prompts.append(prompt)
         return next(answers)
 
+    def fake_stop_all(console) -> None:
+        stop_calls.append("stop")
+
+    async def fake_build_updated_frontend(*, locale: str | None = None, region: str | None = None) -> None:
+        build_calls.append(region)
+
     monkeypatch.setattr(updater_pkg, "check_update", fake_check_update)
     monkeypatch.setattr(updater_pkg, "perform_update", fake_perform_update)
+    monkeypatch.setattr(updater_pkg, "build_updated_frontend", fake_build_updated_frontend)
     monkeypatch.setattr(updater_pkg, "detect_deploy_mode", lambda: "source")
     monkeypatch.setattr(update_cmd.typer, "confirm", fake_confirm)
+    monkeypatch.setattr(service_manager, "stop_all", fake_stop_all)
 
     import asyncio
 
@@ -97,6 +110,8 @@ def test_update_prompts_for_cn_mirror_before_upgrade_confirmation(monkeypatch) -
 
     assert check_regions == ["cn"]
     assert confirm_prompts == ["\n是否使用中国镜像进行升级？", "\n是否立即升级？"]
+    assert stop_calls == ["stop"]
+    assert build_calls == ["cn"]
     assert captured == {
         "latest_tag": "2026.4.2",
         "zipball_url": "https://gitee.example.com/flocks.zip",
@@ -133,6 +148,8 @@ def test_update_force_reinstalls_latest_release_when_already_up_to_date(monkeypa
         )
 
     captured: dict[str, object] = {}
+    stop_calls: list[str] = []
+    build_calls: list[str | None] = []
 
     async def fake_perform_update(
         latest_tag: str,
@@ -151,9 +168,17 @@ def test_update_force_reinstalls_latest_release_when_already_up_to_date(monkeypa
         async for step in _fake_progress():
             yield step
 
+    def fake_stop_all(console) -> None:
+        stop_calls.append("stop")
+
+    async def fake_build_updated_frontend(*, locale: str | None = None, region: str | None = None) -> None:
+        build_calls.append(region)
+
     monkeypatch.setattr(updater_pkg, "check_update", fake_check_update)
     monkeypatch.setattr(updater_pkg, "perform_update", fake_perform_update)
+    monkeypatch.setattr(updater_pkg, "build_updated_frontend", fake_build_updated_frontend)
     monkeypatch.setattr(updater_pkg, "detect_deploy_mode", lambda: "source")
+    monkeypatch.setattr(service_manager, "stop_all", fake_stop_all)
 
     import asyncio
 
@@ -167,5 +192,121 @@ def test_update_force_reinstalls_latest_release_when_already_up_to_date(monkeypa
         "perform_region": "cn",
         "restart": False,
     }
+    assert stop_calls == ["stop"]
+    assert build_calls == ["cn"]
     assert "强制重新安装 v2026.4.2" in output.getvalue()
     assert "升级完成" in output.getvalue()
+
+
+def test_update_executes_flocks_stop_before_upgrade(monkeypatch) -> None:
+    output = StringIO()
+    monkeypatch.setattr(
+        update_cmd,
+        "console",
+        Console(file=output, force_terminal=False, color_system=None, width=120),
+    )
+
+    confirm_prompts: list[str] = []
+    answers = iter([False, True])
+    events: list[str] = []
+
+    async def fake_check_update(*, locale: str | None = None, region: str | None = None) -> VersionInfo:
+        return VersionInfo(
+            current_version="2026.4.1",
+            latest_version="2026.4.2",
+            has_update=True,
+            zipball_url="https://example.com/flocks.zip",
+            tarball_url="https://example.com/flocks.tar.gz",
+            deploy_mode="source",
+            update_allowed=True,
+        )
+
+    async def fake_perform_update(
+        latest_tag: str,
+        *,
+        zipball_url: str | None = None,
+        tarball_url: str | None = None,
+        restart: bool = True,
+        locale: str | None = None,
+        region: str | None = None,
+    ):
+        events.append("perform_update")
+        async for step in _fake_progress():
+            yield step
+
+    def fake_confirm(prompt: str, default: bool = False) -> bool:
+        confirm_prompts.append(prompt)
+        return next(answers)
+
+    def fake_stop_all(console) -> None:
+        events.append("stop")
+
+    async def fake_build_updated_frontend(*, locale: str | None = None, region: str | None = None) -> None:
+        events.append("build")
+
+    monkeypatch.setattr(updater_pkg, "check_update", fake_check_update)
+    monkeypatch.setattr(updater_pkg, "perform_update", fake_perform_update)
+    monkeypatch.setattr(updater_pkg, "build_updated_frontend", fake_build_updated_frontend)
+    monkeypatch.setattr(updater_pkg, "detect_deploy_mode", lambda: "source")
+    monkeypatch.setattr(update_cmd.typer, "confirm", fake_confirm)
+    monkeypatch.setattr(service_manager, "stop_all", fake_stop_all)
+
+    import asyncio
+
+    asyncio.run(update_cmd._update(check=False, yes=False, force=False, region=None))
+
+    assert confirm_prompts == ["\n是否使用中国镜像进行升级？", "\n是否立即升级？"]
+    assert events == ["stop", "perform_update", "build"]
+    assert "已执行 flocks stop" in output.getvalue()
+
+
+def test_update_reports_frontend_build_failure_after_common_upgrade(monkeypatch) -> None:
+    output = StringIO()
+    monkeypatch.setattr(
+        update_cmd,
+        "console",
+        Console(file=output, force_terminal=False, color_system=None, width=120),
+    )
+
+    async def fake_check_update(*, locale: str | None = None, region: str | None = None) -> VersionInfo:
+        return VersionInfo(
+            current_version="2026.4.1",
+            latest_version="2026.4.2",
+            has_update=True,
+            zipball_url="https://example.com/flocks.zip",
+            tarball_url="https://example.com/flocks.tar.gz",
+            deploy_mode="source",
+            update_allowed=True,
+        )
+
+    async def fake_perform_update(
+        latest_tag: str,
+        *,
+        zipball_url: str | None = None,
+        tarball_url: str | None = None,
+        restart: bool = True,
+        locale: str | None = None,
+        region: str | None = None,
+    ):
+        async for step in _fake_progress():
+            yield step
+
+    def fake_stop_all(console) -> None:
+        return None
+
+    async def fake_build_updated_frontend(*, locale: str | None = None, region: str | None = None) -> None:
+        raise RuntimeError("npm run build failed")
+
+    monkeypatch.setattr(updater_pkg, "check_update", fake_check_update)
+    monkeypatch.setattr(updater_pkg, "perform_update", fake_perform_update)
+    monkeypatch.setattr(updater_pkg, "build_updated_frontend", fake_build_updated_frontend)
+    monkeypatch.setattr(updater_pkg, "detect_deploy_mode", lambda: "source")
+    monkeypatch.setattr(service_manager, "stop_all", fake_stop_all)
+
+    import asyncio
+
+    with pytest.raises(typer.Exit) as excinfo:
+        asyncio.run(update_cmd._update(check=False, yes=True, force=False, region=None))
+
+    assert excinfo.value.exit_code == 1
+    assert "前端构建失败" in output.getvalue()

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1994,7 +1994,81 @@ async def test_perform_update_retries_windows_frontend_with_system_npm_after_bun
 
 
 @pytest.mark.asyncio
-async def test_perform_update_retries_windows_frontend_with_full_timeout_after_bundled_install_timeout(
+async def test_build_frontend_workspace_retries_npm_ci_before_switching_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    webui_dir = tmp_path / "webui"
+    webui_dir.mkdir()
+    (webui_dir / "package.json").write_text("{}", encoding="utf-8")
+    (webui_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    bundled_npm = str(tmp_path / "bundled-npm")
+    system_npm = str(tmp_path / "system-npm")
+    run_calls: list[tuple[list[str], dict[str, str] | None]] = []
+    journal_entries: list[str] = []
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        run_calls.append((list(cmd), env))
+        if cmd == [bundled_npm, "install"]:
+            partial_modules = webui_dir / "node_modules" / "@esbuild"
+            partial_modules.mkdir(parents=True, exist_ok=True)
+            return 1, "", "install failed"
+        if cmd == [bundled_npm, "ci"]:
+            assert (webui_dir / "node_modules").exists()
+            return 0, "", ""
+        if cmd == [bundled_npm, "run", "build"]:
+            dist_dir = webui_dir / "dist"
+            dist_dir.mkdir(exist_ok=True)
+            (dist_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(
+        updater,
+        "_resolve_frontend_npm_candidates",
+        lambda *, npm_registry=None: [
+            updater._FrontendNpmCandidate(
+                npm=bundled_npm,
+                env={"npm_config_registry": npm_registry} if npm_registry else None,
+                source="bundled",
+            ),
+            updater._FrontendNpmCandidate(
+                npm=system_npm,
+                env=None,
+                source="system",
+            ),
+        ],
+    )
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(updater, "_record_update_journal", journal_entries.append)
+
+    frontend_error = await updater._build_frontend_workspace(
+        webui_dir,
+        npm_registry="https://registry.npmmirror.com/",
+    )
+
+    assert frontend_error is None
+    assert [call[0] for call in run_calls] == [
+        [bundled_npm, "install"],
+        [bundled_npm, "ci"],
+        [bundled_npm, "run", "build"],
+    ]
+    assert all(
+        call[1] == {"npm_config_registry": "https://registry.npmmirror.com/"}
+        for call in run_calls
+    )
+    assert journal_entries == [
+        (
+            "WARN Frontend dependency install failed (npm install): install failed "
+            "Retrying npm ci with the same npm/node "
+            "after bundled npm install attempt."
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_perform_update_retries_windows_frontend_with_full_timeout_after_bundled_install_and_ci_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -2039,6 +2113,9 @@ async def test_perform_update_retries_windows_frontend_with_full_timeout_after_b
             bundled_modules = install_webui / "node_modules" / "@esbuild"
             bundled_modules.mkdir(parents=True, exist_ok=True)
             (bundled_modules / "bundled.txt").write_text("bundled", encoding="utf-8")
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+        if cmd == [str(bundled_npm), "ci"]:
+            assert (install_webui / "node_modules").exists()
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
         if cmd == [system_npm, "install"]:
             assert not (install_webui / "node_modules").exists()
@@ -2096,10 +2173,11 @@ async def test_perform_update_retries_windows_frontend_with_full_timeout_after_b
     ]
     assert [call[0] for call in frontend_calls] == [
         [str(bundled_npm), "install"],
+        [str(bundled_npm), "ci"],
         [system_npm, "install"],
         [system_npm, "run", "build"],
     ]
-    assert [call[1] for call in frontend_calls] == [300, 300, 300]
+    assert [call[1] for call in frontend_calls] == [300, 300, 300, 300]
 
 
 @pytest.mark.asyncio
@@ -2624,18 +2702,20 @@ async def test_perform_update_reports_frontend_dependency_install_timeout(
         lambda *_args, **_kwargs: events.append("replace")
         or shutil.copytree(staged_webui, install_webui, dirs_exist_ok=True),
     )
+    monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
     monkeypatch.setattr(updater, "_build_restart_argv", lambda install_root=None: ["/usr/bin/python3", "-m", "flocks.cli.main", "start"])
     monkeypatch.setattr(updater, "_rollback_failed_update", lambda *_args: events.append("rollback"))
 
     progresses = [step async for step in updater.perform_update("2026.4.1")]
 
     assert progresses[-1].stage == "error"
-    assert progresses[-1].message == "Frontend dependency install timed out after 300s while running npm install."
+    assert progresses[-1].message == "Frontend dependency install timed out after 300s while running npm ci."
     assert events == [
         "replace",
         "/usr/bin/uv sync",
         "handover",
         "/usr/bin/npm install",
+        "/usr/bin/npm ci",
         "rollback",
     ]
 

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -12,6 +12,13 @@ from flocks.cli import service_manager
 from flocks.updater import updater
 
 
+def _write_pyproject_version(pyproject_path: Path, version: str) -> None:
+    pyproject_path.write_text(
+        '[project]\nname = "flocks"\nversion = "' + version + '"\n',
+        encoding="utf-8",
+    )
+
+
 def test_run_handles_none_process_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     def fake_run(*args, **kwargs):
         return subprocess.CompletedProcess(args=args[0], returncode=0, stdout=None, stderr=None)
@@ -46,24 +53,50 @@ def test_run_replaces_invalid_windows_stderr_bytes(
     assert stderr == "failed�output"
 
 
-def test_get_current_version_replaces_invalid_git_bytes(
+def test_get_current_version_prefers_higher_marker_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(updater, "_VERSION_MARKER_PATH", tmp_path / ".current_version")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path)
+    _write_pyproject_version(tmp_path / "pyproject.toml", "v2026.4.1")
+    (tmp_path / ".current_version").write_text("2026.4.2\n", encoding="utf-8")
+
+    assert updater.get_current_version() == "2026.4.2"
+
+
+def test_get_current_version_prefers_higher_pyproject_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(updater, "_VERSION_MARKER_PATH", tmp_path / ".current_version")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path)
+    _write_pyproject_version(tmp_path / "pyproject.toml", "v2026.5.1")
+    (tmp_path / ".current_version").write_text("2026.4.1\n", encoding="utf-8")
+
+    assert updater.get_current_version() == "2026.5.1"
+
+
+def test_get_current_version_ignores_invalid_marker_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(updater, "_VERSION_MARKER_PATH", tmp_path / ".current_version")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path)
+    _write_pyproject_version(tmp_path / "pyproject.toml", "v2026.4.1")
+    (tmp_path / ".current_version").write_bytes(b"v2026.3.9\x93\n")
+
+    assert updater.get_current_version() == "2026.4.1"
+
+
+def test_get_current_version_returns_empty_when_no_marker_or_pyproject(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(updater, "_VERSION_MARKER_PATH", tmp_path / ".current_version")
     monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path)
 
-    def fake_run(*args, **kwargs):
-        return subprocess.CompletedProcess(
-            args=args[0],
-            returncode=0,
-            stdout=b"v2026.4.1\x93\n",
-            stderr=b"",
-        )
-
-    monkeypatch.setattr(updater.subprocess, "run", fake_run)
-
-    assert updater.get_current_version() == "2026.4.1�"
+    assert updater.get_current_version() == ""
 
 
 @pytest.mark.asyncio
@@ -1295,16 +1328,20 @@ def test_rollback_failed_update_clears_state_when_restore_and_frontend_both_fail
     assert updater._read_upgrade_state() is None
 
 
-def test_backup_current_version_preserves_webui_dist(
+def test_backup_current_version_excludes_all_dist_directories(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     install_root = tmp_path / "install"
     webui_dist = install_root / "webui" / "dist"
+    git_dir = install_root / ".git"
     other_dist = install_root / "dist"
     webui_dist.mkdir(parents=True)
+    git_dir.mkdir(parents=True)
     other_dist.mkdir(parents=True)
     (webui_dist / "index.html").write_text("<html>ok</html>", encoding="utf-8")
+    (git_dir / "HEAD").write_text("ref: refs/heads/main", encoding="utf-8")
+    (install_root / "flocks.json").write_text('{"keep": true}', encoding="utf-8")
     (other_dist / "ignored.txt").write_text("nope", encoding="utf-8")
     backup_dir = tmp_path / "backups"
 
@@ -1315,8 +1352,48 @@ def test_backup_current_version_preserves_webui_dist(
     with tarfile.open(backup_path, "r:gz") as tar:
         names = tar.getnames()
 
-    assert "flocks/webui/dist/index.html" in names
+    assert "flocks/webui/dist/index.html" not in names
+    assert "flocks/flocks.json" in names
+    assert "flocks/.git/HEAD" not in names
     assert "flocks/dist/ignored.txt" not in names
+
+
+@pytest.mark.asyncio
+async def test_build_updated_frontend_uses_current_install_root_and_region_mirror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    install_root = tmp_path / "install"
+    webui_dir = install_root / "webui"
+    webui_dir.mkdir(parents=True)
+    (webui_dir / "package.json").write_text("{}", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            sources=["github", "gitee"],
+        )
+
+    async def fake_build_frontend_workspace(
+        webui_dir: Path,
+        *,
+        npm_registry: str | None = None,
+    ) -> str | None:
+        captured["webui_dir"] = webui_dir
+        captured["npm_registry"] = npm_registry
+        return None
+
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: install_root)
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_build_frontend_workspace", fake_build_frontend_workspace)
+
+    await updater.build_updated_frontend(region="cn")
+
+    assert captured == {
+        "webui_dir": webui_dir,
+        "npm_registry": "https://registry.npmmirror.com/",
+    }
 
 
 def test_cleanup_old_backups_keeps_latest_only(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -1386,18 +1463,22 @@ def test_replace_install_dir_copies_dot_flocks_plugins_from_source(
     (inst_plugins / "obsolete_plugin" / "gone.yaml").parent.mkdir(parents=True)
     (inst_plugins / "obsolete_plugin" / "gone.yaml").write_text("removed", encoding="utf-8")
 
+    (source_dir / "flocks.json").write_text('{"version": "new"}', encoding="utf-8")
     (install_root / "flocks.json").write_text('{"keep": true}', encoding="utf-8")
+    (install_root / ".git").mkdir()
+    (install_root / ".git" / "HEAD").write_text("ref: refs/heads/main", encoding="utf-8")
 
     updater._replace_install_dir(source_dir, install_root)
 
     assert (inst_plugins / "fofa" / "_provider.yaml").read_text(encoding="utf-8") == "version: new"
     assert (inst_plugins / "new_release_plugin" / "tool.yaml").read_text(encoding="utf-8") == "name: new"
     assert not (inst_plugins / "obsolete_plugin").exists()
-    assert (install_root / "flocks.json").read_text(encoding="utf-8") == '{"keep": true}'
+    assert (install_root / "flocks.json").read_text(encoding="utf-8") == '{"version": "new"}'
+    assert (install_root / ".git" / "HEAD").read_text(encoding="utf-8") == "ref: refs/heads/main"
 
 
 @pytest.mark.asyncio
-async def test_perform_update_builds_staged_frontend_before_handover(
+async def test_perform_update_builds_current_frontend_after_handover(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1409,6 +1490,8 @@ async def test_perform_update_builds_staged_frontend_before_handover(
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
     (staged_webui / "dist").mkdir()
     (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
+    install_root = tmp_path / "install-root"
+    install_root.mkdir()
 
     events: list[str] = []
     async def fake_get_updater_config():
@@ -1443,7 +1526,7 @@ async def test_perform_update_builds_staged_frontend_before_handover(
         "_get_updater_config",
         fake_get_updater_config,
     )
-    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: install_root)
     monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
     monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
@@ -1458,7 +1541,8 @@ async def test_perform_update_builds_staged_frontend_before_handover(
     monkeypatch.setattr(
         updater,
         "_replace_install_dir",
-        lambda *_args, **_kwargs: events.append("replace"),
+        lambda *_args, **_kwargs: events.append("replace")
+        or shutil.copytree(staged_webui, install_root / "webui", dirs_exist_ok=True),
     )
     monkeypatch.setattr(updater, "_write_version_marker", lambda version: events.append(f"marker:{version}"))
     monkeypatch.setattr(updater, "_refresh_global_cli_entry", lambda _root: None)
@@ -1474,11 +1558,94 @@ async def test_perform_update_builds_staged_frontend_before_handover(
 
     assert progresses[-1].stage == "error"
     assert "Failed to restart service" in progresses[-1].message
-    assert events[:4] == ["npm-install", "npm-build", "replace", "uv-sync"]
+    assert events[:2] == ["replace", "uv-sync"]
     assert "marker:2026.4.1" in events
     assert "handover" in events
     assert events.index("handover") > events.index("uv-sync")
+    assert events.index("npm-install") > events.index("handover")
+    assert events.index("npm-build") > events.index("npm-install")
     assert "rollback_handover" in events
+
+
+@pytest.mark.asyncio
+async def test_perform_update_errors_when_handover_fails_before_frontend_build(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "flocks.zip"
+    archive_path.write_text("archive", encoding="utf-8")
+    staged_root = tmp_path / "staged"
+    staged_webui = staged_root / "webui"
+    staged_webui.mkdir(parents=True)
+    (staged_webui / "package.json").write_text("{}", encoding="utf-8")
+    (staged_webui / "dist").mkdir()
+    (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
+    install_root = tmp_path / "install-root"
+    install_root.mkdir()
+
+    events: list[str] = []
+
+    async def fake_get_updater_config():
+        return SimpleNamespace(
+            archive_format="zip",
+            sources=["github"],
+            repo="AgentFlocks/Flocks",
+            token=None,
+            gitee_token=None,
+            backup_retain_count=3,
+            base_url=None,
+            gitee_repo=None,
+        )
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        if cmd[1] == "install":
+            events.append("npm-install")
+        elif cmd[:3] == ["/usr/bin/npm", "run", "build"]:
+            events.append("npm-build")
+        else:
+            events.append("uv-sync")
+        return 0, "", ""
+
+    async def fake_download_with_fallback(**_kwargs):
+        return archive_path
+
+    async def fake_sleep(_seconds) -> None:
+        return None
+
+    monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: install_root)
+    monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
+    monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
+    monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
+    monkeypatch.setattr(updater, "_extract_archive", lambda *_args, **_kwargs: staged_root)
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+    monkeypatch.setattr(
+        updater,
+        "_find_executable",
+        lambda name: "/usr/bin/npm" if name in {"npm", "npm.cmd"} else "/usr/bin/uv",
+    )
+    monkeypatch.setattr(
+        updater,
+        "_replace_install_dir",
+        lambda *_args, **_kwargs: events.append("replace")
+        or shutil.copytree(staged_webui, install_root / "webui", dirs_exist_ok=True),
+    )
+    monkeypatch.setattr(updater, "_write_version_marker", lambda version: events.append(f"marker:{version}"))
+    monkeypatch.setattr(updater, "_refresh_global_cli_entry", lambda _root: None)
+    monkeypatch.setattr(updater, "_build_restart_argv", lambda install_root=None: ["/usr/bin/python3", "-m", "flocks.cli.main", "start"])
+    monkeypatch.setattr(updater.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        updater,
+        "_prepare_upgrade_handover",
+        lambda _version: (_ for _ in ()).throw(RuntimeError("handover boom")),
+    )
+    monkeypatch.setattr(updater, "_restore_backup_if_possible", lambda *_args: events.append("restore"))
+
+    progresses = [step async for step in updater.perform_update("2026.4.1")]
+
+    assert progresses[-1].stage == "error"
+    assert progresses[-1].message == "Failed to prepare WebUI handover: handover boom"
+    assert events == ["replace", "uv-sync", "marker:2026.4.1", "restore"]
 
 
 @pytest.mark.asyncio
@@ -1547,14 +1714,6 @@ async def test_perform_update_uses_cn_mirror_profile_for_sources_and_dependency_
     assert progresses[-1].stage == "done"
     assert captured["sources"] == ["gitee", "github"]
     assert run_calls == [
-        (
-            ["/usr/bin/npm", "ci"],
-            {"npm_config_registry": "https://registry.npmmirror.com/"},
-        ),
-        (
-            ["/usr/bin/npm", "run", "build"],
-            {"npm_config_registry": "https://registry.npmmirror.com/"},
-        ),
         (
             ["/usr/bin/uv", "sync", "--default-index", "https://mirrors.aliyun.com/pypi/simple"],
             None,
@@ -1632,6 +1791,8 @@ async def test_perform_update_prefers_bundled_npm_for_windows_frontend_rebuild(
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
     (staged_webui / "dist").mkdir()
     (staged_webui / "dist" / "index.html").write_text("<html></html>", encoding="utf-8")
+    install_root = tmp_path / "install-root"
+    install_root.mkdir()
 
     node_home = tmp_path / "tools" / "node"
     node_home.mkdir(parents=True)
@@ -1664,7 +1825,7 @@ async def test_perform_update_prefers_bundled_npm_for_windows_frontend_rebuild(
         return None
 
     monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
-    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: install_root)
     monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
     monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
@@ -1673,22 +1834,33 @@ async def test_perform_update_prefers_bundled_npm_for_windows_frontend_rebuild(
     monkeypatch.setattr(updater, "_find_executable", lambda name: r"C:\Users\flocks\AppData\Local\Programs\Flocks\tools\uv\uv.exe" if name == "uv" else None)
     monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
     monkeypatch.setattr(updater, "_validate_windows_restart_runtime", fake_validate_windows_restart_runtime)
-    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        updater,
+        "_replace_install_dir",
+        lambda *_args, **_kwargs: shutil.copytree(staged_webui, install_root / "webui", dirs_exist_ok=True),
+    )
     monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
     monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setattr(updater, "_prepare_upgrade_handover", lambda _version: None)
+    monkeypatch.setattr(updater, "_build_restart_argv", lambda install_root=None: [r"C:\tool\python.exe", "-m", "flocks.cli.main", "start"])
+    monkeypatch.setattr(updater.subprocess, "Popen", lambda *_args, **_kwargs: SimpleNamespace(pid=4321))
+    monkeypatch.setattr(updater.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
     monkeypatch.setenv("FLOCKS_NODE_HOME", str(node_home))
     monkeypatch.delenv("FLOCKS_INSTALL_ROOT", raising=False)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
-    progresses = [step async for step in updater.perform_update("2026.4.1", restart=False, locale="zh-CN")]
-
-    assert progresses[-1].stage == "done"
-    assert [call[0] for call in run_calls[:2]] == [
+    with pytest.raises(SystemExit, match="0"):
+        async for _step in updater.perform_update("2026.4.1", locale="zh-CN"):
+            pass
+    frontend_calls = [
+        call for call in run_calls if call[0][0] == str(bundled_npm)
+    ]
+    assert [call[0] for call in frontend_calls] == [
         [str(bundled_npm), "install"],
         [str(bundled_npm), "run", "build"],
     ]
-    install_env = run_calls[0][1]
-    build_env = run_calls[1][1]
+    install_env = frontend_calls[0][1]
+    build_env = frontend_calls[1][1]
     assert install_env is not None
     assert build_env is not None
     assert install_env["npm_config_registry"] == "https://registry.npmmirror.com/"
@@ -1708,6 +1880,9 @@ async def test_perform_update_retries_windows_frontend_with_system_npm_after_bun
     staged_webui = staged_root / "webui"
     staged_webui.mkdir(parents=True)
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
+    install_root = tmp_path / "install-root"
+    install_root.mkdir()
+    install_webui = install_root / "webui"
 
     node_home = tmp_path / "tools" / "node"
     node_home.mkdir(parents=True)
@@ -1736,21 +1911,21 @@ async def test_perform_update_retries_windows_frontend_with_system_npm_after_bun
     async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
         run_calls.append((list(cmd), timeout, env))
         if cmd == [str(bundled_npm), "install"]:
-            bundled_modules = staged_webui / "node_modules" / "@esbuild"
+            bundled_modules = install_webui / "node_modules" / "@esbuild"
             bundled_modules.mkdir(parents=True, exist_ok=True)
             (bundled_modules / "bundled.txt").write_text("bundled", encoding="utf-8")
             return 0, "", ""
         if cmd == [str(bundled_npm), "run", "build"]:
-            stale_dist = staged_webui / "dist"
+            stale_dist = install_webui / "dist"
             stale_dist.mkdir(exist_ok=True)
             (stale_dist / "stale.txt").write_text("stale", encoding="utf-8")
             return 1, "", "bundled build failed"
         if cmd == [system_npm, "install"]:
-            assert not (staged_webui / "node_modules").exists()
-            assert not (staged_webui / "dist").exists()
+            assert not (install_webui / "node_modules").exists()
+            assert not (install_webui / "dist").exists()
             return 0, "", ""
         if cmd == [system_npm, "run", "build"]:
-            dist_dir = staged_webui / "dist"
+            dist_dir = install_webui / "dist"
             dist_dir.mkdir(exist_ok=True)
             (dist_dir / "index.html").write_text("<html></html>", encoding="utf-8")
             return 0, "", ""
@@ -1769,7 +1944,7 @@ async def test_perform_update_retries_windows_frontend_with_system_npm_after_bun
         return None
 
     monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
-    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: install_root)
     monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
     monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
@@ -1778,16 +1953,24 @@ async def test_perform_update_retries_windows_frontend_with_system_npm_after_bun
     monkeypatch.setattr(updater, "_find_executable", fake_find)
     monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
     monkeypatch.setattr(updater, "_validate_windows_restart_runtime", fake_validate_windows_restart_runtime)
-    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        updater,
+        "_replace_install_dir",
+        lambda *_args, **_kwargs: shutil.copytree(staged_webui, install_webui, dirs_exist_ok=True),
+    )
     monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
     monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setattr(updater, "_prepare_upgrade_handover", lambda _version: None)
+    monkeypatch.setattr(updater, "_build_restart_argv", lambda install_root=None: [r"C:\tool\python.exe", "-m", "flocks.cli.main", "start"])
+    monkeypatch.setattr(updater.subprocess, "Popen", lambda *_args, **_kwargs: SimpleNamespace(pid=4321))
+    monkeypatch.setattr(updater.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
     monkeypatch.setenv("FLOCKS_NODE_HOME", str(node_home))
     monkeypatch.delenv("FLOCKS_INSTALL_ROOT", raising=False)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
-    progresses = [step async for step in updater.perform_update("2026.4.1", restart=False, locale="zh-CN")]
-
-    assert progresses[-1].stage == "done"
+    with pytest.raises(SystemExit, match="0"):
+        async for _step in updater.perform_update("2026.4.1", locale="zh-CN"):
+            pass
     frontend_calls = [
         call for call in run_calls if call[0][0] in {str(bundled_npm), system_npm}
     ]
@@ -1822,6 +2005,9 @@ async def test_perform_update_retries_windows_frontend_with_full_timeout_after_b
     staged_webui.mkdir(parents=True)
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
     (staged_webui / "package-lock.json").write_text("{}", encoding="utf-8")
+    install_root = tmp_path / "install-root"
+    install_root.mkdir()
+    install_webui = install_root / "webui"
 
     node_home = tmp_path / "tools" / "node"
     node_home.mkdir(parents=True)
@@ -1849,17 +2035,17 @@ async def test_perform_update_retries_windows_frontend_with_full_timeout_after_b
 
     async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
         run_calls.append((list(cmd), timeout, env))
-        if cmd == [str(bundled_npm), "ci"]:
-            bundled_modules = staged_webui / "node_modules" / "@esbuild"
+        if cmd == [str(bundled_npm), "install"]:
+            bundled_modules = install_webui / "node_modules" / "@esbuild"
             bundled_modules.mkdir(parents=True, exist_ok=True)
             (bundled_modules / "bundled.txt").write_text("bundled", encoding="utf-8")
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
-        if cmd == [system_npm, "ci"]:
-            assert not (staged_webui / "node_modules").exists()
-            assert not (staged_webui / "dist").exists()
+        if cmd == [system_npm, "install"]:
+            assert not (install_webui / "node_modules").exists()
+            assert not (install_webui / "dist").exists()
             return 0, "", ""
         if cmd == [system_npm, "run", "build"]:
-            dist_dir = staged_webui / "dist"
+            dist_dir = install_webui / "dist"
             dist_dir.mkdir(exist_ok=True)
             (dist_dir / "index.html").write_text("<html></html>", encoding="utf-8")
             return 0, "", ""
@@ -1878,7 +2064,7 @@ async def test_perform_update_retries_windows_frontend_with_full_timeout_after_b
         return None
 
     monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
-    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: install_root)
     monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
     monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
@@ -1887,22 +2073,30 @@ async def test_perform_update_retries_windows_frontend_with_full_timeout_after_b
     monkeypatch.setattr(updater, "_find_executable", fake_find)
     monkeypatch.setattr(updater, "_build_uv_sync_env", lambda: None)
     monkeypatch.setattr(updater, "_validate_windows_restart_runtime", fake_validate_windows_restart_runtime)
-    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        updater,
+        "_replace_install_dir",
+        lambda *_args, **_kwargs: shutil.copytree(staged_webui, install_webui, dirs_exist_ok=True),
+    )
     monkeypatch.setattr(updater, "_write_version_marker", lambda _v: None)
     monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setattr(updater, "_prepare_upgrade_handover", lambda _version: None)
+    monkeypatch.setattr(updater, "_build_restart_argv", lambda install_root=None: [r"C:\tool\python.exe", "-m", "flocks.cli.main", "start"])
+    monkeypatch.setattr(updater.subprocess, "Popen", lambda *_args, **_kwargs: SimpleNamespace(pid=4321))
+    monkeypatch.setattr(updater.os, "_exit", lambda code: (_ for _ in ()).throw(SystemExit(code)))
     monkeypatch.setenv("FLOCKS_NODE_HOME", str(node_home))
     monkeypatch.delenv("FLOCKS_INSTALL_ROOT", raising=False)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
-    progresses = [step async for step in updater.perform_update("2026.4.1", restart=False, locale="zh-CN")]
-
-    assert progresses[-1].stage == "done"
+    with pytest.raises(SystemExit, match="0"):
+        async for _step in updater.perform_update("2026.4.1", locale="zh-CN"):
+            pass
     frontend_calls = [
         call for call in run_calls if call[0][0] in {str(bundled_npm), system_npm}
     ]
     assert [call[0] for call in frontend_calls] == [
-        [str(bundled_npm), "ci"],
-        [system_npm, "ci"],
+        [str(bundled_npm), "install"],
+        [system_npm, "install"],
         [system_npm, "run", "build"],
     ]
     assert [call[1] for call in frontend_calls] == [300, 300, 300]
@@ -2285,7 +2479,7 @@ async def test_perform_update_rolls_back_when_replace_fails_on_windows_locked_fi
 
     assert progresses[-1].stage == "error"
     assert "WinError 5" in progresses[-1].message
-    assert events == ["npm-install", "npm-build", "restore"]
+    assert events == ["restore"]
     assert "handover" not in events
 
 
@@ -2363,8 +2557,6 @@ async def test_perform_update_retries_after_windows_file_lock_and_rolls_back_han
     assert progresses[-1].stage == "error"
     assert progresses[-1].message == "No module named uvicorn"
     assert events == [
-        "npm-install",
-        "npm-build",
         "replace-1",
         "handover",
         "replace-2",
@@ -2386,6 +2578,9 @@ async def test_perform_update_reports_frontend_dependency_install_timeout(
     staged_webui.mkdir(parents=True)
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
     (staged_webui / "package-lock.json").write_text("{}", encoding="utf-8")
+    install_root = tmp_path / "install-root"
+    install_root.mkdir()
+    install_webui = install_root / "webui"
 
     events: list[str] = []
 
@@ -2406,10 +2601,12 @@ async def test_perform_update_reports_frontend_dependency_install_timeout(
 
     async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
         events.append(" ".join(cmd))
+        if "sync" in cmd:
+            return 0, "", ""
         raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
 
     monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
-    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: install_root)
     monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
     monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
@@ -2421,17 +2618,30 @@ async def test_perform_update_reports_frontend_dependency_install_timeout(
         lambda name: "/usr/bin/npm" if name in {"npm", "npm.cmd"} else "/usr/bin/uv",
     )
     monkeypatch.setattr(updater, "_prepare_upgrade_handover", lambda _version: events.append("handover") or {})
-    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: events.append("replace"))
+    monkeypatch.setattr(
+        updater,
+        "_replace_install_dir",
+        lambda *_args, **_kwargs: events.append("replace")
+        or shutil.copytree(staged_webui, install_webui, dirs_exist_ok=True),
+    )
+    monkeypatch.setattr(updater, "_build_restart_argv", lambda install_root=None: ["/usr/bin/python3", "-m", "flocks.cli.main", "start"])
+    monkeypatch.setattr(updater, "_rollback_failed_update", lambda *_args: events.append("rollback"))
 
     progresses = [step async for step in updater.perform_update("2026.4.1")]
 
     assert progresses[-1].stage == "error"
-    assert progresses[-1].message == "Frontend dependency install timed out after 300s while running npm ci."
-    assert events == ["/usr/bin/npm ci"]
+    assert progresses[-1].message == "Frontend dependency install timed out after 300s while running npm install."
+    assert events == [
+        "replace",
+        "/usr/bin/uv sync",
+        "handover",
+        "/usr/bin/npm install",
+        "rollback",
+    ]
 
 
 @pytest.mark.asyncio
-async def test_perform_update_does_not_handover_when_staged_frontend_build_fails(
+async def test_perform_update_rolls_back_handover_when_current_frontend_build_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -2441,6 +2651,9 @@ async def test_perform_update_does_not_handover_when_staged_frontend_build_fails
     staged_webui = staged_root / "webui"
     staged_webui.mkdir(parents=True)
     (staged_webui / "package.json").write_text("{}", encoding="utf-8")
+    install_root = tmp_path / "install-root"
+    install_root.mkdir()
+    install_webui = install_root / "webui"
 
     events: list[str] = []
     async def fake_get_updater_config():
@@ -2463,7 +2676,7 @@ async def test_perform_update_does_not_handover_when_staged_frontend_build_fails
         "_get_updater_config",
         fake_get_updater_config,
     )
-    monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
+    monkeypatch.setattr(updater, "_get_repo_root", lambda: install_root)
     monkeypatch.setattr(updater, "get_current_version", lambda: "2026.3.31")
     monkeypatch.setattr(updater, "_download_with_fallback", fake_download_with_fallback)
     monkeypatch.setattr(updater, "_backup_current_version", lambda *_args, **_kwargs: tmp_path / "backup.tar.gz")
@@ -2476,7 +2689,7 @@ async def test_perform_update_does_not_handover_when_staged_frontend_build_fails
         if cmd[1] == "install":
             events.append("npm-install")
             return 0, "", ""
-        events.append("unexpected")
+        events.append("uv-sync")
         return 0, "", ""
 
     monkeypatch.setattr(updater, "_run_async", fake_run_async)
@@ -2486,12 +2699,20 @@ async def test_perform_update_does_not_handover_when_staged_frontend_build_fails
         lambda name: "/usr/bin/npm" if name in {"npm", "npm.cmd"} else "/usr/bin/uv",
     )
     monkeypatch.setattr(updater, "_prepare_upgrade_handover", lambda _version: events.append("handover") or {})
-    monkeypatch.setattr(updater, "_replace_install_dir", lambda *_args, **_kwargs: events.append("replace"))
+    monkeypatch.setattr(
+        updater,
+        "_replace_install_dir",
+        lambda *_args, **_kwargs: events.append("replace")
+        or shutil.copytree(staged_webui, install_webui, dirs_exist_ok=True),
+    )
+    monkeypatch.setattr(updater, "_build_restart_argv", lambda install_root=None: ["/usr/bin/python3", "-m", "flocks.cli.main", "start"])
+    monkeypatch.setattr(updater, "_rollback_failed_update", lambda *_args: events.append("rollback"))
 
     progresses = [step async for step in updater.perform_update("2026.4.1")]
 
     assert progresses[-1].stage == "error"
-    assert events == ["npm-install", "npm-build"]
+    assert progresses[-1].message == "Frontend build failed: boom"
+    assert events == ["replace", "uv-sync", "handover", "npm-install", "npm-build", "rollback"]
 
 
 @pytest.mark.asyncio

--- a/webui/src/api/update.ts
+++ b/webui/src/api/update.ts
@@ -4,7 +4,7 @@ import client from './client';
 // Types
 // ======================================================================
 
-export type UpdateStage = 'fetching' | 'backing_up' | 'applying' | 'syncing' | 'building' | 'restarting' | 'done' | 'error';
+export type UpdateStage = 'fetching' | 'backing_up' | 'applying' | 'syncing' | 'restarting' | 'done' | 'error';
 
 export type DeployMode = 'docker' | 'source';
 

--- a/webui/src/locales/en-US/update.json
+++ b/webui/src/locales/en-US/update.json
@@ -30,7 +30,6 @@
     "backing_up": "Backing up current version",
     "applying": "Applying new version",
     "syncing": "Syncing backend dependencies",
-    "building": "Building frontend",
     "restarting": "Restarting service",
     "done": "Done",
     "error": "Error"

--- a/webui/src/locales/zh-CN/update.json
+++ b/webui/src/locales/zh-CN/update.json
@@ -30,7 +30,6 @@
     "backing_up": "备份当前版本",
     "applying": "应用新版本",
     "syncing": "同步后端依赖",
-    "building": "编译前端",
     "restarting": "重启服务",
     "done": "完成",
     "error": "出错"


### PR DESCRIPTION
## Summary

- When `webui/package-lock.json` exists, frontend dependency install tries `npm install` first, then `npm ci` on the same npm/node candidate before resetting the workspace and falling back to the next candidate.
- Export `build_updated_frontend` from `flocks.updater` (`__init__.py`) for a stable public API.
- Tests: new coverage for install→ci retry, updated Windows timeout and install-timeout expectations.