### PR TITLE
perf(webui,session): code-split routes/modals; per-message parts persistence

### DIFF
--- a/flocks/cli/commands/import_.py
+++ b/flocks/cli/commands/import_.py
@@ -275,9 +275,9 @@ async def _import_session(file_or_url: str, project_id: Optional[str]):
         session_key = f"session:{project_id}:{session_info['id']}"
         await Storage.set(session_key, session_info, "session")
         
-        # Store messages using the runtime's aggregated storage format.
-        # WebUI/back-end reads `message:<session_id>` and
-        # `message_parts:<session_id>` instead of legacy per-message keys.
+        # Store messages using the runtime's per-message parts format.
+        # WebUI/back-end still returns the same export JSON shape through
+        # Message.list_with_parts(); only the storage layout changes.
         message_count = 0
         serialized_messages = []
         serialized_parts = {}
@@ -296,7 +296,8 @@ async def _import_session(file_or_url: str, project_id: Optional[str]):
 
         session_id = session_info["id"]
         await Storage.set(f"message:{session_id}", serialized_messages, "message")
-        await Storage.set(f"message_parts:{session_id}", serialized_parts, "message_parts")
+        for message_id, parts in serialized_parts.items():
+            await Storage.set(f"message_parts:{session_id}:{message_id}", parts, "message_part")
         
         console.print(f"[green]Imported session: {session_info['id']}[/green]")
         console.print(f"  Title: {session_info.get('title', 'Untitled')}")

--- a/flocks/session/message.py
+++ b/flocks/session/message.py
@@ -436,6 +436,8 @@ class Message:
     _parts_cache: Dict[str, Dict[str, List[PartType]]] = {}  # session_id -> message_id -> parts
     _parts_revision_cache: Dict[str, Dict[str, int]] = {}
     _parts_serialized_cache: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+    _parts_storage_format: Dict[str, Literal["legacy", "per_message"]] = {}
+    _parts_persisted_mids: Dict[str, set[str]] = {}
     _parts_flush_tasks: Dict[str, asyncio.Task] = {}
     _lru: OrderedDict[str, bool] = OrderedDict()  # LRU tracker: move_to_end() is O(1)
     
@@ -445,6 +447,7 @@ class Message:
     # Storage key prefixes
     _MESSAGE_PREFIX = "message"
     _PARTS_PREFIX = "message_parts"
+    _PARTS_ITEM_PREFIX = "message_parts"
     _PARTS_PERSIST_DEBOUNCE_MS = 75
 
     @classmethod
@@ -456,6 +459,22 @@ class Message:
     @classmethod
     def _serialize_message_parts(cls, parts: List[PartType]) -> List[Dict[str, Any]]:
         return [p.model_dump() for p in parts]
+
+    @classmethod
+    def _parts_blob_key(cls, session_id: str) -> str:
+        return f"{cls._PARTS_PREFIX}:{session_id}"
+
+    @classmethod
+    def _parts_item_prefix(cls, session_id: str) -> str:
+        return f"{cls._PARTS_ITEM_PREFIX}:{session_id}:"
+
+    @classmethod
+    def _parts_item_key(cls, session_id: str, message_id: str) -> str:
+        return f"{cls._PARTS_ITEM_PREFIX}:{session_id}:{message_id}"
+
+    @classmethod
+    def _is_parts_item_key(cls, key: str, session_id: str) -> bool:
+        return key.startswith(cls._parts_item_prefix(session_id)) and key.count(":") == 2
 
     @classmethod
     def _sync_serialized_parts_for_message(cls, session_id: str, message_id: str) -> Dict[str, List[Dict[str, Any]]]:
@@ -569,6 +588,8 @@ class Message:
                 cls._parts_cache.pop(evict_id, None)
                 cls._parts_revision_cache.pop(evict_id, None)
                 cls._parts_serialized_cache.pop(evict_id, None)
+                cls._parts_storage_format.pop(evict_id, None)
+                cls._parts_persisted_mids.pop(evict_id, None)
                 _session_locks.discard(evict_id)
                 log.debug("message.cache.evicted", {"session_id": evict_id})
             
