### PR TITLE
fix(storage): prevent and recover from SQLite "file is not a database"

### DIFF
--- a/flocks/channel/inbound/session_binding.py
+++ b/flocks/channel/inbound/session_binding.py
@@ -72,6 +72,11 @@ _init_lock = asyncio.Lock()
 # Persistent connection shared by all SessionBindingService instances.
 _db_conn: Optional[aiosqlite.Connection] = None
 _db_ready = False
+# PID that owns ``_db_conn``.  Used to detect ``fork()`` (uvicorn
+# ``--reload`` / multi-worker launches) so a child process never reuses
+# its parent's open SQLite file descriptor — a documented SQLite
+# corruption vector.
+_db_owner_pid: Optional[int] = None
 
 # Register channel_bindings DDL with Storage so the tables are created
 # during Storage.init() as well (idempotent CREATE IF NOT EXISTS).
@@ -88,13 +93,41 @@ async def _get_db() -> aiosqlite.Connection:
     Uses ``Storage.get_db_path()`` to ensure the same database file is
     shared with the rest of the Flocks storage subsystem.
     """
-    global _db_conn, _db_ready
-    if _db_conn is not None and _db_ready:
+    global _db_conn, _db_ready, _db_owner_pid
+
+    current_pid = os.getpid()
+    if (
+        _db_conn is not None
+        and _db_ready
+        and _db_owner_pid is not None
+        and _db_owner_pid == current_pid
+    ):
         return _db_conn
 
     async with _init_lock:
-        if _db_conn is not None and _db_ready:
+        if (
+            _db_conn is not None
+            and _db_ready
+            and _db_owner_pid is not None
+            and _db_owner_pid == current_pid
+        ):
             return _db_conn
+
+        if (
+            _db_conn is not None
+            and _db_owner_pid is not None
+            and _db_owner_pid != current_pid
+        ):
+            # Inherited an open handle from a forked parent — drop the
+            # reference without closing it (closing would tear down the
+            # parent's state too) and rebuild a fresh connection.
+            log.warning("channel.binding.fork_detected", {
+                "parent_pid": _db_owner_pid,
+                "child_pid": current_pid,
+            })
+            _db_conn = None
+            _db_ready = False
+            _db_owner_pid = None
 
         from flocks.storage.storage import Storage
         db_path = Storage.get_db_path()
@@ -109,6 +142,7 @@ async def _get_db() -> aiosqlite.Connection:
         await _db_conn.executescript(_DDL)
         await _migrate_legacy_binding_agent_ids(_db_conn)
         _db_ready = True
+        _db_owner_pid = current_pid
         return _db_conn
 
 
@@ -158,7 +192,7 @@ async def _migrate_legacy_binding_agent_ids(db: aiosqlite.Connection) -> None:
 
 async def close_binding_db() -> None:
     """Close the persistent connection (call during shutdown)."""
-    global _db_conn, _db_ready
+    global _db_conn, _db_ready, _db_owner_pid
     if _db_conn is not None:
         try:
             await _db_conn.close()
@@ -166,6 +200,7 @@ async def close_binding_db() -> None:
             pass
         _db_conn = None
         _db_ready = False
+        _db_owner_pid = None
 
 
 class SessionBindingService:

--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -517,11 +517,21 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         log.warning("instances.dispose.failed", {"error": str(e)})
 
+    # Final WAL checkpoint — *after* every other subsystem has stopped
+    # writing.  This drains any residual frames into the main DB and
+    # truncates the ``-wal`` file to zero length, so the next process
+    # start does not need a WAL recovery step (which is where a poorly
+    # timed power loss can corrupt the main-DB header page).
+    try:
+        await Storage.shutdown()
+    except Exception as e:
+        log.warning("storage.shutdown_failed", {"error": str(e)})
+
     try:
         shutdown_observability()
     except Exception as e:
         log.warning("observability.shutdown_failed", {"error": str(e)})
-    
+
     log.info("server.shutdown")
 
 

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -33,6 +33,26 @@ class StorageError(Exception):
     pass
 
 
+class CheckpointBusyError(StorageError):
+    """``PRAGMA wal_checkpoint`` reported ``busy=1`` (no exception raised).
+
+    SQLite signals contention via the **return row** ``(busy, log_pages,
+    checkpointed_pages)`` rather than a SQL error, so callers must
+    actively inspect the result.  We surface that as a typed exception
+    so callers can distinguish "checkpoint silently no-op'd" from a real
+    success and retry / abort accordingly.
+    """
+
+    def __init__(self, mode: str, log_pages: int, checkpointed_pages: int) -> None:
+        super().__init__(
+            f"wal_checkpoint({mode}) busy: "
+            f"log_pages={log_pages}, checkpointed_pages={checkpointed_pages}"
+        )
+        self.mode = mode
+        self.log_pages = log_pages
+        self.checkpointed_pages = checkpointed_pages
+
+
 class Storage:
     """
     Storage namespace for persistent data operations
@@ -43,6 +63,7 @@ class Storage:
     
     NotFoundError = NotFoundError
     StorageError = StorageError
+    CheckpointBusyError = CheckpointBusyError
     
     _log = Log.create(service="storage")
     _db_path: Optional[Path] = None
@@ -443,7 +464,19 @@ class Storage:
                 "db_path": str(cls._db_path),
                 "size": cls._db_path.stat().st_size,
             })
-            cls._quarantine_corrupt_db(cls._db_path)
+            quarantined = cls._quarantine_corrupt_db(cls._db_path)
+            if quarantined is None:
+                # The pre-flight check confirmed the file is not SQLite,
+                # but the rename failed.  Continuing would let SQLite
+                # open the bad file, raise ``DatabaseError`` *and* delete
+                # the adjacent WAL/SHM sidecars we wanted to preserve
+                # for offline recovery.  Fail loudly instead so the
+                # operator can move the file aside manually.
+                raise StorageError(
+                    f"Storage path {cls._db_path} contains non-SQLite "
+                    f"content and could not be quarantined.  Move the "
+                    f"file aside manually before restarting (see logs)."
+                )
 
         # The schema bootstrap is the very first time we open the DB file
         # in this process, so it is also where any remaining on-disk
@@ -486,7 +519,7 @@ class Storage:
         })
 
     @classmethod
