### PR TITLE
fix(session): WebUI /clear fallback, memory paths, runtime metadata

### DIFF
--- a/flocks/input/dispatcher.py
+++ b/flocks/input/dispatcher.py
@@ -106,11 +106,16 @@ async def dispatch_user_input(event: UserInputEvent, sink: OutputSink) -> Dispat
         async def _collect_prompt(prompt: str) -> None:
             llm_prompts.append(prompt)
 
+        # Pass only the optional callback, not sink.clear_screen: the latter is
+        # always a bound method (truthy) even when no _clear_screen was
+        # registered, which made /clear skip the "Screen cleared." fallback and
+        # publish an empty assistant message on WebUI.
+        clear_cb = getattr(sink, "_clear_screen", None)
         handled = await handle_slash_command(
             parsed.raw_text,
             send_text=_collect_text,
             send_prompt=_collect_prompt,
-            clear_screen=sink.clear_screen,
+            clear_screen=clear_cb,
             surface=sink.surface,
         )
         if handled:

--- a/flocks/memory/bootstrap.py
+++ b/flocks/memory/bootstrap.py
@@ -3,7 +3,7 @@ Memory Bootstrap - Load memory files at session start
 
 Implements OpenClaw-style memory loading:
 1. MEMORY.md - Main long-term memory (auto-injected)
-2. memory/daily/YYYY-MM-DD.md - Daily notes (agent reads today + yesterday)
+2. memory/daily/YYYY-MM-DD.md - Daily notes for any calendar date
 3. memory_search tool - Search all history
 """
 
@@ -26,12 +26,12 @@ MEMORY_INSTRUCTIONS = """
 ## Memory System Guidance
 
 You have access to a persistent memory system for continuity across sessions.
-Memory is stored in a global location and accessible across all your sessions.
+On-disk memory root (absolute path): `{memory_root}`. The same store is shared across all your sessions.
 
 ### Files Available:
 1. `MEMORY.md` - Your long-term curated memory (already injected above)
-2. `daily/{today}.md` - Today's notes (read using memory tools if needed)
-3. `daily/{yesterday}.md` - Yesterday's notes (read using memory tools if needed)
+2. `daily/YYYY-MM-DD.md` - Daily notes for **any** calendar date; substitute the date you need, then read with `memory_get` (path is relative to the memory root above).
+3. Examples for the current session: today `daily/{today}.md`, yesterday `daily/{yesterday}.md` — any other day uses the same pattern with that day's `YYYY-MM-DD`.
 
 ### When to Write Memory:
 - **Daily notes**: Use path `daily/YYYY-MM-DD.md` - Raw logs of what happened today
@@ -57,7 +57,7 @@ class MemoryBootstrap:
     """
     Bootstrap memory files at session start
     
-    Uses Flocks' global memory storage: ~/.flocks/data/memory/
+    Uses Flocks' global memory storage: ``<data_dir>/memory`` (see ``Config.get_data_path()``).
     """
     
     def __init__(self):
@@ -262,10 +262,14 @@ This is your curated long-term memory file. Store important information here:
         today = today_date.strftime("%Y-%m-%d")
         if yesterday is None:
             yesterday = (today_date - timedelta(days=1)).strftime("%Y-%m-%d")
-        
-        instructions = MEMORY_INSTRUCTIONS.replace("{today}", today)
+
+        from flocks.config import Config
+
+        memory_root = (Config.get_data_path() / "memory").resolve()
+        instructions = MEMORY_INSTRUCTIONS.replace("{memory_root}", str(memory_root))
+        instructions = instructions.replace("{today}", today)
         instructions = instructions.replace("{yesterday}", yesterday)
-        
+
         return instructions
     
     async def bootstrap(

--- a/flocks/session/prompt.py
+++ b/flocks/session/prompt.py
@@ -95,6 +95,8 @@ You specialize in cybersecurity operations including:
 - Compliance and hardening (CIS, NIST, PCI-DSS, configuration reviews)
 - Other security operations tasks
 
+IMPORTANT: Precision are core operating principles. All outputs must be grounded in verifiable evidence, explicit context, or validated reasoning. Do not speculate, fabricate facts, or infer beyond the available information. When uncertainty exists, state it clearly and constrain conclusions accordingly.
+
 Best practices for security operations:
 Your work primarily covers threat detection and analysis, incident response, vulnerability assessment, security automation, malware and forensic analysis, and compliance or hardening reviews. 
 Using tools to solve tasks is a core part of your capabilities.
@@ -272,6 +274,8 @@ class SystemPrompt:
         directory: Optional[str] = None,
         vcs: Optional[str] = None,
         session_id: Optional[str] = None,
+        model_id: Optional[str] = None,
+        provider_id: Optional[str] = None,
     ) -> List[str]:
         """Build dynamic runtime metadata that should stay near the prompt tail."""
         del directory, vcs  # Reserved for future runtime metadata.
