### PR TITLE
fix(browser): store daemon IPC files under ~/.flocks/browser

### DIFF
--- a/.flocks/plugins/skills/browser-use/SKILL.md
+++ b/.flocks/plugins/skills/browser-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-use
-description: 统一处理浏览器使用任务，支持 CDP 直连用户本机 Chromium 系浏览器。Use when the user asks to browse websites, interact with pages, fill forms, capture screenshots, reuse an existing Chrome/Chromium/Edge login session, access internal/login-only pages, or automate browser actions.
+description: 统一处理浏览器使用任务，支持 CDP 直连/无头模式 使用用户本机 Chromium 系浏览器。Use when the user asks to browse websites, interact with pages, fill forms, capture screenshots, reuse an existing Chrome/Chromium/Edge login session, access internal/login-only pages, handle access-restricted content, when websearch/webfetch are unavailable, or automate browser actions.
 ---
 
 # Browser Use
@@ -28,19 +28,21 @@ description: 统一处理浏览器使用任务，支持 CDP 直连用户本机 C
 
 ## 自动判定模式
 
-当用户没有明确指出使用模式时,开始自动判断
+当用户没有明确指出使用模式时，按下面两步自动判定：
 
-如果任务天然是后台执行、定时任务、CI/cron、无界面采集，或者用户明确要求本次用 headless 浏览器：
+1. 先判断本次 `cdp-direct` 是否需要 headless 浏览器实例
+   满足以下任一条件时，判定为“使用 headless 浏览器实例的 `cdp-direct` 流程”：
+   - 任务天然是后台执行
+   - 任务属于定时任务、`CI` / `cron`
+   - 用户明确要求本次使用 headless 浏览器
+   - 系统不支持可视化，如服务器
 
-1. 优先判定为 `cdp-headless`
-2. 先读取 `references/cdp-headless.md`
-3. 依赖显式的 `BU_CDP_WS` / `BU_CDP_URL`，不要引导用户去操作日常浏览器 profile 的 inspect 授权页
-4. 如果没有显式 CDP endpoint，再按 `references/cdp-headless.md` 中当前平台对应的后台启动方式启动专用 Chromium 实例；必须让浏览器进程脱离当前 shell 独立存活，并为它分配未被占用的专用 remote debugging 端口，优先复用安装脚本设置的 `AGENT_BROWSER_EXECUTABLE_PATH`
-5. 连通后再读取 `references/cdp-direct.md`，后续页面操作沿用通用 CDP 工作流
-
-### 第0 步：先判断任务类型
-
-根据用户意图判断是否需要 headless 模式，如果需要：先按照`references/cdp-headless.md`启动浏览器实例
+2. 如果判定需要 headless，则按以下顺序执行
+   - 先读取 `references/cdp-headless.md`
+   - 优先使用显式提供的 `BU_CDP_WS` / `BU_CDP_URL`
+   - 不要引导用户去操作日常浏览器 profile 的 inspect 授权页
+   - 如果没有显式 CDP endpoint，再按 `references/cdp-headless.md` 中当前平台对应的后台启动方式启动专用 Chromium 实例；必须让浏览器进程脱离当前 shell 独立存活，并为它分配未被占用的专用 remote debugging 端口，优先复用安装脚本设置的 `AGENT_BROWSER_EXECUTABLE_PATH`
+   - 连通后读取 `references/cdp-direct.md`，后续页面操作统一按 `cdp-direct` 工作流执行
 
 ### 第一步：跑 CDP 可用性检测
 
@@ -68,8 +70,6 @@ flocks browser --doctor
 
 ```text
 browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后访问对应浏览器的 inspect 页面（例如 chrome://inspect/#remote-debugging 或 edge://inspect/#remote-debugging）并勾选 Allow remote debugging
-或
-不使用 CDP 模式，使用agent-browser
 ```
 
 然后等待用户进一步指示。如果用户确认已开启后，不要立刻重跑 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 attach，再运行 `flocks browser --doctor` 做只读确认。
@@ -82,9 +82,7 @@ browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后
 #### 结果 C：`flocks browser --doctor` 失败，或当前机器没有可用 Chrome/Chromium/Edge
 
 说明当前环境不适合 `CDP 直连`。此时要：
-
-1. 明确告诉用户是哪一项不满足，提示需要做什么操作才能达到要求
-2. 提示用户切换到 `agent-browser` 模式
+- 明确告诉用户是哪一项不满足，提示需要做什么操作才能达到要求
 
 ## 执行规则
 
