### PR TITLE
fix(skyeye): accept legacy threat level alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,12 @@ default = true
 ### 4.2 Docker Issues
 
 Docker registry mirror in China
-``` bash
-ghcr.nju.edu.cn/agentflocks/flocks:latest
-```
+
+- 1ms GHCR: `docker pull ghcr.1ms.run/agentflocks/flocks:latest`
+- dockerproxy GHCR: `docker pull ghcr.dockerproxy.net/agentflocks/flocks:latest`
+- gh-proxy prefix: `docker pull docker.gh-proxy.com/ghcr.io/agentflocks/flocks:latest`
+- milu GHCR: `docker pull ghcr.milu.moe/agentflocks/flocks:latest`
+- NJU GHCR: `docker pull ghcr.nju.edu.cn/agentflocks/flocks:latest`
 
 Permission issues for `/home/flocks/.flocks` after startup:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -183,9 +183,12 @@ default = true
 ### 4.2 Docker 问题
 
 Docker 国内镜像地址
-``` bash
-ghcr.nju.edu.cn/agentflocks/flocks:latest
-```
+
+- 1ms GHCR：`docker pull ghcr.1ms.run/agentflocks/flocks:latest`
+- dockerproxy GHCR：`docker pull ghcr.dockerproxy.net/agentflocks/flocks:latest`
+- gh-proxy prefix：`docker pull docker.gh-proxy.com/ghcr.io/agentflocks/flocks:latest`
+- milu GHCR：`docker pull ghcr.milu.moe/agentflocks/flocks:latest`
+- NJU GHCR：`docker pull ghcr.nju.edu.cn/agentflocks/flocks:latest`
 
 启动后 `/home/flocks/.flocks` 权限问题
 

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -367,15 +367,28 @@ def _normalize_param_key(name: str) -> str:
     return "".join(ch for ch in str(name).lower() if ch.isalnum())
 
 
+_SCOPED_SCHEMA_ALIASES: Dict[str, Dict[str, str]] = {
+    # SkyEye historically surfaced "威胁级别", which some callers guessed as
+    # threat_level. Keep the schema canonical on hazard_level, but accept the
+    # legacy guess only for this tool so we do not affect other products.
+    "skyeye_alarm_list": {
+        "threat_level": "hazard_level",
+    },
+}
+
+
 def _remap_schema_kwargs(
     kwargs: Dict[str, Any],
     declared_param_names: List[str],
+    *,
+    tool_name: str | None = None,
 ) -> tuple[Dict[str, Any], Dict[str, str]]:
     """Remap guessed argument keys to declared schema keys when unambiguous.
 
     Only applies conservative normalization (case / separators), and only when
     a normalized key maps to exactly one declared parameter name.
     """
+    scoped_aliases = _SCOPED_SCHEMA_ALIASES.get(tool_name or "", {})
     declared_lookup: Dict[str, List[str]] = {}
     for name in declared_param_names:
         declared_lookup.setdefault(_normalize_param_key(name), []).append(name)
