### PR TITLE
feat(task): five-field cron validation and schedule timezone display

### DIFF
--- a/flocks/cli/commands/task.py
+++ b/flocks/cli/commands/task.py
@@ -15,6 +15,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from flocks.storage.storage import Storage
+from flocks.task.formatting import format_task_datetime, resolve_task_timezone_name
 
 task_app = typer.Typer(
     name="task",
@@ -178,6 +179,7 @@ async def _show_task(task_id: str):
         type_value = "once"
     else:
         type_value = "execution"
+    display_tz = resolve_task_timezone_name(task)
     lines = [
         f"[bold]{task.title}[/bold]",
         f"ID:       {task.id}",
@@ -194,18 +196,20 @@ async def _show_task(task_id: str):
         lines.append(f"Skills:   {', '.join(task.skills)}")
     if task.category:
         lines.append(f"Category: {task.category}")
-    lines.append(f"Created:  {task.created_at.isoformat()}")
+    lines.append(f"Created:  {format_task_datetime(task.created_at, display_tz)}")
     if task.description:
         lines.append(f"Desc:     {task.description}")
     if getattr(task, "trigger", None):
         if task.trigger.cron:
             lines.append(f"Cron:     {task.trigger.cron} ({task.trigger.timezone})")
         if task.trigger.next_run:
-            lines.append(f"Next run: {task.trigger.next_run.isoformat()}")
+            lines.append(
+                f"Next run: {format_task_datetime(task.trigger.next_run, display_tz)}"
+            )
     if getattr(task, "started_at", None):
-        lines.append(f"Started:  {task.started_at.isoformat()}")
+        lines.append(f"Started:  {format_task_datetime(task.started_at, display_tz)}")
     if getattr(task, "completed_at", None):
-        lines.append(f"Finished: {task.completed_at.isoformat()}")
+        lines.append(f"Finished: {format_task_datetime(task.completed_at, display_tz)}")
     if getattr(task, "duration_ms", None) is not None:
         lines.append(f"Duration: {_fmt_duration(task.duration_ms)}")
     if getattr(task, "result_summary", None):
@@ -246,6 +250,7 @@ async def _create_task(title, description, task_type, priority, mode, agent, wor
         TaskPriority,
         TaskSource,
         TaskTrigger,
+        build_schedule,
     )
     from flocks.task.store import TaskStore
     await TaskStore.init()
@@ -257,7 +262,11 @@ async def _create_task(title, description, task_type, priority, mode, agent, wor
             console.print("[red]--cron is required for scheduled tasks[/red]")
             raise typer.Exit(1)
         scheduler_mode = SchedulerMode.CRON
-        trigger = TaskTrigger(cron=cron)
+        try:
+            trigger = build_schedule(run_once=False, cron=cron)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
 
     source = TaskSource(user_prompt=prompt) if prompt else None
 
@@ -352,7 +361,12 @@ async def _scheduled():
     for t in tasks:
         status_icon = "✅" if t.status.value == "active" else "⏸️"
         cron = t.trigger.cron or "-"
-        next_run = t.trigger.next_run.isoformat() if t.trigger.next_run else "-"
+        display_tz = resolve_task_timezone_name(t)
+        next_run = (
+            format_task_datetime(t.trigger.next_run, display_tz)
+            if t.trigger.next_run
+            else "-"
+        )
         table.add_row(status_icon, t.id[:16], t.title, cron, next_run)
 
     console.print(table)

--- a/flocks/task/formatting.py
+++ b/flocks/task/formatting.py
@@ -1,0 +1,24 @@
+"""Helpers for rendering task timestamps consistently."""
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+def resolve_task_timezone_name(task: Any) -> Optional[str]:
+    trigger = getattr(task, "trigger", None)
+    tz_name = getattr(trigger, "timezone", None) if trigger is not None else None
+    return tz_name or None
+
+
+def format_task_datetime(dt: datetime, tz_name: Optional[str] = None) -> str:
+    normalized = dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+    label = tz_name
+    if tz_name:
+        try:
+            normalized = normalized.astimezone(ZoneInfo(tz_name))
+        except ZoneInfoNotFoundError:
+            label = f"{tz_name} (invalid timezone)"
+    if not label:
+        label = normalized.tzname() or "UTC"
+    return f"{normalized.isoformat(sep=' ', timespec='seconds')} ({label})"

--- a/flocks/task/formatting.py
+++ b/flocks/task/formatting.py
@@ -18,7 +18,7 @@ def format_task_datetime(dt: datetime, tz_name: Optional[str] = None) -> str:
         try:
             normalized = normalized.astimezone(ZoneInfo(tz_name))
         except ZoneInfoNotFoundError:
-            label = f"{tz_name} (invalid timezone)"
+            label = f'UTC ("{tz_name}" not found)'
     if not label:
         label = normalized.tzname() or "UTC"
     return f"{normalized.isoformat(sep=' ', timespec='seconds')} ({label})"

--- a/flocks/task/manager.py
+++ b/flocks/task/manager.py
@@ -177,7 +177,7 @@ class TaskManager:
         created_by: str = "rex",
         dedup_key: Optional[str] = None,
     ) -> TaskScheduler:
-        trigger = trigger or TaskTrigger()
+        trigger = trigger.model_copy(deep=True) if trigger is not None else TaskTrigger()
         if trigger.cron:
             trigger.cron = validate_cron_expression(trigger.cron)
         source = source or TaskSource()
@@ -289,7 +289,8 @@ class TaskManager:
                 run_once = scheduler.mode == SchedulerMode.ONCE
             if run_once:
                 scheduler.mode = SchedulerMode.ONCE
-                scheduler.trigger.cron = normalized_cron
+                if cron is not None:
+                    scheduler.trigger.cron = normalized_cron
                 scheduler.trigger.timezone = tz
                 scheduler.trigger.cron_description = cron_description or scheduler.trigger.cron_description
                 scheduler.trigger.run_at = datetime.fromisoformat(run_at) if run_at else scheduler.trigger.run_at

--- a/flocks/task/manager.py
+++ b/flocks/task/manager.py
@@ -26,6 +26,7 @@ from .models import (
     TaskSource,
     TaskStatus,
     TaskTrigger,
+    validate_cron_expression,
 )
 from .queue import TaskQueue
 from .scheduler import TaskScheduler as SchedulerLoop
@@ -177,6 +178,8 @@ class TaskManager:
         dedup_key: Optional[str] = None,
     ) -> TaskScheduler:
         trigger = trigger or TaskTrigger()
+        if trigger.cron:
+            trigger.cron = validate_cron_expression(trigger.cron)
         source = source or TaskSource()
         mgr = cls._instance
         retry = mgr._default_retry.model_copy(deep=True) if mgr else RetryConfig()
@@ -281,24 +284,25 @@ class TaskManager:
                 setattr(scheduler, key, value)
         if any(v is not None for v in [cron, timezone, cron_description, run_once, run_at]):
             tz = timezone or scheduler.trigger.timezone
+            normalized_cron = validate_cron_expression(cron) if cron else None
             if run_once is None:
                 run_once = scheduler.mode == SchedulerMode.ONCE
             if run_once:
                 scheduler.mode = SchedulerMode.ONCE
-                scheduler.trigger.cron = cron
+                scheduler.trigger.cron = normalized_cron
                 scheduler.trigger.timezone = tz
                 scheduler.trigger.cron_description = cron_description or scheduler.trigger.cron_description
                 scheduler.trigger.run_at = datetime.fromisoformat(run_at) if run_at else scheduler.trigger.run_at
                 scheduler.trigger.next_run = scheduler.trigger.run_at
             else:
-                if not cron:
+                if not normalized_cron:
                     raise ValueError("cron is required for recurring scheduled tasks")
                 scheduler.mode = SchedulerMode.CRON
                 scheduler.trigger.run_at = None
-                scheduler.trigger.cron = cron
+                scheduler.trigger.cron = normalized_cron
                 scheduler.trigger.timezone = tz
                 scheduler.trigger.cron_description = cron_description or scheduler.trigger.cron_description
-                scheduler.trigger.next_run = SchedulerLoop.compute_next_run(cron, tz)
+                scheduler.trigger.next_run = SchedulerLoop.compute_next_run(normalized_cron, tz)
         scheduler = await TaskStore.update_scheduler(scheduler)
         return scheduler
 

--- a/flocks/task/models.py
+++ b/flocks/task/models.py
@@ -207,6 +207,19 @@ class TaskExecutionQueueRef(BaseModel):
     started_at: Optional[datetime] = Field(None, alias="startedAt")
 
 
+def validate_cron_expression(cron: str) -> str:
+    normalized = " ".join(cron.split())
+    field_count = len(normalized.split()) if normalized else 0
+    if field_count != 5:
+        raise ValueError(
+            "Invalid cron expression: only 5-field cron is supported "
+            "(`minute hour day month weekday`). "
+            "Example: use `0 6 * * *` for daily 06:00 in Asia/Shanghai. "
+            "6-field Quartz cron such as `0 0 6 * * *` is not supported."
+        )
+    return normalized
+
+
 def build_schedule(
     *,
     run_once: bool = False,
@@ -215,6 +228,7 @@ def build_schedule(
     cron_description: Optional[str] = None,
     timezone: str = "Asia/Shanghai",
 ) -> TaskTrigger:
+    normalized_cron = validate_cron_expression(cron) if cron else None
     if run_once:
         if not run_at and not cron:
             raise ValueError(
@@ -231,7 +245,7 @@ def build_schedule(
         return TaskTrigger(
             run_immediately=False,
             run_at=run_at_dt,
-            cron=cron,
+            cron=normalized_cron,
             timezone=timezone,
             cron_description=cron_description,
         )
@@ -240,7 +254,7 @@ def build_schedule(
         raise ValueError("cron is required for recurring scheduled tasks")
     return TaskTrigger(
         run_immediately=False,
-        cron=cron,
+        cron=normalized_cron,
         timezone=timezone,
         cron_description=cron_description,
     )

--- a/flocks/task/models.py
+++ b/flocks/task/models.py
@@ -12,6 +12,11 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+try:
+    from croniter import croniter  # type: ignore[import-untyped]
+except ImportError:
+    croniter = None
+
 from flocks.utils.id import Identifier
 
 
@@ -215,7 +220,13 @@ def validate_cron_expression(cron: str) -> str:
             "Invalid cron expression: only 5-field cron is supported "
             "(`minute hour day month weekday`). "
             "Example: use `0 6 * * *` for daily 06:00 in Asia/Shanghai. "
-            "6-field Quartz cron such as `0 0 6 * * *` is not supported."
+            "6-field cron (e.g. Quartz format with leading seconds, "
+            "such as `0 0 6 * * *`) and shortcuts such as `@daily` "
+            "are not supported."
+        )
+    if croniter is not None and not croniter.is_valid(normalized):
+        raise ValueError(
+            f"Invalid cron expression: {normalized!r} is not a valid 5-field cron."
         )
     return normalized
 

--- a/flocks/task/plugin_sync.py
+++ b/flocks/task/plugin_sync.py
@@ -44,9 +44,12 @@ async def upsert_task_specs(specs: Sequence[TaskSpec]) -> int:
             try:
                 normalized_cron = validate_cron_expression(spec.cron)
             except ValueError as exc:
+                # On invalid cron, skip the whole spec to avoid partial updates
+                # where title/tags change but trigger settings stay stale.
                 log.warn(
                     "task.plugin.invalid_cron",
                     {
+                        "action": "skipped_entire_spec",
                         "dedup_key": spec.dedup_key,
                         "cron": spec.cron,
                         "error": str(exc),

--- a/flocks/task/plugin_sync.py
+++ b/flocks/task/plugin_sync.py
@@ -20,6 +20,7 @@ async def upsert_task_specs(specs: Sequence[TaskSpec]) -> int:
         TaskPriority,
         TaskSource,
         TaskTrigger,
+        validate_cron_expression,
     )
     from flocks.task.scheduler import TaskScheduler as SchedulerLoop
     from flocks.task.store import TaskStore
@@ -38,6 +39,20 @@ async def upsert_task_specs(specs: Sequence[TaskSpec]) -> int:
             exec_mode = ExecutionMode.AGENT
 
         existing = await TaskStore.get_scheduler_by_dedup_key(spec.dedup_key)
+        normalized_cron = None
+        if spec.task_type == "scheduled" and spec.cron:
+            try:
+                normalized_cron = validate_cron_expression(spec.cron)
+            except ValueError as exc:
+                log.warn(
+                    "task.plugin.invalid_cron",
+                    {
+                        "dedup_key": spec.dedup_key,
+                        "cron": spec.cron,
+                        "error": str(exc),
+                    },
+                )
+                continue
         if existing is not None:
             existing.title = spec.title
             existing.description = spec.description
@@ -50,16 +65,19 @@ async def upsert_task_specs(specs: Sequence[TaskSpec]) -> int:
             )
             existing.context = spec.context
             existing.tags = spec.tags
-            if spec.task_type == "scheduled" and spec.cron:
+            if spec.task_type == "scheduled" and normalized_cron:
                 existing.mode = SchedulerMode.CRON
                 existing.status = (
                     SchedulerStatus.ACTIVE if spec.enabled else SchedulerStatus.DISABLED
                 )
                 existing.trigger = TaskTrigger(
-                    cron=spec.cron,
+                    cron=normalized_cron,
                     timezone=spec.timezone,
                     cron_description=spec.cron_description,
-                    next_run=SchedulerLoop.compute_next_run(spec.cron, spec.timezone),
+                    next_run=SchedulerLoop.compute_next_run(
+                        normalized_cron,
+                        spec.timezone,
+                    ),
                 )
             await TaskStore.update_scheduler(existing)
             continue
@@ -78,10 +96,13 @@ async def upsert_task_specs(specs: Sequence[TaskSpec]) -> int:
                 user_prompt=spec.user_prompt,
             ),
             trigger=TaskTrigger(
-                cron=spec.cron,
+                cron=normalized_cron,
                 timezone=spec.timezone,
                 cron_description=spec.cron_description,
-                next_run=SchedulerLoop.compute_next_run(spec.cron, spec.timezone),
+                next_run=SchedulerLoop.compute_next_run(
+                    normalized_cron,
+                    spec.timezone,
+                ),
             ),
             execution_mode=exec_mode,
             agent_name=spec.agent_name,

--- a/flocks/tool/task/task_center.py
+++ b/flocks/tool/task/task_center.py
@@ -8,6 +8,7 @@ create, list, update, delete, and query tasks via natural language.
 import json
 from typing import Optional
 
+from flocks.task.formatting import format_task_datetime, resolve_task_timezone_name
 from flocks.tool.registry import (
     ParameterType,
     ToolCategory,
@@ -362,6 +363,7 @@ async def task_create(
     if enabled is False:
         scheduler = await TaskManager.disable_scheduler(scheduler.id) or scheduler
 
+    display_tz = resolve_task_timezone_name(scheduler)
     output_lines = [
         f"ID: {scheduler.id}",
         f"Title: {scheduler.title}",
@@ -379,11 +381,17 @@ async def task_create(
             output_lines.append(f"Execution ID: {execution.id}")
             output_lines.append(f"Execution Status: {execution.status.value}")
     elif scheduler.trigger.run_at:
-        output_lines.append(f"Run at: {scheduler.trigger.run_at.isoformat()}")
+        output_lines.append(
+            f"Run at: {format_task_datetime(scheduler.trigger.run_at, display_tz)}"
+        )
     elif scheduler.trigger.cron:
-        output_lines.append(f"Cron: {scheduler.trigger.cron}")
+        output_lines.append(
+            f"Cron: {scheduler.trigger.cron} ({scheduler.trigger.timezone})"
+        )
         if scheduler.trigger.next_run:
-            output_lines.append(f"Next run: {scheduler.trigger.next_run.isoformat()}")
+            output_lines.append(
+                f"Next run: {format_task_datetime(scheduler.trigger.next_run, display_tz)}"
+            )
 
     return ToolResult(
         success=True,
@@ -864,6 +872,7 @@ def _format_task_line(t) -> str:
 def _format_task(t) -> str:
     mode_value = getattr(getattr(t, "mode", None), "value", getattr(t, "mode", None))
     trigger = getattr(t, "trigger", None)
+    display_tz = resolve_task_timezone_name(t)
     if mode_value == "cron":
         type_value = "scheduled"
     elif getattr(trigger, "run_immediately", False):
@@ -882,24 +891,26 @@ def _format_task(t) -> str:
     ]
     if trigger is not None:
         if trigger.run_at:
-            lines.append(f"Run at: {trigger.run_at.isoformat()}")
+            lines.append(f"Run at: {format_task_datetime(trigger.run_at, display_tz)}")
         if trigger.cron:
             lines.append(f"Cron: {trigger.cron} ({trigger.timezone})")
         if trigger.next_run:
-            lines.append(f"Next run: {trigger.next_run.isoformat()}")
+            lines.append(
+                f"Next run: {format_task_datetime(trigger.next_run, display_tz)}"
+            )
         if trigger.cron_description:
             lines.append(f"Schedule desc: {trigger.cron_description}")
     if getattr(t, "queued_at", None):
-        lines.append(f"Queued: {t.queued_at.isoformat()}")
+        lines.append(f"Queued: {format_task_datetime(t.queued_at, display_tz)}")
     if getattr(t, "started_at", None):
-        lines.append(f"Started: {t.started_at.isoformat()}")
+        lines.append(f"Started: {format_task_datetime(t.started_at, display_tz)}")
     if getattr(t, "completed_at", None):
-        lines.append(f"Completed: {t.completed_at.isoformat()}")
+        lines.append(f"Completed: {format_task_datetime(t.completed_at, display_tz)}")
     if getattr(t, "duration_ms", None) is not None:
         lines.append(f"Duration: {t.duration_ms}ms")
     if getattr(t, "result_summary", None):
         lines.append(f"Result:\n{t.result_summary}")
     if getattr(t, "error", None):
         lines.append(f"Error: {t.error}")
-    lines.append(f"Created: {t.created_at.isoformat()}")
+    lines.append(f"Created: {format_task_datetime(t.created_at, display_tz)}")
     return "\n".join(lines)

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -11,11 +11,13 @@ import pytest
 from flocks.cli.commands import task as task_cli_commands
 import flocks.task.background as background_module
 import flocks.task.manager as task_manager_module
+import flocks.task.plugin_sync as plugin_sync_module
 from flocks.server.routes import question as question_routes
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
 from flocks.task.background import BackgroundManager, BackgroundTask, LaunchInput
 from flocks.task.executor import TaskExecutor
+from flocks.task.formatting import format_task_datetime
 from flocks.task.manager import TaskManager
 from flocks.task.models import (
     DeliveryStatus,
@@ -158,7 +160,49 @@ async def test_create_scheduler_rejects_six_field_cron(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_plugin_sync_skips_new_scheduler_with_invalid_six_field_cron():
+async def test_create_scheduler_rejects_out_of_range_five_field_cron(tmp_path: Path):
+    with pytest.raises(ValueError, match="not a valid 5-field cron"):
+        await TaskManager.create_scheduler(
+            title="越界 cron",
+            mode=SchedulerMode.CRON,
+            trigger=TaskTrigger(
+                cron="70 6 * * *",
+                timezone="Asia/Shanghai",
+            ),
+            workspace_directory=str(tmp_path / "workspace"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_scheduler_does_not_mutate_trigger_argument(tmp_path: Path):
+    trigger = TaskTrigger(
+        cron="  0 6 * * *  ",
+        timezone="Asia/Shanghai",
+    )
+
+    scheduler = await TaskManager.create_scheduler(
+        title="不修改调用方 trigger",
+        mode=SchedulerMode.CRON,
+        trigger=trigger,
+        workspace_directory=str(tmp_path / "workspace"),
+    )
+
+    assert trigger.cron == "  0 6 * * *  "
+    assert scheduler.trigger.cron == "0 6 * * *"
+
+
+@pytest.mark.asyncio
+async def test_plugin_sync_skips_new_scheduler_with_invalid_six_field_cron(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    warn_calls: list[tuple[str, dict]] = []
+
+    monkeypatch.setattr(
+        plugin_sync_module.log,
+        "warn",
+        lambda event, props=None: warn_calls.append((event, props or {})),
+    )
+
     created = await upsert_task_specs(
         [
             TaskSpec(
@@ -174,6 +218,24 @@ async def test_plugin_sync_skips_new_scheduler_with_invalid_six_field_cron():
 
     assert created == 0
     assert scheduler is None
+    assert warn_calls == [
+        (
+            "task.plugin.invalid_cron",
+            {
+                "action": "skipped_entire_spec",
+                "dedup_key": "builtin:invalid-cron-new",
+                "cron": "0 0 6 * * *",
+                "error": (
+                    "Invalid cron expression: only 5-field cron is supported "
+                    "(`minute hour day month weekday`). "
+                    "Example: use `0 6 * * *` for daily 06:00 in Asia/Shanghai. "
+                    "6-field cron (e.g. Quartz format with leading seconds, "
+                    "such as `0 0 6 * * *`) and shortcuts such as `@daily` "
+                    "are not supported."
+                ),
+            },
+        )
+    ]
 
 
 @pytest.mark.asyncio
@@ -210,6 +272,34 @@ async def test_plugin_sync_does_not_overwrite_existing_scheduler_with_invalid_si
     assert unchanged.title == "原始内置任务"
     assert unchanged.trigger.cron == "*/5 * * * *"
     assert unchanged.status == SchedulerStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_update_scheduler_with_trigger_run_once_preserves_existing_cron_when_omitted(
+    tmp_path: Path,
+):
+    scheduler = await TaskManager.create_scheduler(
+        title="切成单次任务时保留旧 cron",
+        mode=SchedulerMode.CRON,
+        trigger=TaskTrigger(
+            cron="*/5 * * * *",
+            timezone="Asia/Shanghai",
+        ),
+        workspace_directory=str(tmp_path / "workspace"),
+    )
+
+    updated = await TaskManager.update_scheduler_with_trigger(
+        scheduler.id,
+        fields={},
+        run_once=True,
+        run_at="2026-05-16T06:00:00+08:00",
+    )
+
+    assert updated is not None
+    assert updated.mode == SchedulerMode.ONCE
+    assert updated.trigger.cron == "*/5 * * * *"
+    assert updated.trigger.run_at is not None
+    assert updated.trigger.run_at.isoformat() == "2026-05-16T06:00:00+08:00"
 
 
 @pytest.mark.asyncio
@@ -800,6 +890,16 @@ async def test_cli_show_formats_scheduler_times_in_schedule_timezone(
     panel = rendered[0]
     assert "Created:  2026-05-15 09:53:08+08:00 (Asia/Shanghai)" in panel.renderable
     assert "Next run: 2026-05-16 06:00:00+08:00 (Asia/Shanghai)" in panel.renderable
+
+
+@pytest.mark.asyncio
+async def test_format_task_datetime_uses_utc_label_when_timezone_not_found():
+    rendered = format_task_datetime(
+        datetime(2026, 5, 15, 1, 53, 8, tzinfo=timezone.utc),
+        "Mars/Base",
+    )
+
+    assert rendered == '2026-05-15 01:53:08+00:00 (UTC ("Mars/Base" not found))'
 
 
 @pytest.mark.asyncio

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -142,6 +142,20 @@ async def test_cron_scheduler_does_not_spawn_second_active_execution(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_create_scheduler_rejects_six_field_cron(tmp_path: Path):
+    with pytest.raises(ValueError, match="only 5-field cron is supported"):
+        await TaskManager.create_scheduler(
+            title="非法 cron",
+            mode=SchedulerMode.CRON,
+            trigger=TaskTrigger(
+                cron="0 0 6 * * *",
+                timezone="Asia/Shanghai",
+            ),
+            workspace_directory=str(tmp_path / "workspace"),
+        )
+
+
+@pytest.mark.asyncio
 async def test_recover_stale_running_execution_unblocks_scheduler(tmp_path: Path):
     manager = TaskManager(max_concurrent=1, poll_interval=999, scheduler_interval=999)
     scheduler = await TaskManager.create_scheduler(
@@ -702,6 +716,33 @@ async def test_cli_list_tasks_accepts_legacy_paused_status(monkeypatch: pytest.M
     await task_cli_commands._list_tasks("paused", "scheduled", 10, "json")
 
     assert printed
+
+
+@pytest.mark.asyncio
+async def test_cli_show_formats_scheduler_times_in_schedule_timezone(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    scheduler = TaskScheduler(
+        title="CLI 定时任务详情",
+        mode=SchedulerMode.CRON,
+        trigger=TaskTrigger(
+            cron="0 6 * * *",
+            timezone="Asia/Shanghai",
+            next_run=datetime(2026, 5, 15, 22, 0, tzinfo=timezone.utc),
+        ),
+        created_at=datetime(2026, 5, 15, 1, 53, 8, tzinfo=timezone.utc),
+    )
+    await TaskStore.create_scheduler(scheduler)
+
+    rendered: list[object] = []
+    monkeypatch.setattr(task_cli_commands.console, "print", lambda *args, **kwargs: rendered.append(args[0]))
+
+    await task_cli_commands._show_task(scheduler.id)
+
+    assert rendered
+    panel = rendered[0]
+    assert "Created:  2026-05-15 09:53:08+08:00 (Asia/Shanghai)" in panel.renderable
+    assert "Next run: 2026-05-16 06:00:00+08:00 (Asia/Shanghai)" in panel.renderable
 
 
 @pytest.mark.asyncio

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -29,6 +29,8 @@ from flocks.task.models import (
     TaskStatus,
     TaskTrigger,
 )
+from flocks.task.plugin_models import TaskSpec
+from flocks.task.plugin_sync import upsert_task_specs
 from flocks.task.queue import TaskQueue
 from flocks.task.scheduler import TaskScheduler as SchedulerLoop
 from flocks.task.store import TaskStore
@@ -153,6 +155,61 @@ async def test_create_scheduler_rejects_six_field_cron(tmp_path: Path):
             ),
             workspace_directory=str(tmp_path / "workspace"),
         )
+
+
+@pytest.mark.asyncio
+async def test_plugin_sync_skips_new_scheduler_with_invalid_six_field_cron():
+    created = await upsert_task_specs(
+        [
+            TaskSpec(
+                dedup_key="builtin:invalid-cron-new",
+                title="无效 cron 新任务",
+                cron="0 0 6 * * *",
+                timezone="Asia/Shanghai",
+            )
+        ]
+    )
+
+    scheduler = await TaskStore.get_scheduler_by_dedup_key("builtin:invalid-cron-new")
+
+    assert created == 0
+    assert scheduler is None
+
+
+@pytest.mark.asyncio
+async def test_plugin_sync_does_not_overwrite_existing_scheduler_with_invalid_six_field_cron(
+    tmp_path: Path,
+):
+    scheduler = await TaskManager.create_scheduler(
+        title="原始内置任务",
+        mode=SchedulerMode.CRON,
+        trigger=TaskTrigger(
+            cron="*/5 * * * *",
+            timezone="Asia/Shanghai",
+        ),
+        workspace_directory=str(tmp_path / "workspace"),
+        dedup_key="builtin:invalid-cron-existing",
+    )
+
+    created = await upsert_task_specs(
+        [
+            TaskSpec(
+                dedup_key="builtin:invalid-cron-existing",
+                title="被拒绝的更新",
+                cron="0 0 6 * * *",
+                timezone="Asia/Shanghai",
+                enabled=False,
+            )
+        ]
+    )
+
+    unchanged = await TaskManager.get_scheduler(scheduler.id)
+
+    assert created == 0
+    assert unchanged is not None
+    assert unchanged.title == "原始内置任务"
+    assert unchanged.trigger.cron == "*/5 * * * *"
+    assert unchanged.status == SchedulerStatus.ACTIVE
 
 
 @pytest.mark.asyncio

--- a/tests/tool/test_task_center_compat.py
+++ b/tests/tool/test_task_center_compat.py
@@ -8,7 +8,7 @@ import flocks.tool.task.task_center  # noqa: F401
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
 from flocks.task.manager import TaskManager
-from flocks.task.models import SchedulerMode, TaskTrigger
+from flocks.task.models import SchedulerMode, TaskPriority, TaskScheduler, TaskTrigger
 from flocks.task.store import TaskStore
 from flocks.tool.registry import ToolContext, ToolRegistry
 
@@ -216,6 +216,80 @@ class TestTaskCenterCompatibility:
         assert scheduler.mode == SchedulerMode.CRON
         assert scheduler.trigger.cron == "*/5 * * * *"
         assert scheduler.trigger.run_immediately is False
+
+    @pytest.mark.asyncio
+    async def test_task_create_rejects_six_field_cron_with_hint(self):
+        result = await ToolRegistry.execute(
+            "task_create",
+            ctx=_make_ctx(),
+            title="每天早上 6 点执行",
+            description="误传了 6 段 Quartz cron",
+            cron="0 0 6 * * *",
+            user_prompt="执行巡检",
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "only 5-field cron is supported" in result.error
+        assert "`0 6 * * *`" in result.error
+
+        _, total = await TaskManager.list_schedulers(limit=10)
+        assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_task_update_rejects_six_field_cron_with_hint(self):
+        scheduler = await TaskManager.create_scheduler(
+            title="待更新的定时任务",
+            mode=SchedulerMode.CRON,
+            trigger=TaskTrigger(
+                cron="*/5 * * * *",
+                timezone="Asia/Shanghai",
+            ),
+        )
+
+        result = await ToolRegistry.execute(
+            "task_update",
+            ctx=_make_ctx(),
+            task_id=scheduler.id,
+            cron="0 0 6 * * *",
+            run_once=False,
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "only 5-field cron is supported" in result.error
+        assert "`0 6 * * *`" in result.error
+
+        unchanged = await TaskManager.get_scheduler(scheduler.id)
+        assert unchanged is not None
+        assert unchanged.trigger.cron == "*/5 * * * *"
+
+    @pytest.mark.asyncio
+    async def test_task_status_formats_scheduler_times_in_schedule_timezone(self):
+        scheduler = TaskScheduler(
+            title="每日主机安全巡检",
+            mode=SchedulerMode.CRON,
+            priority=TaskPriority.NORMAL,
+            trigger=TaskTrigger(
+                cron="0 6 * * *",
+                timezone="Asia/Shanghai",
+                next_run=datetime(2026, 5, 15, 22, 0, tzinfo=timezone.utc),
+            ),
+            created_at=datetime(2026, 5, 15, 1, 53, 8, tzinfo=timezone.utc),
+        )
+        await TaskStore.create_scheduler(scheduler)
+
+        result = await ToolRegistry.execute(
+            "task_status",
+            ctx=_make_ctx(),
+            task_id=scheduler.id,
+        )
+
+        assert result.success is True
+        assert result.output is not None
+        assert "Cron: 0 6 * * * (Asia/Shanghai)" in result.output
+        assert "Next run: 2026-05-16 06:00:00+08:00 (Asia/Shanghai)" in result.output
+        assert "Created: 2026-05-15 09:53:08+08:00 (Asia/Shanghai)" in result.output
 
     @pytest.mark.asyncio
     async def test_task_update_can_disable_and_enable_scheduled_task(self):


### PR DESCRIPTION
## Summary

- Enforce **5-field** cron across scheduler creation/updates, CLI scheduled task creation, and task center tools; reject **6-field Quartz** expressions with a clear, copy-pastable example.
- Render task and scheduler timestamps in the **scheduler timezone** in the CLI and `task_center` output for readability (`flocks/task/formatting.py`).
- During **plugin task spec** upsert, validate cron and **skip** invalid specs with structured logging so bad cron cannot create schedulers or overwrite existing ones.