@@ -92,6 +90,7 @@ browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后
 2. `cdp-headless` 是唯一例外：先读取 `references/cdp-headless.md` 完成浏览器启动与连接，再读取 `references/cdp-direct.md` 执行通用页面操作。
 3. 在 `cdp-headless` 中，如果当前任务自己启动了专用浏览器实例，必须记录 PID / 日志 / 专用 profile，并只在任务结束或明确放弃后清理自己启动的实例；不要关闭用户提供的远程浏览器。
 4. 不要同时加载 `references/cdp-direct.md` 和 `references/agent-browser.md`。
+5. `flocks browser` 的 daemon 文件固定放在 `~/.flocks/browser/`，例如 `bu.sock`、`bu.log`、`bu.pid`、`bu.port`。
 
 ## 产品经验Skill
 

--- a/.flocks/plugins/skills/browser-use/references/cdp-headless.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-headless.md
@@ -164,7 +164,7 @@ macOS / Linux：
 
 ```bash
 export BU_CDP_URL="http://127.0.0.1:$BU_HEADLESS_PORT"
-rm -f /tmp/bu-default.sock
+rm -f "$HOME/.flocks/browser/bu.sock"
 flocks browser --setup
 flocks browser -c 'print(page_info())'
 ```
@@ -227,5 +227,6 @@ fi
 - 这种场景必须显式设置 `BU_CDP_WS` 或 `BU_CDP_URL`，让 `flocks browser` 直连你启动的 headless 实例
 - 如果 `9222` 已被其他浏览器实例占用，不要复用它；改用新的专用端口，并同步更新浏览器启动参数与 `BU_CDP_URL` / `BU_CDP_WS`
 - 如果显式切换到了新的 `BU_CDP_URL` / `BU_CDP_WS`，但当前 `BU_NAME` 下还有旧 daemon，优先让 `flocks browser --setup` 重新建连；若仍异常，再执行 `flocks browser -c 'restart_daemon()'`
-- 当 daemon 已经死掉但 POSIX socket 文件还留在 `/tmp/` 时，再手动删除 `/tmp/bu-default.sock`；Windows 不需要这一步
+- `flocks browser` 的 daemon 文件固定放在 `~/.flocks/browser/`，例如 `bu.sock`、`bu.log`、`bu.pid`、`bu.port`
+- 当 daemon 已经死掉但 POSIX socket 文件还留在 `~/.flocks/browser/` 时，再手动删除 `~/.flocks/browser/bu.sock`；Windows 不需要这一步
 - 如果失败并出现 `HTTP 403`，优先回头检查 headless Chrome 是否带了 `--remote-allow-origins=*`

--- a/.flocks/plugins/skills/sangfor-edr-use/references/cdp-workflow.md
+++ b/.flocks/plugins/skills/sangfor-edr-use/references/cdp-workflow.md
@@ -4,7 +4,7 @@
 
 | 项目 | 值 |
 |------|-----|
-| **Browser daemon port 文件** | `{tempfile.gettempdir()}/bu-default.port`（由 Python `tempfile.gettempdir()` 解析，跨平台） |
+| **Browser daemon port 文件** | `~/.flocks/browser/bu.port`（固定路径，跨平台） |
 | **EDR 地址** | **需用户提供**（无默认值） |
 | **目标页面 URL** | `{EDR_URL}/ui/#/index`（首页仪表盘） |
 
