### PR TITLE
fix/workflow llm provider isolation

### DIFF
--- a/flocks/provider/provider.py
+++ b/flocks/provider/provider.py
@@ -8,12 +8,67 @@ from typing import Dict, List, Optional, Any, AsyncIterator, Union
 from pydantic import BaseModel, Field, PrivateAttr
 from enum import Enum
 import os
+import threading
 
 from flocks.utils.log import Log
 from flocks.config.config import Config
 
 
 log = Log.create(service="provider")
+
+
+def _model_info_signature(model: "ModelInfo") -> tuple:
+    """Return a hashable signature of the user-visible fields of a ``ModelInfo``.
+
+    Used by :meth:`Provider.apply_config` to short-circuit the
+    ``_config_models`` rebuild when the desired list matches the existing
+    one. We intentionally compare only the fields that ``apply_config``
+    populates from ``flocks.json``: id / name / provider_id / capabilities /
+    pricing / explicit_keys. Other private attributes (e.g. catalog
+    metadata) are not part of the user contract.
+    """
+    cap = getattr(model, "capabilities", None)
+    cap_sig = (
+        (
+            getattr(cap, "supports_streaming", None),
+            getattr(cap, "supports_tools", None),
+            getattr(cap, "supports_vision", None),
+            getattr(cap, "supports_reasoning", None),
+            getattr(cap, "interleaved", None),
+            getattr(cap, "max_tokens", None),
+            getattr(cap, "context_window", None),
+        )
+        if cap is not None
+        else None
+    )
+    pricing = getattr(model, "pricing", None)
+    pricing_sig = (
+        (
+            pricing.get("input") if isinstance(pricing, dict) else None,
+            pricing.get("output") if isinstance(pricing, dict) else None,
+            pricing.get("currency") if isinstance(pricing, dict) else None,
+        )
+        if pricing is not None
+        else None
+    )
+    explicit = tuple(sorted(getattr(model, "_explicit_keys", set()) or set()))
+    return (
+        getattr(model, "id", None),
+        getattr(model, "name", None),
+        getattr(model, "provider_id", None),
+        cap_sig,
+        pricing_sig,
+        explicit,
+    )
+
+
+def _model_lists_equal(a: List["ModelInfo"], b: List["ModelInfo"]) -> bool:
+    """Order-sensitive equality of two ``ModelInfo`` lists by signature."""
+    if len(a) != len(b):
+        return False
+    return all(
+        _model_info_signature(x) == _model_info_signature(y) for x, y in zip(a, b)
+    )
 
 
 class ProviderType(str, Enum):
@@ -152,7 +207,14 @@ class Provider:
     _providers: Dict[str, "BaseProvider"] = {}
     _models: Dict[str, ModelInfo] = {}
     _initialized = False
-    
+    # Guards the lazy provider-registration sequence in ``_ensure_initialized``.
+    # ``_initialized`` must only flip to ``True`` *after* the registry is
+    # fully populated, otherwise a thread that wins the cheap fast-path read
+    # (``if not cls._initialized``) can return while another thread is still
+    # mid-registration, causing ``Provider.get(...)`` to return ``None`` for
+    # built-in providers that should already exist.
+    _init_lock: "threading.Lock" = threading.Lock()
+
     @classmethod
     async def init(cls) -> None:
         """Initialize provider system"""
@@ -187,10 +249,20 @@ class Provider:
     
     @classmethod
     def _ensure_initialized(cls):
