### PR TITLE
fix(webui): remove stale eslint-disable in DeviceIntegration fetchData

### DIFF
--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -920,7 +920,6 @@ export default function DeviceIntegrationPage() {
       setLoading(false);
       setRefreshing(false);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => { void fetchData(); }, [fetchData]);


### PR DESCRIPTION
## Summary

- remove out date `react-hooks/exhaustive-deps` eslint-disable comment