@@ -587,13 +608,36 @@ class Message:
             else:
                 cls._messages_cache[session_id] = []
             
-            parts_key = f"{cls._PARTS_PREFIX}:{session_id}"
-            stored_parts = await Storage.get(parts_key)
+            item_entries = await Storage.list_entries(prefix=cls._parts_item_prefix(session_id))
+            stored_parts: Dict[str, List[Dict[str, Any]]] = {}
+            persisted_mids: set[str] = set()
+
+            for key, value in item_entries:
+                if not cls._is_parts_item_key(key, session_id):
+                    continue
+                if not isinstance(value, list):
+                    continue
+                msg_id = key.rsplit(":", 1)[1]
+                stored_parts[msg_id] = value
+                persisted_mids.add(msg_id)
+
+            if stored_parts:
+                cls._parts_storage_format[session_id] = "per_message"
+            else:
+                legacy_parts = await Storage.get(cls._parts_blob_key(session_id))
+                if isinstance(legacy_parts, dict):
+                    stored_parts = legacy_parts
+                    persisted_mids = set(legacy_parts.keys())
+                    cls._parts_storage_format[session_id] = "legacy"
+                else:
+                    cls._parts_storage_format[session_id] = "per_message"
             
             if stored_parts:
                 cls._parts_cache[session_id] = {}
                 cls._parts_revision_cache[session_id] = {}
                 for msg_id, parts_data in stored_parts.items():
+                    if not isinstance(parts_data, list):
+                        continue
                     cls._parts_cache[session_id][msg_id] = [
                         cls.deserialize_part(p) for p in parts_data
                     ]
@@ -606,6 +650,7 @@ class Message:
                 cls._parts_cache[session_id] = {}
                 cls._parts_revision_cache[session_id] = {}
                 cls._parts_serialized_cache[session_id] = {}
+            cls._parts_persisted_mids[session_id] = persisted_mids
             
             cls._rebuild_id_index(session_id)
             cls._lru[session_id] = True
@@ -695,26 +740,57 @@ class Message:
     async def _persist_parts(cls, session_id: str, *, message_id: Optional[str] = None) -> None:
         """Persist parts to storage.
 
-        When *message_id* is given, only the parts for that single message are
-        serialised and merged into the stored blob.  This avoids re-serialising
-        every message on every tool-call update (the hot path).
-
-        Falls back to a full write when *message_id* is ``None``.
+        Existing legacy sessions keep writing the aggregated
+        ``message_parts:<session_id>`` blob.  New sessions write each message's
+        parts to ``message_parts:<session_id>:<message_id>`` so hot-path part
+        updates no longer rewrite the full session blob.
         """
-        parts_key = f"{cls._PARTS_PREFIX}:{session_id}"
         all_parts = cls._parts_cache.get(session_id, {})
         serialized = cls._parts_serialized_cache.setdefault(session_id, {})
+        storage_format = cls._parts_storage_format.setdefault(session_id, "per_message")
+
+        if storage_format == "legacy":
+            parts_key = cls._parts_blob_key(session_id)
+            if message_id is not None:
+                serialized[message_id] = cls._serialize_message_parts(all_parts.get(message_id, []))
+            else:
+                serialized = {
+                    mid: cls._serialize_message_parts(mparts)
+                    for mid, mparts in all_parts.items()
+                }
+                cls._parts_serialized_cache[session_id] = serialized
+            cls._parts_persisted_mids[session_id] = set(serialized.keys())
+            await Storage.set(parts_key, serialized, "message_parts")
+            return
 
         if message_id is not None:
-            serialized[message_id] = cls._serialize_message_parts(all_parts.get(message_id, []))
-            await Storage.set(parts_key, serialized)
-        else:
-            serialized = {
-                mid: cls._serialize_message_parts(mparts)
-                for mid, mparts in all_parts.items()
-            }
-            cls._parts_serialized_cache[session_id] = serialized
-            await Storage.set(parts_key, serialized)
+            serialized_one = cls._serialize_message_parts(all_parts.get(message_id, []))
+            serialized[message_id] = serialized_one
+            await Storage.set(
+                cls._parts_item_key(session_id, message_id),
+                serialized_one,
+                "message_part",
+            )
+            cls._parts_persisted_mids.setdefault(session_id, set()).add(message_id)
+            return
+
+        persisted_mids = cls._parts_persisted_mids.setdefault(session_id, set())
+        current_mids = set(all_parts.keys())
+        for mid, mparts in all_parts.items():
+            serialized_one = cls._serialize_message_parts(mparts)
+            if serialized.get(mid) != serialized_one or mid not in persisted_mids:
+                await Storage.set(
+                    cls._parts_item_key(session_id, mid),
+                    serialized_one,
+                    "message_part",
+                )
+            serialized[mid] = serialized_one
+            persisted_mids.add(mid)
+
+        for stale_mid in list(persisted_mids - current_mids):
+            await Storage.delete(cls._parts_item_key(session_id, stale_mid))
+            serialized.pop(stale_mid, None)
+            persisted_mids.discard(stale_mid)
     
     @classmethod
     async def create(
@@ -1176,9 +1252,15 @@ class Message:
                 cls._rebuild_id_index(session_id)
                 if session_id in cls._parts_cache:
                     cls._parts_cache[session_id].pop(message_id, None)
+                cls._parts_revision_cache.get(session_id, {}).pop(message_id, None)
+                cls._parts_serialized_cache.get(session_id, {}).pop(message_id, None)
                 cls._cancel_parts_flush_task(session_id)
                 await cls._persist_messages(session_id)
-                await cls._persist_parts(session_id)
+                if cls._parts_storage_format.get(session_id) == "legacy":
+                    await cls._persist_parts(session_id)
+                else:
+                    await Storage.delete(cls._parts_item_key(session_id, message_id))
+                    cls._parts_persisted_mids.setdefault(session_id, set()).discard(message_id)
                 log.info("message.deleted", {"id": message_id, "session_id": session_id})
                 return True
             return False
@@ -1232,11 +1314,16 @@ class Message:
             count = len(cls._messages_cache.get(session_id, []))
             cls._messages_cache[session_id] = []
             cls._parts_cache[session_id] = {}
+            cls._parts_revision_cache[session_id] = {}
+            cls._parts_serialized_cache[session_id] = {}
+            cls._parts_persisted_mids[session_id] = set()
+            cls._parts_storage_format[session_id] = "per_message"
             cls._cancel_parts_flush_task(session_id)
             
             # Persist changes
             await cls._persist_messages(session_id)
-            await cls._persist_parts(session_id)
+            await Storage.clear(prefix=cls._parts_item_prefix(session_id))
+            await Storage.delete(cls._parts_blob_key(session_id))
             
             log.info("messages.cleared", {
                 "session_id": session_id,
@@ -1261,6 +1348,8 @@ class Message:
             cls._parts_cache.pop(session_id, None)
             cls._parts_revision_cache.pop(session_id, None)
             cls._parts_serialized_cache.pop(session_id, None)
+            cls._parts_storage_format.pop(session_id, None)
+            cls._parts_persisted_mids.pop(session_id, None)
             _session_locks.discard(session_id)
         else:
             for sid in list(cls._parts_flush_tasks):
@@ -1271,6 +1360,8 @@ class Message:
             cls._parts_cache.clear()
             cls._parts_revision_cache.clear()
             cls._parts_serialized_cache.clear()
+            cls._parts_storage_format.clear()
+            cls._parts_persisted_mids.clear()
             _session_locks.clear()
         log.debug("message.cache.invalidated", {"session_id": session_id})
     

--- a/tests/cli/test_export_import.py
+++ b/tests/cli/test_export_import.py
@@ -8,6 +8,7 @@ import flocks.cli.commands.import_ as import_cmd
 import flocks.mcp.server as mcp_server
 from flocks.session.message import Message, MessageWithParts, TextPart, UserMessageInfo
 from flocks.session.session import SessionInfo, SessionTime
+from flocks.storage.storage import Storage
 
 if not hasattr(mcp_server, "get_manager"):
     mcp_server.get_manager = lambda: None
@@ -67,9 +68,9 @@ def test_export_and_import_round_trip(monkeypatch, tmp_path) -> None:
         assert include_archived is False
         return [message]
 
-    stored_entries: list[tuple[str, dict, str | None]] = []
+    stored_entries: list[tuple[str, object, str | None]] = []
 
-    async def fake_set(key: str, value: dict, category: str | None = None):
+    async def fake_set(key: str, value: object, category: str | None = None):
         stored_entries.append((key, value, category))
 
     monkeypatch.setattr(export_cmd.Session, "get_by_id", fake_get_by_id)
@@ -99,7 +100,9 @@ def test_export_and_import_round_trip(monkeypatch, tmp_path) -> None:
     stored = {key: (value, category) for key, value, category in stored_entries}
     assert stored["session:proj_imported:ses_export_test"][0]["projectID"] == "proj_imported"
     assert stored["message:ses_export_test"][0][0]["id"] == "msg_export_test"
-    assert stored["message_parts:ses_export_test"][0]["msg_export_test"][0]["text"] == "hello export"
+    assert "message_parts:ses_export_test" not in stored
+    assert stored["message_parts:ses_export_test:msg_export_test"][0][0]["text"] == "hello export"
+    assert stored["message_parts:ses_export_test:msg_export_test"][1] == "message_part"
 
 
 @pytest.mark.asyncio
@@ -130,6 +133,9 @@ async def test_import_writes_messages_in_runtime_storage_format(monkeypatch, tmp
     assert len(imported[0].parts) == 1
     assert imported[0].parts[0].id == "part_export_test"
     assert imported[0].parts[0].text == "hello export"
+    assert await Storage.get(f"message_parts:{session.id}") is None
+    stored_parts = await Storage.get(f"message_parts:{session.id}:msg_export_test")
+    assert stored_parts[0]["text"] == "hello export"
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_message_parts_persistence.py
+++ b/tests/session/test_message_parts_persistence.py
@@ -1,0 +1,155 @@
+"""Persistence tests for message parts storage formats."""
+
+import pytest
+
+from flocks.session.message import (
+    Message,
+    MessageRole,
+    TextPart,
+    UserMessageInfo,
+)
+from flocks.storage.storage import Storage
+
+
+def _user_message(session_id: str, message_id: str) -> UserMessageInfo:
+    return UserMessageInfo(
+        id=message_id,
+        sessionID=session_id,
+        role="user",
+        time={"created": 1},
+        agent="rex",
+        model={"providerID": "test", "modelID": "test"},
+    )
+
+
+def _text_part(session_id: str, message_id: str, text: str) -> TextPart:
+    return TextPart(
+        id=f"part_{message_id}",
+        sessionID=session_id,
+        messageID=message_id,
+        text=text,
+    )
+
+
+async def _write_legacy_session(session_id: str, messages: dict[str, str]) -> None:
+    serialized_messages = []
+    serialized_parts = {}
+    for message_id, text in messages.items():
+        serialized_messages.append(_user_message(session_id, message_id).model_dump())
+        serialized_parts[message_id] = [
+            _text_part(session_id, message_id, text).model_dump()
+        ]
+
+    await Storage.set(f"message:{session_id}", serialized_messages, "message")
+    await Storage.set(f"message_parts:{session_id}", serialized_parts, "message_parts")
+    Message.invalidate_cache(session_id)
+
+
+@pytest.mark.asyncio
+async def test_new_sessions_write_per_message_parts_keys() -> None:
+    session_id = "ses_parts_per_message_new"
+
+    await Message.create(session_id, MessageRole.USER, "hello", id="msg_a", part_id="part_a")
+    await Message.create(session_id, MessageRole.USER, "world", id="msg_b", part_id="part_b")
+
+    keys = sorted(await Storage.list_keys(prefix=f"message_parts:{session_id}:"))
+    assert keys == [
+        f"message_parts:{session_id}:msg_a",
+        f"message_parts:{session_id}:msg_b",
+    ]
+    assert await Storage.get(f"message_parts:{session_id}") is None
+
+    parts_a = await Storage.get(f"message_parts:{session_id}:msg_a")
+    assert parts_a[0]["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_legacy_blob_reads_without_migration() -> None:
+    session_id = "ses_parts_legacy_read"
+    await _write_legacy_session(session_id, {"msg_a": "legacy text"})
+
+    messages = await Message.list_with_parts(session_id)
+
+    assert len(messages) == 1
+    assert messages[0].parts[0].text == "legacy text"
+    assert await Storage.get(f"message_parts:{session_id}") is not None
+    assert await Storage.list_keys(prefix=f"message_parts:{session_id}:") == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_session_updates_continue_writing_legacy_blob() -> None:
+    session_id = "ses_parts_legacy_update"
+    await _write_legacy_session(session_id, {"msg_a": "old"})
+
+    updated = await Message.update_part(
+        session_id,
+        "msg_a",
+        "part_msg_a",
+        text="new",
+    )
+
+    assert updated is not None
+    legacy_parts = await Storage.get(f"message_parts:{session_id}")
+    assert legacy_parts["msg_a"][0]["text"] == "new"
+    assert await Storage.list_keys(prefix=f"message_parts:{session_id}:") == []
+
+
+@pytest.mark.asyncio
+async def test_per_message_session_updates_only_target_message_key() -> None:
+    session_id = "ses_parts_per_message_update"
+    await Message.create(session_id, MessageRole.USER, "old", id="msg_a", part_id="part_a")
+
+    updated = await Message.update_part(
+        session_id,
+        "msg_a",
+        "part_a",
+        text="new",
+    )
+
+    assert updated is not None
+    assert await Storage.get(f"message_parts:{session_id}") is None
+    parts_a = await Storage.get(f"message_parts:{session_id}:msg_a")
+    assert parts_a[0]["text"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_parts_using_session_storage_format() -> None:
+    legacy_session_id = "ses_parts_delete_legacy"
+    await _write_legacy_session(legacy_session_id, {"msg_a": "a", "msg_b": "b"})
+
+    assert await Message.delete(legacy_session_id, "msg_a") is True
+
+    legacy_parts = await Storage.get(f"message_parts:{legacy_session_id}")
+    assert "msg_a" not in legacy_parts
+    assert "msg_b" in legacy_parts
+    assert await Storage.list_keys(prefix=f"message_parts:{legacy_session_id}:") == []
+
+    per_message_session_id = "ses_parts_delete_per_message"
+    await Message.create(per_message_session_id, MessageRole.USER, "a", id="msg_a", part_id="part_a")
+    await Message.create(per_message_session_id, MessageRole.USER, "b", id="msg_b", part_id="part_b")
+
+    assert await Message.delete(per_message_session_id, "msg_a") is True
+
+    keys = await Storage.list_keys(prefix=f"message_parts:{per_message_session_id}:")
+    assert keys == [f"message_parts:{per_message_session_id}:msg_b"]
+    assert await Storage.get(f"message_parts:{per_message_session_id}") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_legacy_blob_and_per_message_keys() -> None:
+    legacy_session_id = "ses_parts_clear_legacy"
+    await _write_legacy_session(legacy_session_id, {"msg_a": "a"})
+
+    assert await Message.clear(legacy_session_id) == 1
+
+    assert await Storage.get(f"message_parts:{legacy_session_id}") is None
+    assert await Storage.list_keys(prefix=f"message_parts:{legacy_session_id}:") == []
+
+    per_message_session_id = "ses_parts_clear_per_message"
+    await Message.create(per_message_session_id, MessageRole.USER, "a", id="msg_a", part_id="part_a")
+    await Message.create(per_message_session_id, MessageRole.USER, "b", id="msg_b", part_id="part_b")
+
+    assert await Message.clear(per_message_session_id) == 2
+
+    assert await Storage.get(f"message_parts:{per_message_session_id}") is None
+    assert await Storage.list_keys(prefix=f"message_parts:{per_message_session_id}:") == []

--- a/webui/src/components/layout/Layout.tsx
+++ b/webui/src/components/layout/Layout.tsx
@@ -21,12 +21,24 @@ import {
   ServerCog,
   ScrollText,
 } from 'lucide-react';
-import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '@/components/common/LanguageSwitcher';
-import OnboardingModal, { isOnboardingDismissed } from '@/components/common/OnboardingModal';
-import UpdateModal, { UPDATE_DISMISSED_KEY } from '@/components/common/UpdateModal';
-import NotificationModal from '@/components/common/NotificationModal';
+// Modals are only rendered after the user clicks/triggers them; pulling them
+// into the eager Layout chunk costs ~1.7k LOC + i18n keys + lucide icons that
+// the home page never needs. To keep the lazy split effective, we don't
+// re-import the dismissal helpers from the modal modules (a static named
+// import would force Rollup to bundle the whole module eagerly), and instead
+// inline the two localStorage keys here. Keep these in sync with the keys
+// declared in OnboardingModal.tsx / UpdateModal.tsx.
+const ONBOARDING_DISMISSED_KEY = 'flocks_onboarding_dismissed';
+const UPDATE_DISMISSED_KEY = 'flocks-update-dismissed';
+function isOnboardingDismissed(): boolean {
+  return localStorage.getItem(ONBOARDING_DISMISSED_KEY) === 'true';
+}
+const OnboardingModal = lazy(() => import('@/components/common/OnboardingModal'));
+const UpdateModal = lazy(() => import('@/components/common/UpdateModal'));
+const NotificationModal = lazy(() => import('@/components/common/NotificationModal'));
 import { checkUpdate, type VersionInfo } from '@/api/update';
 import {
   ackNotification,
@@ -282,42 +294,50 @@ export default function Layout() {
   }, [acknowledgingNotificationIds.length, removeNotifications, visibleNotifications]);
 
 
-  const navigation = [
-    {
-      name: '',
-      items: [
-        { name: t('flocksHome'), href: '/', icon: Home },
-      ],
-    },
-    {
-      name: t('aiWorkbench'),
-      items: [
-        { name: t('sessions'), href: '/sessions', icon: MessageSquare },
-        { name: t('workspace'), href: '/workspace', icon: FolderOpen },
-        { name: t('tasks'), href: '/tasks', icon: ListTodo },
-        { name: t('workflows'), href: '/workflows', icon: Workflow },
-      ],
-    },
-    {
-      name: t('agentHub'),
-      items: [
-        { name: t('agents'), href: '/agents', icon: Bot },
-        { name: t('skills'), href: '/skills', icon: BookOpen },
-        { name: t('tools'), href: '/tools', icon: Wrench },
-        { name: t('deviceIntegration'), href: '/devices', icon: ServerCog },
-        { name: t('hub'), href: '/hub', icon: Archive },
-        { name: t('models'), href: '/models', icon: Brain },
-        { name: t('channels'), href: '/channels', icon: Radio },
-      ],
-    },
-    {
-      name: t('systemCenter'),
-      items: [
-        { name: t('accountManagement'), href: '/config', icon: UserCog },
-        { name: t('systemLog'), href: '/system-logs', icon: ScrollText },
-      ],
-    },
-  ];
+  // Stable across re-renders triggered by location changes (sidebar nav clicks)
+  // — the array only depends on the i18n translation function, which itself is
+  // stable as long as the language doesn't change. Without this, every route
+  // switch rebuilt the whole nav structure and cascaded re-renders down to
+  // every <Link>, contributing to perceptible navigation lag.
+  const navigation = useMemo(
+    () => [
+      {
+        name: '',
+        items: [
+          { name: t('flocksHome'), href: '/', icon: Home },
+        ],
+      },
+      {
+        name: t('aiWorkbench'),
+        items: [
+          { name: t('sessions'), href: '/sessions', icon: MessageSquare },
+          { name: t('workspace'), href: '/workspace', icon: FolderOpen },
+          { name: t('tasks'), href: '/tasks', icon: ListTodo },
+          { name: t('workflows'), href: '/workflows', icon: Workflow },
+        ],
+      },
+      {
+        name: t('agentHub'),
+        items: [
+          { name: t('agents'), href: '/agents', icon: Bot },
+          { name: t('skills'), href: '/skills', icon: BookOpen },
+          { name: t('tools'), href: '/tools', icon: Wrench },
+          { name: t('deviceIntegration'), href: '/devices', icon: ServerCog },
+          { name: t('hub'), href: '/hub', icon: Archive },
+          { name: t('models'), href: '/models', icon: Brain },
+          { name: t('channels'), href: '/channels', icon: Radio },
+        ],
+      },
+      {
+        name: t('systemCenter'),
+        items: [
+          { name: t('accountManagement'), href: '/config', icon: UserCog },
+          { name: t('systemLog'), href: '/system-logs', icon: ScrollText },
+        ],
+      },
+    ],
+    [t],
+  );
 
   const isFullScreenPage =
     matchPath('/workflows/create', location.pathname) ||
@@ -327,27 +347,31 @@ export default function Layout() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {showOnboarding && (
-        <OnboardingModal
-          onClose={() => setShowOnboarding(false)}
-        />
-      )}
-      {showUpdate && (
-        <UpdateModal
-          initialInfo={updateInfo}
-          onClose={() => setShowUpdate(false)}
-          onDismiss={() => setShowUpdate(false)}
-        />
-      )}
-      {visibleNotifications.length > 0 && (
-        <NotificationModal
-          notifications={visibleNotifications}
-          acknowledgingIds={acknowledgingNotificationIds}
-          onAcknowledge={closeVisibleNotification}
-          onClose={closeVisibleNotification}
-          onDismissForever={dismissVisibleNotificationForever}
-        />
-      )}
+      {/* Modals render lazily — fallback={null} keeps the chunk download
+          invisible to the user (they're already triggering an async UI). */}
+      <Suspense fallback={null}>
+        {showOnboarding && (
+          <OnboardingModal
+            onClose={() => setShowOnboarding(false)}
+          />
+        )}
+        {showUpdate && (
+          <UpdateModal
+            initialInfo={updateInfo}
+            onClose={() => setShowUpdate(false)}
+            onDismiss={() => setShowUpdate(false)}
+          />
+        )}
+        {visibleNotifications.length > 0 && (
+          <NotificationModal
+            notifications={visibleNotifications}
+            acknowledgingIds={acknowledgingNotificationIds}
+            onAcknowledge={closeVisibleNotification}
+            onClose={closeVisibleNotification}
+            onDismissForever={dismissVisibleNotificationForever}
+          />
+        )}
+      </Suspense>
 
       {sidebarOpen && (
         <div

--- a/webui/src/routes/index.tsx
+++ b/webui/src/routes/index.tsx
@@ -5,13 +5,18 @@ import Layout from '@/components/layout/Layout';
 import RoutePageSkeleton from '@/components/common/RoutePageSkeleton';
 import AuthLayout from '@/components/layout/AuthLayout';
 import Home from '@/pages/Home';
-import SessionPage from '@/pages/Session';
-import AgentPage from '@/pages/Agent';
-import LoginPage from '@/pages/Login';
-import SetupAdminPage from '@/pages/SetupAdmin';
-import ForceChangePasswordPage from '@/pages/ForceChangePassword';
 import { useAuth } from '@/contexts/AuthContext';
 
+// All non-Home pages are code-split. Home stays eager because it's the very
+// first frame after auth and we don't want a Suspense flash on initial paint.
+// In particular, Session/Agent and the auth screens are kept lazy so heavy
+// transitive deps (SessionChat ~2.7k LOC + react-markdown + rehype/remark +
+// highlight.js) are not pulled into the main entry chunk.
+const SessionPage = lazy(() => import('@/pages/Session'));
+const AgentPage = lazy(() => import('@/pages/Agent'));
+const LoginPage = lazy(() => import('@/pages/Login'));
+const SetupAdminPage = lazy(() => import('@/pages/SetupAdmin'));
+const ForceChangePasswordPage = lazy(() => import('@/pages/ForceChangePassword'));
 const WorkflowListPage = lazy(() => import('@/pages/Workflow'));
 const WorkflowCreate = lazy(() => import('@/pages/WorkflowCreate'));
 const WorkflowEditor = lazy(() => import('@/pages/WorkflowEditor'));
@@ -67,24 +72,32 @@ export function Routes() {
 
   if (!bootstrapped) {
     return (
-      <RouterRoutes>
-        <Route path="/setup-admin" element={<SetupAdminPage />} />
-        <Route path="*" element={<Navigate to="/setup-admin" replace />} />
-      </RouterRoutes>
+      <Suspense fallback={<RoutePageSkeleton />}>
+        <RouterRoutes>
+          <Route path="/setup-admin" element={<SetupAdminPage />} />
+          <Route path="*" element={<Navigate to="/setup-admin" replace />} />
+        </RouterRoutes>
+      </Suspense>
     );
   }
 
   if (!user) {
     return (
-      <RouterRoutes>
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="*" element={<Navigate to="/login" replace />} />
-      </RouterRoutes>
+      <Suspense fallback={<RoutePageSkeleton />}>
+        <RouterRoutes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="*" element={<Navigate to="/login" replace />} />
+        </RouterRoutes>
+      </Suspense>
     );
   }
 
   if (user.must_reset_password) {
-    return <ForceChangePasswordPage />;
+    return (
+      <Suspense fallback={<RoutePageSkeleton />}>
+        <ForceChangePasswordPage />
+      </Suspense>
+    );
   }
 
   return (
@@ -93,17 +106,17 @@ export function Routes() {
       <Route path="/setup-admin" element={<Navigate to="/" replace />} />
       <Route path="/" element={<Layout />}>
         <Route index element={<Home />} />
-        
+
         {/* AI 工作台 */}
-        <Route path="sessions" element={<SessionPage />} />
-        <Route path="agents" element={<AgentPage />} />
+        <Route path="sessions" element={<LazyRoute><SessionPage /></LazyRoute>} />
+        <Route path="agents" element={<LazyRoute><AgentPage /></LazyRoute>} />
         <Route path="workflows" element={<LazyRoute><WorkflowListPage /></LazyRoute>} />
         <Route path="workflows/new" element={<LazyRoute><WorkflowCreate /></LazyRoute>} />
         <Route path="workflows/:id" element={<LazyRoute><WorkflowDetail /></LazyRoute>} />
         <Route path="workflows/:id/edit" element={<LazyRoute><WorkflowEditor /></LazyRoute>} />
         <Route path="tasks" element={<LazyRoute><TaskPage /></LazyRoute>} />
         <Route path="workspace" element={<LazyRoute><WorkspacePage /></LazyRoute>} />
-        
+
         {/* 设备接入 */}
         <Route path="devices" element={<LazyRoute><DeviceIntegrationPage /></LazyRoute>} />
 
@@ -114,7 +127,7 @@ export function Routes() {
         <Route path="skills" element={<LazyRoute><SkillPage /></LazyRoute>} />
         {/* MCP 已整合到工具清单页面 */}
         <Route path="mcp" element={<Navigate to="/tools" replace />} />
-        
+
         {/* 系统中心 */}
         <Route path="config" element={<LazyRoute><ConfigPage /></LazyRoute>} />
         <Route path="config/*" element={<Navigate to="/config" replace />} />


### PR DESCRIPTION
## Summary

### WebUI performance
- **Code-split heavy routes**: Lazy-load `Session`, `Agent`, and auth pages (`Login`, `SetupAdmin`, `ForceChangePassword`) so SessionChat (~2.7k LOC) and markdown/highlight deps stay out of the main entry chunk; Home remains eager to avoid an initial Suspense flash.
- **Lazy-load Layout modals**: Defer `OnboardingModal`, `UpdateModal`, and `NotificationModal` until shown; inline localStorage dismissal keys to avoid eager static imports that would defeat the split.
- **Memoize sidebar navigation**: Wrap nav config in `useMemo` keyed on `t` to avoid rebuilding links on every route change and reduce perceptible navigation lag.

### Session storage
- **Per-message parts keys**: New sessions persist parts to `message_parts:<session_id>:<message_id>` so tool-call hot paths no longer rewrite the full session blob.
- **Legacy compatibility**: Existing aggregated `message_parts:<session_id>` blobs continue to load and persist in place.
- **CLI import**: Align `flocks import` with the per-message storage layout.