### PR TITLE
fix(workflow): isolate LLM provider from shared singleton

### DIFF
--- a/flocks/workflow/llm.py
+++ b/flocks/workflow/llm.py
@@ -1,64 +1,12 @@
 import asyncio
-import threading
+from copy import copy
 from dataclasses import dataclass
 import time
 from typing import Any, Dict, Optional
-from weakref import WeakKeyDictionary
 
 from flocks.config.config import Config
 from flocks.provider.provider import ChatMessage, Provider, ProviderConfig
 from flocks.workflow._async_runtime import run_sync as _run_sync_on_shared_loop
-from flocks.workflow import _async_runtime as _async_runtime_mod
-
-
-_provider_locks_guard = threading.Lock()
-_provider_locks: Dict[str, threading.Lock] = {}
-
-# Tracks which event loop currently "owns" each provider's ``_client``.
-# Key   : the provider instance (weakly referenced so we don't pin singletons).
-# Value : ``id(loop)`` of the loop that created or last validated ``_client``.
-#
-# Rationale: ``httpx.AsyncClient`` (and the OpenAI/Anthropic SDK clients that
-# wrap it) bind themselves to the *currently running* event loop on first
-# ``await``. The session uses uvicorn's main loop while workflows use the
-# dedicated ``flocks-workflow-llm-loop``. If a workflow call inherits a
-# provider client that the session created on the main loop, attempting to
-# ``await`` it from the workflow loop raises "got Future attached to a
-# different loop" / hangs. We track the owning loop here so that
-# ``_prepare_provider`` can reset the client when the caller crosses loops,
-# while still reusing the connection pool for back-to-back same-loop calls.
-_provider_client_loop_marker: "WeakKeyDictionary[Any, int]" = WeakKeyDictionary()
-
-
-def _get_provider_lock(provider_id: str) -> threading.Lock:
-    """Return a process-wide lock keyed by ``provider_id``.
-
-    Used to serialize the (apply_config -> configure -> reset _client) sequence
-    in ``LLMClient._prepare_provider`` against any concurrent session/agent
-    request reading ``provider._config`` / ``provider._client``. Locks are
-    created lazily and cached forever — the set of provider ids is bounded
-    and small.
-    """
-    lock = _provider_locks.get(provider_id)
-    if lock is not None:
-        return lock
-    with _provider_locks_guard:
-        lock = _provider_locks.get(provider_id)
-        if lock is None:
-            lock = threading.Lock()
-            _provider_locks[provider_id] = lock
-    return lock
-
-
-def _workflow_loop_id() -> Optional[int]:
-    """Return ``id(loop)`` of the shared workflow async loop, or ``None``.
-
-    The workflow loop is created lazily on first ``_run_sync_on_shared_loop``
-    call. We read it directly from ``_async_runtime`` so callers don't need to
-    actually submit a coroutine just to discover the loop id.
-    """
-    loop = getattr(_async_runtime_mod, "_loop", None)
-    return id(loop) if loop is not None else None
 
 
 def _run_coro_sync(coro):
@@ -248,122 +196,98 @@ class LLMClient:
                 )
         return None
 
-    def _prepare_provider(self, provider_id: str) -> Any:
-        """Apply workflow-side overrides on the shared Provider singleton.
+    def _clone_provider_for_workflow(self, shared_provider: Any) -> Any:
+        """Create a workflow-local provider instance from the shared singleton.
 