-        """Ensure providers are initialized"""
-        if not cls._initialized:
-            cls._initialized = True
-            
+        """Ensure providers are initialized (thread-safe lazy init).
+
+        Uses double-checked locking so the hot path (already initialized)
+        is a single dict-attribute read with no lock contention, while
+        concurrent first-time callers see a fully populated registry —
+        not a half-built one — before returning.
+        """
+        if cls._initialized:
+            return
+
+        with cls._init_lock:
+            if cls._initialized:
+                return
+
             # Auto-register built-in providers (Batch 1+2)
             providers_to_register = [
                 ("openai", "flocks.provider.sdk.openai", "OpenAIProvider"),
@@ -246,9 +318,14 @@ class Provider:
                     log.debug("provider.auto_registered", {"provider": provider_id})
                 except Exception as e:
                     log.warning("provider.register.failed", {"provider": provider_id, "error": str(e)})
-            
+
             # Load dynamic providers from flocks.json
             cls._load_dynamic_providers()
+
+            # Flip the "initialized" flag only after the registry is fully
+            # populated. Other threads spinning on the fast-path check above
+            # then see a complete registry, not a half-built one.
+            cls._initialized = True
     
     @classmethod
     def _load_dynamic_providers(cls):
@@ -622,25 +699,50 @@ class Provider:
             if api_key is None and base_url is None and not options_data:
                 continue
 
-            provider.configure(ProviderConfig(
+            # ----- Idempotent ProviderConfig update -------------------------------
+            # ``apply_config`` is called from many hot paths: every session
+            # step (``session.runner._step``), every workflow ``llm.ask``,
+            # the ``/session/*`` HTTP routes, plus startup. When session and
+            # workflow run concurrently on different event loops they would
+            # otherwise rewrite the same ``provider._config`` repeatedly and
+            # race on the ``_config_models`` rebuild. Skip mutation whenever
+            # the desired config already matches.
+            desired_cfg = ProviderConfig(
                 provider_id=pid,
                 api_key=api_key,
                 base_url=base_url,
                 custom_settings=options_data,
-            ))
+            )
+            current_cfg = provider._config
+            current_unchanged = (
+                current_cfg is not None
+                and getattr(current_cfg, "api_key", None) == desired_cfg.api_key
+                and getattr(current_cfg, "base_url", None) == desired_cfg.base_url
+                and (getattr(current_cfg, "custom_settings", None) or {})
+                == (desired_cfg.custom_settings or {})
+            )
+            if not current_unchanged:
+                provider.configure(desired_cfg)
 
             # Update provider display name from flocks.json only for providers
             # that support custom naming (openai-compatible instances and custom-* providers).
             # Standard catalog providers (anthropic, openai, etc.) always keep their SDK name.
             if pid == "openai-compatible" or pid.startswith("custom-"):
                 config_name = getattr(pconfig, "name", None)
-                if config_name and isinstance(config_name, str):
+                if (
+                    config_name
+                    and isinstance(config_name, str)
+                    and provider.name != config_name
+                ):
                     provider.name = config_name
-            
-            # Load models from config
+
+            # ----- Idempotent _config_models rebuild ------------------------------
+            # Build the desired model list first, then assign atomically so
+            # readers (e.g. a session calling ``get_models()`` on another
+            # thread) never observe a half-rebuilt list.
             models_config = getattr(pconfig, "models", None)
             if models_config:
-                provider._config_models = []
+                desired_models: List[ModelInfo] = []
                 if isinstance(models_config, dict):
                     for model_id, model_data in models_config.items():
                         try:
@@ -680,19 +782,26 @@ class Provider:
                                 pricing=_pricing,
                             )
                             model_info._explicit_keys = _explicit_keys
-                            provider._config_models.append(model_info)
+                            desired_models.append(model_info)
                         except Exception as e:
                             log.warning("provider.config_model.parse_failed", {
                                 "provider_id": pid,
                                 "model_id": model_id,
                                 "error": str(e)
                             })