@@ -386,6 +399,12 @@ def _remap_schema_kwargs(
     for key, value in kwargs.items():
         if key in declared_param_names:
             remapped[key] = value
+            continue
+        scoped_target = scoped_aliases.get(key)
+        if scoped_target in declared_param_names:
+            aliases[key] = scoped_target
+            if scoped_target not in remapped:
+                remapped[scoped_target] = value
             continue
         normalized = _normalize_param_key(key)
         candidates = declared_lookup.get(normalized, [])
@@ -451,6 +470,7 @@ class Tool:
                 effective_kwargs, remap_aliases = _remap_schema_kwargs(
                     effective_kwargs,
                     declared_param_names,
+                    tool_name=self.info.name,
                 )
                 if remap_aliases:
                     log.info("tool.execute.param_remapped", {

--- a/tests/skill/test_skyeye_project_skills.py
+++ b/tests/skill/test_skyeye_project_skills.py
@@ -10,14 +10,14 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 def test_parse_skyeye_project_skill_files() -> None:
     skill_files = [
-        PROJECT_ROOT / ".flocks" / "plugins" / "skills" / "skyeye-data-fetch" / "SKILL.md",
+        PROJECT_ROOT / ".flocks" / "plugins" / "skills" / "skyeye-use" / "SKILL.md",
         PROJECT_ROOT / ".flocks" / "plugins" / "skills" / "skyeye-sensor-data-fetch" / "SKILL.md",
     ]
 
     parsed = [Skill._parse_skill_md(str(skill_file)) for skill_file in skill_files]
 
     assert parsed[0] is not None
-    assert parsed[0].name == "skyeye-data-fetch"
+    assert parsed[0].name == "skyeye-use"
     assert "SkyEye" in parsed[0].description
 
     assert parsed[1] is not None
@@ -30,5 +30,5 @@ async def test_discover_skyeye_project_skills() -> None:
     skills = await Skill.refresh()
     skill_names = {skill.name for skill in skills}
 
-    assert "skyeye-data-fetch" in skill_names
+    assert "skyeye-use" in skill_names
     assert "skyeye-sensor-data-fetch" in skill_names

--- a/tests/tool/test_onesec_api_tool.py
+++ b/tests/tool/test_onesec_api_tool.py
@@ -18,7 +18,7 @@ def _load_tool(yaml_name: str):
         / ".flocks"
         / "plugins"
         / "tools"
-        / "api"
+        / "device"
         / "onesec_v2_8_2"
         / yaml_name
     )
@@ -121,7 +121,7 @@ async def test_onesec_dns_search_queries_uses_signed_query_params_and_doc_payloa
             pageitemsnum=50,
         )
 
-    assert tool.info.source == "api"
+    assert tool.info.source == "device"
     assert tool.info.provider == "onesec_api_v2_8_2"
     assert result.success is True
     assert result.output["items"] == [{"domain": "example.com"}]

--- a/tests/tool/test_skyeye_api_tools.py
+++ b/tests/tool/test_skyeye_api_tools.py
@@ -9,7 +9,7 @@ from flocks.tool.tool_loader import yaml_to_tool
 
 
 def _load_tool(yaml_name: str):
-    yaml_path = Path.cwd() / ".flocks" / "plugins" / "tools" / "api" / "skyeye_v4_0_14_0_SP2" / yaml_name
+    yaml_path = Path.cwd() / ".flocks" / "plugins" / "tools" / "device" / "skyeye_v4_0_14_0_SP2" / yaml_name
     raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
     return yaml_to_tool(raw, yaml_path)
 
@@ -90,7 +90,7 @@ async def test_skyeye_dashboard_view_tool_uses_custom_login_flow():
     ):
         result = await tool.handler(ToolContext(session_id="test", message_id="test"))
 
-    assert tool.info.source == "api"
+    assert tool.info.source == "device"
     assert tool.info.provider == "skyeye_api_v4_0_14_0_SP2"
     assert result.success is True
     assert result.output["data"]["items"] == {"value": 42}
@@ -166,6 +166,59 @@ async def test_skyeye_alarm_list_returns_clear_error_when_not_configured():
 
     assert result.success is False
     assert "base URL" in result.error
+
+
+@pytest.mark.asyncio
+async def test_skyeye_alarm_list_accepts_legacy_threat_level_alias():
+    tool = _load_tool("skyeye_alarm_list.yaml")
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {
+        "skyeye_api_key": "login-key-123",
+    }.get(key)
+    fake_session = _FakeSession([
+        _FakeResponse(json_payload={"access_token": "token-123", "status": 200}),
+        _FakeResponse(text_payload='<html><meta name="csrf-token" content="abcdef1234567890"></html>'),
+        _FakeResponse(json_payload={"data": {"items": [], "total": 0}, "status": 1000, "message": "ok"}),
+    ])
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={
+                "apiKey": "{secret:skyeye_api_key}",
+                "base_url": "https://skyeye.local",
+                "custom_settings": {
+                    "api_prefix": "api",
+                    "api_version": "v1",
+                    "username": "tapadmin",
+                },
+            },
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+    ):
+        result = await tool.execute(ToolContext(session_id="test", message_id="test"), threat_level="3")
+
+    assert result.success is True
+    method, request_url, request_kwargs = fake_session.calls[2]
+    assert method == "GET"
+    assert request_url == "https://skyeye.local/api/v1/alarm/alarm/list"
+    assert request_kwargs["params"]["hazard_level"] == "3"
+    assert "threat_level" not in request_kwargs["params"]
+
+
+@pytest.mark.asyncio
+async def test_skyeye_alarm_list_still_rejects_unknown_level_fields():
+    tool = _load_tool("skyeye_alarm_list.yaml")
+
+    result = await tool.execute(
+        ToolContext(session_id="test", message_id="test"),
+        hazard_rating="critical",
+    )
+
+    assert result.success is False
+    assert "unknown parameters" in (result.error or "").lower()
+    assert "hazard_rating" in (result.error or "")
 
 
 @pytest.mark.asyncio