@@ -107,11 +107,10 @@ powershell -Command "& '<FLOCKS_VENV>\Scripts\python.exe' '<FLOCKS_PLUGINS>\skil
 ```python
 import json
 import socket
-import tempfile
 import time
 from pathlib import Path
 
-port_file = Path(tempfile.gettempdir()) / "bu-default.port"
+port_file = Path.home() / ".flocks" / "browser" / "bu.port"
 port = int(port_file.read_text().strip())
 
 def send_cmd(sock, cmd):

--- a/.flocks/plugins/skills/sangfor-edr-use/references/fetch_edr_system_state.py
+++ b/.flocks/plugins/skills/sangfor-edr-use/references/fetch_edr_system_state.py
@@ -2,9 +2,12 @@ import argparse
 import json
 import re
 import socket
-import tempfile
 import time
 from pathlib import Path
+
+
+BROWSER_DAEMON_PORT_FILE = Path.home() / ".flocks" / "browser" / "bu.port"
+
 
 def send_cmd(sock, cmd):
     sock.sendall((json.dumps(cmd) + "\n").encode())
@@ -104,9 +107,9 @@ def main():
     parser.add_argument("--raw", action="store_true", help="Print raw page text")
     args = parser.parse_args()
 
-    port_file = Path(tempfile.gettempdir()) / "bu-default.port"
+    port_file = BROWSER_DAEMON_PORT_FILE
     if not port_file.exists():
-        print("ERROR: Browser daemon port file not found")
+        print(f"ERROR: Browser daemon port file not found: {port_file}")
         print("Please run: flocks browser --setup")
         exit(1)
 

--- a/.flocks/plugins/skills/sangfor-xdr-use/references/cdp-workflow.md
+++ b/.flocks/plugins/skills/sangfor-xdr-use/references/cdp-workflow.md
@@ -4,7 +4,7 @@
 
 | 项目 | 值 |
 |------|-----|
-| **Browser daemon port 文件** | `{tempfile.gettempdir()}/bu-default.port`（由 Python `tempfile.gettempdir()` 解析，跨平台） |
+| **Browser daemon port 文件** | `~/.flocks/browser/bu.port`（固定路径，跨平台） |
 | **XDR 地址** | **需用户提供**（无默认值） |
 | **目标页面 URL** | `{XDR_URL}/#/apex-business/settings/run/state` |
 
