### PR TITLE
skills: PowerShell guidance for flocks browser

### DIFF
--- a/.flocks/plugins/skills/browser-use/SKILL.md
+++ b/.flocks/plugins/skills/browser-use/SKILL.md
@@ -60,6 +60,8 @@ browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后
 
 然后等待用户进一步指示。如果用户确认已开启后，不要立刻重跑 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 attach，再运行 `flocks browser --doctor` 做只读确认。
 
+如果用户在 `Windows PowerShell` 中执行 `flocks browser -c`，优先使用单行代码并用分号分隔；多行单引号字符串容易因为换行/转义处理差异而触发假失败。
+
 - 如果 `--setup` / `-c` 成功，或随后 `--doctor` 通过：立即使用 `CDP 直连`，并立刻阅读 `references/cdp-direct.md`
 - 如果仍未通过：继续提示用户检查 remote debugging，或提示切到 `agent-browser`
 

--- a/.flocks/plugins/skills/browser-use/references/cdp-direct.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-direct.md
@@ -52,6 +52,7 @@ print(page_info())
 
 - `flocks browser -c '...'` 执行的是一段 Python 代码，不是交互式 REPL；如果希望看到结果，必须显式 `print(...)`。
 - 多行代码请直接写成真正的多行 shell 字符串或 heredoc；不要把 `\n` 当字面量塞进单引号参数里。
+- 在 `Windows PowerShell` 中，优先把 `flocks browser -c` 写成单行并用分号分隔；多行单引号字符串的换行/转义处理不稳定，容易让代码没有完整传给 Python。
 
 常用 helpers：
 

--- a/.flocks/plugins/skills/web2cli/SKILL.md
+++ b/.flocks/plugins/skills/web2cli/SKILL.md
@@ -48,6 +48,7 @@ mkdir -p "$CAPTURE_ROOT/captures"
 
 - `flocks browser -c '...'` 会把代码直接交给 Python `exec()`，表达式不会像 REPL 一样自动回显；需要输出时必须显式 `print(...)`。
 - 多行代码要直接写成真正的多行字符串或 heredoc，不要把 `\n` 当成字面量塞进单引号字符串里。
+- 在 `Windows PowerShell` 中，优先把 `flocks browser -c` 写成单行并用分号分隔；多行单引号字符串的换行/转义处理不稳定，容易让代码没有完整传给 Python。
 
 各类输出位置固定如下：
 


### PR DESCRIPTION
## Summary
- Document that on Windows PowerShell, `flocks browser -c` should prefer single-line code with semicolons, because multiline single-quoted strings can break quoting and truncate what reaches Python.
- Applied consistently to `browser-use` (SKILL + `cdp-direct` reference) and `web2cli` skills.