--- a/tests/tool/test_skyeye_sensor_skill_cli.py
+++ b/tests/tool/test_skyeye_sensor_skill_cli.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 from rich.console import Console
 
 
-SCRIPTS_DIR = Path(__file__).resolve().parents[2] / ".flocks" / "skills" / "skyeye-sensor-data-fetch" / "scripts"
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / ".flocks" / "plugins" / "skills" / "skyeye-sensor-data-fetch" / "scripts"
 
 
 @pytest.fixture
@@ -73,14 +73,14 @@ def _run_cli(cli_module, monkeypatch: pytest.MonkeyPatch, args: list[str]) -> st
 
     result = CliRunner().invoke(cli_module.cli, args)
     assert result.exit_code == 0, result.output
-    return output.getvalue()
+    return output.getvalue() + result.output
 
 
 @pytest.mark.parametrize(
     ("args", "expected_fragment"),
     [
-        (["alarm", "count", "--days", "1"], "告警趋势"),
-        (["alarm", "list", "--days", "1"], "测试告警"),
+        (["alarm", "count", "--table", "--days", "1"], "告警趋势"),
+        (["alarm", "list", "--table", "--days", "1"], "测试告警"),
     ],
 )
 def test_skyeye_sensor_skill_cli_commands(

--- a/tests/tool/test_skyeye_skill_cli.py
+++ b/tests/tool/test_skyeye_skill_cli.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 from rich.console import Console
 
 
-SCRIPTS_DIR = Path(__file__).resolve().parents[2] / ".flocks" / "skills" / "skyeye-data-fetch" / "scripts"
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / ".flocks" / "plugins" / "skills" / "skyeye-use" / "scripts"
 
 
 @pytest.fixture
@@ -33,10 +33,14 @@ def cli_module(monkeypatch: pytest.MonkeyPatch):
 
 
 class FakeSkyeyeClient:
+    last_alarm_list_kwargs = None
+    last_alarm_count_kwargs = None
+
     def __init__(self, *args, **kwargs) -> None:
         pass
 
     def get_alarm_list(self, **kwargs):
+        type(self).last_alarm_list_kwargs = kwargs
         return {
             "code": 0,
             "data": {
@@ -56,6 +60,7 @@ class FakeSkyeyeClient:
         }
 
     def get_alarm_count(self, **kwargs):
+        type(self).last_alarm_count_kwargs = kwargs
         return {"code": 0, "data": {"high": 3, "critical": 1}}
 
     def search_log_analysis(self, **kwargs):
@@ -77,6 +82,8 @@ class FakeSkyeyeClient:
 
 def _run_cli(cli_module, monkeypatch: pytest.MonkeyPatch, args: list[str]) -> str:
     output = io.StringIO()
+    FakeSkyeyeClient.last_alarm_list_kwargs = None
+    FakeSkyeyeClient.last_alarm_count_kwargs = None
     monkeypatch.setattr(cli_module, "SkyeyeClient", FakeSkyeyeClient)
     monkeypatch.setattr(
         cli_module,
@@ -86,15 +93,15 @@ def _run_cli(cli_module, monkeypatch: pytest.MonkeyPatch, args: list[str]) -> st
 
     result = CliRunner().invoke(cli_module.cli, args)
     assert result.exit_code == 0, result.output
-    return output.getvalue()
+    return output.getvalue() + result.output
 
 
 @pytest.mark.parametrize(
     ("args", "expected_fragment"),
     [
-        (["--json-output", "alarm", "list", "--days", "1"], '"测试告警"'),
-        (["alarm", "count", "--days", "1"], "告警统计"),
-        (["log", "search", "alarm_sip:(10.0.0.1)", "--mode", "expert_model"], "日志搜索结果"),
+        (["--table", "alarm", "list", "--days", "1"], "测试告警"),
+        (["--table", "alarm", "count", "--days", "1"], "告警统计"),
+        (["--table", "log", "search", "alarm_sip:(10.0.0.1)", "--mode", "expert_model"], "日志搜索结果"),
     ],
 )
 def test_skyeye_skill_cli_commands(
@@ -105,3 +112,31 @@ def test_skyeye_skill_cli_commands(
 ):
     output = _run_cli(cli_module, monkeypatch, args)
     assert expected_fragment in output
+
+
+def test_skyeye_skill_cli_alarm_list_forwards_hazard_level_filter(
+    cli_module,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _run_cli(
+        cli_module,
+        monkeypatch,
+        ["alarm", "list", "--days", "1", "--filter", "hazard_level=3,2"],
+    )
+
+    assert FakeSkyeyeClient.last_alarm_list_kwargs is not None
+    assert FakeSkyeyeClient.last_alarm_list_kwargs["hazard_level"] == "3,2"
+
+
+def test_skyeye_skill_cli_alarm_count_forwards_hazard_level_filter(
+    cli_module,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _run_cli(
+        cli_module,
+        monkeypatch,
+        ["alarm", "count", "--days", "1", "--filter", "hazard_level=3,2"],
+    )
+
+    assert FakeSkyeyeClient.last_alarm_count_kwargs is not None
+    assert FakeSkyeyeClient.last_alarm_count_kwargs["hazard_level"] == "3,2"

--- a/tests/tool/test_tdp_skyeye_api_plugins.py
+++ b/tests/tool/test_tdp_skyeye_api_plugins.py
@@ -6,8 +6,8 @@ from flocks.tool.registry import ToolContext, ToolResult
 from flocks.tool.tool_loader import _read_yaml_raw, yaml_to_tool
 
 _WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
-_TDP_HANDLER = _WORKSPACE_ROOT / ".flocks/plugins/tools/api/tdp_v3_3_10/tdp.handler.py"
-_SKYEYE_HANDLER = _WORKSPACE_ROOT / ".flocks/plugins/tools/api/skyeye_v4_0_14_0_SP2/skyeye.handler.py"
+_TDP_HANDLER = _WORKSPACE_ROOT / ".flocks/plugins/tools/device/tdp_v3_3_10/tdp.handler.py"
+_SKYEYE_HANDLER = _WORKSPACE_ROOT / ".flocks/plugins/tools/device/skyeye_v4_0_14_0_SP2/skyeye.handler.py"
 
 
 def _load_module(module_name: str, module_path: Path):
@@ -717,6 +717,7 @@ async def test_skyeye_alarm_list_forwards_extended_filters():
             attack_sip="1.1.1.1",
             attack_stage="recon",
             asset_group="237",
+            hazard_level="2,3",
             is_alarm_black_ip=1,
             limit=10,
         )
@@ -732,12 +733,13 @@ async def test_skyeye_alarm_list_forwards_extended_filters():
     assert params["attack_sip"] == "1.1.1.1"
     assert params["attack_stage"] == "recon"
     assert params["asset_group"] == "237"
+    assert params["hazard_level"] == "2,3"
     assert params["is_alarm_black_ip"] == 1
     assert params["limit"] == 10
 
 
 def test_tdp_incident_yaml_loads_with_provider():
-    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/api/tdp_v3_3_10/tdp_incident_list.yaml"
+    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/device/tdp_v3_3_10/tdp_incident_list.yaml"
     raw = _read_yaml_raw(yaml_path)
     tool = yaml_to_tool(raw, yaml_path)
 
@@ -769,7 +771,7 @@ def test_tdp_query_yaml_promotes_semantic_top_level_fields():
     }
 
     for filename, fields in expected_fields.items():
-        yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/api/tdp_v3_3_10" / filename
+        yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/device/tdp_v3_3_10" / filename
         raw = _read_yaml_raw(yaml_path)
         properties = raw["inputSchema"]["properties"]
         for field in fields:
@@ -777,7 +779,7 @@ def test_tdp_query_yaml_promotes_semantic_top_level_fields():
 
 
 def test_tdp_platform_yaml_uses_keyword_and_requires_confirmation():
-    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/api/tdp_v3_3_10/tdp_platform_config.yaml"
+    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/device/tdp_v3_3_10/tdp_platform_config.yaml"
     raw = _read_yaml_raw(yaml_path)
     tool = yaml_to_tool(raw, yaml_path)
 
@@ -790,7 +792,7 @@ def test_tdp_platform_yaml_uses_keyword_and_requires_confirmation():
 
 
 def test_tdp_policy_yaml_requires_confirmation_and_uses_object_ioc_list():
-    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/api/tdp_v3_3_10/tdp_policy_settings.yaml"
+    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/device/tdp_v3_3_10/tdp_policy_settings.yaml"
     raw = _read_yaml_raw(yaml_path)
     tool = yaml_to_tool(raw, yaml_path)
 
@@ -802,7 +804,7 @@ def test_tdp_policy_yaml_requires_confirmation_and_uses_object_ioc_list():
 
 
 def test_tdp_log_yaml_uses_object_columns_and_supports_cascade_asset_group():
-    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/api/tdp_v3_3_10/tdp_log_search.yaml"
+    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/device/tdp_v3_3_10/tdp_log_search.yaml"
     raw = _read_yaml_raw(yaml_path)
     tool = yaml_to_tool(raw, yaml_path)
 
@@ -814,12 +816,13 @@ def test_tdp_log_yaml_uses_object_columns_and_supports_cascade_asset_group():
 
 
 def test_skyeye_alarm_list_yaml_loads_with_provider():
-    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/api/skyeye_v4_0_14_0_SP2/skyeye_alarm_list.yaml"
+    yaml_path = _WORKSPACE_ROOT / ".flocks/plugins/tools/device/skyeye_v4_0_14_0_SP2/skyeye_alarm_list.yaml"
     raw = _read_yaml_raw(yaml_path)
     tool = yaml_to_tool(raw, yaml_path)
 
     assert tool.info.name == "skyeye_alarm_list"
     assert tool.info.provider == "skyeye_api_v4_0_14_0_SP2"
+    assert tool.info.source == "device"
 
 
 def test_skyeye_verify_ssl_defaults_false_when_unset():


### PR DESCRIPTION
Summary
修复 SkyEye 告警查询对旧字段 threat_level 的兼容问题，在保持标准字段 hazard_level 不变的前提下，避免调用在 schema 预校验阶段失败。
将兼容映射限制在 skyeye_alarm_list 范围内，避免误伤 OneSec 等本来就合法使用 threat_level 的其他设备能力。
补充并修正 SkyEye 相关测试，覆盖旧字段兼容、新字段透传、未知字段报错，以及当前 device 插件目录和 skyeye-use skill 路径。
同步更新 README.md 和 README_zh.md，补充国内 Docker 镜像源，方便国内环境拉取镜像。
Validation
已运行 SkyEye 相关回归测试
已验证公共 schema alias / unknown parameter 行为未被破坏
已验证 OneSec 的 threat_level 用例仍正常通过
我本地执行通过的验证命令是：

source .venv/bin/activate && pytest tests/tool/test_skyeye_api_tools.py tests/tool/test_tdp_skyeye_api_plugins.py tests/tool/test_skyeye_skill_cli.py tests/tool/test_skyeye_sensor_skill_cli.py tests/skill/test_skyeye_project_skills.py tests/tool/test_onesec_api_tool.py::test_onesec_dns_get_recent_blocked_queries_passes_doc_example_fields tests/tool/test_tools.py::TestErrorHandling::test_schema_param_alias_remap_accepts_case_separator_variants tests/tool/test_tools.py::TestErrorHandling::test_unknown_params_returns_schema_hint_for_all_tools