-        Concurrency contract:
-            * The (apply_config -> configure -> _client reset) sequence is
-              serialized per-provider via :func:`_get_provider_lock` so that
-              an in-flight session ``provider.chat_stream`` cannot observe a
-              half-mutated ``provider._config`` / ``provider._client``.
-            * The reconfigure + client reset is *idempotent*: if the desired
-              ProviderConfig (api_key / base_url / relevant custom_settings)
-              already matches what the provider holds, we skip both
-              ``provider.configure(...)`` and ``provider._client = None``.
-              This protects long-running session HTTP connection pools from
-              being recreated on every workflow ``llm.ask()`` call.
+        Workflow calls run on a dedicated background loop while session / agent
+        calls run on the server loop. Sharing the same provider instance across
+        those callers makes both ``_config`` and any cached async client
+        (``_client``) a process-wide race point. The workflow therefore uses an
+        isolated provider instance seeded from the shared provider's current
+        config/runtime state, but never mutates the shared singleton itself.
         """
-        with _get_provider_lock(provider_id):
+        try:
+            isolated_provider = type(shared_provider)()
+        except Exception:
+            isolated_provider = copy(shared_provider)
+
+        for attr in ("id", "name", "_api_key", "_base_url", "_endpoint"):
+            if hasattr(shared_provider, attr):
+                try:
+                    setattr(isolated_provider, attr, getattr(shared_provider, attr))
+                except Exception:
+                    pass
+
+        for attr in ("_config_models", "_custom_models"):
+            if hasattr(shared_provider, attr):
+                value = getattr(shared_provider, attr)
+                cloned_value = list(value) if isinstance(value, list) else value
+                try:
+                    setattr(isolated_provider, attr, cloned_value)
+                except Exception:
+                    pass
+
+        if hasattr(isolated_provider, "_client"):
             try:
-                _run_coro_sync(Provider.apply_config(provider_id=provider_id))
+                setattr(isolated_provider, "_client", None)
             except Exception:
-                # Keep workflow runtime resilient: provider apply_config failure
-                # should not block ask() for environments driven by env vars.
                 pass
 
-            provider = self._get_provider(provider_id)
-            cfg = getattr(provider, "_config", None)
-            existing_custom = getattr(cfg, "custom_settings", None) or {}
-            custom_settings = (
-                dict(existing_custom) if isinstance(existing_custom, dict) else {}
-            )
-            # Only override ``trust_env`` when the user explicitly set
-            # ``workflow.llm.trust_env`` in flocks config. Otherwise inherit
-            # whatever the session / agent already configured.
-            if self.trust_env_explicit:
-                custom_settings["trust_env"] = self.trust_env
+        return isolated_provider
 
-            desired_api_key = (
-                self.api_key
-                if self.api_key is not None
-                else getattr(cfg, "api_key", None)
-            )
-            desired_base_url = (
-                self.base_url
-                if self.base_url is not None
-                else getattr(cfg, "base_url", None)
-            )
+    def _prepare_provider(self, provider_id: str) -> Any:
+        """Build a workflow-local provider without mutating the shared singleton."""
+        try:
+            _run_coro_sync(Provider.apply_config(provider_id=provider_id))
+        except Exception:
+            # Keep workflow runtime resilient: provider apply_config failure
+            # should not block ask() for environments driven by env vars.
+            pass
 
-            # Idempotency check: only reconfigure when something material
-            # actually changed. ``custom_settings`` may legitimately carry
-            # provider-specific tunables (verify_ssl, region, …) set by the
-            # session — comparing the full dict avoids accidental drops.
-            unchanged = (
-                cfg is not None
-                and getattr(cfg, "api_key", None) == desired_api_key
-                and getattr(cfg, "base_url", None) == desired_base_url
-                and (existing_custom if isinstance(existing_custom, dict) else {})
-                == custom_settings
-            )
-            if not unchanged:
-                provider.configure(
-                    ProviderConfig(
-                        provider_id=provider_id,
-                        api_key=desired_api_key,
-                        base_url=desired_base_url,
-                        custom_settings=custom_settings,
-                    )
+        shared_provider = self._get_provider(provider_id)
+        provider = self._clone_provider_for_workflow(shared_provider)
+        cfg = getattr(shared_provider, "_config", None)
+        existing_custom = getattr(cfg, "custom_settings", None) or {}
+        custom_settings = (
+            dict(existing_custom) if isinstance(existing_custom, dict) else {}
+        )
+        if self.trust_env_explicit:
+            custom_settings["trust_env"] = self.trust_env
+
+        desired_api_key = (
+            self.api_key
+            if self.api_key is not None
+            else getattr(cfg, "api_key", None)
+        )
+        if desired_api_key is None:
+            desired_api_key = getattr(shared_provider, "_api_key", None)
+
+        desired_base_url = (
+            self.base_url
+            if self.base_url is not None
+            else getattr(cfg, "base_url", None)
+        )
+        if desired_base_url is None:
+            desired_base_url = getattr(shared_provider, "_base_url", None)
+        if desired_base_url is None:
+            desired_base_url = getattr(shared_provider, "_endpoint", None)
+
+        if (
+            cfg is not None
+            or self.api_key is not None
+            or self.base_url is not None
+            or self.trust_env_explicit
+        ):
+            provider.configure(
+                ProviderConfig(
+                    provider_id=provider_id,
+                    api_key=desired_api_key,
+                    base_url=desired_base_url,
+                    custom_settings=custom_settings,
                 )
+            )
 
-            # Decide whether the existing SDK client can be reused safely.
-            #
-            # Two cases force a client reset (i.e. ``_client = None`` so that
-            # the next ``_get_client()`` rebuilds it on the workflow loop):
-            #
-            #   1. The provider config materially changed (handled above).
-            #   2. The current ``_client`` was last used by a *different*
-            #      event loop than the workflow loop. ``httpx.AsyncClient``
-            #      binds to the loop where it first awaited; cross-loop
-            #      reuse triggers "got Future attached to a different loop"
-            #      or silent hangs.
-            workflow_loop_id = _workflow_loop_id()
-            client_obj = getattr(provider, "_client", None)
-            client_loop_id = (
-                _provider_client_loop_marker.get(provider)
-                if client_obj is not None
-                else None
-            )
-            must_reset_for_loop = (
-                client_obj is not None
-                and workflow_loop_id is not None
-                and client_loop_id != workflow_loop_id
-            )
-            if not unchanged or must_reset_for_loop:
-                if hasattr(provider, "_client"):
-                    try:
-                        setattr(provider, "_client", None)
-                    except Exception:
-                        pass
-                # The next ``_get_client()`` will build a fresh client on
-                # the workflow loop; remember that ownership.
-                if workflow_loop_id is not None:
-                    try:
-                        _provider_client_loop_marker[provider] = workflow_loop_id
-                    except TypeError:
-                        # ``provider`` is not weak-referenceable (rare for
-                        # test doubles) — fall back to a regular attribute.
-                        try:
-                            setattr(provider, "_workflow_client_loop_id", workflow_loop_id)
-                        except Exception:
-                            pass
-            elif workflow_loop_id is not None and client_obj is not None:
-                # Client is being reused for another workflow call on the
-                # same loop — refresh the marker so we keep tracking it.
-                try:
-                    _provider_client_loop_marker[provider] = workflow_loop_id
-                except TypeError:
-                    pass
-            return provider
+        return provider
 
     def _format_target(self, target: _ResolvedTarget) -> str:
         return f"{target.provider_id}/{target.model_id}"

--- a/tests/workflow/test_llm_provider_isolation.py
+++ b/tests/workflow/test_llm_provider_isolation.py
@@ -1,20 +1,17 @@
 """Regression tests for ``flocks.workflow.llm.LLMClient._prepare_provider``.
 
