### PR TITLE
fix(browser): improve setup flow for stale daemon and remote debugging

### DIFF
--- a/.flocks/plugins/skills/browser-use/SKILL.md
+++ b/.flocks/plugins/skills/browser-use/SKILL.md
@@ -72,12 +72,16 @@ flocks browser --doctor
 browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后访问对应浏览器的 inspect 页面（例如 chrome://inspect/#remote-debugging 或 edge://inspect/#remote-debugging）并勾选 Allow remote debugging
 ```
 
-然后等待用户进一步指示。如果用户确认已开启后，不要立刻重跑 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 attach，再运行 `flocks browser --doctor` 做只读确认。
+然后等待用户进一步指示，不要直接操作。
+
+当用户确认已开启remote-debugging后:
+1. 执行 `flocks browser --setup` 触发交互式 attach，不要用短超时包装该命令
+2. 再运行 `flocks browser --doctor` 做只读确认。
+3. 如果还失败，先执行 `flocks browser --reload` 清理旧 daemon，再重新执行 `flocks browser --setup`，避免因为残留 daemon 造成干扰。
 
 如果用户在 `Windows PowerShell` 中执行 `flocks browser -c`，优先使用单行代码并用分号分隔；多行单引号字符串容易因为换行/转义处理差异而触发假失败。
 
-- 如果 `--setup` / `-c` 成功，或随后 `--doctor` 通过：立即使用 `CDP 直连`，并立刻阅读 `references/cdp-direct.md`
-- 如果仍未通过：继续提示用户检查 remote debugging，或提示切到 `agent-browser`
+- 如果 `--setup` 成功，随后 `--doctor` 通过：立即使用 `CDP 直连`，并立刻阅读 `references/cdp-direct.md`
 
 #### 结果 C：`flocks browser --doctor` 失败，或当前机器没有可用 Chrome/Chromium/Edge
 

--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -46,10 +46,7 @@ def _needs_chrome_remote_debugging_prompt(msg: str | None) -> bool:
         or "remote-debugging page" in lower
         or "inspect/#remote-debugging" in lower
         or "not live yet" in lower
-        or (
-            "ws handshake failed" in lower
-            and ("403" in lower or "opening handshake" in lower or "timed out" in lower or "timeout" in lower)
-        )
+        or ("ws handshake failed" in lower and "403" in lower)
     )
 
 
@@ -221,14 +218,15 @@ def ensure_daemon(
             time.sleep(0.2)
         msg = _log_tail(name) or ""
         if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
-            if _open_inspect:
-                _open_browser_inspect()
+            restart_daemon(name)
+            if not _open_inspect:
+                raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
+            _open_browser_inspect()
             print(
                 f"{BROWSER_LABEL}: click Allow on your browser's inspect page "
                 "(for example chrome://inspect or edge://inspect), and tick the checkbox if shown",
                 file=sys.stderr,
             )
-            restart_daemon(name)
             continue
         raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
 
@@ -413,13 +411,16 @@ def run_setup() -> int:
             print(f"daemon already running; restarting to attach via {endpoint_name}.")
             restart_daemon()
         else:
-            print("daemon already running; nothing to do.")
-            return 0
+            if _daemon_has_current_protocol():
+                print("daemon already running and attached; nothing to do.")
+                return 0
+            print("daemon already running but browser connection is stale; restarting.")
+            restart_daemon()
     if not endpoint_name and not _chrome_running():
         print("no Chrome/Chromium/Edge process detected. please start your browser and rerun `flocks browser --setup`.")
         return 1
     try:
-        ensure_daemon(wait=20.0)
+        ensure_daemon(wait=20.0, _open_inspect=False)
         print("daemon is up.")
         return 0
     except RuntimeError as error:

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -36,9 +36,9 @@ def test_local_chrome_mode_is_false_when_process_env_provides_remote_cdp_url(mon
     assert not admin._is_local_chrome_mode()
 
 
-def test_handshake_timeout_needs_chrome_remote_debugging_prompt() -> None:
+def test_handshake_timeout_does_not_open_chrome_inspect() -> None:
     msg = "CDP WS handshake failed: timed out during opening handshake"
-    assert admin._needs_chrome_remote_debugging_prompt(msg)
+    assert not admin._needs_chrome_remote_debugging_prompt(msg)
 
 
 def test_handshake_403_needs_chrome_remote_debugging_prompt() -> None:
@@ -232,7 +232,8 @@ def test_run_setup_uses_generic_remote_debugging_wording(monkeypatch, capsys) ->
     monkeypatch.setattr(admin, "daemon_alive", lambda: False)
     monkeypatch.setattr(admin, "_chrome_running", lambda: True)
     monkeypatch.setattr(admin, "_is_local_chrome_mode", lambda env=None: True)
-    monkeypatch.setattr(admin, "_open_browser_inspect", lambda: None)
+    open_calls = []
+    monkeypatch.setattr(admin, "_open_browser_inspect", lambda: open_calls.append(True))
 
     calls = {"count": 0}
 
@@ -252,6 +253,25 @@ def test_run_setup_uses_generic_remote_debugging_wording(monkeypatch, capsys) ->
     assert "browser remote debugging is not enabled on the current profile." in out
     assert "opening your browser's inspect page" in out
     assert "if the browser shows the profile picker" in out
+    assert open_calls == [True]
+
+
+def test_run_setup_restarts_stale_existing_local_daemon(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "_daemon_has_current_protocol", lambda: False)
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    restarted = []
+    ensure_calls = []
+    monkeypatch.setattr(admin, "restart_daemon", lambda name=None: restarted.append(name))
+    monkeypatch.setattr(admin, "ensure_daemon", lambda **kwargs: ensure_calls.append(kwargs))
+
+    assert admin.run_setup() == 0
+
+    out = capsys.readouterr().out
+    assert "browser connection is stale; restarting" in out
+    assert "daemon is up." in out
+    assert restarted == [None]
+    assert ensure_calls == [{"wait": 20.0, "_open_inspect": False}]
 
 
 def test_run_setup_allows_explicit_remote_cdp_without_local_browser(monkeypatch, capsys) -> None:
@@ -266,7 +286,7 @@ def test_run_setup_allows_explicit_remote_cdp_without_local_browser(monkeypatch,
     out = capsys.readouterr().out
     assert "attaching via BU_CDP_WS" in out
     assert "daemon is up." in out
-    assert ensure_calls == [{"wait": 20.0}]
+    assert ensure_calls == [{"wait": 20.0, "_open_inspect": False}]
 
 
 def test_run_setup_restarts_existing_daemon_for_explicit_remote_cdp(monkeypatch, capsys) -> None:
@@ -285,7 +305,7 @@ def test_run_setup_restarts_existing_daemon_for_explicit_remote_cdp(monkeypatch,
     assert "restarting to attach via BU_CDP_URL" in out
     assert "daemon is up." in out
     assert restarted == [None]
-    assert ensure_calls == [{"wait": 20.0}]
+    assert ensure_calls == [{"wait": 20.0, "_open_inspect": False}]
 
 
 def test_run_doctor_uses_generic_browser_wording_when_missing(monkeypatch, capsys) -> None:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -710,6 +710,7 @@ def test_start_all_stops_services_before_starting(monkeypatch) -> None:
     monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: (call_order.append("ensure_runtime_dirs"), paths)[1])
     monkeypatch.setattr(service_manager, "service_lock", lambda _paths: _record_call(call_order, "service_lock"))
     monkeypatch.setattr(service_manager, "stop_one", lambda port, _pid_file, _name, _console: call_order.append(f"stop_one:{port}"))
+    monkeypatch.setattr(service_manager, "stop_all_browser_daemons", lambda: call_order.append("stop_browser") or [])
     monkeypatch.setattr(service_manager, "_start_all_without_stop", lambda _config, _console: call_order.append("_start_all_without_stop"))
 
     service_manager.start_all(service_manager.ServiceConfig(), console=None)
@@ -719,6 +720,7 @@ def test_start_all_stops_services_before_starting(monkeypatch) -> None:
         "service_lock",
         "stop_one:5173",
         "stop_one:8000",
+        "stop_browser",
         "_start_all_without_stop",
     ]
 
@@ -738,6 +740,7 @@ def test_restart_all_stops_then_starts_under_lock(monkeypatch) -> None:
     monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: (call_order.append("ensure_runtime_dirs"), paths)[1])
     monkeypatch.setattr(service_manager, "service_lock", lambda _paths: _record_call(call_order, "service_lock"))
     monkeypatch.setattr(service_manager, "stop_one", lambda port, _pid_file, _name, _console: call_order.append(f"stop_one:{port}"))
+    monkeypatch.setattr(service_manager, "stop_all_browser_daemons", lambda: call_order.append("stop_browser") or [])
     monkeypatch.setattr(service_manager, "_start_all_without_stop", lambda _config, _console: call_order.append("_start_all_without_stop"))
 
     service_manager.restart_all(service_manager.ServiceConfig(), console=None)
@@ -747,6 +750,7 @@ def test_restart_all_stops_then_starts_under_lock(monkeypatch) -> None:
         "service_lock",
         "stop_one:5173",
         "stop_one:8000",
+        "stop_browser",
         "_start_all_without_stop",
     ]
 

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Message } from '@/types';
 
 import {
+  default as SessionChat,
   getEditingActionBarClassName,
   getMessageBubbleClassName,
   getMessageGroupClassName,
@@ -11,6 +14,92 @@ import {
   shouldRefetchFinishedMessage,
   truncateToolDisplayText,
 } from './SessionChat';
+
+const clientGetMock = vi.fn();
+const clientPostMock = vi.fn();
+const useSessionMessagesMock = vi.fn();
+const tMock = (key: string) => ({
+  'chat.placeholder': '请输入消息',
+  'chat.emptyText': '暂无消息',
+  'chat.sending': '发送中...',
+  'chat.thinking': '思考中...',
+  'chat.streaming': '继续输出中...',
+  'chat.compacting': '压缩中...',
+}[key] ?? key);
+const pendingQuestionsHookMock = {
+  pendingQuestions: {},
+  handleQuestionAsked: vi.fn(),
+  submitAnswer: vi.fn(),
+  submitReject: vi.fn(),
+  removeByRequestId: vi.fn(),
+  fetchPendingQuestions: vi.fn().mockResolvedValue(undefined),
+  clearAll: vi.fn(),
+};
+const toastMock = {
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: tMock,
+  }),
+}));
+
+vi.mock('@/hooks/useSessions', () => ({
+  useSessionMessages: (...args: unknown[]) => useSessionMessagesMock(...args),
+}));
+
+vi.mock('@/hooks/useSSE', () => ({
+  useSSE: () => ({ status: 'connected' }),
+}));
+
+vi.mock('@/hooks/useReasoningToggle', () => ({
+  useReasoningToggle: () => ({
+    getPartExpanded: () => false,
+    togglePart: vi.fn(),
+    isReasoningDone: true,
+  }),
+}));
+
+vi.mock('@/hooks/usePendingQuestions', () => ({
+  usePendingQuestions: () => pendingQuestionsHookMock,
+}));
+
+vi.mock('./Toast', () => ({
+  useToast: () => toastMock,
+}));
+
+vi.mock('@/api/client', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => clientGetMock(...args),
+    post: (...args: unknown[]) => clientPostMock(...args),
+  },
+  getApiBase: () => '',
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+  clientGetMock.mockResolvedValue({ data: {} });
+  clientPostMock.mockResolvedValue({ data: {} });
+  pendingQuestionsHookMock.fetchPendingQuestions.mockResolvedValue(undefined);
+  useSessionMessagesMock.mockReturnValue({
+    messages: [],
+    loading: false,
+    refetch: vi.fn(),
+    addMessage: vi.fn(),
+    updateMessage: vi.fn(),
+    updateMessagePart: vi.fn(),
+    replaceMessageText: vi.fn(),
+    truncateAfterMessage: vi.fn(),
+  });
+});
 
 function makeMessage(overrides: Partial<Message> & { id: string }): Message {
   return {
@@ -118,6 +207,44 @@ describe('getStandaloneThinkingBubbleClassName', () => {
     expect(getStandaloneThinkingBubbleClassName(true)).toBe(
       getMessageBubbleClassName({ compact: true, isUser: false, isEditing: false }),
     );
+  });
+});
+
+describe('SessionChat standalone thinking indicator', () => {
+  it('keeps only the bouncing dots during the initial assistant loading state', async () => {
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'user-1',
+          role: 'user',
+          parts: [{ id: 'user-1-part', type: 'text', text: 'hello' }] as Message['parts'],
+        }),
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    const { container } = render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      initialMessage: 'hello',
+    }));
+
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledWith(
+        '/api/session/sess-1/prompt_async',
+        expect.objectContaining({ parts: expect.any(Array) }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.animate-bounce').length).toBeGreaterThanOrEqual(3);
+      expect(container.textContent).not.toContain('思考中...');
+    });
   });
 });
 

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -554,6 +554,7 @@ export default function SessionChat({
     updateMessage,
     updateMessagePart,
     replaceMessageText,
+    markMessageStopped,
     truncateAfterMessage,
   } =
     useSessionMessages(sessionId || undefined);
@@ -576,7 +577,15 @@ export default function SessionChat({
 
       if (!properties || !sessionId) return;
 
-      if (type === 'message.updated' && properties.info?.sessionID === sessionId) {
+      if (type === 'session.updated' && properties.id === sessionId && properties.status === 'idle') {
+        setIsStreaming(false);
+        const lastAsstMsg = [...messagesRef.current].reverse().find(
+          (message) => message.role === 'assistant' && !message.finish,
+        );
+        if (lastAsstMsg?.parts?.length) {
+          markMessageStopped(lastAsstMsg.id);
+        }
+      } else if (type === 'message.updated' && properties.info?.sessionID === sessionId) {
         updateMessage(properties.info);
         if (properties.info.finish || properties.info.time?.completed) {
           const shouldRefetch = shouldRefetchFinishedMessage({
@@ -665,6 +674,7 @@ export default function SessionChat({
       sessionId,
       updateMessage,
       updateMessagePart,
+      markMessageStopped,
       refetch,
       handleQuestionAsked,
       removeByRequestId,
@@ -1302,6 +1312,9 @@ export default function SessionChat({
       abortedMessageIdRef.current = lastAsstMsg?.id || null;
       abortingRef.current = true;
       await client.post(`/api/session/${sessionId}/abort`);
+      if (lastAsstMsg?.id) {
+        markMessageStopped(lastAsstMsg.id);
+      }
       setIsStreaming(false);
       setTimeout(() => { abortingRef.current = false; }, ABORT_SSE_SETTLE_DELAY);
     } catch (err) {
@@ -1309,7 +1322,7 @@ export default function SessionChat({
       abortingRef.current = false;
       abortedMessageIdRef.current = null;
     }
-  }, [sessionId]);
+  }, [markMessageStopped, sessionId]);
 
   // Fire onStreamingDone when isStreaming transitions true → false
   useEffect(() => {
@@ -1654,7 +1667,6 @@ export default function SessionChat({
                             <div className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
                             <div className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
                           </div>
-                          <span>{t('chat.thinking')}</span>
                         </div>
                       </div>
                     </div>

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -285,4 +285,79 @@ describe('updateMessagePart scheduling', () => {
 
     expect(result.current.messages.map((msg) => msg.id)).toEqual(['msg-1']);
   });
+
+  it('markMessageStopped keeps partial text and freezes running tools', async () => {
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.addMessage(makeMsg({
+        id: 'msg-stop',
+        role: 'assistant',
+        parts: [
+          { id: 'reason-1', type: 'reasoning', text: '分析中' } as any,
+          {
+            id: 'tool-1',
+            type: 'tool',
+            state: {
+              status: 'running',
+              title: 'Read file',
+              time: { start: 100 },
+            },
+          } as any,
+          { id: 'text-1', type: 'text', text: '已经输出一半' } as any,
+        ],
+      }));
+    });
+
+    await act(async () => {
+      result.current.markMessageStopped('msg-stop');
+    });
+
+    const msg = result.current.messages.find((item) => item.id === 'msg-stop');
+    expect(msg?.finish).toBe('stop');
+    expect((msg?.parts as any[])[2].text).toBe('已经输出一半');
+    expect((msg?.parts as any[])[1].state.status).toBe('error');
+    expect((msg?.parts as any[])[1].state.error).toBe('Tool execution was interrupted');
+    expect((msg?.parts as any[])[1].state.time.end).toBeDefined();
+  });
+
+  it('refetch preserves locally stopped assistant content when backend snapshot is weaker', async () => {
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.addMessage(makeMsg({
+        id: 'msg-stop',
+        role: 'assistant',
+        parts: [
+          { id: 'tool-1', type: 'tool', state: { status: 'completed', output: 'ok' } } as any,
+          { id: 'text-1', type: 'text', text: '保留这段已输出文本' } as any,
+        ],
+      }));
+      result.current.markMessageStopped('msg-stop');
+    });
+
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: [{
+        info: {
+          id: 'msg-stop',
+          sessionID: 'sess-1',
+          role: 'assistant',
+          time: { created: 123 },
+        },
+        parts: [],
+      }],
+    } as any);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    const msg = result.current.messages.find((item) => item.id === 'msg-stop');
+    expect(msg?.finish).toBe('stop');
+    expect(msg?.parts).toHaveLength(2);
+    expect((msg?.parts as any[])[1].text).toBe('保留这段已输出文本');
+    expect((msg?.parts as any[])[0].state.status).toBe('completed');
+  });
 });

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -4,6 +4,55 @@ import client from '@/api/client';
 import type { Session, Message } from '@/types';
 
 const VISIBLE_CATEGORIES = new Set(['user', 'workflow', 'entity-config']);
+const ABORTED_TOOL_ERROR = 'Tool execution was interrupted';
+
+function finalizeStoppedMessageParts(parts: Message['parts'], stoppedAt = Date.now()): Message['parts'] {
+  return parts.map((part) => {
+    if (
+      (part.type !== 'tool' && part.type !== 'toolCall')
+      || part.state?.status !== 'running'
+    ) {
+      return part;
+    }
+
+    const nextTime = part.state.time
+      ? { ...part.state.time, end: part.state.time.end ?? stoppedAt }
+      : undefined;
+
+    return {
+      ...part,
+      state: {
+        ...part.state,
+        status: 'error',
+        error: part.state.error || ABORTED_TOOL_ERROR,
+        ...(nextTime ? { time: nextTime } : {}),
+      },
+    };
+  });
+}
+
+function mergeFetchedMessages(prev: Message[], fetched: Message[]): Message[] {
+  const previousById = new Map(prev.map((message) => [message.id, message]));
+
+  return fetched.map((message) => {
+    const existing = previousById.get(message.id);
+    if (!existing) return message;
+
+    // Aborted assistant replies may never be fully persisted by the backend.
+    // Keep the richer local snapshot so partial streamed text/tool state doesn't
+    // disappear or regress on a later refetch.
+    if (existing.finish === 'stop' && !message.finish) {
+      return {
+        ...message,
+        parts: existing.parts,
+        finish: existing.finish,
+        compacted: message.compacted ?? existing.compacted,
+      };
+    }
+
+    return message;
+  });
+}
 
 /**
  * Pure reducer for updating a message part in the messages list.
@@ -185,7 +234,7 @@ export function useSessionMessages(sessionId?: string) {
         compacted: msg.info.compacted || null,
       }));
       
-      setMessages(messagesData);
+      setMessages(prev => mergeFetchedMessages(prev, messagesData));
     } catch (err: any) {
       setError(err.message || 'Failed to fetch messages');
     } finally {
@@ -322,6 +371,18 @@ export function useSessionMessages(sessionId?: string) {
         return {
           ...message,
           parts,
+        };
+      }));
+    },
+    markMessageStopped: (messageId: string) => {
+      setMessages(prev => prev.map((message) => {
+        if (message.id !== messageId) return message;
+        if (message.finish === 'stop') return message;
+
+        return {
+          ...message,
+          finish: 'stop',
+          parts: finalizeStoppedMessageParts(message.parts),
         };
       }));
     },


### PR DESCRIPTION
## Summary

- `flocks browser --setup` 在本地 daemon 已运行但连接过期时会自动重启，避免误判为“无需操作”
- 仅对 CDP WS 403 握手失败弹出 inspect 引导；超时不再误开 Chrome inspect 页
- `ensure_daemon` 在需要用户授权 remote debugging 时先重启 daemon 再打开 inspect
- 更新 `browser-use` skill 的 attach/reload 工作流说明
- 补充 `start_all`/`restart_all` 会先停止 browser daemon 的测试断言