### PR TITLE
fix(workflow,syslog): stop FD exhaustion under sustained syslog flood

### DIFF
--- a/flocks/ingest/syslog/manager.py
+++ b/flocks/ingest/syslog/manager.py
@@ -31,6 +31,65 @@ _MAX_QUEUE_SIZE = 1000
 # under busy event-loops; anything >5s would make the HTTP save endpoint feel
 # hung when the user makes a typo.
 _BIND_WAIT_TIMEOUT_S = 3.0
+# Minimum interval between two ``syslog.queue_full_dropped`` warnings; a
+# sustained queue overflow is aggregated into a single warning per window.
+_DROP_LOG_WINDOW_S = 1.0
+
+
+class _DropWarningThrottle:
+    """Aggregate per-workflow ``QueueFull`` drops into windowed warnings.
+
+    The listener's ``on_msg`` callback runs synchronously from the UDP
+    protocol layer; without throttling, each dropped datagram emits its own
+    log record, which (a) drowns out the surrounding logs and (b) can make
+    the very logging itself a bottleneck.  This helper keeps a small running
+    tally and emits at most one warning per ``window_s`` seconds, plus an
+    explicit ``flush`` for the trailing count when the flood stops.
+    """
+
+    def __init__(
+        self,
+        workflow_id: str,
+        queue: asyncio.Queue,
+        window_s: float = _DROP_LOG_WINDOW_S,
+    ) -> None:
+        self._workflow_id = workflow_id
+        self._queue = queue
+        self._window_s = float(window_s)
+        self._count: int = 0
+        self._last_log: float = 0.0
+
+    @property
+    def count(self) -> int:
+        """Current un-flushed drop count (useful for tests)."""
+        return self._count
+
+    def record_drop(self) -> None:
+        """Account for one dropped datagram; emit if the window elapsed."""
+        self._count += 1
+        if time.monotonic() - self._last_log >= self._window_s:
+            self._flush(trigger="threshold")
+
+    def maybe_flush(self) -> None:
+        """Emit a warning if the trailing count has waited long enough."""
+        if self._count > 0 and time.monotonic() - self._last_log >= self._window_s:
+            self._flush(trigger="flush")
+
+    def flush_remaining(self, trigger: str = "shutdown") -> None:
+        """Emit any leftover count regardless of window; used on shutdown."""
+        if self._count > 0:
+            self._flush(trigger=trigger)
+
+    def _flush(self, *, trigger: str) -> None:
+        log.warning("syslog.queue_full_dropped", {
+            "workflow_id": self._workflow_id,
+            "queue_size": self._queue.qsize(),
+            "queue_capacity": self._queue.maxsize,
+            "dropped_in_window": int(self._count),
+            "trigger": trigger,
+        })
+        self._count = 0
+        self._last_log = time.monotonic()
 
 
 class SyslogManager:
