### PR TITLE
fix(workflow): compact execution storage and trim history

### DIFF
--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -48,6 +48,7 @@ from flocks.ingest.syslog.constants import WORKFLOW_SYSLOG_CONFIG_PREFIX
 from flocks.workflow.execution_store import (
     compact_history_for_storage,
     compact_outputs_for_storage,
+    compact_step_for_storage,
     create_execution_record,
     normalize_execution_status as _normalize_execution_status,
     record_execution_result as _record_execution_result,
@@ -506,10 +507,7 @@ async def _run_workflow_execution_task(
         # that ships it to SQLite) stays bounded, even when a workflow node
         # returns tens of thousands of alerts that are already persisted to
         # JSONL on disk.
-        step_dict = step_result.model_dump(mode="json")
-        raw_outputs = step_dict.get("outputs")
-        if isinstance(raw_outputs, dict):
-            step_dict["outputs"] = compact_outputs_for_storage(raw_outputs)
+        step_dict = compact_step_for_storage(step_result.model_dump(mode="json"))
         step_history.append(step_dict)
         _write_progress({
             "executionLog": list(step_history),

--- a/flocks/session/recorder.py
+++ b/flocks/session/recorder.py
@@ -177,7 +177,10 @@ class Recorder:
         # Import lazily here to avoid an import cycle:
         # execution_store -> Recorder, while the recorder only needs the
         # compaction helpers when serializing workflow audit records.
-        from flocks.workflow.execution_store import compact_outputs_for_storage
+        from flocks.workflow.execution_store import (
+            compact_outputs_for_storage,
+            compact_step_for_storage,
+        )
 
         paths = cls.paths()
         path = paths.workflow_dir / f"{exec_id}.jsonl"
@@ -201,9 +204,19 @@ class Recorder:
 
         if isinstance(history, list):
             for idx, step in enumerate(history, 1):
-                step_outputs = step.get("outputs") if isinstance(step, dict) else None
-                if isinstance(step_outputs, dict):
-                    step_outputs = compact_outputs_for_storage(step_outputs)
+                step_record = (
+                    compact_step_for_storage(step) if isinstance(step, dict) else step
+                )
+                step_inputs = (
+                    step_record.get("inputs")
+                    if isinstance(step_record, dict)
+                    else step.get("inputs")
+                )
+                step_outputs = (
+                    step_record.get("outputs")
+                    if isinstance(step_record, dict)
+                    else step.get("outputs")
+                )
                 await cls.append_jsonl(
                     path,
                     {
@@ -213,8 +226,8 @@ class Recorder:
                         "workflow_id": workflow_id,
                         "step": idx,
                         "node_id": step.get("node_id") or step.get("nodeId") or step.get("node"),
-                        "inputs": _safe_truncate(step.get("inputs")),
-                        "outputs": _safe_truncate(step_outputs if step_outputs is not None else step.get("outputs")),
+                        "inputs": _safe_truncate(step_inputs),
+                        "outputs": _safe_truncate(step_outputs),
                         "stdout": _safe_truncate(step.get("stdout")),
                         "error": _safe_truncate(step.get("error")),
                         "traceback": _safe_truncate(step.get("traceback")),

--- a/flocks/session/recorder.py
+++ b/flocks/session/recorder.py
@@ -174,9 +174,17 @@ class Recorder:
         workflow_id: Optional[str],
         run_result: Dict[str, Any],
     ) -> None:
+        # Import lazily here to avoid an import cycle:
+        # execution_store -> Recorder, while the recorder only needs the
+        # compaction helpers when serializing workflow audit records.
+        from flocks.workflow.execution_store import compact_outputs_for_storage
+
         paths = cls.paths()
         path = paths.workflow_dir / f"{exec_id}.jsonl"
         history = run_result.get("executionLog") or run_result.get("history") or []
+        summary_outputs = run_result.get("outputResults") or run_result.get("outputs")
+        if isinstance(summary_outputs, dict):
+            summary_outputs = compact_outputs_for_storage(summary_outputs)
         await cls.append_jsonl(
             path,
             {
@@ -187,12 +195,15 @@ class Recorder:
                 "status": run_result.get("status"),
                 "error": _safe_truncate(run_result.get("errorMessage") or run_result.get("error")),
                 "steps": len(history) if isinstance(history, list) else None,
-                "outputs": _safe_truncate(run_result.get("outputResults") or run_result.get("outputs")),
+                "outputs": _safe_truncate(summary_outputs),
             },
         )
 
         if isinstance(history, list):
             for idx, step in enumerate(history, 1):
+                step_outputs = step.get("outputs") if isinstance(step, dict) else None
+                if isinstance(step_outputs, dict):
+                    step_outputs = compact_outputs_for_storage(step_outputs)
                 await cls.append_jsonl(
                     path,
                     {
@@ -203,7 +214,7 @@ class Recorder:
                         "step": idx,
                         "node_id": step.get("node_id") or step.get("nodeId") or step.get("node"),
                         "inputs": _safe_truncate(step.get("inputs")),
-                        "outputs": _safe_truncate(step.get("outputs")),
+                        "outputs": _safe_truncate(step_outputs if step_outputs is not None else step.get("outputs")),
                         "stdout": _safe_truncate(step.get("stdout")),
                         "error": _safe_truncate(step.get("error")),
                         "traceback": _safe_truncate(step.get("traceback")),

--- a/flocks/tool/task/run_workflow.py
+++ b/flocks/tool/task/run_workflow.py
@@ -20,6 +20,8 @@ from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 from flocks.session.recorder import Recorder
 from flocks.workflow.execution_store import (
+    compact_history_for_storage,
+    compact_outputs_for_storage,
     create_execution_record,
     normalize_execution_status,
     record_execution_result,
@@ -529,6 +531,9 @@ async def run_workflow_tool(
             step_dict = dict(step_result)
         else:
             step_dict = {"node_id": None, "outputs": {}, "error": str(step_result)}
+        raw_outputs = step_dict.get("outputs")
+        if isinstance(raw_outputs, dict):
+            step_dict["outputs"] = compact_outputs_for_storage(raw_outputs)
         tracked_history.append(step_dict)
         _update_execution_progress({
             "executionLog": list(tracked_history),
@@ -677,11 +682,11 @@ async def run_workflow_tool(
                 )
             status_value, error_message = resolve_execution_outcome(outcome_result)  # type: ignore[arg-type]
             current_data.update({
-                "outputResults": result_dict.get("outputs"),
+                "outputResults": compact_outputs_for_storage(result_dict.get("outputs")),
                 "status": status_value,
                 "finishedAt": int(time.time() * 1000),
                 "duration": time.time() - execution_started_at,
-                "executionLog": result_dict.get("history") or list(tracked_history),
+                "executionLog": compact_history_for_storage(result_dict.get("history")) or list(tracked_history),
                 "errorMessage": error_message,
                 "currentNodeId": result_dict.get("last_node_id"),
                 "currentPhase": status_value,
@@ -752,7 +757,7 @@ async def run_workflow_tool(
                 "status": "error",
                 "finishedAt": int(time.time() * 1000),
                 "errorMessage": error_msg,
-                "executionLog": list(tracked_history),
+                "executionLog": compact_history_for_storage(list(tracked_history)),
                 "currentPhase": "error",
                 "currentStepIndex": len(tracked_history),
             })

--- a/flocks/tool/task/run_workflow.py
+++ b/flocks/tool/task/run_workflow.py
@@ -22,6 +22,7 @@ from flocks.session.recorder import Recorder
 from flocks.workflow.execution_store import (
     compact_history_for_storage,
     compact_outputs_for_storage,
+    compact_step_for_storage,
     create_execution_record,
     normalize_execution_status,
     record_execution_result,
@@ -531,10 +532,7 @@ async def run_workflow_tool(
             step_dict = dict(step_result)
         else:
             step_dict = {"node_id": None, "outputs": {}, "error": str(step_result)}
-        raw_outputs = step_dict.get("outputs")
-        if isinstance(raw_outputs, dict):
-            step_dict["outputs"] = compact_outputs_for_storage(raw_outputs)
-        tracked_history.append(step_dict)
+        tracked_history.append(compact_step_for_storage(step_dict))
         _update_execution_progress({
             "executionLog": list(tracked_history),
             "currentNodeId": step_dict.get("node_id"),
@@ -710,6 +708,9 @@ async def run_workflow_tool(
                 },
             })
 
+        compacted_outputs = compact_outputs_for_storage(result_dict.get("outputs"))
+        compacted_history = compact_history_for_storage(result_dict.get("history"))
+
         # If workflow failed, include error in ToolResult
         if not success and error:
             return ToolResult(
@@ -724,8 +725,8 @@ async def run_workflow_tool(
                     "steps": result_dict.get("steps", 0),
                     "run_id": result_dict.get("run_id"),
                     "last_node_id": result_dict.get("last_node_id"),
-                    "outputs": result_dict.get("outputs", {}),
-                    "history": result_dict.get("history", []),
+                    "outputs": compacted_outputs,
+                    "history": compacted_history,
                 }
             )
         
@@ -740,8 +741,8 @@ async def run_workflow_tool(
                 "steps": result_dict.get("steps", 0),
                 "run_id": result_dict.get("run_id"),
                 "last_node_id": result_dict.get("last_node_id"),
-                "outputs": result_dict.get("outputs", {}),
-                "history": result_dict.get("history", []),
+                "outputs": compacted_outputs,
+                "history": compacted_history,
             }
         )
         

--- a/flocks/workflow/execution_store.py
+++ b/flocks/workflow/execution_store.py
@@ -103,11 +103,12 @@ def compact_history_for_storage(
     return result
 
 # Maximum number of execution history records retained per workflow.
-# Older records are pruned automatically to prevent a syslog flood from bloating Storage.
-_MAX_EXECUTION_HISTORY_PER_WORKFLOW = 500
+# Keep this intentionally small so high-frequency workflows do not keep
+# inflating the SQLite row set and matching JSONL audit files indefinitely.
+_MAX_EXECUTION_HISTORY_PER_WORKFLOW = 30
 # Trim is an O(N) scan over all workflow_execution rows; only run it every Nth
 # call per workflow to amortise the cost under high syslog throughput.
-_TRIM_CHECK_INTERVAL = 50
+_TRIM_CHECK_INTERVAL = 5
 _trim_counters: Dict[str, int] = {}
 
 # Per-workflow lock to serialize read-modify-write of stats. Concurrent
@@ -345,6 +346,9 @@ async def _trim_execution_history(workflow_id: str) -> None:
     excess = len(wf_entries) - _MAX_EXECUTION_HISTORY_PER_WORKFLOW
     for key, _ in wf_entries[:excess]:
         try:
+            exec_id = key.rsplit("/", 1)[-1]
             await Storage.remove(key)
+            record_path = Recorder.paths().workflow_dir / f"{exec_id}.jsonl"
+            await asyncio.to_thread(record_path.unlink, missing_ok=True)
         except Exception:
             pass

--- a/flocks/workflow/execution_store.py
+++ b/flocks/workflow/execution_store.py
@@ -74,13 +74,32 @@ def compact_outputs_for_storage(
     return compacted
 
 
+def compact_step_for_storage(
+    step: Any,
+    *,
+    keys: Iterable[str] = DEFAULT_LARGE_LIST_KEYS,
+    size_threshold: int = DEFAULT_COMPACT_SIZE_THRESHOLD,
+) -> Any:
+    """Return a copy of one history step with large ``inputs``/``outputs`` compacted."""
+    if not isinstance(step, dict):
+        return step
+    step_copy = dict(step)
+    for field in ("inputs", "outputs"):
+        raw_value = step_copy.get(field)
+        if isinstance(raw_value, dict):
+            step_copy[field] = compact_outputs_for_storage(
+                raw_value, keys=keys, size_threshold=size_threshold
+            )
+    return step_copy
+
+
 def compact_history_for_storage(
     history: Any,
     *,
     keys: Iterable[str] = DEFAULT_LARGE_LIST_KEYS,
     size_threshold: int = DEFAULT_COMPACT_SIZE_THRESHOLD,
 ) -> List[Any]:
-    """Strip large alert lists from step outputs in workflow history.
+    """Strip large alert lists from step inputs/outputs in workflow history.
 
     Returns an empty list when *history* is falsy.  Non-dict step entries
     (defensive: shouldn't happen with normal ``StepResult`` dumps) are
@@ -88,19 +107,10 @@ def compact_history_for_storage(
     """
     if not history:
         return []
-    result: List[Any] = []
-    for step in history:
-        if not isinstance(step, dict):
-            result.append(step)
-            continue
-        step_copy = dict(step)
-        raw_outputs = step_copy.get("outputs")
-        if isinstance(raw_outputs, dict):
-            step_copy["outputs"] = compact_outputs_for_storage(
-                raw_outputs, keys=keys, size_threshold=size_threshold
-            )
-        result.append(step_copy)
-    return result
+    return [
+        compact_step_for_storage(step, keys=keys, size_threshold=size_threshold)
+        for step in history
+    ]
 
 # Maximum number of execution history records retained per workflow.
 # Keep this intentionally small so high-frequency workflows do not keep

--- a/tests/session/test_recorder.py
+++ b/tests/session/test_recorder.py
@@ -314,7 +314,7 @@ class TestRecordWorkflowExecution:
                     "executionLog": [
                         {
                             "node_id": "node_1",
-                            "inputs": {"source": "sensor"},
+                            "inputs": {"raw_alerts": large_alerts, "source": "sensor"},
                             "outputs": {"raw_alerts": large_alerts, "message": "ok"},
                             "duration_ms": 12,
                         }
@@ -338,7 +338,7 @@ class TestRecordWorkflowExecution:
             "message": "ok",
         }
         assert "raw_alerts" not in step["outputs"]
-        assert step["inputs"] == {"source": "sensor"}
+        assert step["inputs"] == {"_raw_alerts_count": 150, "source": "sensor"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/session/test_recorder.py
+++ b/tests/session/test_recorder.py
@@ -301,6 +301,45 @@ class TestRecordWorkflowExecution:
         record = json.loads(path.read_text(encoding="utf-8").strip())
         assert record["workflow_id"] is None
 
+    @pytest.mark.asyncio
+    async def test_compacts_large_workflow_outputs_before_writing_jsonl(self, tmp_path):
+        large_alerts = [{"id": idx, "payload": "x" * 20} for idx in range(150)]
+        with patch("flocks.session.recorder._record_dir", return_value=tmp_path):
+            await Recorder.record_workflow_execution(
+                exec_id="exec_004",
+                workflow_id="wf_004",
+                run_result={
+                    "status": "success",
+                    "outputResults": {"enriched_alerts": large_alerts, "message": "done"},
+                    "executionLog": [
+                        {
+                            "node_id": "node_1",
+                            "inputs": {"source": "sensor"},
+                            "outputs": {"raw_alerts": large_alerts, "message": "ok"},
+                            "duration_ms": 12,
+                        }
+                    ],
+                },
+            )
+
+        path = tmp_path / "workflow" / "exec_004.jsonl"
+        lines = path.read_text(encoding="utf-8").strip().split("\n")
+        records = [json.loads(line) for line in lines]
+        summary = next(record for record in records if record["type"] == "workflow.summary")
+        step = next(record for record in records if record["type"] == "workflow.step")
+
+        assert summary["outputs"] == {
+            "_enriched_alerts_count": 150,
+            "message": "done",
+        }
+        assert "enriched_alerts" not in summary["outputs"]
+        assert step["outputs"] == {
+            "_raw_alerts_count": 150,
+            "message": "ok",
+        }
+        assert "raw_alerts" not in step["outputs"]
+        assert step["inputs"] == {"source": "sensor"}
+
 
 # ---------------------------------------------------------------------------
 # LRU lock eviction

--- a/tests/workflow/test_execution_store_compact.py
+++ b/tests/workflow/test_execution_store_compact.py
@@ -27,6 +27,7 @@ from flocks.workflow.execution_store import (
     _trim_execution_history,
     compact_history_for_storage,
     compact_outputs_for_storage,
+    compact_step_for_storage,
 )
 from flocks.storage.storage import Storage
 
@@ -159,6 +160,20 @@ def test_compact_outputs_drastically_reduces_serialised_size() -> None:
 # ── compact_history_for_storage ───────────────────────────────────────────────
 
 
+def test_compact_step_compacts_inputs_and_outputs() -> None:
+    big = _make_alerts(5_000)
+    step = {
+        "node_id": "normalize",
+        "inputs": {"raw_alerts": big, "source": "syslog"},
+        "outputs": {"normalized_alerts": big, "message": "ok"},
+    }
+
+    compacted = compact_step_for_storage(step)
+
+    assert compacted["inputs"] == {"_raw_alerts_count": 5_000, "source": "syslog"}
+    assert compacted["outputs"] == {"_normalized_alerts_count": 5_000, "message": "ok"}
+
+
 def test_compact_history_compacts_each_step_outputs() -> None:
     big = _make_alerts(5_000)
     history = [
@@ -215,6 +230,22 @@ def test_compact_history_skips_step_with_non_dict_outputs() -> None:
 
     # Non-dict outputs are left as-is (defensive pass-through).
     assert compacted[0]["outputs"] == "string-output"
+
+
+def test_compact_history_compacts_each_step_inputs() -> None:
+    big = _make_alerts(5_000)
+    history = [
+        {
+            "node_id": "dedup",
+            "inputs": {"enriched_alerts": big, "dedup_key": "x"},
+            "outputs": {"unique_alerts": big},
+        },
+    ]
+
+    compacted = compact_history_for_storage(history)
+
+    assert compacted[0]["inputs"] == {"_enriched_alerts_count": 5_000, "dedup_key": "x"}
+    assert compacted[0]["outputs"] == {"_unique_alerts_count": 5_000}
 
 
 # ── Defaults exposed to callers ───────────────────────────────────────────────

--- a/tests/workflow/test_execution_store_compact.py
+++ b/tests/workflow/test_execution_store_compact.py
@@ -18,13 +18,17 @@ stripping legitimately small metadata lists.
 from __future__ import annotations
 
 from typing import Any, Dict, List
+from unittest.mock import AsyncMock, patch
 
+import pytest
 from flocks.workflow.execution_store import (
     DEFAULT_COMPACT_SIZE_THRESHOLD,
     DEFAULT_LARGE_LIST_KEYS,
+    _trim_execution_history,
     compact_history_for_storage,
     compact_outputs_for_storage,
 )
+from flocks.storage.storage import Storage
 
 
 def _make_alerts(n: int) -> List[Dict[str, Any]]:
@@ -278,3 +282,49 @@ def test_compact_outputs_covers_raw_alerts_in_input_params() -> None:
     assert compacted["_raw_alerts_count"] == 5_000
     assert "raw_alerts" not in compacted
     assert compacted["source_log_type"] == "tdp"
+
+
+@pytest.mark.asyncio
+async def test_trim_execution_history_keeps_only_30_and_deletes_matching_jsonl(
+    tmp_path,
+) -> None:
+    workflow_id = "wf-trim"
+    entries = []
+    for idx in range(32):
+        exec_id = f"exec-{idx:02d}"
+        entries.append((
+            f"workflow_execution/{exec_id}",
+            {
+                "id": exec_id,
+                "workflowId": workflow_id,
+                "startedAt": idx,
+            },
+        ))
+        workflow_record = tmp_path / "workflow" / f"{exec_id}.jsonl"
+        workflow_record.parent.mkdir(parents=True, exist_ok=True)
+        workflow_record.write_text('{"type":"workflow.summary"}\n', encoding="utf-8")
+
+    # Another workflow's record should be ignored entirely.
+    entries.append((
+        "workflow_execution/other-exec",
+        {"id": "other-exec", "workflowId": "wf-other", "startedAt": 0},
+    ))
+    other_record = tmp_path / "workflow" / "other-exec.jsonl"
+    other_record.parent.mkdir(parents=True, exist_ok=True)
+    other_record.write_text('{"type":"workflow.summary"}\n', encoding="utf-8")
+
+    remove_mock = AsyncMock(return_value=None)
+    with patch.object(Storage, "list_entries", AsyncMock(return_value=entries)), \
+         patch.object(Storage, "remove", remove_mock), \
+         patch("flocks.session.recorder._record_dir", return_value=tmp_path):
+        await _trim_execution_history(workflow_id)
+
+    removed_keys = [call.args[0] for call in remove_mock.await_args_list]
+    assert removed_keys == [
+        "workflow_execution/exec-00",
+        "workflow_execution/exec-01",
+    ]
+    assert not (tmp_path / "workflow" / "exec-00.jsonl").exists()
+    assert not (tmp_path / "workflow" / "exec-01.jsonl").exists()
+    assert (tmp_path / "workflow" / "exec-02.jsonl").exists()
+    assert other_record.exists()

--- a/tests/workflow/test_tool_run_workflow.py
+++ b/tests/workflow/test_tool_run_workflow.py
@@ -368,6 +368,7 @@ class TestRunWorkflowToolExecution:
             kwargs["on_step_complete"]({
                 "node_id": "node-1",
                 "node_type": "python",
+                "inputs": {"raw_alerts": large_alerts, "source": "syslog"},
                 "outputs": {"raw_alerts": large_alerts, "message": "ok"},
             })
             return FakeRunWorkflowResult(
@@ -380,6 +381,7 @@ class TestRunWorkflowToolExecution:
                     {
                         "node_id": "node-1",
                         "node_type": "python",
+                        "inputs": {"raw_alerts": large_alerts, "source": "syslog"},
                         "outputs": {"raw_alerts": large_alerts, "message": "ok"},
                     }
                 ],
@@ -422,7 +424,23 @@ class TestRunWorkflowToolExecution:
 
         assert result.success is True
         progress_payload = storage_write.await_args_list[-1].args[1]
+        assert progress_payload["executionLog"][0]["inputs"] == {
+            "_raw_alerts_count": 150,
+            "source": "syslog",
+        }
         assert progress_payload["executionLog"][0]["outputs"] == {
+            "_raw_alerts_count": 150,
+            "message": "ok",
+        }
+        assert result.metadata["outputs"] == {
+            "_enriched_alerts_count": 150,
+            "message": "done",
+        }
+        assert result.metadata["history"][0]["inputs"] == {
+            "_raw_alerts_count": 150,
+            "source": "syslog",
+        }
+        assert result.metadata["history"][0]["outputs"] == {
             "_raw_alerts_count": 150,
             "message": "ok",
         }
@@ -431,6 +449,10 @@ class TestRunWorkflowToolExecution:
         assert final_exec_data["outputResults"] == {
             "_enriched_alerts_count": 150,
             "message": "done",
+        }
+        assert final_exec_data["executionLog"][0]["inputs"] == {
+            "_raw_alerts_count": 150,
+            "source": "syslog",
         }
         assert final_exec_data["executionLog"][0]["outputs"] == {
             "_raw_alerts_count": 150,

--- a/tests/workflow/test_tool_run_workflow.py
+++ b/tests/workflow/test_tool_run_workflow.py
@@ -43,6 +43,10 @@ def _runtime_tuple(*, run_fn: Mock, installer_cls: Mock | None = None):
     return installer, run_fn, FakeRunWorkflowResult
 
 
+def _make_large_alerts(count: int) -> list[dict[str, Any]]:
+    return [{"id": idx, "payload": "x" * 20} for idx in range(count)]
+
+
 # =============================================================================
 # Fixtures
 # =============================================================================
@@ -348,6 +352,91 @@ class TestRunWorkflowToolExecution:
         record_result.assert_awaited_once()
         assert storage_write.await_count >= 1
         assert any(update.get("workflow_execution_id") == "exec-registered" for update in metadata_updates)
+
+    @pytest.mark.anyio
+    async def test_run_workflow_compacts_large_outputs_for_progress_and_final_record(
+        self,
+        tool_context_with_permission,
+        simple_workflow,
+    ):
+        large_alerts = _make_large_alerts(150)
+        metadata_updates: list[dict[str, Any]] = []
+        tool_context_with_permission._metadata_callback = metadata_updates.append
+
+        def run_side_effect(**kwargs):
+            kwargs["on_step_start"]("run-compacted", 1, MagicMock(id="node-1", type="python"), {})
+            kwargs["on_step_complete"]({
+                "node_id": "node-1",
+                "node_type": "python",
+                "outputs": {"raw_alerts": large_alerts, "message": "ok"},
+            })
+            return FakeRunWorkflowResult(
+                status="SUCCEEDED",
+                run_id="run-compacted",
+                steps=1,
+                last_node_id="node-1",
+                outputs={"enriched_alerts": large_alerts, "message": "done"},
+                history=[
+                    {
+                        "node_id": "node-1",
+                        "node_type": "python",
+                        "outputs": {"raw_alerts": large_alerts, "message": "ok"},
+                    }
+                ],
+                error=None,
+            )
+
+        mock_run = Mock(name="run_workflow", side_effect=run_side_effect)
+        create_execution = AsyncMock(return_value={
+            "id": "exec-compacted",
+            "workflowId": "test-workflow-001",
+            "inputParams": {},
+            "status": "running",
+            "startedAt": 1,
+            "executionLog": [],
+        })
+        storage_read = AsyncMock(return_value={
+            "id": "exec-compacted",
+            "workflowId": "test-workflow-001",
+            "inputParams": {},
+            "status": "running",
+            "startedAt": 1,
+            "executionLog": [],
+        })
+        storage_write = AsyncMock(return_value=None)
+        record_result = AsyncMock(return_value=None)
+
+        with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)), \
+             patch.object(run_workflow_module, "resolve_workflow_id_from_source", return_value="test-workflow-001"), \
+             patch.object(run_workflow_module, "create_execution_record", create_execution), \
+             patch.object(run_workflow_module.Storage, "read", storage_read), \
+             patch.object(run_workflow_module.Storage, "write", storage_write), \
+             patch.object(run_workflow_module, "record_execution_result", record_result), \
+             patch.object(run_workflow_module, "_record_workflow_tool_result", AsyncMock(return_value=None)):
+            result = await ToolRegistry.execute(
+                "run_workflow",
+                ctx=tool_context_with_permission,
+                workflow=simple_workflow,
+                inputs={},
+            )
+
+        assert result.success is True
+        progress_payload = storage_write.await_args_list[-1].args[1]
+        assert progress_payload["executionLog"][0]["outputs"] == {
+            "_raw_alerts_count": 150,
+            "message": "ok",
+        }
+
+        final_exec_data = record_result.await_args.args[2]
+        assert final_exec_data["outputResults"] == {
+            "_enriched_alerts_count": 150,
+            "message": "done",
+        }
+        assert final_exec_data["executionLog"][0]["outputs"] == {
+            "_raw_alerts_count": 150,
+            "message": "ok",
+        }
+        assert any(update.get("workflow_execution_id") == "exec-compacted" for update in metadata_updates)
 
     @pytest.mark.anyio
     async def test_run_workflow_uses_isolated_child_tool_context(


### PR DESCRIPTION
## Summary
- Compact large alert lists in workflow execution records (outputs, step inputs/outputs, and `ToolResult.metadata`) before writing to SQLite, JSONL audit logs, or returning to agents — replaces lists with `_<key>_count` when above the size threshold.
- Cap per-workflow execution history at 30 records and delete matching `{exec_id}.jsonl` audit files when pruning oldest entries.
- Add `compact_step_for_storage` helper shared by `run_workflow`, HTTP workflow routes, and `Recorder`.