@@ -107,11 +107,10 @@ powershell -Command "& '<FLOCKS_VENV>\Scripts\python.exe' '<FLOCKS_PLUGINS>\skil
 ```python
 import json
 import socket
-import tempfile
 import time
 from pathlib import Path
 
-port_file = Path(tempfile.gettempdir()) / "bu-default.port"
+port_file = Path.home() / ".flocks" / "browser" / "bu.port"
 port = int(port_file.read_text().strip())
 
 def send_cmd(sock, cmd):

--- a/.flocks/plugins/skills/sangfor-xdr-use/references/fetch_xdr_system_state.py
+++ b/.flocks/plugins/skills/sangfor-xdr-use/references/fetch_xdr_system_state.py
@@ -2,9 +2,12 @@ import argparse
 import json
 import re
 import socket
-import tempfile
 import time
 from pathlib import Path
+
+
+BROWSER_DAEMON_PORT_FILE = Path.home() / ".flocks" / "browser" / "bu.port"
+
 
 def send_cmd(sock, cmd):
     sock.sendall((json.dumps(cmd) + "\n").encode())
@@ -153,9 +156,9 @@ def main():
     parser.add_argument("--raw", action="store_true", help="Print raw page text")
     args = parser.parse_args()
 
-    port_file = Path(tempfile.gettempdir()) / "bu-default.port"
+    port_file = BROWSER_DAEMON_PORT_FILE
     if not port_file.exists():
-        print("ERROR: Browser daemon port file not found")
+        print(f"ERROR: Browser daemon port file not found: {port_file}")
         print("Please run: flocks browser --setup")
         exit(1)
 

--- a/.flocks/plugins/skills/web2cli/SKILL.md
+++ b/.flocks/plugins/skills/web2cli/SKILL.md
@@ -415,7 +415,7 @@ else:
 
 `cdp-direct` 必须保留用户原有的 tab 不受影响。
 
-### 11. 迭代与 skill 沉淀
+### 11.  skill 集成
 
 将 CLI 按 `references/cli-in-skill.md` 集成为 skill；
 

--- a/flocks/browser/_ipc.py
+++ b/flocks/browser/_ipc.py
@@ -6,13 +6,12 @@ import re
 import socket
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 
 IS_WINDOWS = sys.platform == "win32"
-BH_TMP_DIR = os.environ.get("BH_TMP_DIR")
-_TMP = Path(BH_TMP_DIR or (tempfile.gettempdir() if IS_WINDOWS else "/tmp"))
+BU_TMP_DIR = str(Path.home() / ".flocks" / "browser")
+_TMP = Path(BU_TMP_DIR).expanduser()
 _TMP.mkdir(parents=True, exist_ok=True)
 _NAME_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
 
@@ -27,7 +26,7 @@ def _check(name: str) -> str:
 def _stem(name: str) -> str:
     """Return the daemon file stem for the given browser session name."""
     _check(name)
-    return "bu" if BH_TMP_DIR else f"bu-{name}"
+    return "bu" if BU_TMP_DIR else f"bu-{name}"
 
 
 def log_path(name: str) -> Path:

--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -78,7 +78,7 @@ def daemon_alive(name: str | None = None) -> bool:
 
 def _daemon_endpoint_names() -> list[str]:
     suffix = ".port" if ipc.IS_WINDOWS else ".sock"
-    if ipc.BH_TMP_DIR:
+    if ipc.BU_TMP_DIR:
         return [NAME] if (ipc._TMP / f"bu{suffix}").exists() else []
     names: list[str] = []
     for path in sorted(ipc._TMP.glob(f"bu-*{suffix}")):

--- a/flocks/session/streaming/stream_processor.py
+++ b/flocks/session/streaming/stream_processor.py
@@ -563,7 +563,7 @@ class StreamProcessor:
             from flocks.hooks.pipeline import HookPipeline
             hook_ctx = await HookPipeline.run_tool_before({
                 "sessionID": self.session_id,
-                "workspace": self.workspace_dir,
+                "workspace": self._workspace_dir,
                 "agent": self.agent.name,
                 "tool": {
                     "name": tool_name,
@@ -720,7 +720,7 @@ class StreamProcessor:
                 from flocks.hooks.pipeline import HookPipeline
                 hook_ctx = await HookPipeline.run_tool_after({
                     "sessionID": self.session_id,
-                    "workspace": self.workspace_dir,
+                    "workspace": self._workspace_dir,
                     "agent": self.agent.name,
                     "tool": {
                         "name": tool_name,

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -74,21 +74,9 @@ def test_generic_remote_debugging_message_triggers_prompt() -> None:
     assert admin._needs_chrome_remote_debugging_prompt(msg)
 
 
-def test_daemon_endpoint_names_discovers_valid_socket_names(tmp_path, monkeypatch) -> None:
+def test_daemon_endpoint_names_with_bu_tmp_dir_returns_local_name_when_sock_exists(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", None)
-    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
-    (tmp_path / "bu-default.sock").touch()
-    (tmp_path / "bu-remote_1.sock").touch()
-    (tmp_path / "bu-invalid.name.sock").touch()
-    (tmp_path / "not-bu-default.sock").touch()
-
-    assert admin._daemon_endpoint_names() == ["default", "remote_1"]
-
-
-def test_daemon_endpoint_names_with_bh_tmp_dir_returns_local_name_when_sock_exists(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", str(tmp_path))
+    monkeypatch.setattr(admin.ipc, "BU_TMP_DIR", str(tmp_path))
     monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
     monkeypatch.setattr(admin, "NAME", "session-xyz")
     (tmp_path / "bu.sock").touch()
@@ -96,9 +84,9 @@ def test_daemon_endpoint_names_with_bh_tmp_dir_returns_local_name_when_sock_exis
     assert admin._daemon_endpoint_names() == ["session-xyz"]
 
 
-def test_daemon_endpoint_names_with_bh_tmp_dir_returns_empty_when_sock_missing(tmp_path, monkeypatch) -> None:
+def test_daemon_endpoint_names_with_bu_tmp_dir_returns_empty_when_sock_missing(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.ipc, "BH_TMP_DIR", str(tmp_path))
+    monkeypatch.setattr(admin.ipc, "BU_TMP_DIR", str(tmp_path))
     monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
     monkeypatch.setattr(admin, "NAME", "session-xyz")
 

--- a/tests/browser/test_ipc.py
+++ b/tests/browser/test_ipc.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from flocks.browser import _ipc as ipc
+
+
+def test_browser_ipc_files_live_under_flocks_browser_dir() -> None:
+    expected_dir = Path.home() / ".flocks" / "browser"
+
+    assert Path(ipc.BU_TMP_DIR) == expected_dir
+    assert ipc.log_path("default") == expected_dir / "bu.log"
+    assert ipc.pid_path("default") == expected_dir / "bu.pid"
+    assert ipc.port_path("default") == expected_dir / "bu.port"
+    if ipc.IS_WINDOWS:
+        assert ipc.sock_addr("default") == "tcp:bu"
+    else:
+        assert ipc.sock_addr("default") == str(expected_dir / "bu.sock")


### PR DESCRIPTION
## Summary

- Move browser daemon IPC artifacts (socket, port, pid, log) from system temp (`/tmp` or `tempfile.gettempdir()`) to a stable per-user directory: `~/.flocks/browser/`.
- Rename `BH_TMP_DIR` to `BU_TMP_DIR` and align `browser-use`, `cdp-headless`, Sangfor EDR/XDR skills, and fetch scripts with the new path.
- Fix `StreamProcessor` tool hook context to use `_workspace_dir` instead of the non-existent `workspace_dir`.
- Add `tests/browser/test_ipc.py` and update admin endpoint discovery tests.