@@ -100,7 +159,11 @@ class SyslogManager:
 
             {"state": "binding|listening|failed|stopped", "error": "..." | None,
              "host": "...", "port": 5140, "protocol": "udp|tcp",
-             "queueSize": 12, "queueCapacity": 200, "workerCount": 8}
+             "queueSize": 12, "queueCapacity": <queue.maxsize>,
+             "workerCount": <_MAX_CONCURRENT_EXECUTIONS>}
+
+        ``queueCapacity`` always mirrors the runtime ``asyncio.Queue.maxsize``
+        of the active listener (currently ``_MAX_QUEUE_SIZE``).
         """
         status = dict(self._listener_status.get(workflow_id) or {"state": "stopped"})
         q = self._queues.get(workflow_id)
@@ -251,10 +314,10 @@ class SyslogManager:
         protocol = str(config.get("protocol") or "udp").lower()
         format_hint = str(config.get("format") or "auto")
 
-        # Throttle drop-warnings so a sustained syslog flood does not turn into
-        # a log flood of its own.  We aggregate the dropped count and emit at
-        # most one warning per second per workflow.
-        drop_state: Dict[str, float] = {"count": 0, "last_log": 0.0}
+        # Aggregate per-window drop warnings so a sustained queue overflow
+        # does not turn into its own log flood.  The trailing count is
+        # flushed by a 1-second polling task plus a shutdown best-effort.
+        throttle = _DropWarningThrottle(workflow_id, queue)
 
         # NOTE: keep this callback synchronous so the UDP protocol layer can
         # invoke it inline from datagram_received() without creating an
@@ -263,17 +326,17 @@ class SyslogManager:
             try:
                 queue.put_nowait(parsed)
             except asyncio.QueueFull:
-                drop_state["count"] += 1
-                now = time.monotonic()
-                if now - drop_state["last_log"] >= 1.0:
-                    log.warning("syslog.queue_full_dropped", {
-                        "workflow_id": workflow_id,
-                        "queue_size": queue.qsize(),
-                        "queue_capacity": queue.maxsize,
-                        "dropped_in_window": int(drop_state["count"]),
-                    })
-                    drop_state["count"] = 0
-                    drop_state["last_log"] = now
+                throttle.record_drop()
+
+        async def _periodic_drop_flush() -> None:
+            """Flush leftover drop count when the flood stops."""
+            while not abort.is_set():
+                try:
+                    await asyncio.wait_for(abort.wait(), timeout=_DROP_LOG_WINDOW_S)
+                    return  # abort signalled
+                except asyncio.TimeoutError:
+                    pass
+                throttle.maybe_flush()
 
         async def _bind_and_serve() -> None:
             """Bind the socket synchronously then mark the listener ready.
@@ -290,6 +353,7 @@ class SyslogManager:
             # runs on the next event-loop tick — by which point the bind has
             # either succeeded or raised.
             mark_task = asyncio.create_task(_mark_ready_after_bind())
+            flush_task = asyncio.create_task(_periodic_drop_flush())
             try:
                 if protocol == "tcp":
                     await run_tcp_syslog_server(host, port, format_hint, on_msg, abort_event=abort)
@@ -298,6 +362,11 @@ class SyslogManager:
             finally:
                 if not mark_task.done():
                     mark_task.cancel()
+                if not flush_task.done():
+                    flush_task.cancel()
+                # Best-effort: emit any leftover drop count on shutdown so a
+                # tail of dropped messages isn't silently lost.
+                throttle.flush_remaining()
 
         async def _mark_ready_after_bind() -> None:
             # Give the bind one event-loop tick to complete (or raise) so we

--- a/flocks/ingest/syslog/manager.py
+++ b/flocks/ingest/syslog/manager.py
@@ -23,8 +23,9 @@ log = Log.create(service="syslog.manager")
 
 # Maximum concurrent workflow executions per workflow to avoid FD exhaustion and SQLite write contention
 _MAX_CONCURRENT_EXECUTIONS = 8
-# Maximum number of buffered syslog messages per workflow; excess messages are dropped with a warning
-_MAX_QUEUE_SIZE = 200
+# Maximum number of buffered syslog messages per workflow; excess messages are dropped with a warning.
+# Increased from 200 to 1000 to absorb larger inbound bursts before the worker pool catches up.
+_MAX_QUEUE_SIZE = 1000
 # Maximum time we wait for the listener to either bind successfully or fail
 # during ``restart_workflow``.  Any value <0.5s makes the call too aggressive
 # under busy event-loops; anything >5s would make the HTTP save endpoint feel
@@ -250,6 +251,11 @@ class SyslogManager:
         protocol = str(config.get("protocol") or "udp").lower()
         format_hint = str(config.get("format") or "auto")
 
+        # Throttle drop-warnings so a sustained syslog flood does not turn into
+        # a log flood of its own.  We aggregate the dropped count and emit at
+        # most one warning per second per workflow.
+        drop_state: Dict[str, float] = {"count": 0, "last_log": 0.0}
+
         # NOTE: keep this callback synchronous so the UDP protocol layer can
         # invoke it inline from datagram_received() without creating an
         # asyncio task per packet. That preserves the queue-based backpressure.
