### PR TITLE
feat(catalog): add deepseek-v4-flash to threatbook-cn-llm and threatb…

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -194,6 +194,23 @@
           "cache_read": 1.3,
           "currency": "CNY"
         }
+      },
+      "deepseek-v4-flash": {
+        "name": "deepseek-v4-flash",
+        "family": "deepseek-v4",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 200000,
+          "max_output_tokens": 128000
+        },
+        "pricing": {
+          "input": 1.0,
+          "output": 2.0,
+          "currency": "CNY"
+        }
       }
     }
   },
@@ -333,6 +350,23 @@
         "pricing": {
           "input": 2.5,
           "output": 10.0,
+          "currency": "CNY"
+        }
+      },
+      "deepseek-v4-flash": {
+        "name": "deepseek-v4-flash",
+        "family": "deepseek-v4",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 200000,
+          "max_output_tokens": 128000
+        },
+        "pricing": {
+          "input": 1.0,
+          "output": 2.0,
           "currency": "CNY"
         }
       }

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -238,10 +238,18 @@ class TestCuratedCatalogModels:
             "qwen3.6-plus",
             "qwen3-max",
             "kimi-k2.6",
+            "deepseek-v4-flash",
         }
 
         qwen = next(m for m in models if m.id == "qwen3.6-plus")
         assert qwen.capabilities.supports_vision is True
+
+        flash_cn = next(m for m in models if m.id == "deepseek-v4-flash")
+        assert flash_cn.pricing.input == 1.0
+        assert flash_cn.pricing.output == 2.0
+        assert flash_cn.pricing.currency == "CNY"
+        assert flash_cn.limits.context_window == 200000
+        assert flash_cn.limits.max_output_tokens == 128000
 
         kimi = next(m for m in models if m.id == "kimi-k2.6")
         assert kimi.capabilities.supports_vision is True
@@ -267,10 +275,18 @@ class TestCuratedCatalogModels:
             "GLM-5",
             "qwen3.6-plus",
             "qwen3-max",
+            "deepseek-v4-flash",
         }
 
         qwen = next(m for m in models if m.id == "qwen3.6-plus")
         assert qwen.capabilities.supports_vision is True
+
+        flash_io = next(m for m in models if m.id == "deepseek-v4-flash")
+        assert flash_io.pricing.input == 1.0
+        assert flash_io.pricing.output == 2.0
+        assert flash_io.pricing.currency == "CNY"
+        assert flash_io.limits.context_window == 200000
+        assert flash_io.limits.max_output_tokens == 128000
 
         m27 = next(m for m in models if m.id == "minimax-m2.7")
         assert m27.capabilities.interleaved["field"] == "reasoning_details"


### PR DESCRIPTION
feat(catalog): add deepseek-v4-flash to threatbook-cn-llm and threatbook-io-llm
Add deepseek-v4-flash model to both ThreatBook LLM providers (CN and IO)
with 200K context window, 128K max output, and CNY ¥1/¥2 per million tokens
pricing (input/output). Update catalog tests to assert the new model's
limits and pricing.