### PR TITLE
fix(webui): narrow uploaded document attachment type

### DIFF
--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -385,9 +385,13 @@ function isAllowedUploadFile(file: File): boolean {
   return ALLOWED_UPLOAD_EXTENSIONS.has(getFileExtension(file.name));
 }
 
-function isUploadedDocumentAttachment(
-  attachment: { status: string; workspacePath?: string; isImage?: boolean },
-): attachment is { status: string; workspacePath: string; isImage?: boolean } {
+function isUploadedDocumentAttachment<T extends {
+  status: string;
+  workspacePath?: string;
+  isImage?: boolean;
+}>(
+  attachment: T,
+): attachment is T & { workspacePath: string } {
   return attachment.status === 'success' && !attachment.isImage && Boolean(attachment.workspacePath);
 }
 


### PR DESCRIPTION
## Summary
- update the uploaded document attachment type guard in `SessionChat` to preserve the generic item shape
- ensure `listUploadedDocumentPaths` narrows `workspacePath` to `string` after filtering so the WebUI TypeScript build no longer fails on this path

## Test plan
- [x] `npm --prefix "/Users/zgy/workspace/flocks-2/webui" run test:run -- SessionChat`
- [x] verified the previous `SessionChat.tsx:415` `TS2322` error no longer appears in TypeScript output
- [ ] `npm --prefix "/Users/zgy/workspace/flocks-2/webui" run build` (currently blocked by a separate existing `qrcode.react` type-resolution error in `src/pages/Channel/index.tsx`)

Made with [Cursor](https://cursor.com)