### PR TITLE
fix(provider): preserve Azure tool call history

### DIFF
--- a/flocks/provider/sdk/azure.py
+++ b/flocks/provider/sdk/azure.py
@@ -13,6 +13,7 @@ from flocks.provider.provider import (
     ChatResponse,
     StreamChunk,
 )
+from flocks.provider.sdk.openai_base import format_openai_messages
 from flocks.utils.log import Log
 
 log = Log.create(service="provider.azure")
@@ -118,11 +119,7 @@ class AzureProvider(BaseProvider):
         """Send chat completion request to Azure OpenAI"""
         client = self._get_client()
         
-        # Convert messages to OpenAI format
-        formatted_messages = [
-            {"role": msg.role, "content": msg.content}
-            for msg in messages
-        ]
+        formatted_messages = format_openai_messages(messages)
         
         # Extract parameters
         temperature = kwargs.get("temperature", 0.7)
@@ -176,11 +173,7 @@ class AzureProvider(BaseProvider):
         """Send streaming chat completion request to Azure OpenAI"""
         client = self._get_client()
         
-        # Convert messages to OpenAI format
-        formatted_messages = [
-            {"role": msg.role, "content": msg.content}
-            for msg in messages
-        ]
+        formatted_messages = format_openai_messages(messages)
         
         # Extract parameters
         temperature = kwargs.get("temperature", 0.7)

--- a/tests/provider/test_azure_provider.py
+++ b/tests/provider/test_azure_provider.py
@@ -180,3 +180,53 @@ async def test_azure_chat_stream_still_emits_text_chunks():
 
     assert [chunk.delta for chunk in emitted] == ["hello", ""]
     assert emitted[-1].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_azure_chat_stream_preserves_tool_call_history():
+    client = _FakeAzureClient([
+        _chunk(
+            delta=SimpleNamespace(content=None, tool_calls=None),
+            finish_reason="stop",
+        ),
+    ])
+    provider = AzureProvider()
+    provider._get_client = lambda: client
+
+    messages = [
+        ChatMessage(role="user", content="call a sub agent"),
+        ChatMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "delegate_task",
+                        "arguments": '{"prompt":"say ok"}',
+                    },
+                }
+            ],
+        ),
+        ChatMessage(
+            role="tool",
+            content="sub agent result",
+            tool_call_id="call_1",
+            name="delegate_task",
+        ),
+    ]
+
+    emitted = [
+        chunk
+        async for chunk in provider.chat_stream(
+            model_id="gpt-5.4-mini",
+            messages=messages,
+        )
+    ]
+
+    request_messages = client.completions.last_request["messages"]
+    assert request_messages[1]["tool_calls"][0]["id"] == "call_1"
+    assert request_messages[2]["tool_call_id"] == "call_1"
+    assert request_messages[2]["name"] == "delegate_task"
+    assert emitted[-1].finish_reason == "stop"


### PR DESCRIPTION
## Summary
修复 Azure OpenAI 在子 agent/tool 调用后的下一轮请求中丢失 `tool_calls` / `tool_call_id` 历史字段的问题，避免 Azure 返回 `role="tool"` 消息缺少前置 `tool_calls` 的 400 错误。

## Test
- `source .venv/bin/activate && pytest tests/provider/test_openai_base_provider.py tests/provider/test_azure_provider.py`