### PR TITLE
fix(tools): align OneSEC v2.8.2 connectivity probe with handler

### DIFF
--- a/.flocks/plugins/tools/api/onesec_v2_8_2/_test.yaml
+++ b/.flocks/plugins/tools/api/onesec_v2_8_2/_test.yaml
@@ -2,12 +2,13 @@ schema_version: 1
 provider: onesec_api
 
 # Service-level connectivity probe.
-# `dns_get_public_ip_list` is a lightweight GET with no required params
-# that verifies both base_url reachability and HMAC credential signing.
+# `threat_query_bd_version` is a lightweight read-only call with no required
+# params. It keeps the probe focused on basic auth/reachability, matching the
+# handler's built-in OneSEC connectivity action selection.
 connectivity:
-  tool: onesec_dns
+  tool: onesec_threat
   params:
-    action: dns_get_public_ip_list
+    action: threat_query_bd_version
 
 # Tool-level test samples shown in the WebUI ToolDetailDrawer drop-down.
 # `label` is the default (English) display string; `label_cn` is the

--- a/tests/tool/test_probe_loader.py
+++ b/tests/tool/test_probe_loader.py
@@ -233,6 +233,13 @@ class TestConnectivityParsing:
         assert spec.tool == "ngtip_query"
         assert not hasattr(spec, "success_when")
 
+    def test_onesec_manifest_uses_threat_connectivity_probe(self):
+        spec = get_connectivity_spec("onesec_api_v2_8_2")
+
+        assert spec is not None
+        assert spec.tool == "onesec_threat"
+        assert spec.params == {"action": "threat_query_bd_version"}
+
 
 class TestFixtureParsing:
     def setup_method(self):


### PR DESCRIPTION
## Summary
- Switch `onesec_api_v2_8_2` manifest connectivity probe from `onesec_dns` / `dns_get_public_ip_list` to `onesec_threat` / `threat_query_bd_version` so it matches the handler's built-in OneSEC connectivity action and stays a lightweight read-only call.
- Add a unit test asserting the parsed connectivity spec for `onesec_api_v2_8_2`.