@@ -257,10 +263,17 @@ class SyslogManager:
             try:
                 queue.put_nowait(parsed)
             except asyncio.QueueFull:
-                log.warning("syslog.queue_full_dropped", {
-                    "workflow_id": workflow_id,
-                    "queue_size": queue.qsize(),
-                })
+                drop_state["count"] += 1
+                now = time.monotonic()
+                if now - drop_state["last_log"] >= 1.0:
+                    log.warning("syslog.queue_full_dropped", {
+                        "workflow_id": workflow_id,
+                        "queue_size": queue.qsize(),
+                        "queue_capacity": queue.maxsize,
+                        "dropped_in_window": int(drop_state["count"]),
+                    })
+                    drop_state["count"] = 0
+                    drop_state["last_log"] = now
 
         async def _bind_and_serve() -> None:
             """Bind the socket synchronously then mark the listener ready.

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
@@ -33,6 +35,23 @@ _logger = logging.getLogger("flocks.workflow.runner")
 
 _SANDBOX_MODE_ON_VALUES = {"on", "all", "non-main"}
 
+# ---------------------------------------------------------------------------
+# Config cache – avoids spawning a new event-loop (and its self-pipe FDs) on
+# every workflow execution when run_workflow() is called from a thread pool
+# worker (e.g. via asyncio.to_thread()).  Each asyncio.run() call inside a
+# thread creates a _UnixSelectorEventLoop whose socketpair FDs are normally
+# closed, but under high concurrency (8+ syslog workers) the repeated
+# create/destroy cycle can exhaust the process fd limit before GC runs,
+# triggering [Errno 24] Too many open files and the cascade of
+# AttributeError: '_UnixSelectorEventLoop' has no attribute '_ssock'.
+# A 30-second TTL is a reasonable balance: config changes are uncommon,
+# and the short window means a reload never lags by more than 30 s.
+# ---------------------------------------------------------------------------
+_config_cache: Dict[str, Any] = {}
+_config_cache_ts: float = 0.0
+_config_cache_ttl: float = 30.0
+_config_cache_lock = threading.Lock()
+
 
 def _run_coro_sync(coro):
     """Run async coroutine from sync context safely."""
@@ -48,21 +67,41 @@ def _run_coro_sync(coro):
 
 
 def _load_config_data() -> Dict[str, Any]:
-    """Load merged config data, returning empty dict on failures."""
+    """Load merged config data with a short-lived TTL cache.
+
+    Calling ``asyncio.run()`` (via ``_run_coro_sync``) inside a thread-pool
+    worker creates a temporary event loop each time.  Under high-frequency
+    syslog loads the repeated creation / teardown of those loops can exhaust
+    the process file-descriptor limit.  The cache amortises that cost: the
+    coroutine is only executed once per ``_config_cache_ttl`` seconds.
+    """
+    global _config_cache, _config_cache_ts
+
+    now = time.monotonic()
+    with _config_cache_lock:
+        if now - _config_cache_ts < _config_cache_ttl and _config_cache:
+            return dict(_config_cache)
+
     try:
         cfg = _run_coro_sync(Config.get())
     except Exception as exc:
         _logger.debug("workflow runtime: failed to load config: %s", exc)
-        return {}
+        with _config_cache_lock:
+            return dict(_config_cache)
 
+    result: Dict[str, Any] = {}
     if hasattr(cfg, "model_dump"):
         try:
             dumped = cfg.model_dump(by_alias=True, exclude_none=True, mode="json")
             if isinstance(dumped, dict):
-                return dumped
+                result = dumped
         except Exception as exc:
             _logger.debug("workflow runtime: failed to dump config: %s", exc)
-    return {}
+
+    with _config_cache_lock:
+        _config_cache = result
+        _config_cache_ts = time.monotonic()
+    return result
 
 
 def _resolve_workflow_runtime_preference(tool_context: Optional[Any]) -> Literal["sandbox", "host"]:

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -101,7 +101,11 @@ def _load_config_data() -> Dict[str, Any]:
     with _config_cache_lock:
         _config_cache = result
         _config_cache_ts = time.monotonic()
-    return result
+        # Return a shallow copy on this cold path too, mirroring the hit
+        # path above.  Without it the very first caller would receive the
+        # exact ``_config_cache`` dict and a top-level mutation on their
+        # "snapshot" would leak into every subsequent cached read.
+        return dict(_config_cache)
 
 
 def _resolve_workflow_runtime_preference(tool_context: Optional[Any]) -> Literal["sandbox", "host"]:

--- a/tests/ingest/test_syslog_drop_throttle.py
+++ b/tests/ingest/test_syslog_drop_throttle.py
@@ -1,0 +1,134 @@
+"""Regression tests for ``_DropWarningThrottle``.
+
+The throttle replaced a one-warning-per-drop ``log.warning`` with a windowed
+aggregate so a sustained ``QueueFull`` flood does not flood the log itself.
+These tests pin three behavioural contracts so future refactors do not
+silently regress to either the old per-drop spew **or** to silently dropping
+the trailing count.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from flocks.ingest.syslog import manager as syslog_manager
+
+
+@pytest.fixture
+def captured_warnings() -> List[Dict[str, Any]]:
+    """Capture every call to ``syslog.manager.log.warning``."""
+    seen: List[Dict[str, Any]] = []
+
+    def _record(event: str, fields: Dict[str, Any] | None = None, **_kwargs: Any) -> None:
+        seen.append({"event": event, "fields": dict(fields or {})})
+
+    with patch.object(syslog_manager.log, "warning", side_effect=_record):
+        yield seen
+
+
+def _make_full_queue(maxsize: int = 4) -> asyncio.Queue:
+    q: asyncio.Queue = asyncio.Queue(maxsize=maxsize)
+    for i in range(maxsize):
+        q.put_nowait({"_seq": i})
+    return q
+
+
+@pytest.mark.asyncio
+async def test_record_drop_aggregates_under_one_warning_per_window(
+    captured_warnings: List[Dict[str, Any]],
+) -> None:
+    """A burst of drops within the window must collapse to <=1 warning."""
+    queue = _make_full_queue()
+    throttle = syslog_manager._DropWarningThrottle(
+        workflow_id="wf-throttle",
+        queue=queue,
+        window_s=10.0,  # long window so the burst never crosses it
+    )
+
+    # First drop fires immediately (last_log is 0.0 → elapsed >> window_s).
+    for _ in range(500):
+        throttle.record_drop()
+
+    drop_warnings = [w for w in captured_warnings if w["event"] == "syslog.queue_full_dropped"]
+    assert len(drop_warnings) == 1, (
+        f"expected exactly one aggregated warning, got {len(drop_warnings)}"
+    )
+    payload = drop_warnings[0]["fields"]
+    assert payload["workflow_id"] == "wf-throttle"
+    assert payload["trigger"] == "threshold"
+    # The aggregated count must reflect the burst minus drops counted *after*
+    # the warning fired (since the warning resets the counter on first fire).
+    assert payload["dropped_in_window"] == 1
+    # And the still-buffered count must equal the rest of the burst.
+    assert throttle.count == 499
+
+
+@pytest.mark.asyncio
+async def test_maybe_flush_emits_trailing_count_after_window(
+    captured_warnings: List[Dict[str, Any]],
+) -> None:
+    """After the window elapses, ``maybe_flush`` must emit the leftover count."""
+    queue = _make_full_queue()
+    throttle = syslog_manager._DropWarningThrottle(
+        workflow_id="wf-flush",
+        queue=queue,
+        window_s=0.05,  # tiny window so the test runs fast
+    )
+
+    for _ in range(10):
+        throttle.record_drop()
+
+    # Window not elapsed yet → no extra warning, count holds the tail.
+    assert throttle.count == 9
+    throttle.maybe_flush()
+    assert throttle.count == 9  # still within window
+
+    # Sleep just past the window then flush.
+    await asyncio.sleep(0.07)
+    throttle.maybe_flush()
+    assert throttle.count == 0
+
+    flush_warnings = [
+        w for w in captured_warnings
+        if w["event"] == "syslog.queue_full_dropped" and w["fields"].get("trigger") == "flush"
+    ]
+    assert len(flush_warnings) == 1
+    assert flush_warnings[0]["fields"]["dropped_in_window"] == 9
+
+
+@pytest.mark.asyncio
+async def test_flush_remaining_emits_unconditionally(
+    captured_warnings: List[Dict[str, Any]],
+) -> None:
+    """``flush_remaining`` is the shutdown safety net — must ignore the window."""
+    queue = _make_full_queue()
+    throttle = syslog_manager._DropWarningThrottle(
+        workflow_id="wf-shutdown",
+        queue=queue,
+        window_s=10.0,  # long window so a normal flush would be suppressed
+    )
+
+    # Seed the counter with a few drops; first one fires "threshold", the
+    # rest accumulate silently because the window has not elapsed.
+    for _ in range(5):
+        throttle.record_drop()
+    captured_warnings.clear()
+
+    throttle.flush_remaining()
+
+    shutdown_warnings = [
+        w for w in captured_warnings
+        if w["event"] == "syslog.queue_full_dropped" and w["fields"].get("trigger") == "shutdown"
+    ]
+    assert len(shutdown_warnings) == 1
+    assert shutdown_warnings[0]["fields"]["dropped_in_window"] == 4
+    assert throttle.count == 0
+
+    # A second call with no pending drops must be a silent no-op.
+    captured_warnings.clear()
+    throttle.flush_remaining()
+    assert captured_warnings == []