-    async def _checkpoint(cls, *, mode: str = "TRUNCATE") -> None:
+    async def _checkpoint(cls, *, mode: str = "TRUNCATE") -> tuple[int, int, int]:
         """Run ``PRAGMA wal_checkpoint(<mode>)`` against the active DB.
 
         ``TRUNCATE`` flushes the WAL back into the main DB and resets the
@@ -494,20 +527,51 @@ class Storage:
         does **not** need a WAL recovery step and therefore cannot crash
         midway through rewriting the main-DB header page.
 
-        Quietly returns when no DB has been initialised yet — callers can
-        invoke this unconditionally during shutdown.
+        SQLite reports contention by returning a row of integers rather
+        than raising — specifically ``(busy, log_pages, checkpointed_pages)``
+        where ``busy=1`` means at least one reader/writer was holding a
+        lock that prevented the requested mode from completing.  We
+        fetch that row, surface ``busy=1`` as :class:`CheckpointBusyError`,
+        and otherwise return the tuple so callers can record metrics.
+
+        Quietly returns ``(0, 0, 0)`` when no DB has been initialised
+        yet — callers can invoke this unconditionally during shutdown.
         """
         if cls._db_path is None:
-            return
+            return (0, 0, 0)
         if not cls._db_path.exists():
-            return
+            return (0, 0, 0)
         valid_modes = {"PASSIVE", "FULL", "RESTART", "TRUNCATE"}
         mode_normalised = mode.upper()
         if mode_normalised not in valid_modes:
             raise ValueError(f"invalid checkpoint mode: {mode!r}")
         async with cls.connect(cls._db_path) as db:
-            await db.execute(f"PRAGMA wal_checkpoint({mode_normalised})")
+            cursor = await db.execute(
+                f"PRAGMA wal_checkpoint({mode_normalised})"
+            )
+            row = await cursor.fetchone()
             await db.commit()
+
+        # Some aiosqlite paths / wrapped connections may return no row
+        # for a PRAGMA statement.  We treat that as success because we
+        # have no signal to act on — the caller would have observed an
+        # exception if the PRAGMA had actually failed.
+        if row is None or len(row) < 3:
+            return (0, 0, 0)
+
+        busy = int(row[0])
+        log_pages = int(row[1])
+        checkpointed_pages = int(row[2])
+        if busy != 0:
+            raise CheckpointBusyError(
+                mode_normalised, log_pages, checkpointed_pages
+            )
+        return (busy, log_pages, checkpointed_pages)
+
+    # Tunables for the shutdown WAL drain.  Kept as class attributes so
+    # tests can override them without touching globals.
+    _shutdown_checkpoint_attempts = 3
+    _shutdown_checkpoint_backoff_s = 0.1
 
     @classmethod
     async def shutdown(cls) -> None:
@@ -518,22 +582,76 @@ class Storage:
         consistent (no pending WAL frames waiting to be replayed), then
         clears the in-memory ``_initialized`` / ``_init_pid`` flags.
 
-        The call is wrapped in a try/except so it can be put at the very
-        end of an ASGI lifespan without risking a crash during shutdown
-        — the worst case is a slightly larger WAL on the next start, not
-        a broken shutdown path.
+        Failure handling:
+
+        * If the checkpoint cannot acquire the locks it needs (SQLite
+          returns ``busy=1`` without raising) we retry a few times with
+          a short backoff.  This handles the common case where a
+          background task is still draining when shutdown starts.
+        * If every attempt is still busy we record a structured
+          ``checkpoint.unfinished`` warning rather than a misleading
+          ``done`` so operators can spot the residual-WAL risk.
+        * Any other exception (e.g. disk full) is logged at ``warn`` so
+          shutdown cannot itself crash the lifespan.
+
+        The in-memory state is always cleared at the end because the
+        process is exiting regardless.
         """
         if not cls._initialized:
             return
+
+        attempts = max(int(cls._shutdown_checkpoint_attempts), 1)
+        backoff = max(float(cls._shutdown_checkpoint_backoff_s), 0.0)
+        last_busy: Optional[CheckpointBusyError] = None
+        last_failure: Optional[Exception] = None
+
         try:
-            await cls._checkpoint(mode="TRUNCATE")
-            cls._log.info("storage.shutdown.checkpoint.done", {
+            for attempt in range(1, attempts + 1):
+                try:
+                    _, log_pages, checkpointed = await cls._checkpoint(
+                        mode="TRUNCATE"
+                    )
+                    cls._log.info("storage.shutdown.checkpoint.done", {
+                        "db_path": str(cls._db_path) if cls._db_path else None,
+                        "log_pages": log_pages,
+                        "checkpointed_pages": checkpointed,
+                        "attempts": attempt,
+                    })
+                    return
+                except CheckpointBusyError as exc:
+                    last_busy = exc
+                    cls._log.warn("storage.shutdown.checkpoint.busy", {
+                        "attempt": attempt,
+                        "max_attempts": attempts,
+                        "mode": exc.mode,
+                        "log_pages": exc.log_pages,
+                        "checkpointed_pages": exc.checkpointed_pages,
+                    })
+                    if attempt < attempts:
+                        await asyncio.sleep(backoff * attempt)
+                except Exception as exc:
+                    last_failure = exc
+                    cls._log.warn("storage.shutdown.checkpoint.failed", {
+                        "db_path": str(cls._db_path) if cls._db_path else None,
+                        "error": str(exc),
+                        "error_type": type(exc).__name__,
+                    })
+                    break
+
+            # Reached only on persistent busy or fatal failure.  Do NOT
+            # log "done" — that would mask the residual-WAL risk this
+            # whole method exists to prevent.
+            cls._log.warn("storage.shutdown.checkpoint.unfinished", {
                 "db_path": str(cls._db_path) if cls._db_path else None,
-            })
-        except Exception as exc:
-            cls._log.warn("storage.shutdown.checkpoint.failed", {
-                "db_path": str(cls._db_path) if cls._db_path else None,
-                "error": str(exc),
+                "busy": last_busy is not None,
+                "log_pages": getattr(last_busy, "log_pages", None),
+                "checkpointed_pages": getattr(last_busy, "checkpointed_pages", None),
+                "fatal_error": str(last_failure) if last_failure else None,
+                "hint": (
+                    "WAL was not truncated; next startup will run WAL "
+                    "recovery and remains at risk of header corruption if "
+                    "killed mid-recovery."
+                ),
             })
         finally:
             cls._initialized = False

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -5,6 +5,7 @@ Provides SQLite-based storage similar to Flocks's Storage namespace
 """
 
 import asyncio
+import os
 
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -46,12 +47,40 @@ class Storage:
     _log = Log.create(service="storage")
     _db_path: Optional[Path] = None
     _initialized = False
