### PR TITLE
fix(provider): classify API builtin status from descriptor path

### DIFF
--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -1202,12 +1202,40 @@ def _get_api_service_tool_infos(provider_id: str) -> List[Any]:
 def _is_api_service_builtin(provider_id: str, tools: Optional[List[Any]] = None) -> bool:
     """Check if an API service is built-in (project-level or core).
 
-    A service is built-in if it has at least one registered tool and ALL of
-    its tools have native=True (project-level .flocks/plugins/ or core code).
-    User-level tools (~/.flocks/plugins/) have native=False.
+    Prefer the ``_provider.yaml`` descriptor location when available: a
+    descriptor under ``<cwd>/.flocks/plugins/tools/api`` is project-level
+    (built-in for delete-protection purposes), while a descriptor under
+    ``~/.flocks/plugins/tools/api`` is user-installed and therefore
+    deletable.  This avoids false positives when the in-memory tool
+    registry still carries stale ``native=True`` flags for the same
+    provider from an earlier refresh.
+
+    When no descriptor exists (for older/core registrations), fall back to
+    the historical rule: the service is built-in if it has at least one
+    registered tool and ALL of its tools have ``native=True``.
 
     Pass pre-fetched *tools* to avoid a redundant registry scan.
     """
+    from flocks.config.api_versioning import discover_api_service_descriptors
+
+    project_root = Path.cwd() / ".flocks" / "plugins" / "tools" / "api"
+    user_root = Path.home() / ".flocks" / "plugins" / "tools" / "api"
+
+    for descriptor in discover_api_service_descriptors():
+        if descriptor.storage_key != provider_id:
+            continue
+        provider_dir = descriptor.provider_yaml.parent.resolve()
+        try:
+            provider_dir.relative_to(project_root.resolve())
+            return True
+        except ValueError:
+            pass
+        try:
+            provider_dir.relative_to(user_root.resolve())
+            return False
+        except ValueError:
+            pass
+
     if tools is None:
         tools = _get_api_service_tool_infos(provider_id)
     if not tools:

--- a/tests/hub/test_bundled_tools.py
+++ b/tests/hub/test_bundled_tools.py
@@ -543,6 +543,59 @@ class TestDeleteApiServiceCascade:
         entries = catalog.list_catalog(plugin_type="tool", state=["available"])
         assert any(e.id == "onesig_v2_5_3_D20250710" for e in entries)
 
+    async def test_delete_api_service_rejects_project_level_plugin(self, isolated_hub):
+        """Project-level API plugins stay protected even without relying on
+        the tool registry's in-memory ``native`` flags.
+        """
+        from fastapi import HTTPException
+
+        from flocks.config import api_versioning as versioning
+        from flocks.config.config_writer import ConfigWriter
+        from flocks.server.routes.provider import delete_api_service
+
+        project_plugin_dir = (
+            isolated_hub["project"] / ".flocks" / "plugins" / "tools" / "api" / "project_tool"
+        )
+        project_plugin_dir.mkdir(parents=True)
+        (project_plugin_dir / "_provider.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "project_tool",
+                    "service_id": "project_api",
+                    "version": "1.0.0",
+                },
+                allow_unicode=True,
+            ),
+            encoding="utf-8",
+        )
+        (project_plugin_dir / "project_tool_login.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "project_tool_login",
+                    "description": "fixture login tool",
+                    "provider": "project_api",
+                    "handler": {
+                        "type": "http",
+                        "method": "POST",
+                        "url": "https://example/login",
+                    },
+                    "parameters": [],
+                },
+                allow_unicode=True,
+            ),
+            encoding="utf-8",
+        )
+        versioning._reset_descriptor_cache()
+
+        storage_key = "project_api_v1_0_0"
+        ConfigWriter.set_api_service(storage_key, {"enabled": True})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_api_service(storage_key)
+
+        assert exc_info.value.status_code == 403
+        assert ConfigWriter.get_api_service_raw(storage_key) == {"enabled": True}
+
 
 # ---------------------------------------------------------------------------
 # Security validation


### PR DESCRIPTION
## Summary

- Determine whether an API service is built-in (and therefore protected from deletion) by resolving the `_provider.yaml` descriptor location first, instead of relying solely on in-memory `native` flags in the tool registry.
- Treat descriptors under `<cwd>/.flocks/plugins/tools/api` as project-level (non-deletable); descriptors under `~/.flocks/plugins/tools/api` as user-installed (deletable).
- Fall back to the previous behavior—built-in only when every registered tool has `native=True`—when no descriptor is available (legacy/core registrations).
- Add a regression test ensuring project-level API plugins remain protected even when registry `native` flags are stale.

## Motivation

After a registry refresh, user-installed tools can still carry stale `native=True` values. That caused `_is_api_service_builtin` to incorrectly block deletion of user-level API services.