@@ -289,6 +293,10 @@ class SystemPrompt:
         ]
         if session_id:
             lines.append(f"Session ID: {session_id}")
+        if model_id:
+            lines.append(f"Model: {model_id}")
+        if provider_id:
+            lines.append(f"Provider: {provider_id}")
         return ["\n".join(lines)]
 
     @classmethod
@@ -1061,12 +1069,16 @@ class SessionPrompt:
                 "session_id": session_id,
                 "directory": session_directory,
                 "runtime_day": runtime_day,
+                "model_id": model_id,
+                "provider_id": provider_id,
             },
             builder=lambda: cls._join_prompt_parts(
                 SystemPrompt.runtime_metadata(
                     directory=session_directory,
                     vcs=vcs,
                     session_id=session_id,
+                    model_id=model_id,
+                    provider_id=provider_id,
                 ),
             ),
         ))

--- a/flocks/tool/task/run_workflow.py
+++ b/flocks/tool/task/run_workflow.py
@@ -82,7 +82,7 @@ When to use:
 How to use:
 - Provide the workflow definition (dictionary, JSON string, or file path).
 - The workflow file path should be an absolute path. IMPORTANT: In JSON, file paths must be quoted strings (e.g. "workflow": "/path/to/workflow.json"). Unquoted paths will cause parse errors.
-- Optional: Provide input parameters, timeout settings, and whether to use LLM for logic node codegen.
+- Parameters: Provide input parameters, timeout settings. If inputs are not provided, ask user to provide them.
 
 Note:
 - This tool depends on an existing workflow file.

--- a/tests/memory/test_memory_openclaw_integration.py
+++ b/tests/memory/test_memory_openclaw_integration.py
@@ -186,7 +186,12 @@ class TestMemoryBootstrap:
         assert "Memory System" in instructions
         assert "MEMORY.md" in instructions
         assert "daily/" in instructions
+        assert "YYYY-MM-DD" in instructions
+        assert "daily/2026-02-09.md" in instructions
+        assert "daily/2026-02-08.md" in instructions
         assert "memory_search" in instructions
+        assert "{memory_root}" not in instructions
+        assert "On-disk memory root" in instructions
     
     @pytest.mark.asyncio
     async def test_bootstrap(self):

--- a/tests/server/test_input_dispatcher.py
+++ b/tests/server/test_input_dispatcher.py
@@ -50,6 +50,28 @@ class TestDispatchUserInput:
         assert not llm
 
     @pytest.mark.asyncio
+    async def test_clear_without_clear_callback_sends_fallback_text(self):
+        direct = []
+        llm = []
+        sink = CallbackOutputSink(
+            "webui",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append(llm, (prompt, display)),
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_test",
+            text="/clear",
+            parts=[{"type": "text", "text": "/clear"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "direct"
+        assert direct == ["Screen cleared."]
+        assert not llm
+
+    @pytest.mark.asyncio
     async def test_llm_command_routes_raw_slash_text(self):
         direct = []
         llm = []

--- a/tests/session/test_prompt_tokens.py
+++ b/tests/session/test_prompt_tokens.py
@@ -7,6 +7,7 @@ Covers:
 - SessionPrompt.count_message_tokens(): multi-message counting
 - SessionPrompt.load_template() / render_template(): template processing
 - SystemPrompt.environment(): env info injection
+- SystemPrompt.runtime_metadata(): session/model/provider tail block
 - SystemPrompt.provider(): model-to-prompt-file routing
 """
 
@@ -214,6 +215,30 @@ class TestSystemPromptEnvironment:
         result = await SystemPrompt.environment("/tmp")
         assert len(result) > 0
         assert any(len(s) > 0 for s in result)
+
+
+# ---------------------------------------------------------------------------
+# SystemPrompt.runtime_metadata()
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptRuntimeMetadata:
+    def test_includes_session_model_provider_when_set(self) -> None:
+        block = SystemPrompt.runtime_metadata(
+            session_id="ses_test",
+            model_id="claude-sonnet-4-20250514",
+            provider_id="anthropic",
+        )[0]
+        assert "Session ID: ses_test" in block
+        assert "Model: claude-sonnet-4-20250514" in block
+        assert "Provider: anthropic" in block
+
+    def test_omits_optional_lines_when_unset(self) -> None:
+        block = SystemPrompt.runtime_metadata()[0]
+        assert "Session ID:" not in block
+        assert "Model:" not in block
+        assert "Provider:" not in block
+        assert "## Runtime Metadata" in block
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix WebUI `/clear` when no screen-clear callback is registered: pass only `_clear_screen` so slash handling still emits the "Screen cleared." fallback instead of an empty assistant path.
- Memory bootstrap instructions now include the resolved on-disk memory root and clarify `daily/YYYY-MM-DD.md` for any date; tests updated.
- System prompt runtime tail block can include `model_id` and `provider_id`; add grounding/precision copy for security ops; `run_workflow` tool text asks for missing inputs.