### PR TITLE
fix(mcp): thread-safe MCP client across loops; workflow service MCP lifespan

### DIFF
--- a/flocks/mcp/client.py
+++ b/flocks/mcp/client.py
@@ -118,6 +118,7 @@ class McpClient:
         self._connected = False
         self._transport_type: Optional[str] = None
         self._command_queue: asyncio.Queue[_ClientCommand] | None = None
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
         self._owner_task: asyncio.Task[None] | None = None
         self._owner_error: BaseException | None = None
     
@@ -140,6 +141,7 @@ class McpClient:
         loop = asyncio.get_running_loop()
         startup_future: asyncio.Future[None] = loop.create_future()
         self._owner_error = None
+        self._owner_loop = loop
         self._command_queue = asyncio.Queue()
 
         owner_task = asyncio.create_task(
@@ -225,6 +227,7 @@ class McpClient:
         self._connected = False
         self._transport_type = None
         self._command_queue = None
+        self._owner_loop = None
         if self._owner_task is not None and self._owner_task.done():
             self._owner_task = None
         if clear_owner_error:
@@ -629,15 +632,12 @@ class McpClient:
 
         try:
             if owner_task is not None and not owner_task.done() and self._command_queue is not None:
-                response = asyncio.get_running_loop().create_future()
-                await self._command_queue.put(_ClientCommand(action="disconnect", response=response))
-                await response
+                await self._submit_command("disconnect")
             elif owner_task is not None and not owner_task.done():
-                owner_task.cancel()
+                self._cancel_task_threadsafe(owner_task)
 
             if owner_task is not None:
-                with contextlib.suppress(asyncio.CancelledError):
-                    await owner_task
+                await self._await_task(owner_task)
         except Exception as exc:
             log.error("mcp.client.disconnect_error", {
                 "server": self.name,
@@ -753,6 +753,38 @@ class McpClient:
                 ) from self._owner_error
             raise RuntimeError(f"Client not connected: {self.name}")
 
+        owner_loop = self._owner_loop
+        if owner_loop is None:
+            raise RuntimeError(f"Client owner loop not initialized: {self.name}")
+
+        current_loop = asyncio.get_running_loop()
+        if current_loop is owner_loop:
+            return await self._submit_command_on_owner_loop(action, payload)
+
+        if not owner_loop.is_running():
+            owner_error = self._owner_error or RuntimeError(f"Client not connected: {self.name}")
+            raise owner_error
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._submit_command_on_owner_loop(action, payload),
+            owner_loop,
+        )
+        return await asyncio.wrap_future(future)
+
+    async def _submit_command_on_owner_loop(
+        self,
+        action: str,
+        payload: Dict[str, Any],
+    ) -> Any:
+        """Submit a command from the owner loop and await the response."""
+        owner_task = self._owner_task
+        if self._command_queue is None or owner_task is None:
+            if self._owner_error is not None:
+                raise RuntimeError(
+                    f"Client not connected: {self.name}: {_extract_root_cause(self._owner_error)}"
+                ) from self._owner_error
+            raise RuntimeError(f"Client not connected: {self.name}")
+
         response = asyncio.get_running_loop().create_future()
         command = _ClientCommand(action=action, payload=payload, response=response)
         await self._command_queue.put(command)
@@ -762,6 +794,36 @@ class McpClient:
             response.set_exception(owner_error)
 
         return await response
+
+    async def _await_task(self, task: asyncio.Task[Any]) -> None:
+        """Await a task safely from the owner loop or another loop."""
+        owner_loop = self._owner_loop
+        current_loop = asyncio.get_running_loop()
+        if owner_loop is None or current_loop is owner_loop:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            return
+
+        if not owner_loop.is_running():
+            return
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._await_task_on_owner_loop(task),
+            owner_loop,
+        )
+        await asyncio.wrap_future(future)
+
+    async def _await_task_on_owner_loop(self, task: asyncio.Task[Any]) -> None:
+        """Await a task that belongs to the owner loop."""
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    def _cancel_task_threadsafe(self, task: asyncio.Task[Any]) -> None:
+        """Cancel a task from the owner loop or another thread/loop."""
+        owner_loop = self._owner_loop
+        if owner_loop is None or not owner_loop.is_running():
+            return
+        owner_loop.call_soon_threadsafe(task.cancel)
     
     @property
     def is_connected(self) -> bool:

--- a/flocks/mcp/client.py
+++ b/flocks/mcp/client.py
@@ -631,7 +631,7 @@ class McpClient:
             return
 
         try:
-            if owner_task is not None and not owner_task.done() and self._command_queue is not None:
+            if owner_task is not None and not owner_task.done() and self._connected and self._command_queue is not None:
                 await self._submit_command("disconnect")
             elif owner_task is not None and not owner_task.done():
                 self._cancel_task_threadsafe(owner_task)

--- a/flocks/server/routes/mcp.py
+++ b/flocks/server/routes/mcp.py
@@ -476,13 +476,54 @@ async def update_mcp_server(name: str, request: McpUpdateRequest):
         _persist_mcp_server_config(name, clean_config)
 
         status = await MCP.status()
-        if name in status:
+        previous_status = status.get(name)
+        was_connected = (
+            previous_status is not None
+            and previous_status.status == McpStatus.CONNECTED
+        )
+        should_reconnect = was_connected and clean_config.get("enabled", True) is not False
+
+        if previous_status is not None:
             await MCP.remove(name)
+
+        reconnected = False
+        reconnect_error: Optional[str] = None
+        if should_reconnect:
+            reconnect_timeout_seconds = max(float(clean_config.get("timeout", 30.0) or 30.0), 1.0) + 2.0
+            try:
+                reconnected = await asyncio.wait_for(
+                    MCP.connect(name, clean_config),
+                    timeout=reconnect_timeout_seconds,
+                )
+            except asyncio.TimeoutError:
+                reconnect_error = (
+                    f"Connection timed out while reconnecting MCP server: {name}"
+                )
+            except Exception as exc:
+                reconnect_error = str(exc)
+            if not reconnected and reconnect_error is None:
+                reconnect_status = (await MCP.status()).get(name)
+                reconnect_error = (
+                    getattr(reconnect_status, "error", None)
+                    if reconnect_status is not None
+                    else None
+                ) or f"Failed to reconnect MCP server: {name}"
+
+        message = f"MCP server '{name}' updated successfully."
+        if should_reconnect and reconnected:
+            message = f"MCP server '{name}' updated and reconnected successfully."
+        elif should_reconnect and reconnect_error:
+            message = (
+                f"MCP server '{name}' updated successfully, but reconnect failed: "
+                f"{reconnect_error}"
+            )
 
         return {
             "success": True,
-            "message": f"MCP server '{name}' updated successfully.",
+            "message": message,
             "config": _to_frontend_mcp_config(clean_config),
+            "reconnected": reconnected,
+            "reconnect_error": reconnect_error,
         }
     except HTTPException:
         raise

--- a/flocks/workflow/service_runtime.py
+++ b/flocks/workflow/service_runtime.py
@@ -6,12 +6,17 @@ import argparse
 import asyncio
 import json
 import time
+from contextlib import asynccontextmanager
 from typing import Any, Dict, Optional
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from flocks.mcp import MCP, get_manager
+from flocks.utils.log import Log
 from flocks.workflow.runner import RunWorkflowResult, run_workflow
+
+log = Log.create(service="workflow.service_runtime")
 
 
 class InvokeRequest(BaseModel):
@@ -31,7 +36,21 @@ def create_service_app(
     release_id: str,
 ) -> FastAPI:
     """Build service app bound to one workflow snapshot."""