-                
-                if provider._config_models:
-                    log.info("provider.config_models.loaded", {
-                        "provider_id": pid,
-                        "count": len(provider._config_models)
-                    })
+
+                # Skip mutation when the desired list matches what the
+                # provider already exposes — avoids racing readers on the
+                # mutable ``_config_models`` attribute and silences noisy
+                # ``config_models.loaded`` logging on every session step.
+                existing_models = list(getattr(provider, "_config_models", []) or [])
+                if not _model_lists_equal(existing_models, desired_models):
+                    provider._config_models = desired_models
+                    if desired_models:
+                        log.info("provider.config_models.loaded", {
+                            "provider_id": pid,
+                            "count": len(desired_models)
+                        })
     
     @classmethod
     async def chat(

--- a/flocks/workflow/llm.py
+++ b/flocks/workflow/llm.py
@@ -1,11 +1,64 @@
 import asyncio
+import threading
 from dataclasses import dataclass
 import time
 from typing import Any, Dict, Optional
+from weakref import WeakKeyDictionary
 
 from flocks.config.config import Config
 from flocks.provider.provider import ChatMessage, Provider, ProviderConfig
 from flocks.workflow._async_runtime import run_sync as _run_sync_on_shared_loop
+from flocks.workflow import _async_runtime as _async_runtime_mod
+
+
+_provider_locks_guard = threading.Lock()
+_provider_locks: Dict[str, threading.Lock] = {}
+
+# Tracks which event loop currently "owns" each provider's ``_client``.
+# Key   : the provider instance (weakly referenced so we don't pin singletons).
+# Value : ``id(loop)`` of the loop that created or last validated ``_client``.
+#
+# Rationale: ``httpx.AsyncClient`` (and the OpenAI/Anthropic SDK clients that
+# wrap it) bind themselves to the *currently running* event loop on first
+# ``await``. The session uses uvicorn's main loop while workflows use the
+# dedicated ``flocks-workflow-llm-loop``. If a workflow call inherits a
+# provider client that the session created on the main loop, attempting to
+# ``await`` it from the workflow loop raises "got Future attached to a
+# different loop" / hangs. We track the owning loop here so that
+# ``_prepare_provider`` can reset the client when the caller crosses loops,
+# while still reusing the connection pool for back-to-back same-loop calls.
+_provider_client_loop_marker: "WeakKeyDictionary[Any, int]" = WeakKeyDictionary()
+
+
+def _get_provider_lock(provider_id: str) -> threading.Lock:
+    """Return a process-wide lock keyed by ``provider_id``.
+
+    Used to serialize the (apply_config -> configure -> reset _client) sequence
+    in ``LLMClient._prepare_provider`` against any concurrent session/agent
+    request reading ``provider._config`` / ``provider._client``. Locks are
+    created lazily and cached forever — the set of provider ids is bounded
+    and small.
+    """
+    lock = _provider_locks.get(provider_id)
+    if lock is not None:
+        return lock
+    with _provider_locks_guard:
+        lock = _provider_locks.get(provider_id)
+        if lock is None:
+            lock = threading.Lock()
+            _provider_locks[provider_id] = lock
+    return lock
+
+
+def _workflow_loop_id() -> Optional[int]:
+    """Return ``id(loop)`` of the shared workflow async loop, or ``None``.
+
+    The workflow loop is created lazily on first ``_run_sync_on_shared_loop``
+    call. We read it directly from ``_async_runtime`` so callers don't need to
+    actually submit a coroutine just to discover the loop id.
+    """
+    loop = getattr(_async_runtime_mod, "_loop", None)
+    return id(loop) if loop is not None else None
 
 
 def _run_coro_sync(coro):
@@ -57,6 +110,12 @@ class LLMClient:
         self.api_key = (api_key or "").strip() or None
         self.base_url = (base_url or "").strip() or None
         workflow_llm_cfg = self._load_workflow_llm_config()
+        # Only treat ``trust_env`` as user-specified when it actually appears
+        # in workflow.llm config. Otherwise we leave the provider's existing
+        # ``custom_settings['trust_env']`` untouched, which prevents workflow
+        # calls from silently flipping the trust_env policy chosen by the
+        # session / agent that shares the same Provider singleton.
+        self.trust_env_explicit = "trust_env" in workflow_llm_cfg
         self.trust_env = _coerce_bool(workflow_llm_cfg.get("trust_env"), False)
 
         Provider._ensure_initialized()
@@ -190,35 +249,121 @@ class LLMClient:
         return None
 
     def _prepare_provider(self, provider_id: str) -> Any:
-        try:
-            _run_coro_sync(Provider.apply_config(provider_id=provider_id))
-        except Exception:
-            # Keep workflow runtime resilient: provider apply_config failure
-            # should not block ask() for environments driven by env vars.
-            pass
+        """Apply workflow-side overrides on the shared Provider singleton.
 
-        provider = self._get_provider(provider_id)
-        cfg = getattr(provider, "_config", None)
-        existing_custom = getattr(cfg, "custom_settings", None) or {}
-        custom_settings = dict(existing_custom) if isinstance(existing_custom, dict) else {}
-        custom_settings["trust_env"] = self.trust_env
-
-        provider.configure(
-            ProviderConfig(
-                provider_id=provider_id,
-                api_key=self.api_key if self.api_key is not None else getattr(cfg, "api_key", None),
-                base_url=self.base_url if self.base_url is not None else getattr(cfg, "base_url", None),
-                custom_settings=custom_settings,
-            )
-        )
-
-        # Some async SDK clients are loop-bound. Reset and recreate per call.
-        if hasattr(provider, "_client"):
+        Concurrency contract:
+            * The (apply_config -> configure -> _client reset) sequence is
+              serialized per-provider via :func:`_get_provider_lock` so that
+              an in-flight session ``provider.chat_stream`` cannot observe a
+              half-mutated ``provider._config`` / ``provider._client``.
+            * The reconfigure + client reset is *idempotent*: if the desired
+              ProviderConfig (api_key / base_url / relevant custom_settings)
+              already matches what the provider holds, we skip both
+              ``provider.configure(...)`` and ``provider._client = None``.
+              This protects long-running session HTTP connection pools from
+              being recreated on every workflow ``llm.ask()`` call.
+        """
+        with _get_provider_lock(provider_id):
             try:
-                setattr(provider, "_client", None)
+                _run_coro_sync(Provider.apply_config(provider_id=provider_id))
             except Exception:
+                # Keep workflow runtime resilient: provider apply_config failure
+                # should not block ask() for environments driven by env vars.
                 pass
-        return provider
+
+            provider = self._get_provider(provider_id)
+            cfg = getattr(provider, "_config", None)
+            existing_custom = getattr(cfg, "custom_settings", None) or {}
+            custom_settings = (
+                dict(existing_custom) if isinstance(existing_custom, dict) else {}
+            )
+            # Only override ``trust_env`` when the user explicitly set
+            # ``workflow.llm.trust_env`` in flocks config. Otherwise inherit
+            # whatever the session / agent already configured.
+            if self.trust_env_explicit:
+                custom_settings["trust_env"] = self.trust_env
+
+            desired_api_key = (
+                self.api_key
+                if self.api_key is not None
+                else getattr(cfg, "api_key", None)
+            )
+            desired_base_url = (
+                self.base_url
+                if self.base_url is not None
+                else getattr(cfg, "base_url", None)
+            )
+
+            # Idempotency check: only reconfigure when something material
+            # actually changed. ``custom_settings`` may legitimately carry
+            # provider-specific tunables (verify_ssl, region, …) set by the
+            # session — comparing the full dict avoids accidental drops.
+            unchanged = (
+                cfg is not None
+                and getattr(cfg, "api_key", None) == desired_api_key
+                and getattr(cfg, "base_url", None) == desired_base_url
+                and (existing_custom if isinstance(existing_custom, dict) else {})
+                == custom_settings
+            )
+            if not unchanged:
+                provider.configure(
+                    ProviderConfig(
+                        provider_id=provider_id,
+                        api_key=desired_api_key,
+                        base_url=desired_base_url,
+                        custom_settings=custom_settings,
+                    )
+                )
+
+            # Decide whether the existing SDK client can be reused safely.
+            #
+            # Two cases force a client reset (i.e. ``_client = None`` so that
+            # the next ``_get_client()`` rebuilds it on the workflow loop):
+            #
+            #   1. The provider config materially changed (handled above).
+            #   2. The current ``_client`` was last used by a *different*
+            #      event loop than the workflow loop. ``httpx.AsyncClient``
+            #      binds to the loop where it first awaited; cross-loop
+            #      reuse triggers "got Future attached to a different loop"
+            #      or silent hangs.
+            workflow_loop_id = _workflow_loop_id()
+            client_obj = getattr(provider, "_client", None)
+            client_loop_id = (
+                _provider_client_loop_marker.get(provider)
+                if client_obj is not None
+                else None
+            )
+            must_reset_for_loop = (
+                client_obj is not None
+                and workflow_loop_id is not None
+                and client_loop_id != workflow_loop_id
+            )
+            if not unchanged or must_reset_for_loop:
+                if hasattr(provider, "_client"):
+                    try:
+                        setattr(provider, "_client", None)
+                    except Exception:
+                        pass
+                # The next ``_get_client()`` will build a fresh client on
+                # the workflow loop; remember that ownership.
+                if workflow_loop_id is not None:
+                    try:
+                        _provider_client_loop_marker[provider] = workflow_loop_id
+                    except TypeError:
+                        # ``provider`` is not weak-referenceable (rare for
+                        # test doubles) — fall back to a regular attribute.
+                        try:
+                            setattr(provider, "_workflow_client_loop_id", workflow_loop_id)
+                        except Exception:
+                            pass
+            elif workflow_loop_id is not None and client_obj is not None:
+                # Client is being reused for another workflow call on the
+                # same loop — refresh the marker so we keep tracking it.
+                try:
+                    _provider_client_loop_marker[provider] = workflow_loop_id
+                except TypeError:
+                    pass
+            return provider
 
     def _format_target(self, target: _ResolvedTarget) -> str:
         return f"{target.provider_id}/{target.model_id}"

--- a/tests/provider/test_provider_apply_config_idempotent.py
+++ b/tests/provider/test_provider_apply_config_idempotent.py
@@ -1,0 +1,173 @@
+"""Idempotency tests for ``Provider.apply_config``.
+
+The session calls ``Provider.apply_config(provider_id=...)`` on every
+step, and the workflow does the same per ``llm.ask``. Before the fix
+both call sites unconditionally rewrote ``provider._config`` and
+rebuilt ``provider._config_models`` from scratch — which (a) caused
+race-prone reads on the mutable model list across event loops, and
+(b) created noisy ``provider.config_models.loaded`` log entries on
+every hot-path call.
+
+These tests pin down that consecutive ``apply_config`` calls with the
+same backing flocks.json are now a no-op at the mutation level.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from flocks.provider.provider import (
+    ModelCapabilities,
+    ModelInfo,
+    Provider,
+    ProviderConfig,
+)
+
+
+class _Recorder:
+    """Wraps a provider so we can count ``configure`` calls and
+    ``_config_models`` rebuilds during ``apply_config``.
+    """
+
+    def __init__(self, real_provider: Any) -> None:
+        self.real_provider = real_provider
+        self.configure_calls = 0
+        self.models_assignments = 0
+        # Capture the ``_config_models`` setter via property descriptor.
+        original_setattr = type(real_provider).__setattr__
+
+        recorder = self
+
+        def patched_setattr(self_obj, key, value):
+            if key == "_config_models":
+                recorder.models_assignments += 1
+            original_setattr(self_obj, key, value)
+
+        self._original_setattr = original_setattr
+        self._patched_setattr = patched_setattr
+
+    def __enter__(self):
+        type(self.real_provider).__setattr__ = self._patched_setattr
+        original_configure = self.real_provider.configure
+
+        def patched_configure(cfg):
+            self.configure_calls += 1
+            return original_configure(cfg)
+
+        self._original_configure = original_configure
+        self.real_provider.configure = patched_configure
+        return self
+
+    def __exit__(self, *_args, **_kwargs):
+        type(self.real_provider).__setattr__ = self._original_setattr
+        self.real_provider.configure = self._original_configure
+
+
+def _build_fake_config(provider_id: str) -> Any:
+    """Return a SimpleNamespace mimicking ``ConfigInfo`` shape needed by
+    ``apply_config``: ``.provider`` dict -> ``.options`` (with model_dump)
+    and ``.models``.
+    """
+    options = SimpleNamespace(
+        model_dump=lambda exclude_none, by_alias: {
+            "api_key": "static-key",
+            "base_url": "https://static.example.com",
+            "trust_env": False,
+        }
+    )
+    model_options = {
+        "static-model": SimpleNamespace(
+            model_dump=lambda: {
+                "name": "Static Model",
+                "supports_streaming": True,
+                "supports_tools": True,
+                "supports_vision": False,
+                "supports_reasoning": False,
+                "max_tokens": 4096,
+            }
+        )
+    }
+    return SimpleNamespace(
+        provider={
+            provider_id: SimpleNamespace(options=options, models=model_options),
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_config_is_idempotent_for_unchanged_input() -> None:
+    """Two consecutive ``apply_config`` calls with the same config must
+    skip both ``provider.configure(...)`` and ``_config_models`` rebuild
+    on the second call.
+    """
+    Provider._ensure_initialized()
+    provider = Provider.get("openai-compatible")
+    assert provider is not None
+
+    fake_cfg = _build_fake_config("openai-compatible")
+
+    with patch(
+        "flocks.provider.provider.Config.get", return_value=fake_cfg
+    ):
+        # First call primes the provider with the desired config.
+        await Provider.apply_config(provider_id="openai-compatible")
+
+        with _Recorder(provider) as rec:
+            # Second call should observe no material change and skip.
+            await Provider.apply_config(provider_id="openai-compatible")
+
+        assert rec.configure_calls == 0, (
+            "apply_config must not re-run provider.configure when the "
+            "desired ProviderConfig matches the existing one"
+        )
+        assert rec.models_assignments == 0, (
+            "apply_config must not rebuild _config_models when the desired "
+            "model list matches the existing one"
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_config_still_mutates_when_input_changes() -> None:
+    """A genuine config change (different api_key) must still trigger
+    ``provider.configure`` exactly once.
+    """
+    Provider._ensure_initialized()
+    provider = Provider.get("openai-compatible")
+    assert provider is not None
+
+    # First, prime with one config.
+    first_cfg = _build_fake_config("openai-compatible")
+    with patch(
+        "flocks.provider.provider.Config.get", return_value=first_cfg
+    ):
+        await Provider.apply_config(provider_id="openai-compatible")
+
+    # Second, swap api_key.
+    second_options = SimpleNamespace(
+        model_dump=lambda exclude_none, by_alias: {
+            "api_key": "rotated-key",
+            "base_url": "https://static.example.com",
+            "trust_env": False,
+        }
+    )
+    second_cfg = SimpleNamespace(
+        provider={
+            "openai-compatible": SimpleNamespace(
+                options=second_options,
+                models=first_cfg.provider["openai-compatible"].models,
+            )
+        }
+    )
+
+    with patch(
+        "flocks.provider.provider.Config.get", return_value=second_cfg
+    ), _Recorder(provider) as rec:
+        await Provider.apply_config(provider_id="openai-compatible")
+
+    assert rec.configure_calls == 1, (
+        f"expected exactly 1 configure call on api_key change, got {rec.configure_calls}"
+    )

--- a/tests/provider/test_provider_lazy_init_thread_safe.py
+++ b/tests/provider/test_provider_lazy_init_thread_safe.py
@@ -1,0 +1,110 @@
+"""Thread-safety tests for ``Provider._ensure_initialized`` (DCLP).
+
+The lazy-init path previously flipped ``_initialized = True`` *before*
+running ``providers_to_register`` and ``_load_dynamic_providers``. A
+concurrent caller that arrived between those two events would skip the
+slow path and immediately try ``Provider.get(...)``, returning ``None``
+because the registry was not yet populated.
+
+These tests pin down the post-fix contract:
+* ``_ensure_initialized`` is idempotent and safe under concurrency.
+* By the time *any* caller observes ``_initialized == True``, every
+  built-in provider is already registered.
+* ``apply_config`` (also gated on ``_ensure_initialized``) does not
+  trip on a half-initialized registry.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Optional
+
+import pytest
+
+from flocks.provider.provider import Provider
+
+
+# A handful of well-known built-in provider ids that must always be present
+# once initialization is complete. Picked from the registration list inside
+# ``_ensure_initialized``.
+_REQUIRED_BUILTIN_PROVIDERS = (
+    "openai",
+    "anthropic",
+    "google",
+    "openai-compatible",
+    "threatbook-cn-llm",
+)
+
+
+def _force_reinit() -> None:
+    """Drop the singleton state so the next ``_ensure_initialized`` runs
+    the full registration path again. Used only by these tests.
+    """
+    Provider._initialized = False
+    Provider._providers.clear()
+    Provider._models.clear()
+
+
+def test_ensure_initialized_is_idempotent_single_threaded() -> None:
+    _force_reinit()
+    Provider._ensure_initialized()
+    snapshot = dict(Provider._providers)
+    Provider._ensure_initialized()
+    Provider._ensure_initialized()
+    assert dict(Provider._providers) == snapshot
+
+
+def test_ensure_initialized_concurrent_callers_see_complete_registry() -> None:
+    """The fix: every concurrent caller observes a fully populated registry.
+
+    Pre-fix, the cheap fast-path check (``if not _initialized``) raced
+    against the slow registration loop because ``_initialized`` was set
+    to ``True`` *before* registration. After the fix the flag flips only
+    after ``_load_dynamic_providers()`` returns.
+    """
+    _force_reinit()
+
+    barrier = threading.Barrier(parties=20)
+    missing_snapshots: List[Optional[List[str]]] = []
+    snapshots_lock = threading.Lock()
+
+    def worker() -> None:
+        # Align all threads as tightly as possible so most of them race
+        # on the same ``_ensure_initialized`` call.
+        barrier.wait()
+        Provider._ensure_initialized()
+        missing = [
+            pid
+            for pid in _REQUIRED_BUILTIN_PROVIDERS
+            if Provider.get(pid) is None
+        ]
+        with snapshots_lock:
+            missing_snapshots.append(missing if missing else None)
+
+    with ThreadPoolExecutor(max_workers=20) as pool:
+        futs = [pool.submit(worker) for _ in range(20)]
+        for fut in as_completed(futs):
+            fut.result()
+
+    failed = [m for m in missing_snapshots if m]
+    assert not failed, (
+        "After ``_ensure_initialized()`` every caller must see all built-in "
+        f"providers registered. Missing snapshots: {failed!r}"
+    )
+
+
+def test_initialized_flag_is_only_true_after_registration() -> None:
+    """Direct check that the flag flip happens AFTER registration.
+
+    Reset state, then assert that the very first state we see after
+    initialization already contains the required providers.
+    """
+    _force_reinit()
+    assert Provider._initialized is False
+    Provider._ensure_initialized()
+    assert Provider._initialized is True
+    for pid in _REQUIRED_BUILTIN_PROVIDERS:
+        assert Provider.get(pid) is not None, (
+            f"provider {pid!r} should be registered once _initialized is True"
+        )

--- a/tests/workflow/test_llm_provider_isolation.py
+++ b/tests/workflow/test_llm_provider_isolation.py
@@ -1,0 +1,264 @@
+"""Regression tests for ``flocks.workflow.llm.LLMClient._prepare_provider``.
+
+These tests pin down the contract that protects concurrent ``session`` /
+``agent`` callers when a workflow runs ``llm.ask()`` against the same
+``Provider`` singleton:
+
+* The reconfigure-and-reset sequence is **idempotent**: if the workflow's
+  desired config matches what the provider already holds, neither
+  ``provider.configure(...)`` nor the ``provider._client = None`` reset is
+  performed. This keeps long-running httpx connection pools from being
+  thrown away on every workflow LLM call.
+* ``trust_env`` is only overridden when the user explicitly set
+  ``workflow.llm.trust_env`` in flocks config. Otherwise any value that the
+  session previously placed in ``provider._config.custom_settings`` is
+  preserved untouched.
+* When the config does materially change (e.g. api_key flip), the
+  reconfigure path still runs and ``_client`` is reset, as before.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+from flocks.provider.provider import ProviderConfig
+from flocks.workflow import llm as workflow_llm
+
+
+class _FakeProvider:
+    """Minimal stand-in for a registered ``BaseProvider`` instance.
+
+    Records every ``configure`` invocation so tests can assert idempotency.
+    """
+
+    def __init__(
+        self,
+        provider_id: str = "fake-provider",
+        *,
+        api_key: Optional[str] = "session-key",
+        base_url: Optional[str] = "https://session.example.com",
+        custom_settings: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.id = provider_id
+        self._config: Optional[ProviderConfig] = ProviderConfig(
+            provider_id=provider_id,
+            api_key=api_key,
+            base_url=base_url,
+            custom_settings=dict(custom_settings or {}),
+        )
+        self._client: Any = object()
+        self.configure_calls: List[ProviderConfig] = []
+
+    def configure(self, config: ProviderConfig) -> None:
+        self.configure_calls.append(config)
+        self._config = config
+
+    def is_configured(self) -> bool:
+        return self._config is not None and self._config.api_key is not None
+
+
+@pytest.fixture
+def fake_provider() -> _FakeProvider:
+    return _FakeProvider(
+        custom_settings={"trust_env": True, "verify_ssl": False},
+    )
+
+
+@pytest.fixture
+def patched_runtime(fake_provider: _FakeProvider):
+    """Patch out the IO-heavy bits of ``LLMClient`` for unit testing.
+
+    * ``Provider._ensure_initialized`` becomes a no-op.
+    * ``Provider.get`` returns our fake.
+    * ``_run_coro_sync`` short-circuits so ``Provider.apply_config`` /
+      ``Config.get`` never reach a real event loop.
+    """
+
+    def _fake_run_coro_sync(coro):
+        # Drain the coroutine to avoid "coroutine was never awaited" warnings.
+        try:
+            coro.close()
+        except Exception:
+            pass
+        return {}
+
+    with patch.object(
+        workflow_llm.Provider, "_ensure_initialized", lambda: None
+    ), patch.object(
+        workflow_llm.Provider, "get", lambda provider_id: fake_provider
+    ), patch.object(
+        workflow_llm, "_run_coro_sync", side_effect=_fake_run_coro_sync
+    ):
+        yield
+
+
+def _build_client(
+    *,
+    workflow_trust_env_set: bool = False,
+    workflow_trust_env: bool = False,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> workflow_llm.LLMClient:
+    """Build an ``LLMClient`` while controlling whether the workflow config
+    actually contains a ``trust_env`` key.
+    """
+    workflow_cfg: Dict[str, Any] = {}
+    if workflow_trust_env_set:
+        workflow_cfg["trust_env"] = workflow_trust_env
+
+    with patch.object(
+        workflow_llm.LLMClient,
+        "_load_workflow_llm_config",
+        return_value=workflow_cfg,
+    ):
+        return workflow_llm.LLMClient(
+            api_key=api_key,
+            base_url=base_url,
+            provider_id="fake-provider",
+        )
+
+
+def test_prepare_provider_is_idempotent_when_config_unchanged(
+    patched_runtime, fake_provider: _FakeProvider
+) -> None:
+    """No workflow overrides + no explicit trust_env => no reconfigure, no client reset."""
+    client = _build_client()
+
+    original_client = fake_provider._client
+    assert original_client is not None
+
+    client._prepare_provider("fake-provider")
+    client._prepare_provider("fake-provider")
+    client._prepare_provider("fake-provider")
+
+    assert fake_provider.configure_calls == [], (
+        "expected zero reconfigure calls when desired config matches existing"
+    )
+    assert fake_provider._client is original_client, (
+        "expected provider._client to be preserved across idempotent calls"
+    )
+
+
+def test_prepare_provider_does_not_override_session_trust_env(
+    patched_runtime, fake_provider: _FakeProvider
+) -> None:
+    """If workflow.llm.trust_env is not set, session-supplied custom_settings stay intact."""
+    client = _build_client(
+        workflow_trust_env_set=False, workflow_trust_env=False
+    )
+
+    client._prepare_provider("fake-provider")
+
+    assert fake_provider._config is not None
+    assert fake_provider._config.custom_settings == {
+        "trust_env": True,
+        "verify_ssl": False,
+    }
+    assert fake_provider.configure_calls == [], (
+        "trust_env was not explicitly set -> provider.configure must not be called"
+    )
+
+
+def test_prepare_provider_overrides_when_workflow_trust_env_explicit(
+    patched_runtime, fake_provider: _FakeProvider
+) -> None:
+    """If workflow.llm.trust_env IS set, override custom_settings and reset _client."""
+    client = _build_client(
+        workflow_trust_env_set=True, workflow_trust_env=False
+    )
+
+    client._prepare_provider("fake-provider")
+
+    assert len(fake_provider.configure_calls) == 1
+    applied = fake_provider.configure_calls[0]
+    assert applied.custom_settings is not None
+    assert applied.custom_settings.get("trust_env") is False
+    # verify_ssl was carried over from the session-side custom_settings
+    assert applied.custom_settings.get("verify_ssl") is False
+    assert fake_provider._client is None, (
+        "trust_env actually changed -> the SDK client must be reset"
+    )
+
+
+def test_prepare_provider_reconfigures_when_api_key_changes(
+    patched_runtime, fake_provider: _FakeProvider
+) -> None:
+    """A new api_key is a material change -> reconfigure + client reset."""
+    client = _build_client(api_key="workflow-supplied-key")
+
+    client._prepare_provider("fake-provider")
+
+    assert len(fake_provider.configure_calls) == 1
+    assert fake_provider.configure_calls[0].api_key == "workflow-supplied-key"
+    assert fake_provider._client is None
+
+
+def test_prepare_provider_reconfigures_when_base_url_changes(
+    patched_runtime, fake_provider: _FakeProvider
+) -> None:
+    """A new base_url is also a material change."""
+    client = _build_client(base_url="https://workflow.example.com")
+
+    client._prepare_provider("fake-provider")
+
+    assert len(fake_provider.configure_calls) == 1
+    assert (
+        fake_provider.configure_calls[0].base_url
+        == "https://workflow.example.com"
+    )
+    assert fake_provider._client is None
+
+
+def test_get_provider_lock_is_per_provider(patched_runtime) -> None:
+    """Same provider_id returns the same lock instance; different ids get different locks."""
+    lock_a1 = workflow_llm._get_provider_lock("fake-provider")
+    lock_a2 = workflow_llm._get_provider_lock("fake-provider")
+    lock_b = workflow_llm._get_provider_lock("other-provider")
+
+    assert lock_a1 is lock_a2
+    assert lock_a1 is not lock_b
+
+
+def test_prepare_provider_resets_client_when_owning_loop_changes(
+    patched_runtime, fake_provider: _FakeProvider
+) -> None:
+    """If the existing _client belongs to a different loop, reset it even when config is unchanged.
+
+    This guards against ``httpx.AsyncClient`` cross-loop reuse: a session
+    bound the client to uvicorn's main loop, the workflow loop must not
+    inherit it without rebuilding on the workflow loop.
+    """
+    client = _build_client()
+    # Simulate the workflow loop having id=999, while ``_client`` was last
+    # used on a different loop (e.g. the session's main loop with id=111).
+    with patch.object(workflow_llm, "_workflow_loop_id", return_value=999):
+        workflow_llm._provider_client_loop_marker[fake_provider] = 111
+
+        original_client = fake_provider._client
+        assert original_client is not None
+
+        client._prepare_provider("fake-provider")
+
+        # Even though no config field changed, the client must be reset so
+        # the next ``_get_client()`` rebuilds it on the workflow loop.
+        assert fake_provider._client is None
+        # And the marker is updated to the workflow loop.
+        assert workflow_llm._provider_client_loop_marker.get(fake_provider) == 999
+
+
+def test_prepare_provider_keeps_client_when_owning_loop_matches(
+    patched_runtime, fake_provider: _FakeProvider
+) -> None:
+    """When the existing _client already belongs to the workflow loop, do not reset."""
+    client = _build_client()
+    with patch.object(workflow_llm, "_workflow_loop_id", return_value=555):
+        workflow_llm._provider_client_loop_marker[fake_provider] = 555
+
+        original_client = fake_provider._client
+        client._prepare_provider("fake-provider")
+
+        assert fake_provider._client is original_client
+        assert fake_provider.configure_calls == []


### PR DESCRIPTION
isolate workflow LLMClient from session
Provider singleton"). It closes three more concurrency holes that surfaced
during the second-pass review:

A. Cross-loop httpx.AsyncClient reuse (regression risk introduced by the
   idempotent reset in 3c7b300d). `httpx.AsyncClient` binds to whichever
   event loop awaits it first. Session runs on uvicorn's main loop; the
   workflow runs on the dedicated flocks-workflow-llm-loop. If session
   created the client first, workflow inheriting it on a different loop
   raises "got Future attached to a different loop" or silently hangs.

   `_prepare_provider` now tracks the owning loop of `provider._client`
   via a module-level `WeakKeyDictionary` and forces a reset whenever the
   workflow loop id differs from the marker — even if the config itself
   is unchanged. Same-loop back-to-back calls still reuse the client.

B. `Provider._ensure_initialized()` lazy init was not thread-safe: the
   `_initialized` flag was flipped *before* `providers_to_register` and
   `_load_dynamic_providers()` finished, so a concurrent caller could
   take the fast path and observe an empty `_providers` registry. The
   workflow `_warmup_llm()` helper papered over this for itself but the
   session had no such guard — concurrent session/agent boot would hit
   "Provider X not found" intermittently.

   Now uses double-checked locking with `threading.Lock` and only flips
   `_initialized = True` after the registry is fully populated.

C. `Provider.apply_config()` is called on every session step *and*
   inside workflow `llm.ask()`. Previously each call unconditionally
   rewrote `provider._config` and rebuilt `provider._config_models`,
   causing race-prone reads on the mutable model list across loops.

   `apply_config` is now idempotent: it skips both `provider.configure(...)`
   and the `_config_models` rebuild when the desired values already
   match what the provider holds. Model-list rebuild remains atomic
   (build full list then assign) so readers never observe a half-built
   list.