### PR TITLE
fix(webui): harden agents and workflow list hooks on errors

### DIFF
--- a/webui/src/hooks/useAgents.test.tsx
+++ b/webui/src/hooks/useAgents.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAgents } from './useAgents';
+
+const { listMock } = vi.hoisted(() => ({
+  listMock: vi.fn(),
+}));
+
+vi.mock('@/api/agent', () => ({
+  agentAPI: {
+    list: listMock,
+  },
+}));
+
+describe('useAgents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty array when the API payload is not an array', async () => {
+    listMock.mockResolvedValue({
+      data: { items: [] },
+    });
+
+    const { result } = renderHook(() => useAgents());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.agents).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/webui/src/hooks/useAgents.ts
+++ b/webui/src/hooks/useAgents.ts
@@ -11,9 +11,10 @@ export function useAgents() {
       setLoading(true);
       setError(null);
       const response = await agentAPI.list();
-      setAgents(response.data);
+      setAgents(Array.isArray(response.data) ? response.data : []);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch agents');
+      setAgents([]);
     } finally {
       setLoading(false);
     }

--- a/webui/src/hooks/useWorkflow.test.tsx
+++ b/webui/src/hooks/useWorkflow.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useWorkflows } from './useWorkflow';
+
+const { listMock, getMock } = vi.hoisted(() => ({
+  listMock: vi.fn(),
+  getMock: vi.fn(),
+}));
+
+vi.mock('@/api/workflow', () => ({
+  workflowAPI: {
+    list: listMock,
+    get: getMock,
+  },
+}));
+
+function makeWorkflow() {
+  return {
+    id: 'wf-1',
+    name: 'Workflow One',
+    category: 'default',
+    workflowJson: {
+      start: 'node-1',
+      nodes: [{ id: 'node-1', type: 'python' }],
+      edges: [],
+    },
+    status: 'active' as const,
+    source: 'global' as const,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    stats: {
+      callCount: 1,
+      successCount: 1,
+      errorCount: 0,
+      totalRuntime: 1,
+      avgRuntime: 1,
+      thumbsUp: 0,
+      thumbsDown: 0,
+    },
+  };
+}
+
+describe('useWorkflows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clears workflows when a silent refetch fails', async () => {
+    listMock.mockResolvedValueOnce({
+      data: [makeWorkflow()],
+    });
+    listMock.mockRejectedValueOnce(new Error('Session expired'));
+
+    const { result } = renderHook(() => useWorkflows());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.workflows).toHaveLength(1);
+
+    window.dispatchEvent(new Event('focus'));
+
+    await waitFor(() => {
+      expect(result.current.workflows).toEqual([]);
+    });
+
+    expect(result.current.error).toBe('Session expired');
+  });
+});

--- a/webui/src/hooks/useWorkflow.ts
+++ b/webui/src/hooks/useWorkflow.ts
@@ -24,7 +24,7 @@ export function useWorkflows(category?: string, status?: string) {
       }
     } catch (err: any) {
       setError(err.message || 'Failed to fetch workflows');
-      if (!silent) setWorkflows([]);
+      setWorkflows([]);
     } finally {
       loadingRef.current = false;
       if (!silent) setLoading(false);


### PR DESCRIPTION
Fix #264 

## Summary
- **useAgents**: Treat non-array API payloads as empty list; clear `agents` when the list request throws.
- **useWorkflows**: On list failure, always clear `workflows` so silent background refetches cannot leave stale rows after auth/session errors.