--- a/tests/workflow/test_runner_config_cache.py
+++ b/tests/workflow/test_runner_config_cache.py
@@ -1,0 +1,151 @@
+"""Regression tests for ``flocks.workflow.runner._load_config_data``.
+
+The TTL cache was introduced to stop ``asyncio.run(Config.get())`` from
+spawning a fresh ``_UnixSelectorEventLoop`` (and its self-pipe ``socketpair``
+FDs) on every workflow execution, which under high-frequency syslog loads
+exhausted the process FD limit.  These tests pin the externally observable
+behaviour of the cache so that future refactors do not silently regress to
+the old per-call-fetch behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from flocks.workflow import runner as runner_module
+
+
+class _FakeConfig:
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self._payload = payload
+
+    def model_dump(self, **_kwargs: Any) -> Dict[str, Any]:
+        return dict(self._payload)
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_cache() -> None:
+    """Each test starts from a clean cache and restores it afterwards."""
+    runner_module._config_cache = {}
+    runner_module._config_cache_ts = 0.0
+    yield
+    runner_module._config_cache = {}
+    runner_module._config_cache_ts = 0.0
+
+
+def _install_fake_config_get(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: Dict[str, Any],
+    *,
+    calls: Dict[str, int] | None = None,
+    raises_after: int | None = None,
+) -> Dict[str, int]:
+    """Replace ``Config.get`` with an awaitable that returns ``payload``.
+
+    ``Config.get`` is a coroutine; ``runner._load_config_data`` calls
+    ``_run_coro_sync(Config.get())`` so the stub must itself be awaitable
+    (i.e. an ``async def``).  ``_run_coro_sync`` is also patched so the test
+    avoids spawning real event loops.
+    """
+    state: Dict[str, int] = calls if calls is not None else {"n": 0}
+
+    async def _fake_get() -> _FakeConfig:
+        state["n"] += 1
+        if raises_after is not None and state["n"] > raises_after:
+            raise RuntimeError("transient")
+        return _FakeConfig(payload)
+
+    monkeypatch.setattr(runner_module.Config, "get", staticmethod(_fake_get))
+
+    # Drive the coroutine synchronously without standing up a real event
+    # loop (that is exactly what the cache is meant to avoid).
+    def _runner_run_coro_sync(coro):
+        try:
+            coro.send(None)
+        except StopIteration as stop:
+            return stop.value
+        raise AssertionError("fake Config.get must not suspend")
+
+    monkeypatch.setattr(runner_module, "_run_coro_sync", _runner_run_coro_sync)
+    return state
+
+
+def test_load_config_data_caches_within_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Within the TTL window ``Config.get`` must be invoked exactly once."""
+    fake_payload = {"sandbox": {"mode": "off"}}
+    calls = _install_fake_config_get(monkeypatch, fake_payload)
+
+    result_a = runner_module._load_config_data()
+    result_b = runner_module._load_config_data()
+    result_c = runner_module._load_config_data()
+
+    assert result_a == fake_payload
+    assert result_b == fake_payload
+    assert result_c == fake_payload
+    # The whole point of the cache is to amortise the underlying call.
+    assert calls["n"] == 1
+
+
+def test_load_config_data_reloads_after_ttl_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After the TTL elapses ``Config.get`` must be invoked again."""
+    fake_payload = {"sandbox": {"mode": "off"}}
+    calls = _install_fake_config_get(monkeypatch, fake_payload)
+
+    runner_module._load_config_data()
+    assert calls["n"] == 1
+
+    # Simulate the TTL elapsing by rewinding the cache timestamp.
+    runner_module._config_cache_ts = (
+        runner_module._config_cache_ts - runner_module._config_cache_ttl - 1.0
+    )
+    runner_module._load_config_data()
+    assert calls["n"] == 2
+
+
+def test_load_config_data_returns_a_shallow_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Top-level key reassignment in the caller's snapshot must not leak.
+
+    The contract is a *shallow* ``dict(_config_cache)`` copy — nested
+    structures are intentionally shared (cheap, and callers are expected
+    to treat the result as read-only).  This test pins the shallow-copy
+    contract that the cache implementation relies on so a future change
+    to ``return _config_cache`` (no copy) is caught.
+    """
+    fake_payload = {"sandbox": {"mode": "off"}, "other": {"k": "v"}}
+    _install_fake_config_get(monkeypatch, fake_payload)
+
+    snapshot = runner_module._load_config_data()
+    snapshot["sandbox"] = {"mode": "tampered"}  # replace top-level key
+    snapshot["new_top_level"] = "added"
+
+    fresh = runner_module._load_config_data()
+    # Top-level mutations on the caller copy must not leak back to the cache.
+    assert fresh["sandbox"] == {"mode": "off"}
+    assert "new_top_level" not in fresh
+
+
+def test_load_config_data_falls_back_to_cache_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient ``Config.get`` failure must reuse the last good snapshot."""
+    fake_payload = {"sandbox": {"mode": "off"}}
+    calls = _install_fake_config_get(monkeypatch, fake_payload, raises_after=1)
+
+    # First call seeds the cache successfully.
+    assert runner_module._load_config_data() == fake_payload
+    assert calls["n"] == 1
+
+    # Expire the TTL to force a refresh; the underlying call will now raise.
+    runner_module._config_cache_ts = (
+        runner_module._config_cache_ts - runner_module._config_cache_ttl - 1.0
+    )
+
+    # Cached snapshot survives the transient failure.
+    assert runner_module._load_config_data() == fake_payload
+    assert calls["n"] == 2


### PR DESCRIPTION
fix(workflow,syslog): stop FD exhaustion under sustained syslog flood

Under a sustained syslog burst the backend was crashing with
OSError: [Errno 24] Too many open files on the dedup state lock, followed
by a cascade of AttributeError: '_UnixSelectorEventLoop' object has no
attribute '_ssock' from event-loop __del__. Root cause: run_workflow() is
invoked from a thread-pool worker (asyncio.to_thread), and
_load_config_data called asyncio.run(Config.get()) per execution. Each
temporary _UnixSelectorEventLoop allocates a self-pipe socketpair (2 FDs);
under 8 concurrent syslog workers the create/destroy cycle outpaces GC and
drives the process past its FD limit, after which every subsequent dedup
open(lock_path) fails and the bounded syslog queue (cap 200) overflows.

Fixes:
* flocks/workflow/runner.py: cache _load_config_data for 30 s ...
* flocks/ingest/syslog/manager.py: raise the per-workflow queue cap ...