+    # PID of the process that called ``init()``.  Used by ``_ensure_init`` to
+    # detect ``fork()`` (uvicorn ``--reload`` / multiprocessing workers) and
+    # re-initialise per-process state so the parent's open SQLite file
+    # descriptors and ``_initialized=True`` flag are never silently inherited
+    # — a known SQLite corruption vector.
+    _init_pid: Optional[int] = None
     _extension_ddls: List[str] = []
     _sqlite_timeout_s = 5.0
     _sqlite_busy_timeout_ms = 5000
     _sqlite_journal_mode = "WAL"
+    # Auto-checkpoint after this many WAL pages (default SQLite is 1000 ≈
+    # 4 MB).  We shrink it so the WAL never accumulates more than a few
+    # hundred KB of un-checkpointed writes — shortening the window in
+    # which a process kill / power loss leaves SQLite needing to rewrite
+    # main-DB page 1 (the header) during the next start-up recovery.
+    _sqlite_wal_autocheckpoint_pages = 200
+    # ``NORMAL`` is the documented safe sync level for WAL mode (see
+    # https://www.sqlite.org/pragma.html#pragma_synchronous): writes still
+    # survive process crashes, and only the very last few transactions may be
+    # lost on hard power-loss.  We set it explicitly so the value cannot drift
+    # to ``OFF`` via some future PRAGMA or accidental ``synchronous=0`` and
+    # silently weaken durability.
+    _sqlite_synchronous = "NORMAL"
     _sqlite_write_retry_attempts = 6
     _sqlite_write_retry_base_delay_s = 0.05
+
+    # Substrings that mark an SQLite file as unrecoverably damaged at open
+    # time.  We deliberately keep this list short and English-only because
+    # SQLite always raises these errors in English regardless of locale.
+    _DB_CORRUPTION_TOKENS = (
+        "file is not a database",
+        "file is encrypted or is not a database",
+        "database disk image is malformed",
+    )
 
     @classmethod
     def _invalidate_runtime_caches(cls) -> None:
@@ -86,7 +115,11 @@ class Storage:
     ) -> aiosqlite.Connection:
         """Apply the runtime SQLite contract to an async connection."""
         await conn.execute(f"PRAGMA journal_mode={cls._sqlite_journal_mode}")
+        await conn.execute(f"PRAGMA synchronous={cls._sqlite_synchronous}")
         await conn.execute(f"PRAGMA busy_timeout={cls._sqlite_busy_timeout_ms}")
+        await conn.execute(
+            f"PRAGMA wal_autocheckpoint={cls._sqlite_wal_autocheckpoint_pages}"
+        )
         await conn.execute("PRAGMA foreign_keys = ON")
         return conn
 
@@ -94,9 +127,145 @@ class Storage:
     def configure_sync_connection(cls, conn: sqlite3.Connection) -> sqlite3.Connection:
         """Apply the runtime SQLite contract to a sync connection."""
         conn.execute(f"PRAGMA journal_mode={cls._sqlite_journal_mode}")
+        conn.execute(f"PRAGMA synchronous={cls._sqlite_synchronous}")
         conn.execute(f"PRAGMA busy_timeout={cls._sqlite_busy_timeout_ms}")
+        conn.execute(
+            f"PRAGMA wal_autocheckpoint={cls._sqlite_wal_autocheckpoint_pages}"
+        )
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
+
+    # SQLite database files begin with this 16-byte magic string (see
+    # https://www.sqlite.org/fileformat.html#magic_header_string).  A
+    # non-empty file that does not start with this sequence is guaranteed
+    # to trip ``DatabaseError: file is not a database`` on the first I/O.
+    _SQLITE_MAGIC = b"SQLite format 3\x00"
+
+    @classmethod
+    def _file_has_invalid_sqlite_header(cls, db_path: Path) -> bool:
+        """Return ``True`` when *db_path* exists, is non-empty, and is not SQLite.
+
+        We use this as a fast pre-flight check before opening the database
+        so that ``aiosqlite``/SQLite never gets a chance to delete the WAL
+        and SHM sidecars next to a corrupted main DB — preserving them on
+        disk for later offline recovery.
+        """
+        try:
+            if not db_path.is_file():
+                return False
+            if db_path.stat().st_size == 0:
+                return False
+            with db_path.open("rb") as fh:
+                header = fh.read(len(cls._SQLITE_MAGIC))
+        except OSError:
+            return False
+        return header != cls._SQLITE_MAGIC
+
+    @classmethod
+    def _is_db_corruption_error(cls, exc: BaseException) -> bool:
+        """Return whether *exc* indicates an unrecoverably damaged DB file.
+
+        SQLite reports these as ``DatabaseError`` (or wrapped variants via
+        aiosqlite).  We match by both ``sqlite_errorcode`` and a small set of
+        well-known message substrings — sufficient because SQLite emits
+        these errors in English regardless of the process locale.
+        """
+        notadb = getattr(sqlite3, "SQLITE_NOTADB", None)
+        corrupt = getattr(sqlite3, "SQLITE_CORRUPT", None)
+        corruption_codes = {code for code in (notadb, corrupt) if code is not None}
+
+        seen: set[int] = set()
+        queue: List[BaseException] = [exc]
+        while queue:
+            current = queue.pop(0)
+            if current is None:
+                continue
+            ident = id(current)
+            if ident in seen:
+                continue
+            seen.add(ident)
+
+            error_code = getattr(current, "sqlite_errorcode", None)
+            if error_code is not None and error_code in corruption_codes:
+                return True
+
+            module_name = getattr(type(current), "__module__", "")
+            is_sqlite_error = (
+                isinstance(current, sqlite3.Error)
+                or module_name.startswith("sqlite3")
+                or module_name.startswith("aiosqlite")
+            )
+            if is_sqlite_error:
+                text = str(current).lower()
+                if any(token in text for token in cls._DB_CORRUPTION_TOKENS):
+                    return True
+
+            cause = getattr(current, "__cause__", None)
+            context = getattr(current, "__context__", None)
+            if cause is not None:
+                queue.append(cause)
+            if context is not None:
+                queue.append(context)
+
+        return False
+
+    @classmethod
+    def _quarantine_corrupt_db(cls, db_path: Path) -> Optional[Path]:
+        """Move a damaged DB (and its WAL/SHM sidecars) to a timestamped name.
+
+        Returns the new location of the main file so callers can surface it
+        in logs or recovery instructions.  Returns ``None`` when there was
+        nothing to quarantine (no main file present), or when the rename
+        failed — in which case the caller must propagate the original error
+        because we cannot safely recreate the file in place.
+        """
+        db_path = Path(db_path)
+        if not db_path.exists():
+            return None
+
+        from datetime import UTC
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+        suffix = f".corrupt.{timestamp}"
+
+        new_main = db_path.with_name(db_path.name + suffix)
+        # Avoid collision if multiple corruptions happen within the same
+        # second — fall back to a counter suffix.
+        counter = 1
+        while new_main.exists():
+            new_main = db_path.with_name(f"{db_path.name}{suffix}.{counter}")
+            counter += 1
+
+        try:
+            db_path.rename(new_main)
+        except OSError as exc:
+            cls._log.error("storage.quarantine.rename_failed", {
+                "path": str(db_path),
+                "error": str(exc),
+            })
+            return None
+
+        for sidecar_name in (f"{db_path.name}-wal", f"{db_path.name}-shm"):
+            side_path = db_path.with_name(sidecar_name)
+            if not side_path.exists():
+                continue
+            try:
+                side_path.rename(side_path.with_name(sidecar_name + suffix))
+            except OSError as exc:
+                cls._log.warn("storage.quarantine.sidecar_rename_failed", {
+                    "path": str(side_path),
+                    "error": str(exc),
+                })
+
+        cls._log.error("storage.corruption.quarantined", {
+            "original_path": str(db_path),
+            "quarantined_path": str(new_main),
+            "hint": (
+                "Server is starting with a fresh empty database. "
+                "Run scripts/recover_raw_flocks_db.py against the "
+                "quarantined file to attempt data recovery."
+            ),
+        })
+        return new_main
 
     @classmethod
     def _is_sqlite_busy_error(cls, exc: Exception) -> bool:
@@ -241,7 +410,7 @@ class Storage:
     async def init(cls, db_path: Optional[Path] = None) -> None:
         """
         Initialize storage system
-        
+
         Args:
             db_path: Path to SQLite database file
         """
@@ -252,15 +421,133 @@ class Storage:
 
         db_path = Path(db_path)
         # Tests and short-lived processes may initialize Storage against a
-        # temporary database that later disappears. Allow re-initialization when
-        # the target path changes or the old path is no longer usable.
-        if cls._initialized and cls._db_path == db_path and db_path.exists():
+        # temporary database that later disappears.  We also force a
+        # reinit after ``fork()`` (detected via PID mismatch) to avoid the
+        # child silently reusing the parent's open SQLite handle.
+        current_pid = os.getpid()
+        same_path = cls._db_path == db_path and db_path.exists()
+        same_process = cls._init_pid is None or cls._init_pid == current_pid
+        if cls._initialized and same_path and same_process:
             return
-        
+
         cls._db_path = db_path
         cls._db_path.parent.mkdir(parents=True, exist_ok=True)
         cls._invalidate_runtime_caches()
-        
+
+        # Fast-path: if the file on disk is non-empty but does not carry
+        # the SQLite magic header, quarantine it *before* opening so that
+        # SQLite never gets a chance to delete adjacent WAL/SHM sidecars
+        # — those sidecars are what the offline recovery script reads.
+        if cls._file_has_invalid_sqlite_header(cls._db_path):
+            cls._log.error("storage.corruption.invalid_header", {
+                "db_path": str(cls._db_path),
+                "size": cls._db_path.stat().st_size,
+            })
+            cls._quarantine_corrupt_db(cls._db_path)
+
+        # The schema bootstrap is the very first time we open the DB file
+        # in this process, so it is also where any remaining on-disk
+        # corruption surfaces as ``DatabaseError: file is not a database``
+        # (or "disk image is malformed") — for example when only an
+        # internal SQLite page is damaged while the header still looks
+        # valid.  When the failure is unrecoverable we quarantine the
+        # damaged file, leave a recovery hint in the logs, and retry once
+        # against a fresh empty database — keeping the server bootable.
+        try:
+            await cls._bootstrap_schema()
+        except Exception as exc:
+            if not cls._is_db_corruption_error(exc):
+                raise
+            cls._log.error("storage.corruption.detected_on_init", {
+                "db_path": str(cls._db_path),
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            })
+            quarantined = cls._quarantine_corrupt_db(cls._db_path)
+            if quarantined is None:
+                raise
+            await cls._bootstrap_schema()
+
+        # Drain any residual WAL frames left by the previous process so the
+        # next ``SIGKILL`` does not have to truncate a 4 MB-class WAL during
+        # recovery (which is exactly when main-DB page 1 / the header can
+        # get a half-written update).  This is a no-op on a freshly created
+        # DB.  Best-effort — we never want this to break startup.
+        try:
+            await cls._checkpoint(mode="TRUNCATE")
+        except Exception as exc:
+            cls._log.warn("storage.startup_checkpoint.failed", {"error": str(exc)})
+
+        cls._init_pid = os.getpid()
+        cls._initialized = True
+        cls._log.info("storage.initialized", {
+            "db_path": str(db_path),
+            "pid": cls._init_pid,
+        })
+
+    @classmethod
+    async def _checkpoint(cls, *, mode: str = "TRUNCATE") -> None:
+        """Run ``PRAGMA wal_checkpoint(<mode>)`` against the active DB.
+
+        ``TRUNCATE`` flushes the WAL back into the main DB and resets the
+        ``-wal`` file to zero length, which means the next process start
+        does **not** need a WAL recovery step and therefore cannot crash
+        midway through rewriting the main-DB header page.
+
+        Quietly returns when no DB has been initialised yet — callers can
+        invoke this unconditionally during shutdown.
+        """
+        if cls._db_path is None:
+            return
+        if not cls._db_path.exists():
+            return
+        valid_modes = {"PASSIVE", "FULL", "RESTART", "TRUNCATE"}
+        mode_normalised = mode.upper()
+        if mode_normalised not in valid_modes:
+            raise ValueError(f"invalid checkpoint mode: {mode!r}")
+        async with cls.connect(cls._db_path) as db:
+            await db.execute(f"PRAGMA wal_checkpoint({mode_normalised})")
+            await db.commit()
+
+    @classmethod
+    async def shutdown(cls) -> None:
+        """Flush the WAL and release state — call once during process exit.
+
+        This is the missing counterpart to ``init()``.  It performs a
+        ``wal_checkpoint(TRUNCATE)`` so the on-disk DB is left fully
+        consistent (no pending WAL frames waiting to be replayed), then
+        clears the in-memory ``_initialized`` / ``_init_pid`` flags.
+
+        The call is wrapped in a try/except so it can be put at the very
+        end of an ASGI lifespan without risking a crash during shutdown
+        — the worst case is a slightly larger WAL on the next start, not
+        a broken shutdown path.
+        """
+        if not cls._initialized:
+            return
+        try:
+            await cls._checkpoint(mode="TRUNCATE")
+            cls._log.info("storage.shutdown.checkpoint.done", {
+                "db_path": str(cls._db_path) if cls._db_path else None,
+            })
+        except Exception as exc:
+            cls._log.warn("storage.shutdown.checkpoint.failed", {
+                "db_path": str(cls._db_path) if cls._db_path else None,
+                "error": str(exc),
+            })
+        finally:
+            cls._initialized = False
+            cls._init_pid = None
+
+    @classmethod
+    async def _bootstrap_schema(cls) -> None:
+        """Create the storage tables and run registered extension DDLs.
+
+        Split out from ``init()`` so we can call it twice in the rare case
+        where the existing DB file is corrupted and gets quarantined: the
+        first call surfaces the corruption, and the second call (after the
+        rename) bootstraps a fresh database in its place.
+        """
         async def _create_storage_table() -> None:
             async with cls.connect(cls._db_path) as db:
                 await db.execute("""
@@ -279,7 +566,7 @@ class Storage:
             action="init.create_storage_table",
             target=str(cls._db_path),
         )
-        
+
         # Initialize vector storage tables (for memory system)
         try:
             from flocks.storage.vector import ensure_vector_tables
@@ -306,9 +593,6 @@ class Storage:
                 )
             except Exception as e:
                 cls._log.warn("storage.extension_ddl.failed", {"error": str(e)})
-
-        cls._initialized = True
-        cls._log.info("storage.initialized", {"db_path": str(db_path)})
 
     @classmethod
     async def _create_model_management_tables(cls) -> None:
@@ -384,7 +668,36 @@ class Storage:
     
     @classmethod
     async def _ensure_init(cls) -> None:
-        """Ensure storage is initialized"""
+        """Ensure storage is initialized for the *current* process.
+
+        SQLite explicitly warns against using a connection opened in a
+        parent across ``fork()``.  uvicorn ``--reload`` and any future
+        multi-worker launch will fork *after* this module has been
+        imported, which copies the parent's ``_initialized=True`` flag
+        into the child.  Without the PID check below the child would
+        reuse the parent's open file descriptor — a classic SQLite
+        corruption vector ("locking problems will result").
+
+        We detect that case by remembering the PID that called
+        :meth:`init` and forcing a fresh per-process initialisation
+        whenever the current PID differs.
+        """
+        current_pid = os.getpid()
+        forked = (
+            cls._initialized
+            and cls._init_pid is not None
+            and cls._init_pid != current_pid
+        )
+        if forked:
+            cls._log.warn("storage.fork_detected", {
+                "parent_pid": cls._init_pid,
+                "child_pid": current_pid,
+                "hint": "Reinitialising Storage to avoid sharing SQLite "
+                        "file descriptors across processes.",
+            })
+            cls._initialized = False
+            cls._init_pid = None
+
         if not cls._initialized or cls._db_path is None or not cls._db_path.exists():
             await cls.init(cls._db_path)
     

--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -1,6 +1,7 @@
 """Task Store — SQLite persistence for scheduler/execution domain."""
 
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -26,11 +27,28 @@ log = Log.create(service="task.store")
 class TaskStore:
     _initialized = False
     _conn: Optional[aiosqlite.Connection] = None
+    # PID of the process that opened ``_conn``.  Used to detect ``fork()``
+    # in uvicorn ``--reload`` / multi-worker launches and force a fresh
+    # connection in the child — SQLite explicitly warns that sharing a
+    # connection across ``fork()`` corrupts the DB.
+    _init_pid: Optional[int] = None
 
     @classmethod
     async def init(cls) -> None:
-        if cls._initialized:
+        current_pid = os.getpid()
+        if cls._initialized and cls._init_pid == current_pid:
             return
+        if cls._initialized and cls._init_pid is not None and cls._init_pid != current_pid:
+            # Inherited an open connection from a forked parent — discard
+            # the handle (do **not** close it; that would tear down the
+            # parent's connection state too) and rebuild from scratch.
+            log.warn("task.store.fork_detected", {
+                "parent_pid": cls._init_pid,
+                "child_pid": current_pid,
+            })
+            cls._conn = None
+            cls._initialized = False
+            cls._init_pid = None
         await Storage._ensure_init()
         cls._conn = await aiosqlite.connect(
             Storage._db_path,
@@ -43,6 +61,7 @@ class TaskStore:
         await cls._conn.commit()
         await cls._normalize_legacy_paused_executions()
         cls._initialized = True
+        cls._init_pid = current_pid
         log.info("task.store.initialized")
 
     @classmethod
@@ -51,9 +70,18 @@ class TaskStore:
             await cls._conn.close()
             cls._conn = None
             cls._initialized = False
+            cls._init_pid = None
 
     @classmethod
     async def _db(cls) -> aiosqlite.Connection:
+        # Trigger fork-safety re-init when called from a child process
+        # that inherited an already-initialised module.
+        if (
+            cls._initialized
+            and cls._init_pid is not None
+            and cls._init_pid != os.getpid()
+        ):
+            await cls.init()
         if not cls._conn:
             await cls.init()
         return cls._conn  # type: ignore[return-value]

--- a/tests/storage/test_sqlite_connection_config.py
+++ b/tests/storage/test_sqlite_connection_config.py
@@ -47,9 +47,14 @@ async def test_storage_connect_applies_runtime_sqlite_pragmas() -> None:
             busy_timeout = (await cursor.fetchone())[0]
         async with db.execute("PRAGMA foreign_keys") as cursor:
             foreign_keys = (await cursor.fetchone())[0]
+        async with db.execute("PRAGMA synchronous") as cursor:
+            synchronous = (await cursor.fetchone())[0]
 
     assert busy_timeout == Storage._sqlite_busy_timeout_ms
     assert foreign_keys == 1
+    # ``synchronous=NORMAL`` resolves to integer 1; we assert the explicit
+    # mode so the durability contract for WAL mode does not silently weaken.
+    assert synchronous == 1
 
 
 def test_storage_connect_sync_applies_runtime_sqlite_pragmas() -> None:
@@ -60,9 +65,11 @@ def test_storage_connect_sync_applies_runtime_sqlite_pragmas() -> None:
     with Storage.connect_sync() as db:
         busy_timeout = db.execute("PRAGMA busy_timeout").fetchone()[0]
         foreign_keys = db.execute("PRAGMA foreign_keys").fetchone()[0]
+        synchronous = db.execute("PRAGMA synchronous").fetchone()[0]
 
     assert busy_timeout == Storage._sqlite_busy_timeout_ms
     assert foreign_keys == 1
+    assert synchronous == 1
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -482,3 +482,121 @@ async def test_storage_shutdown_is_safe_to_call_when_not_initialised():
          patch.object(Storage, "_init_pid", None):
         # Must not raise.
         await Storage.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_storage_checkpoint_raises_when_sqlite_reports_busy(tmp_path):
+    """``PRAGMA wal_checkpoint`` returns ``busy=1`` *without* raising.
+
+    Reproduces the silent-failure mode flagged by review: a concurrent
+    reader holds a shared lock, so ``TRUNCATE`` cannot complete and SQLite
+    returns ``(1, log_pages, 0)`` from the PRAGMA — no SQL exception.
+    The contract is that ``Storage._checkpoint`` surfaces this as
+    :class:`CheckpointBusyError` so callers cannot mistakenly report
+    success.
+    """
+    import aiosqlite
+
+    db_path = tmp_path / "busy.db"
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None):
+        await Storage.init(db_path)
+
+        # Hold a long-running reader transaction to keep a shared lock.
+        # SQLite's ``TRUNCATE`` mode requires a brief exclusive moment,
+        # which this reader prevents → busy=1.
+        reader = await aiosqlite.connect(
+            str(db_path), timeout=Storage._sqlite_timeout_s
+        )
+        try:
+            await reader.execute("BEGIN")
+            await reader.execute("SELECT * FROM storage")
+            # Generate at least one WAL frame so the checkpoint has
+            # something to flush (otherwise it can trivially succeed).
+            await Storage.set("contend:key", {"v": 1})
+
+            with pytest.raises(Storage.CheckpointBusyError) as exc_info:
+                await Storage._checkpoint(mode="TRUNCATE")
+
+            err = exc_info.value
+            assert err.mode == "TRUNCATE"
+            # SQLite reports how many pages were *not* drained.
+            assert err.log_pages >= 0
+            assert err.checkpointed_pages >= 0
+        finally:
+            await reader.close()
+            await Storage.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_storage_shutdown_reports_unfinished_on_persistent_busy(tmp_path):
+    """A persistently busy checkpoint must not be logged as "done".
+
+    We replace ``_checkpoint`` with a stub that always raises
+    :class:`CheckpointBusyError` and assert that ``shutdown()``:
+      * does not raise,
+      * does not log the success path, and
+      * still clears the in-memory state (since the process is exiting).
+    """
+    db_path = tmp_path / "unfinished.db"
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None):
+        await Storage.init(db_path)
+
+        events: list[str] = []
+        real_info = Storage._log.info
+        real_warn = Storage._log.warn
+
+        def _spy_info(event, *_args, **_kwargs):
+            events.append(f"info:{event}")
+            return real_info(event, *_args, **_kwargs)
+
+        def _spy_warn(event, *_args, **_kwargs):
+            events.append(f"warn:{event}")
+            return real_warn(event, *_args, **_kwargs)
+
+        async def _always_busy(*, mode="TRUNCATE"):
+            raise Storage.CheckpointBusyError(mode, log_pages=42, checkpointed_pages=0)
+
+        with patch.object(Storage._log, "info", side_effect=_spy_info), \
+             patch.object(Storage._log, "warn", side_effect=_spy_warn), \
+             patch.object(Storage, "_checkpoint", side_effect=_always_busy), \
+             patch.object(Storage, "_shutdown_checkpoint_attempts", 2), \
+             patch.object(Storage, "_shutdown_checkpoint_backoff_s", 0.0):
+            await Storage.shutdown()
+
+        assert any("warn:storage.shutdown.checkpoint.busy" in e for e in events), events
+        assert any("warn:storage.shutdown.checkpoint.unfinished" in e for e in events), events
+        assert not any("info:storage.shutdown.checkpoint.done" in e for e in events), (
+            "shutdown must not log success when the WAL was not truncated"
+        )
+        assert Storage._initialized is False
+        assert Storage._init_pid is None
+
+
+@pytest.mark.asyncio
+async def test_storage_init_raises_when_quarantine_fails_on_invalid_header(tmp_path):
+    """Invalid-header fast-path must abort init when quarantine fails.
+
+    If we keep going after a failed rename, SQLite will open the bad
+    file and delete the adjacent WAL/SHM sidecars we wanted to preserve
+    for offline recovery — defeating the purpose of the fast-path
+    pre-flight check.
+    """
+    db_path = tmp_path / "garbage.db"
+    db_path.write_bytes(b"This is garbage, not a sqlite file\n")
+    db_path.with_name("garbage.db-wal").write_bytes(b"wal payload")
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None), \
+         patch.object(Storage, "_quarantine_corrupt_db", return_value=None):
+        with pytest.raises(Storage.StorageError, match="could not be quarantined"):
+            await Storage.init(db_path)
+
+    # Sidecars must still be present and untouched.
+    assert db_path.exists()
+    assert db_path.with_name("garbage.db-wal").exists()
+    assert db_path.with_name("garbage.db-wal").read_bytes() == b"wal payload"

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -3,6 +3,7 @@ Tests for storage module
 """
 
 from contextlib import asynccontextmanager
+import os
 import sqlite3
 import pytest
 from pathlib import Path
@@ -220,3 +221,264 @@ async def test_storage_init_retries_when_create_table_hits_sqlite_busy(tmp_path)
 
     assert call_count["count"] == 1
     assert db_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# DB corruption recovery (file is not a database)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_storage_init_quarantines_invalid_header_and_boots(tmp_path):
+    """Non-SQLite garbage at the DB path is renamed aside so init still succeeds.
+
+    Reproduces the production failure ``sqlite3.DatabaseError: file is not a
+    database`` (which historically killed server startup) and asserts that:
+      * ``Storage.init()`` no longer raises,
+      * the corrupt main file is preserved under a ``.corrupt.<ts>`` suffix
+        for offline recovery, and
+      * adjacent WAL/SHM sidecars are quarantined alongside it.
+    """
+    db_path = tmp_path / "flocks.db"
+    db_path.write_bytes(b"This is garbage, not a sqlite file\n")
+    db_path.with_name("flocks.db-wal").write_bytes(b"fake wal payload")
+    db_path.with_name("flocks.db-shm").write_bytes(b"fake shm payload")
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None):
+        await Storage.init(db_path)
+
+    # Fresh DB is now usable
+    await Storage.set("hello", {"value": 1})
+    assert await Storage.get("hello") == {"value": 1}
+
+    siblings = sorted(p.name for p in tmp_path.iterdir())
+    assert "flocks.db" in siblings
+    corrupt_files = [name for name in siblings if ".corrupt." in name]
+    assert any(name.startswith("flocks.db.corrupt.") for name in corrupt_files), siblings
+    assert any(name.startswith("flocks.db-wal.corrupt.") for name in corrupt_files), siblings
+    assert any(name.startswith("flocks.db-shm.corrupt.") for name in corrupt_files), siblings
+
+
+@pytest.mark.asyncio
+async def test_storage_init_recovers_when_pragma_reports_corruption(tmp_path):
+    """Files whose magic header is valid but inner pages are damaged still recover.
+
+    Forges a payload that begins with the real SQLite magic header so the
+    fast-path check passes, then fails on the first PRAGMA — exercising the
+    fallback quarantine+retry branch inside ``Storage.init``.
+    """
+    db_path = tmp_path / "flocks.db"
+    db_path.write_bytes(Storage._SQLITE_MAGIC + b"\xff" * 2048)
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None):
+        await Storage.init(db_path)
+
+    await Storage.set("hello", {"value": 2})
+    assert await Storage.get("hello") == {"value": 2}
+
+    assert db_path.exists()
+    quarantined = [
+        p for p in tmp_path.iterdir()
+        if p.name.startswith("flocks.db.corrupt.")
+    ]
+    assert quarantined, list(tmp_path.iterdir())
+
+
+def test_is_db_corruption_error_recognizes_known_messages():
+    """Both ``NotADBError`` and ``DatabaseError`` variants are flagged as corruption."""
+    not_a_db = sqlite3.DatabaseError("file is not a database")
+    malformed = sqlite3.DatabaseError("database disk image is malformed")
+    encrypted = sqlite3.DatabaseError("file is encrypted or is not a database")
+    benign = sqlite3.OperationalError("database is locked")
+    other = ValueError("file is not a database")  # non-sqlite exception
+
+    assert Storage._is_db_corruption_error(not_a_db) is True
+    assert Storage._is_db_corruption_error(malformed) is True
+    assert Storage._is_db_corruption_error(encrypted) is True
+    assert Storage._is_db_corruption_error(benign) is False
+    assert Storage._is_db_corruption_error(other) is False
+
+
+def test_is_db_corruption_error_recognizes_sqlite_error_code():
+    """Recognise corruption via the ``SQLITE_NOTADB`` error code, not just text."""
+    notadb_code = getattr(sqlite3, "SQLITE_NOTADB", None)
+    if notadb_code is None:
+        pytest.skip("SQLite build does not expose SQLITE_NOTADB")
+    exc = sqlite3.DatabaseError("custom wrapper text")
+    exc.sqlite_errorcode = notadb_code
+    assert Storage._is_db_corruption_error(exc) is True
+
+
+def test_file_has_invalid_sqlite_header_only_flags_non_sqlite(tmp_path):
+    """Empty / missing / SQLite-magic files must not be treated as corrupt."""
+    missing = tmp_path / "missing.db"
+    empty = tmp_path / "empty.db"
+    empty.touch()
+    sqlite_like = tmp_path / "ok.db"
+    sqlite_like.write_bytes(Storage._SQLITE_MAGIC + b"\x00" * 100)
+    bad = tmp_path / "bad.db"
+    bad.write_bytes(b"not a sqlite file")
+
+    assert Storage._file_has_invalid_sqlite_header(missing) is False
+    assert Storage._file_has_invalid_sqlite_header(empty) is False
+    assert Storage._file_has_invalid_sqlite_header(sqlite_like) is False
+    assert Storage._file_has_invalid_sqlite_header(bad) is True
+
+
+# ---------------------------------------------------------------------------
+# Durability: WAL checkpoint on shutdown / startup, fork-safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_storage_shutdown_truncates_wal_file(tmp_path):
+    """``Storage.shutdown()`` must drain the WAL so next start needs no recovery.
+
+    This is the missing counterpart to ``init()`` and the root-cause fix for
+    the ``file is not a database`` corruption pattern: a SIGKILL during WAL
+    recovery is what writes a half-baked main-DB header page.  After a clean
+    shutdown the ``-wal`` file must be zero-length.
+
+    To stop SQLite's automatic *last-connection checkpoint* from masking the
+    test (it normally drains the WAL whenever the last open connection
+    closes), we keep a holder connection open across the writes — exactly
+    like the long-lived ``TaskStore`` / ``session_binding`` connections do
+    in production — so the WAL stays non-empty until ``shutdown()`` runs.
+    """
+    import aiosqlite
+
+    db_path = tmp_path / "shutdown.db"
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None):
+        await Storage.init(db_path)
+
+        holder = await aiosqlite.connect(
+            str(db_path), timeout=Storage._sqlite_timeout_s
+        )
+        try:
+            await Storage.configure_connection(holder)
+            for i in range(50):
+                await Storage.set(f"key_{i}", {"i": i})
+
+            wal_file = db_path.with_name(db_path.name + "-wal")
+            assert wal_file.exists(), "WAL mode should produce a -wal sidecar"
+            assert wal_file.stat().st_size > 0
+        finally:
+            await holder.close()
+            # After the holder closes, SQLite *may* auto-checkpoint, but our
+            # contract is that ``shutdown()`` truncates the WAL deterministically
+            # regardless of what the kernel-side autoflush did.
+
+        await Storage.shutdown()
+
+        wal_file = db_path.with_name(db_path.name + "-wal")
+        # The WAL is now either fully removed or truncated to zero bytes —
+        # both are acceptable post-checkpoint states.
+        if wal_file.exists():
+            assert wal_file.stat().st_size == 0, (
+                "wal_checkpoint(TRUNCATE) should leave the WAL empty so the "
+                "next process start does not need to do WAL recovery"
+            )
+        assert Storage._initialized is False
+        assert Storage._init_pid is None
+
+
+@pytest.mark.asyncio
+async def test_storage_init_truncates_residual_wal_from_previous_run(tmp_path):
+    """A leftover WAL from a SIGKILL'd previous process is drained on startup.
+
+    Simulates the worst-case sequence:
+      1. Process writes data while a long-lived connection keeps the WAL open.
+      2. Process is SIGKILL'd before shutdown can checkpoint — the holder
+         connection's file descriptor is dropped without close().
+      3. Next process starts → must drain the residual WAL *before* a
+         second crash creates a half-recovered main-DB.
+    """
+    import aiosqlite
+
+    db_path = tmp_path / "startup.db"
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None):
+        await Storage.init(db_path)
+        holder = await aiosqlite.connect(
+            str(db_path), timeout=Storage._sqlite_timeout_s
+        )
+        try:
+            await Storage.configure_connection(holder)
+            for i in range(50):
+                await Storage.set(f"k{i}", {"i": i})
+
+            wal_file = db_path.with_name(db_path.name + "-wal")
+            assert wal_file.stat().st_size > 0, "expected WAL to grow"
+        finally:
+            # Simulate SIGKILL: close the holder so the test can clean up,
+            # but skip the explicit ``Storage.shutdown()``.
+            await holder.close()
+
+        Storage._initialized = False
+        Storage._init_pid = None
+        Storage._db_path = None
+
+    # Fresh ``init`` on the same file should drain any residual WAL.
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None):
+        await Storage.init(db_path)
+        wal_file = db_path.with_name(db_path.name + "-wal")
+        if wal_file.exists():
+            assert wal_file.stat().st_size == 0, (
+                "Startup checkpoint should have truncated the residual WAL"
+            )
+
+
+@pytest.mark.asyncio
+async def test_storage_detects_fork_and_reinitialises(tmp_path):
+    """``_ensure_init`` must rebuild Storage state after a ``fork()``.
+
+    Sharing an open SQLite connection across processes is documented to
+    corrupt the DB.  We simulate ``fork()`` by mutating ``_init_pid`` to a
+    PID that cannot match the current process and verify that the next
+    ``_ensure_init`` call rebuilds — and that the rebuild is a no-op fast
+    path on subsequent calls within the same (child) process.
+    """
+    db_path = tmp_path / "fork.db"
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None):
+        await Storage.init(db_path)
+        assert Storage._init_pid == os.getpid()
+
+        # Pretend this process *is* the child of a forked parent: the
+        # parent had PID 1 (which is never our own pid in pytest).
+        Storage._init_pid = 1
+        assert Storage._initialized is True
+
+        # Spy on init so we can prove it gets called again.
+        call_count = {"n": 0}
+        real_init = Storage.init
+
+        async def _spy(db_path=None):
+            call_count["n"] += 1
+            await real_init(db_path)
+
+        with patch.object(Storage, "init", side_effect=_spy):
+            await Storage._ensure_init()
+
+        assert call_count["n"] == 1, (
+            "Fork must trigger a fresh init in the child process"
+        )
+        assert Storage._init_pid == os.getpid()
+
+
+@pytest.mark.asyncio
+async def test_storage_shutdown_is_safe_to_call_when_not_initialised():
+    """``shutdown()`` is a no-op when init was never called or failed."""
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None):
+        # Must not raise.
+        await Storage.shutdown()