-These tests pin down the contract that protects concurrent ``session`` /
-``agent`` callers when a workflow runs ``llm.ask()`` against the same
-``Provider`` singleton:
+The workflow LLM path must no longer mutate the process-wide Provider
+singleton that the session / agent runner uses. Instead it should build an
+isolated provider instance seeded from the shared provider's current config.
 
-* The reconfigure-and-reset sequence is **idempotent**: if the workflow's
-  desired config matches what the provider already holds, neither
-  ``provider.configure(...)`` nor the ``provider._client = None`` reset is
-  performed. This keeps long-running httpx connection pools from being
-  thrown away on every workflow LLM call.
-* ``trust_env`` is only overridden when the user explicitly set
-  ``workflow.llm.trust_env`` in flocks config. Otherwise any value that the
-  session previously placed in ``provider._config.custom_settings`` is
-  preserved untouched.
-* When the config does materially change (e.g. api_key flip), the
-  reconfigure path still runs and ``_client`` is reset, as before.
+These tests pin down that contract:
+
+* ``_prepare_provider()`` returns a distinct provider instance and leaves the
+  shared provider's ``_config`` / ``_client`` untouched.
+* workflow-specific overrides (api_key / base_url / trust_env) are applied
+  only to the isolated provider instance.
+* Providers that are configured purely via runtime/env state (``_api_key``
+  with no ``_config``) remain usable when workflow overrides are applied.
 """
 
 from __future__ import annotations
@@ -29,10 +26,7 @@ from flocks.workflow import llm as workflow_llm
 
 
 class _FakeProvider:
-    """Minimal stand-in for a registered ``BaseProvider`` instance.
-
-    Records every ``configure`` invocation so tests can assert idempotency.
-    """
+    """Minimal stand-in for a registered provider instance."""
 
     def __init__(
         self,
@@ -41,14 +35,23 @@ class _FakeProvider:
         api_key: Optional[str] = "session-key",
         base_url: Optional[str] = "https://session.example.com",
         custom_settings: Optional[Dict[str, Any]] = None,
+        configured: bool = True,
     ) -> None:
         self.id = provider_id
-        self._config: Optional[ProviderConfig] = ProviderConfig(
-            provider_id=provider_id,
-            api_key=api_key,
-            base_url=base_url,
-            custom_settings=dict(custom_settings or {}),
+        self.name = f"Provider {provider_id}"
+        self._api_key = api_key
+        self._base_url = base_url
+        self._config: Optional[ProviderConfig] = (
+            ProviderConfig(
+                provider_id=provider_id,
+                api_key=api_key,
+                base_url=base_url,
+                custom_settings=dict(custom_settings or {}),
+            )
+            if configured
+            else None
         )
+        self._config_models: List[str] = ["model-a"]
         self._client: Any = object()
         self.configure_calls: List[ProviderConfig] = []
 
@@ -57,7 +60,8 @@ class _FakeProvider:
         self._config = config
 
     def is_configured(self) -> bool:
-        return self._config is not None and self._config.api_key is not None
+        api_key = self._config.api_key if self._config else self._api_key
+        return api_key is not None
 
 
 @pytest.fixture
@@ -121,144 +125,148 @@ def _build_client(
         )
 
 
-def test_prepare_provider_is_idempotent_when_config_unchanged(
+def test_prepare_provider_returns_isolated_instance_when_config_unchanged(
     patched_runtime, fake_provider: _FakeProvider
 ) -> None:
-    """No workflow overrides + no explicit trust_env => no reconfigure, no client reset."""
+    """Workflow should clone the provider instead of mutating the shared singleton."""
     client = _build_client()
 
     original_client = fake_provider._client
     assert original_client is not None
 
-    client._prepare_provider("fake-provider")
-    client._prepare_provider("fake-provider")
-    client._prepare_provider("fake-provider")
+    prepared = client._prepare_provider("fake-provider")
 
-    assert fake_provider.configure_calls == [], (
-        "expected zero reconfigure calls when desired config matches existing"
+    assert prepared is not fake_provider
+    assert prepared._client is None, (
+        "workflow provider should always start with an isolated client cache"
     )
     assert fake_provider._client is original_client, (
-        "expected provider._client to be preserved across idempotent calls"
+        "shared provider client must not be reset by workflow preparation"
     )
+    assert fake_provider.configure_calls == []
+    assert prepared._config is not None
+    assert prepared._config == fake_provider._config
+    assert prepared._config_models == fake_provider._config_models
+    assert prepared._config_models is not fake_provider._config_models
 
 
 def test_prepare_provider_does_not_override_session_trust_env(
     patched_runtime, fake_provider: _FakeProvider
 ) -> None:
-    """If workflow.llm.trust_env is not set, session-supplied custom_settings stay intact."""
+    """If workflow.llm.trust_env is not set, shared custom_settings stay untouched."""
     client = _build_client(
         workflow_trust_env_set=False, workflow_trust_env=False
     )
 
-    client._prepare_provider("fake-provider")
+    prepared = client._prepare_provider("fake-provider")
 
     assert fake_provider._config is not None
     assert fake_provider._config.custom_settings == {
         "trust_env": True,
         "verify_ssl": False,
     }
-    assert fake_provider.configure_calls == [], (
-        "trust_env was not explicitly set -> provider.configure must not be called"
-    )
+    assert fake_provider.configure_calls == []
+    assert prepared._config is not None
+    assert prepared._config.custom_settings == {
+        "trust_env": True,
+        "verify_ssl": False,
+    }
 
 
 def test_prepare_provider_overrides_when_workflow_trust_env_explicit(
     patched_runtime, fake_provider: _FakeProvider
 ) -> None:
-    """If workflow.llm.trust_env IS set, override custom_settings and reset _client."""
+    """If workflow.llm.trust_env IS set, only the isolated provider is overridden."""
     client = _build_client(
         workflow_trust_env_set=True, workflow_trust_env=False
     )
 
-    client._prepare_provider("fake-provider")
+    prepared = client._prepare_provider("fake-provider")
 
-    assert len(fake_provider.configure_calls) == 1
-    applied = fake_provider.configure_calls[0]
-    assert applied.custom_settings is not None
-    assert applied.custom_settings.get("trust_env") is False
-    # verify_ssl was carried over from the session-side custom_settings
-    assert applied.custom_settings.get("verify_ssl") is False
-    assert fake_provider._client is None, (
-        "trust_env actually changed -> the SDK client must be reset"
-    )
+    assert fake_provider.configure_calls == []
+    assert fake_provider._config is not None
+    assert fake_provider._config.custom_settings == {
+        "trust_env": True,
+        "verify_ssl": False,
+    }
+    assert prepared._config is not None
+    assert prepared._config.custom_settings == {
+        "trust_env": False,
+        "verify_ssl": False,
+    }
+    assert prepared._client is None
 
 
 def test_prepare_provider_reconfigures_when_api_key_changes(
     patched_runtime, fake_provider: _FakeProvider
 ) -> None:
-    """A new api_key is a material change -> reconfigure + client reset."""
+    """A workflow api_key override must only affect the isolated provider."""
     client = _build_client(api_key="workflow-supplied-key")
 
-    client._prepare_provider("fake-provider")
+    prepared = client._prepare_provider("fake-provider")
 
-    assert len(fake_provider.configure_calls) == 1
-    assert fake_provider.configure_calls[0].api_key == "workflow-supplied-key"
-    assert fake_provider._client is None
+    assert fake_provider.configure_calls == []
+    assert fake_provider._config is not None
+    assert fake_provider._config.api_key == "session-key"
+    assert prepared._config is not None
+    assert prepared._config.api_key == "workflow-supplied-key"
+    assert prepared._client is None
 
 
 def test_prepare_provider_reconfigures_when_base_url_changes(
     patched_runtime, fake_provider: _FakeProvider
 ) -> None:
-    """A new base_url is also a material change."""
+    """A workflow base_url override must only affect the isolated provider."""
     client = _build_client(base_url="https://workflow.example.com")
 
-    client._prepare_provider("fake-provider")
+    prepared = client._prepare_provider("fake-provider")
 
-    assert len(fake_provider.configure_calls) == 1
-    assert (
-        fake_provider.configure_calls[0].base_url
-        == "https://workflow.example.com"
-    )
-    assert fake_provider._client is None
-
-
-def test_get_provider_lock_is_per_provider(patched_runtime) -> None:
-    """Same provider_id returns the same lock instance; different ids get different locks."""
-    lock_a1 = workflow_llm._get_provider_lock("fake-provider")
-    lock_a2 = workflow_llm._get_provider_lock("fake-provider")
-    lock_b = workflow_llm._get_provider_lock("other-provider")
-
-    assert lock_a1 is lock_a2
-    assert lock_a1 is not lock_b
+    assert fake_provider.configure_calls == []
+    assert fake_provider._config is not None
+    assert fake_provider._config.base_url == "https://session.example.com"
+    assert prepared._config is not None
+    assert prepared._config.base_url == "https://workflow.example.com"
+    assert prepared._client is None
 
 
-def test_prepare_provider_resets_client_when_owning_loop_changes(
-    patched_runtime, fake_provider: _FakeProvider
+def test_prepare_provider_uses_runtime_api_key_when_shared_config_missing(
+    patched_runtime,
 ) -> None:
-    """If the existing _client belongs to a different loop, reset it even when config is unchanged.
+    """Workflow overrides must not erase runtime/env credentials.
 
-    This guards against ``httpx.AsyncClient`` cross-loop reuse: a session
-    bound the client to uvicorn's main loop, the workflow loop must not
-    inherit it without rebuilding on the workflow loop.
+    Providers may be configured only via constructor/runtime state with
+    ``_config is None``. When workflow sets ``trust_env``, the isolated
+    provider still needs a usable api_key copied from the shared provider.
     """
