### PR TITLE
fix(mcp): accept legacy env alias for local server config

### DIFF
--- a/flocks/config/config.py
+++ b/flocks/config/config.py
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, Literal
 from enum import Enum
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 # ==================== Permission System ====================
@@ -187,11 +187,14 @@ class McpOAuthConfig(BaseModel):
 
 class McpLocalConfig(BaseModel):
     """MCP local server configuration"""
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
     
     type: Literal["local"]
     command: List[str]
-    environment: Optional[Dict[str, str]] = None
+    environment: Optional[Dict[str, str]] = Field(
+        None,
+        validation_alias=AliasChoices("environment", "env"),
+    )
     enabled: Optional[bool] = None
     timeout: Optional[int] = Field(None, gt=0)
 

--- a/flocks/mcp/server.py
+++ b/flocks/mcp/server.py
@@ -194,6 +194,9 @@ class McpServerManager:
             
             # Credentials are already resolved via {secret:xxx} in config loading.
             # No separate injection needed.
+            server_env = config.get("environment")
+            if server_env is None:
+                server_env = config.get("env")
             
             # 1. Create client
             client = McpClient(
@@ -202,7 +205,7 @@ class McpServerManager:
                 url=config.get('url'),
                 command=config.get('command'),
                 headers=config.get('headers'),
-                env=config.get('environment'),
+                env=server_env,
                 auth_config=config.get('auth'),
                 transport=config.get('transport', 'auto'),
                 timeout=config.get('timeout', 30.0)

--- a/flocks/mcp/utils.py
+++ b/flocks/mcp/utils.py
@@ -104,6 +104,11 @@ def normalize_mcp_config_aliases(config: Dict[str, Any]) -> Dict[str, Any]:
     elif server_type == "stdio":
         normalized["type"] = "local"
 
+    if normalized.get("type") in LOCAL_MCP_TYPES:
+        if "environment" not in normalized and "env" in normalized:
+            normalized["environment"] = normalized["env"]
+        normalized.pop("env", None)
+
     transport = str(normalized.get("transport", "")).strip().lower()
     if normalized.get("type") in REMOTE_MCP_TYPES:
         if transport in ("", "auto"):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -47,6 +47,29 @@ async def test_config_loading():
     assert config.keybinds is not None
 
 
+def test_local_mcp_config_accepts_legacy_env_alias():
+    """Legacy ``env`` should hydrate the canonical ``environment`` field."""
+    config = ConfigInfo.model_validate(
+        {
+            "mcp": {
+                "demo": {
+                    "type": "local",
+                    "command": ["python", "-m", "demo"],
+                    "env": {"DEMO_TOKEN": "secret"},
+                }
+            }
+        }
+    )
+
+    server = config.mcp["demo"]
+    assert server.environment == {"DEMO_TOKEN": "secret"}
+    assert server.model_dump(exclude_none=True) == {
+        "type": "local",
+        "command": ["python", "-m", "demo"],
+        "environment": {"DEMO_TOKEN": "secret"},
+    }
+
+
 @pytest.mark.asyncio
 async def test_config_file_loading(tmp_path):
     """Test loading configuration from file"""

--- a/tests/mcp/test_mcp_server.py
+++ b/tests/mcp/test_mcp_server.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from flocks.mcp.server import McpServerManager
+from flocks.mcp.types import McpStatus
+
+
+class _FakeMcpClient:
+    def __init__(
+        self,
+        *,
+        name: str,
+        server_type: str,
+        url=None,
+        command=None,
+        headers=None,
+        env=None,
+        auth_config=None,
+        transport: str = "auto",
+        timeout: float = 30.0,
+    ) -> None:
+        self.name = name
+        self.server_type = server_type
+        self.url = url
+        self.command = command
+        self.headers = headers
+        self.env = env
+        self.auth_config = auth_config
+        self.transport = transport
+        self.timeout = timeout
+
+    async def connect(self) -> None:
+        return None
+
+    async def list_tools(self) -> list:
+        return []
+
+    async def list_resources(self) -> list:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_connect_and_register_accepts_legacy_env_alias(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+
+    class CapturingClient(_FakeMcpClient):
+        def __init__(self, **kwargs) -> None:
+            super().__init__(**kwargs)
+            captured["env"] = self.env
+
+    monkeypatch.setattr("flocks.mcp.server.McpClient", CapturingClient)
+
+    manager = McpServerManager()
+    await manager._connect_and_register(
+        "legacy-demo",
+        {
+            "type": "local",
+            "command": ["python", "-m", "demo"],
+            "env": {"DEMO_TOKEN": "secret"},
+        },
+    )
+
+    assert captured["env"] == {"DEMO_TOKEN": "secret"}
+    assert manager._status["legacy-demo"].status == McpStatus.CONNECTED

--- a/tests/mcp/test_mcp_utils.py
+++ b/tests/mcp/test_mcp_utils.py
@@ -151,6 +151,21 @@ class TestNormalizeMcpConfig:
             "command": ["uvx", "mcp-server", "--port", "8080"],
         }
 
+    def test_normalizes_legacy_env_alias_for_local_servers(self):
+        config = normalize_mcp_config(
+            {
+                "type": "stdio",
+                "command": "uvx",
+                "args": ["mcp-server"],
+                "env": {"DEMO_TOKEN": "secret"},
+            }
+        )
+        assert config == {
+            "type": "local",
+            "command": ["uvx", "mcp-server"],
+            "environment": {"DEMO_TOKEN": "secret"},
+        }
+
     def test_normalizes_sse_alias_to_remote_transport(self):
         config = normalize_mcp_config(
             {


### PR DESCRIPTION
## Summary

- Accept the legacy `env` key for local MCP server configuration and map it to the canonical `environment` field.
- Normalize stdio/local MCP configs so `env` is converted to `environment` during alias normalization.
- Resolve `environment` or `env` when `McpServerManager` connects a local server.
- Add unit tests for config loading, config normalization, and server connection.
- Fix #281 

## Why

Some existing MCP configs still use `env` instead of `environment`. Without alias support, those variables were ignored and local MCP servers could start without the expected environment.

## Test Plan

- [x] `uv run pytest tests/config/test_config.py::test_local_mcp_config_accepts_legacy_env_alias`
- [x] `uv run pytest tests/mcp/test_mcp_utils.py::TestNormalizeMcpConfig::test_normalizes_legacy_env_alias_for_local_servers`
- [x] `uv run pytest tests/mcp/test_mcp_server.py`