### PR DESCRIPTION
## Summary

Two-layer fix for the recurring `sqlite3.DatabaseError: file is not a database` crash that kills server startup and disables session features.

**Layer 1 — root-cause prevention (the application-level corruption vectors we *can* close):**

- **No code path ever ran `PRAGMA wal_checkpoint`.** WAL grew up to the SQLite default 1000-page (~4 MB) auto-checkpoint threshold, so every `SIGKILL` / power loss left a non-trivial WAL that had to be replayed on the next start — and replay rewrites main-DB page 1 (the header), which is where the corruption lands.
  - `Storage.shutdown()` now runs `wal_checkpoint(TRUNCATE)` at the very end of the FastAPI lifespan.
  - `Storage.init()` does the same on startup to drain any residual WAL left by an earlier crash, *before* a second crash can land during recovery.
- **`PRAGMA wal_autocheckpoint=200`** (≈ 800 KB) shrinks the un-persisted window 5× compared to the SQLite default.
- **`synchronous=NORMAL` is now set explicitly** so the WAL durability contract cannot silently drift to `OFF`.
- **Fork-safety** for the three long-lived SQLite connection holders (`Storage`, `TaskStore`, `session_binding`):
  - Each records its owning PID at init time.
  - Calls in a child PID rebuild the connection without closing the parent's handle. Sharing a SQLite connection across `fork()` is the documented corruption vector and is highly relevant for `uvicorn --reload` / future multi-worker launches.