-    client = _build_client()
-    # Simulate the workflow loop having id=999, while ``_client`` was last
-    # used on a different loop (e.g. the session's main loop with id=111).
-    with patch.object(workflow_llm, "_workflow_loop_id", return_value=999):
-        workflow_llm._provider_client_loop_marker[fake_provider] = 111
+    shared_provider = _FakeProvider(
+        api_key="runtime-key",
+        base_url="https://runtime.example.com",
+        custom_settings={"verify_ssl": False},
+        configured=False,
+    )
 
-        original_client = fake_provider._client
-        assert original_client is not None
+    def _fake_run_coro_sync(coro):
+        try:
+            coro.close()
+        except Exception:
+            pass
+        return {}
 
-        client._prepare_provider("fake-provider")
+    with patch.object(
+        workflow_llm.Provider, "_ensure_initialized", lambda: None
+    ), patch.object(
+        workflow_llm.Provider, "get", lambda provider_id: shared_provider
+    ), patch.object(
+        workflow_llm, "_run_coro_sync", side_effect=_fake_run_coro_sync
+    ):
+        client = _build_client(
+            workflow_trust_env_set=True,
+            workflow_trust_env=False,
+        )
+        prepared = client._prepare_provider("fake-provider")
 
-        # Even though no config field changed, the client must be reset so
-        # the next ``_get_client()`` rebuilds it on the workflow loop.
-        assert fake_provider._client is None
-        # And the marker is updated to the workflow loop.
-        assert workflow_llm._provider_client_loop_marker.get(fake_provider) == 999
-
-
-def test_prepare_provider_keeps_client_when_owning_loop_matches(
-    patched_runtime, fake_provider: _FakeProvider
-) -> None:
-    """When the existing _client already belongs to the workflow loop, do not reset."""
-    client = _build_client()
-    with patch.object(workflow_llm, "_workflow_loop_id", return_value=555):
-        workflow_llm._provider_client_loop_marker[fake_provider] = 555
-
-        original_client = fake_provider._client
-        client._prepare_provider("fake-provider")
-
-        assert fake_provider._client is original_client
-        assert fake_provider.configure_calls == []
+    assert shared_provider._config is None
+    assert prepared._config is not None
+    assert prepared._config.api_key == "runtime-key"
+    assert prepared._config.base_url == "https://runtime.example.com"
+    assert prepared._config.custom_settings == {"trust_env": False}


### PR DESCRIPTION
## Summary

- Workflow `LLMClient._prepare_provider` now clones a workflow-local provider from the shared singleton instead of mutating it under per-provider locks and event-loop markers.
- Prevents cross-loop `httpx.AsyncClient` reuse and session/workflow races on `_config` / `_client` during `llm.ask()` calls.
- Workflow overrides (`api_key`, `base_url`, `trust_env`) apply only to the isolated instance; the shared provider used by session/agent is left untouched.