-    app = FastAPI(title="Flocks Workflow Service", version="0.2.0")
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        try:
+            await MCP.init()
+        except Exception as exc:
+            log.warning("workflow_service.mcp.init_failed", {"error": str(exc)})
+        try:
+            yield
+        finally:
+            try:
+                await get_manager().shutdown()
+            except Exception as exc:
+                log.warning("workflow_service.mcp.shutdown_failed", {"error": str(exc)})
+
+    app = FastAPI(title="Flocks Workflow Service", version="0.2.0", lifespan=lifespan)
     app.state.workflow_json = workflow_json
     app.state.workflow_id = workflow_id
     app.state.release_id = release_id

--- a/flocks/workflow/service_runtime.py
+++ b/flocks/workflow/service_runtime.py
@@ -10,6 +10,7 @@ from contextlib import asynccontextmanager
 from typing import Any, Dict, Optional
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from flocks.mcp import MCP, get_manager
@@ -38,10 +39,15 @@ def create_service_app(
     """Build service app bound to one workflow snapshot."""
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
+        _app.state.mcp_ready = False
+        _app.state.mcp_error = None
         try:
             await MCP.init()
         except Exception as exc:
+            _app.state.mcp_error = str(exc)
             log.warning("workflow_service.mcp.init_failed", {"error": str(exc)})
+        else:
+            _app.state.mcp_ready = True
         try:
             yield
         finally:
@@ -57,15 +63,33 @@ def create_service_app(
 
     @app.get("/health")
     async def health() -> Dict[str, Any]:
-        return {
-            "ok": True,
+        payload = {
+            "ok": bool(app.state.mcp_ready),
+            "mcp_ready": bool(app.state.mcp_ready),
+            "mcp_error": app.state.mcp_error,
             "workflow_id": app.state.workflow_id,
             "release_id": app.state.release_id,
         }
+        if app.state.mcp_ready:
+            return payload
+        return JSONResponse(status_code=503, content=payload)
 
     @app.post("/invoke")
     async def invoke(req: InvokeRequest) -> Dict[str, Any]:
         started = time.time()
+        if not app.state.mcp_ready:
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "request_id": req.request_id,
+                    "workflow_id": app.state.workflow_id,
+                    "release_id": app.state.release_id,
+                    "status": "FAILED",
+                    "error": app.state.mcp_error or "MCP subsystem is not ready",
+                    "duration_ms": int((time.time() - started) * 1000),
+                },
+            )
+
         try:
             result: RunWorkflowResult = await asyncio.to_thread(
                 run_workflow,

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -259,3 +259,39 @@ class TestMcpClientCrossLoopSubmission:
         assert owner_task.done() is True
         assert client._owner_loop is None
         assert client._command_queue is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_while_connecting_cancels_owner_task(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        client = McpClient(
+            name="demo",
+            server_type="remote",
+            url="https://example.com/mcp",
+        )
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def fake_remote(startup_future):
+            del startup_future
+            started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        monkeypatch.setattr(client, "_connect_remote", fake_remote)
+
+        connect_task = asyncio.create_task(client.connect())
+        await started.wait()
+
+        await client.disconnect()
+
+        with pytest.raises(RuntimeError, match="Connection closed before initialization: demo"):
+            await connect_task
+
+        assert cancelled.is_set() is True
+        assert client._owner_task is None
+        assert client._command_queue is None

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from contextlib import asynccontextmanager
 from types import MethodType
 from unittest.mock import AsyncMock
@@ -176,3 +177,85 @@ class TestMcpClientTransportSelection:
             await client._connect_local(startup_future)
 
         assert fake_stderr.closed is True
+
+
+class TestMcpClientCrossLoopSubmission:
+    @pytest.mark.asyncio
+    async def test_call_tool_from_another_loop_reuses_owner_loop(self):
+        client = McpClient(
+            name="demo",
+            server_type="remote",
+            url="https://example.com/mcp",
+        )
+        owner_loop = asyncio.get_running_loop()
+        client._connected = True
+        client._owner_loop = owner_loop
+        client._command_queue = asyncio.Queue()
+
+        observed: dict[str, object] = {}
+
+        async def owner() -> None:
+            while True:
+                command = await client._command_queue.get()
+                observed["owner_loop"] = asyncio.get_running_loop()
+                observed["action"] = command.action
+                observed["payload"] = dict(command.payload)
+                if command.action == "disconnect":
+                    if command.response is not None and not command.response.done():
+                        command.response.set_result(None)
+                    return
+                if command.response is not None and not command.response.done():
+                    command.response.set_result(
+                        {
+                            "ok": True,
+                            "loop_matches": asyncio.get_running_loop() is owner_loop,
+                            "payload": dict(command.payload),
+                        }
+                    )
+
+        client._owner_task = asyncio.create_task(owner())
+
+        result = await asyncio.to_thread(
+            lambda: asyncio.run(client.call_tool("demo_tool", {"value": "x"}))
+        )
+
+        assert result == {
+            "ok": True,
+            "loop_matches": True,
+            "payload": {"name": "demo_tool", "arguments": {"value": "x"}},
+        }
+        assert observed["owner_loop"] is owner_loop
+        assert observed["action"] == "call_tool"
+
+        await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_from_another_loop_finishes_owner_task(self):
+        client = McpClient(
+            name="demo",
+            server_type="remote",
+            url="https://example.com/mcp",
+        )
+        client._connected = True
+        client._owner_loop = asyncio.get_running_loop()
+        client._command_queue = asyncio.Queue()
+        disconnect_seen = threading.Event()
+
+        async def owner() -> None:
+            while True:
+                command = await client._command_queue.get()
+                if command.action == "disconnect":
+                    disconnect_seen.set()
+                    if command.response is not None and not command.response.done():
+                        command.response.set_result(None)
+                    return
+
+        owner_task = asyncio.create_task(owner())
+        client._owner_task = owner_task
+
+        await asyncio.to_thread(lambda: asyncio.run(client.disconnect()))
+
+        assert disconnect_seen.is_set() is True
+        assert owner_task.done() is True
+        assert client._owner_loop is None
+        assert client._command_queue is None

--- a/tests/server/routes/test_mcp_routes.py
+++ b/tests/server/routes/test_mcp_routes.py
@@ -354,6 +354,7 @@ class TestMcpRoutes:
     ):
         stored_configs: dict[str, dict] = {}
         removed_servers: list[str] = []
+        attempted_reconnects: list[tuple[str, dict]] = []
 
         async def fake_config_get(cls):
             return type(
@@ -377,6 +378,10 @@ class TestMcpRoutes:
             removed_servers.append(name)
             return True
 
+        async def fake_connect(name: str, config: dict) -> bool:
+            attempted_reconnects.append((name, dict(config)))
+            return True
+
         monkeypatch.setattr(
             mcp_routes.Config,
             "get",
@@ -393,6 +398,7 @@ class TestMcpRoutes:
         )
         monkeypatch.setattr(mcp_routes.MCP, "status", fake_status)
         monkeypatch.setattr(mcp_routes.MCP, "remove", fake_remove)
+        monkeypatch.setattr(mcp_routes.MCP, "connect", fake_connect)
         monkeypatch.setattr(
             mcp_routes.ConfigWriter,
             "add_mcp_server",
@@ -410,10 +416,23 @@ class TestMcpRoutes:
         assert data["success"] is True
         assert data["config"]["type"] == "sse"
         assert data["config"]["url"] == "https://new.example.com/mcp"
+        assert data["reconnected"] is True
+        assert data["reconnect_error"] is None
         assert stored_configs["qianxin-mcp"]["type"] == "remote"
         assert stored_configs["qianxin-mcp"]["url"] == "https://new.example.com/mcp"
         assert stored_configs["qianxin-mcp"]["headers"]["Api-Key"] == "{secret:qianxin_mcp_key}"
         assert removed_servers == ["qianxin-mcp"]
+        assert attempted_reconnects == [
+            (
+                "qianxin-mcp",
+                {
+                    "type": "remote",
+                    "url": "https://new.example.com/mcp",
+                    "transport": "sse",
+                    "headers": {"Api-Key": "{secret:qianxin_mcp_key}"},
+                },
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_update_mcp_server_can_disable_and_persist_state(
@@ -475,6 +494,89 @@ class TestMcpRoutes:
         assert resp.status_code == 200, resp.text
         assert stored_configs["panther"]["enabled"] is False
         assert removed_servers == ["panther"]
+
+    @pytest.mark.asyncio
+    async def test_update_mcp_server_returns_warning_when_reconnect_fails(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        stored_configs: dict[str, dict] = {}
+        removed_servers: list[str] = []
+        attempted_reconnects: list[str] = []
+
+        async def fake_config_get(cls):
+            return type(
+                "ConfigStub",
+                (),
+                {
+                    "mcp": {
+                        "GaodeMap": {
+                            "type": "remote",
+                            "url": "https://old.example.com/mcp",
+                            "auth": {
+                                "type": "apikey",
+                                "location": "header",
+                                "param_name": "Authorization",
+                                "value": "{secret:GaodeMap_mcp_key}",
+                            },
+                        }
+                    }
+                },
+            )()
+
+        async def fake_status() -> dict[str, McpStatusInfo]:
+            return {"GaodeMap": McpStatusInfo(status=McpStatus.CONNECTED)}
+
+        async def fake_remove(name: str) -> bool:
+            removed_servers.append(name)
+            return True
+
+        async def fake_connect(name: str, config: dict) -> bool:
+            attempted_reconnects.append(name)
+            return False
+
+        monkeypatch.setattr(
+            mcp_routes.Config,
+            "get",
+            classmethod(fake_config_get),
+        )
+        monkeypatch.setattr(
+            mcp_routes.ConfigWriter,
+            "get_mcp_server",
+            lambda name: {
+                "type": "remote",
+                "url": "https://old.example.com/mcp",
+                "auth": {
+                    "type": "apikey",
+                    "location": "header",
+                    "param_name": "Authorization",
+                    "value": "{secret:GaodeMap_mcp_key}",
+                },
+            },
+        )
+        monkeypatch.setattr(mcp_routes.MCP, "status", fake_status)
+        monkeypatch.setattr(mcp_routes.MCP, "remove", fake_remove)
+        monkeypatch.setattr(mcp_routes.MCP, "connect", fake_connect)
+        monkeypatch.setattr(
+            mcp_routes.ConfigWriter,
+            "add_mcp_server",
+            lambda name, config: stored_configs.__setitem__(name, config),
+        )
+        monkeypatch.setattr(tool_loader, "save_mcp_config", lambda name, config: None)
+
+        resp = await client.put(
+            "/api/mcp/GaodeMap",
+            json={"config": {"url": "https://new.example.com/mcp"}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is True
+        assert data["reconnected"] is False
+        assert data["reconnect_error"] == "Failed to reconnect MCP server: GaodeMap"
+        assert "reconnect failed" in data["message"]
+        assert stored_configs["GaodeMap"]["url"] == "https://new.example.com/mcp"
+        assert removed_servers == ["GaodeMap"]
+        assert attempted_reconnects == ["GaodeMap"]
 
     @pytest.mark.asyncio
     async def test_update_mcp_server_extracts_url_api_key_before_persisting(

--- a/tests/server/routes/test_workflow_run_route.py
+++ b/tests/server/routes/test_workflow_run_route.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from flocks.mcp import MCP
+from flocks.tool import ToolContext
+import flocks.server.routes.workflow as workflow_module
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_execution_task_reuses_existing_mcp_without_reinit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    init_mock = AsyncMock()
+    run_mock = Mock(
+        return_value=SimpleNamespace(
+            outputs={"ok": True},
+            history=[],
+            last_node_id="node-1",
+            steps=1,
+        )
+    )
+    record_result = AsyncMock(return_value=None)
+    storage_read = AsyncMock(
+        return_value={
+            "id": "exec-1",
+            "workflowId": "wf-1",
+            "currentNodeType": "tool",
+            "executionLog": [],
+        }
+    )
+
+    monkeypatch.setattr(MCP, "init", init_mock)
+    monkeypatch.setattr(workflow_module, "run_workflow", run_mock)
+    monkeypatch.setattr(workflow_module, "_resolve_execution_outcome", lambda _result: ("success", None))
+    monkeypatch.setattr(workflow_module, "_record_execution_result", record_result)
+    monkeypatch.setattr(workflow_module.Storage, "read", storage_read)
+    monkeypatch.setattr(workflow_module.Storage, "write", AsyncMock(return_value=None))
+    monkeypatch.setattr(workflow_module, "compact_outputs_for_storage", lambda value: value)
+    monkeypatch.setattr(workflow_module, "compact_history_for_storage", lambda value: value)
+
+    req = workflow_module.WorkflowRunRequest(inputs={"ip": "8.8.8.8"}, trace=False)
+    tool_context = ToolContext(session_id="session-1", message_id="message-1", agent="rex")
+
+    await workflow_module._run_workflow_execution_task(
+        workflow_id="wf-1",
+        workflow_json={"id": "wf-1", "start": "node-1", "nodes": [], "edges": []},
+        req=req,
+        exec_id="exec-1",
+        cancel_event=workflow_module.threading.Event(),
+        tool_context=tool_context,
+    )
+
+    init_mock.assert_not_awaited()
+    run_mock.assert_called_once()
+    assert run_mock.call_args.kwargs["tool_context"] is tool_context
+    record_result.assert_awaited_once()

--- a/tests/workflow/test_tool_run_workflow.py
+++ b/tests/workflow/test_tool_run_workflow.py
@@ -9,18 +9,24 @@ Tests cover:
 - Permission handling
 """
 
+import asyncio
 import pytest
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
 from typing import Dict, Any
 
 # Import the tool system
 from flocks.tool import (
+    ParameterType,
+    ToolCategory,
     ToolRegistry,
     ToolContext,
+    ToolParameter,
     ToolResult,
 )
 
 import flocks.tool.task.run_workflow as run_workflow_module
+from flocks.mcp.client import McpClient
+from flocks.workflow.runner import RunWorkflowResult, run_workflow
 
 
 class FakeRunWorkflowResult:
@@ -84,6 +90,7 @@ def simple_workflow():
         "id": "test-workflow-001",
         "name": "Test Workflow",
         "metadata": {},
+        "start": "node-1",
         "nodes": [
             {
                 "id": "node-1",
@@ -104,6 +111,7 @@ def workflow_with_requirements():
         "metadata": {
             "requirements": ["requests>=2.31,<3"]
         },
+        "start": "node-1",
         "nodes": [
             {
                 "id": "node-1",
@@ -122,6 +130,7 @@ def workflow_with_inputs():
         "id": "test-workflow-003",
         "name": "Test Workflow with Inputs",
         "metadata": {},
+        "start": "node-1",
         "nodes": [
             {
                 "id": "node-1",
@@ -737,3 +746,94 @@ class TestRunWorkflowToolIntegration:
         assert result is not None
         assert result.success is True
         assert "Status: SUCCEEDED" in (result.output or "")
+
+    @pytest.mark.asyncio
+    async def test_run_workflow_integration_reuses_cross_loop_mcp_client(
+        self,
+        tool_context,
+    ):
+        tool_name = "test_fake_mcp_cross_loop_tool"
+        client = McpClient(
+            name="demo",
+            server_type="remote",
+            url="https://example.com/mcp",
+        )
+        owner_loop = asyncio.get_running_loop()
+        client._connected = True
+        client._owner_loop = owner_loop
+        client._command_queue = asyncio.Queue()
+        observed: dict[str, Any] = {}
+
+        async def owner() -> None:
+            while True:
+                command = await client._command_queue.get()
+                if command.action == "disconnect":
+                    if command.response is not None and not command.response.done():
+                        command.response.set_result(None)
+                    return
+                observed["action"] = command.action
+                observed["payload"] = dict(command.payload)
+                if command.response is not None and not command.response.done():
+                    command.response.set_result("owner-loop-ok")
+
+        client._owner_task = asyncio.create_task(owner())
+
+        @ToolRegistry.register_function(
+            name=tool_name,
+            description="Cross-loop MCP-backed test tool",
+            category=ToolCategory.SYSTEM,
+            parameters=[
+                ToolParameter(
+                    name="value",
+                    type=ParameterType.STRING,
+                    description="Payload value",
+                    required=True,
+                )
+            ],
+        )
+        async def _tool(_ctx: ToolContext, value: str) -> ToolResult:
+            result = await client.call_tool("demo_tool", {"value": value})
+            return ToolResult(success=True, output=result)
+
+        workflow = {
+            "id": "integration-mcp-cross-loop",
+            "name": "Integration MCP Cross Loop Workflow",
+            "metadata": {},
+            "start": "tool-node",
+            "nodes": [
+                {
+                    "id": "tool-node",
+                    "type": "tool",
+                    "tool_name": tool_name,
+                    "tool_args": {"value": "demo"},
+                    "output_key": "result",
+                }
+            ],
+            "edges": [],
+        }
+
+        try:
+            with patch.object(
+                run_workflow_module,
+                "_get_workflow_runtime",
+                return_value=(Mock(name="RequirementsInstaller"), run_workflow, RunWorkflowResult),
+            ):
+                result = await ToolRegistry.execute(
+                    "run_workflow",
+                    ctx=tool_context,
+                    workflow=workflow,
+                    inputs={},
+                    ensure_requirements=False,
+                )
+        finally:
+            await client.disconnect()
+            ToolRegistry.unregister(tool_name)
+            ToolRegistry._enabled_defaults.pop(tool_name, None)
+
+        assert result.success is True
+        assert "owner-loop-ok" in (result.output or "")
+        assert observed["action"] == "call_tool"
+        assert observed["payload"] == {
+            "name": "demo_tool",
+            "arguments": {"value": "demo"},
+        }

--- a/tests/workflow/test_workflow_service_runtime.py
+++ b/tests/workflow/test_workflow_service_runtime.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from fastapi.testclient import TestClient
 
@@ -25,28 +25,36 @@ def test_service_runtime_lifespan_initializes_and_shuts_down_mcp(
     with TestClient(app, raise_server_exceptions=True) as client:
         response = client.get("/health")
         assert response.status_code == 200
-        assert response.json()["workflow_id"] == "wf-1"
+        assert response.json() == {
+            "ok": True,
+            "mcp_ready": True,
+            "mcp_error": None,
+            "workflow_id": "wf-1",
+            "release_id": "rel-1",
+        }
 
     init_mock.assert_awaited_once()
     shutdown_mock.assert_awaited_once()
 
 
-def test_service_runtime_lifespan_tolerates_mcp_init_failure(
+def test_service_runtime_lifespan_reports_mcp_init_failure(
     monkeypatch,
 ) -> None:
     init_mock = AsyncMock(side_effect=RuntimeError("mcp init boom"))
     shutdown_mock = AsyncMock()
     manager = SimpleNamespace(shutdown=shutdown_mock)
-    run_result = SimpleNamespace(
-        status="SUCCEEDED",
-        run_id="run-1",
-        outputs={"ok": True},
-        error=None,
+    run_workflow_mock = Mock(
+        return_value=SimpleNamespace(
+            status="SUCCEEDED",
+            run_id="run-1",
+            outputs={"ok": True},
+            error=None,
+        )
     )
 
     monkeypatch.setattr(service_runtime.MCP, "init", init_mock)
     monkeypatch.setattr(service_runtime, "get_manager", lambda: manager)
-    monkeypatch.setattr(service_runtime, "run_workflow", lambda **_kwargs: run_result)
+    monkeypatch.setattr(service_runtime, "run_workflow", run_workflow_mock)
 
     app = service_runtime.create_service_app(
         workflow_json={"id": "wf-1", "start": "node-1", "nodes": [], "edges": []},
@@ -55,10 +63,21 @@ def test_service_runtime_lifespan_tolerates_mcp_init_failure(
     )
 
     with TestClient(app, raise_server_exceptions=True) as client:
-        response = client.post("/invoke", json={"inputs": {"ip": "8.8.8.8"}})
-        assert response.status_code == 200
-        assert response.json()["status"] == "SUCCEEDED"
-        assert response.json()["outputs"] == {"ok": True}
+        health_response = client.get("/health")
+        assert health_response.status_code == 503
+        assert health_response.json() == {
+            "ok": False,
+            "mcp_ready": False,
+            "mcp_error": "mcp init boom",
+            "workflow_id": "wf-1",
+            "release_id": "rel-1",
+        }
+
+        invoke_response = client.post("/invoke", json={"inputs": {"ip": "8.8.8.8"}})
+        assert invoke_response.status_code == 503
+        assert invoke_response.json()["detail"]["status"] == "FAILED"
+        assert invoke_response.json()["detail"]["error"] == "mcp init boom"
 
     init_mock.assert_awaited_once()
     shutdown_mock.assert_awaited_once()
+    run_workflow_mock.assert_not_called()

--- a/tests/workflow/test_workflow_service_runtime.py
+++ b/tests/workflow/test_workflow_service_runtime.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+import flocks.workflow.service_runtime as service_runtime
+
+
+def test_service_runtime_lifespan_initializes_and_shuts_down_mcp(
+    monkeypatch,
+) -> None:
+    init_mock = AsyncMock()
+    shutdown_mock = AsyncMock()
+    manager = SimpleNamespace(shutdown=shutdown_mock)
+
+    monkeypatch.setattr(service_runtime.MCP, "init", init_mock)
+    monkeypatch.setattr(service_runtime, "get_manager", lambda: manager)
+
+    app = service_runtime.create_service_app(
+        workflow_json={"id": "wf-1", "start": "node-1", "nodes": [], "edges": []},
+        workflow_id="wf-1",
+        release_id="rel-1",
+    )
+
+    with TestClient(app, raise_server_exceptions=True) as client:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json()["workflow_id"] == "wf-1"
+
+    init_mock.assert_awaited_once()
+    shutdown_mock.assert_awaited_once()
+
+
+def test_service_runtime_lifespan_tolerates_mcp_init_failure(
+    monkeypatch,
+) -> None:
+    init_mock = AsyncMock(side_effect=RuntimeError("mcp init boom"))
+    shutdown_mock = AsyncMock()
+    manager = SimpleNamespace(shutdown=shutdown_mock)
+    run_result = SimpleNamespace(
+        status="SUCCEEDED",
+        run_id="run-1",
+        outputs={"ok": True},
+        error=None,
+    )
+
+    monkeypatch.setattr(service_runtime.MCP, "init", init_mock)
+    monkeypatch.setattr(service_runtime, "get_manager", lambda: manager)
+    monkeypatch.setattr(service_runtime, "run_workflow", lambda **_kwargs: run_result)
+
+    app = service_runtime.create_service_app(
+        workflow_json={"id": "wf-1", "start": "node-1", "nodes": [], "edges": []},
+        workflow_id="wf-1",
+        release_id="rel-1",
+    )
+
+    with TestClient(app, raise_server_exceptions=True) as client:
+        response = client.post("/invoke", json={"inputs": {"ip": "8.8.8.8"}})
+        assert response.status_code == 200
+        assert response.json()["status"] == "SUCCEEDED"
+        assert response.json()["outputs"] == {"ok": True}
+
+    init_mock.assert_awaited_once()
+    shutdown_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary

- **MCP client**: Track the owner event loop and submit commands via `run_coroutine_threadsafe` when callers run on a different loop, so disconnect and tool calls stay consistent across threads/loops.
- **Workflow service**: Add FastAPI lifespan hooks to initialize MCP on startup and shut down the MCP manager on teardown (with tolerant logging on failure).
- **Tests**: Add coverage for cross-loop `call_tool` / `disconnect`, workflow tool integration, workflow run route (no duplicate MCP init), and service runtime lifespan behavior.