**Layer 2 — safety net for irreducible external causes (power loss, NFS, AV, disk-full):**

- Pre-flight SQLite magic-header probe before opening, so a corrupt file is quarantined *before* `aiosqlite` deletes its `-wal`/`-shm` sidecars — the existing `scripts/recover_raw_flocks_db.py` needs them.
- If `Storage.init()` still trips a `SQLITE_NOTADB` / `SQLITE_CORRUPT` / "database disk image is malformed" error, the main DB and its sidecars are renamed to `<name>.corrupt.<UTC-timestamp>`, a fresh empty DB is created so the server keeps booting, and a loud log explains how to run the recovery script offline.

## Files changed

| File | Why |
|---|---|
| `flocks/storage/storage.py` | New `shutdown()` / `_checkpoint()` / `_quarantine_corrupt_db()` / `_is_db_corruption_error()` / `_file_has_invalid_sqlite_header()`; fork-safe `_ensure_init`; `synchronous=NORMAL` + `wal_autocheckpoint=200` pragmas. |
| `flocks/server/app.py` | Calls `await Storage.shutdown()` at the end of the lifespan, after every other DB-using subsystem has stopped writing. |
| `flocks/task/store.py` | PID-based fork detection on the long-lived `_conn`. |
| `flocks/channel/inbound/session_binding.py` | PID-based fork detection on the long-lived `_db_conn`. |
| `tests/storage/test_storage.py` | +8 new tests: quarantine fast-path (magic header), quarantine slow-path (PRAGMA failure), corruption-error classifier (message and `sqlite_errorcode` paths), invalid-header detector, shutdown TRUNCATE, startup TRUNCATE of residual WAL, fork-detection re-init, shutdown idempotence. |
| `tests/storage/test_sqlite_connection_config.py` | Locks `synchronous=NORMAL` into the connection contract on both async and sync paths. |

## Behavioural change for operators

- After this PR, the server *will not* refuse to start when it finds a damaged `~/.flocks/data/flocks.db`. It quarantines the bad file as `flocks.db.corrupt.<UTC-timestamp>` (and the same suffix on `-wal`/`-shm`), boots with a fresh empty DB, and writes the recovery instructions to the log.
- Offline recovery: `uv run python scripts/recover_raw_flocks_db.py ~/.flocks/data/flocks.db.corrupt.<ts>`.

## Test plan

- [x] `pytest tests/storage/` (25 tests) — green.
- [x] `pytest tests/server/concurrency/` (8) + `tests/task/test_task.py` (29) + `tests/integration/test_task_queue_integration.py` (8) + `tests/channel/` (276) — green.
- [x] Reproduced the original failure (`echo garbage > ~/.flocks/data/flocks.db`), verified the server now boots into a fresh DB with `flocks.db.corrupt.<ts>` and `-wal`/`-shm` siblings preserved for the recovery script.
- [x] Verified `synchronous=NORMAL`, `wal_autocheckpoint=200` are visible from both async and sync paths.