### PR TITLE
Fix/device mcp tool visibility

### DIFF
--- a/.flocks/plugins/tools/device/sangfor_sip_v92/_provider.yaml
+++ b/.flocks/plugins/tools/device/sangfor_sip_v92/_provider.yaml
@@ -72,6 +72,13 @@ notes: |
      - api_services.sangfor_sip.username = "your_username"
      - sangfor_sip_password = "your_password"（secret）
 
+  连通测试地址拼装规则：
+    - 仅填写 `host`（默认）→ 拼装为 `https://{host}:{port}`，
+      端口缺省为 7443（HTTPS）。
+    - 若需以非 HTTPS 方式探测（极少见，仅用于联调环境），
+      请在 `host` 字段中显式写入完整 scheme，例如
+      `http://10.1.2.3`，系统不会再为其加 `https://` 前缀。
+
   `verify_ssl` 由表单底部「SSL 验证」开关控制，下列字段都会被
   识别为 SSL 验证开关，按以下优先级取值：
     1. `verify_ssl`                  （主键）

--- a/flocks/server/routes/device.py
+++ b/flocks/server/routes/device.py
@@ -248,12 +248,29 @@ async def route_test_device(device_id: str, body: Optional[DeviceTestRequest] = 
         raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="Device not found")
 
     db_fields: dict = json.loads(row["fields"] or "{}")
-    persisted_base_url = (resolve_for_runtime(db_fields).get("base_url") or "").strip()
+    resolved = resolve_for_runtime(db_fields)
+    persisted_base_url = (resolved.get("base_url") or "").strip()
 
     # Form overrides take priority over the DB row so the toggle on screen is
     # what gets used for the probe.
     override_base_url = (body.base_url.strip() if body and body.base_url else "")
     base_url = override_base_url or persisted_base_url
+
+    # Some providers (e.g. Sangfor SIP) store host + port instead of base_url.
+    # Fall back to constructing the URL from those fields so the connectivity
+    # test works without requiring a separate base_url field.
+    if not base_url:
+        host = (resolved.get("host") or "").strip()
+        port = (resolved.get("port") or "").strip()
+        if host:
+            # If the operator already typed a scheme into the host field
+            # (e.g. "http://10.1.2.3"), respect it instead of double-prefixing.
+            has_scheme = "://" in host
+            if has_scheme:
+                base_url = f"{host}:{port}" if port else host
+            else:
+                base_url = f"https://{host}:{port}" if port else f"https://{host}"
+
     if not base_url:
         return DeviceTestResult(success=False, message="未配置设备地址（base_url），请先填写")
 

--- a/flocks/server/routes/device.py
+++ b/flocks/server/routes/device.py
@@ -272,7 +272,10 @@ async def route_test_device(device_id: str, body: Optional[DeviceTestRequest] = 
                 base_url = f"https://{host}:{port}" if port else f"https://{host}"
 
     if not base_url:
-        return DeviceTestResult(success=False, message="未配置设备地址（base_url），请先填写")
+        return DeviceTestResult(
+            success=False,
+            message="未配置设备地址（base_url 或 host），请先填写",
+        )
 
     if body is not None and body.verify_ssl is not None:
         verify_ssl = bool(body.verify_ssl)

--- a/flocks/server/routes/mcp.py
+++ b/flocks/server/routes/mcp.py
@@ -481,7 +481,17 @@ async def update_mcp_server(name: str, request: McpUpdateRequest):
             previous_status is not None
             and previous_status.status == McpStatus.CONNECTED
         )
-        should_reconnect = was_connected and clean_config.get("enabled", True) is not False
+        # Reconnect when:
+        # 1. Server was already connected (config change) OR
+        # 2. Server is being enabled for the first time (was disabled/absent)
+        #    and there is no credential/config blocker.
+        # In both cases the new config must have enabled != False.
+        becoming_enabled = clean_config.get("enabled", True) is not False
+        was_previously_active = previous_status is not None
+        should_reconnect = becoming_enabled and (
+            was_connected
+            or (not was_previously_active and not get_connect_block_reason(clean_config))
+        )
 
         if previous_status is not None:
             await MCP.remove(name)

--- a/flocks/server/routes/mcp.py
+++ b/flocks/server/routes/mcp.py
@@ -481,16 +481,24 @@ async def update_mcp_server(name: str, request: McpUpdateRequest):
             previous_status is not None
             and previous_status.status == McpStatus.CONNECTED
         )
-        # Reconnect when:
-        # 1. Server was already connected (config change) OR
-        # 2. Server is being enabled for the first time (was disabled/absent)
-        #    and there is no credential/config blocker.
-        # In both cases the new config must have enabled != False.
+        # Reconnect whenever the user just saved a config that asks the
+        # server to be enabled AND the config is complete enough to try.
+        # This covers three real flows:
+        #
+        #   * config change while already connected — pre-existing case;
+        #   * first enable from a previously-disabled/never-seen server —
+        #     the runtime ``status`` dict is empty for that name;
+        #   * fixing credentials after a failed connect — runtime state
+        #     was FAILED/DISCONNECTED and the user just saved the corrected
+        #     config; they expect a re-try without an extra click.
+        #
+        # ``get_connect_block_reason`` short-circuits when the config is
+        # still incomplete (e.g. ``{secret:...}`` placeholder with no value
+        # in the secret store) so we never spin up doomed connect attempts.
         becoming_enabled = clean_config.get("enabled", True) is not False
-        was_previously_active = previous_status is not None
-        should_reconnect = becoming_enabled and (
-            was_connected
-            or (not was_previously_active and not get_connect_block_reason(clean_config))
+        should_reconnect = (
+            becoming_enabled
+            and not get_connect_block_reason(clean_config)
         )
 
         if previous_status is not None:

--- a/flocks/tool/device/startup.py
+++ b/flocks/tool/device/startup.py
@@ -59,8 +59,39 @@ async def _heal_stale_service_ids() -> None:
         log.warn("tool.device.startup.heal_failed", {"error": str(exc)})
 
 
+def _device_type_storage_keys() -> set[str]:
+    """Return the set of ``storage_key`` values whose ``_provider.yaml``
+    declares ``integration_type: device``.
+
+    Pure-API plugins (``integration_type: api``) must be excluded from the
+    device sync loop: they have no rows in ``device_integrations``, so
+    ``sync_service_tool_state`` would always find 0 enabled devices and
+    incorrectly set ``api_services[sk].enabled = false``, silently disabling
+    those tools on every restart.
+
+    Scans every descriptor's YAML once per call (cheap at startup; we
+    intentionally don't memoize across calls so test fixtures that swap
+    plugin directories still see fresh data).
+    """
+    keys: set[str] = set()
+    try:
+        import yaml as _yaml
+        from flocks.config.api_versioning import discover_api_service_descriptors
+
+        for desc in discover_api_service_descriptors():
+            try:
+                data = _yaml.safe_load(desc.provider_yaml.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if isinstance(data, dict) and data.get("integration_type") == "device":
+                keys.add(desc.storage_key)
+    except Exception:
+        pass
+    return keys
+
+
 async def _sync_all() -> None:
-    """Re-sync tool visibility for every service_id we know about.
+    """Re-sync tool visibility for every *device-type* service_id we know about.
 
     "Know about" includes both:
       * service_ids that still have rows in ``device_integrations``, and
@@ -69,6 +100,11 @@ async def _sync_all() -> None:
         service before restart).  Without sweeping the config we'd leave
         stale ``enabled=true`` flags on tools whose owning devices no
         longer exist.
+
+    Pure API integrations (``integration_type: api``) are intentionally
+    excluded: they never have ``device_integrations`` rows, so the sync
+    would always judge them as "0 enabled devices" and disable their tools
+    on every startup.
     """
     try:
         async with Storage.connect(Storage.get_db_path()) as db:
@@ -77,14 +113,20 @@ async def _sync_all() -> None:
 
         # Also discover service_ids from existing api_services entries so we
         # can clear out config rows whose backing devices have been removed.
+        # IMPORTANT: only include storage_keys whose integration_type is
+        # "device"; pure-API services are managed independently and must
+        # not be touched here.
         config_service_ids: list[str] = []
         try:
             from flocks.config.config_writer import ConfigWriter
             from flocks.tool.device.store import storage_key_to_service_id
 
+            device_keys = _device_type_storage_keys()
             existing = ConfigWriter.list_api_services_raw() or {}
             for sk in existing.keys():
                 if not isinstance(sk, str):
+                    continue
+                if sk not in device_keys:
                     continue
                 try:
                     config_service_ids.append(storage_key_to_service_id(sk))

--- a/flocks/tool/device/sync.py
+++ b/flocks/tool/device/sync.py
@@ -94,6 +94,10 @@ async def sync_service_tool_state(
             ConfigWriter.set_api_service(sk, entry)
 
         ToolRegistry._sync_api_service_states()
+        # Re-apply user-level tool_settings so that individual tools the user
+        # explicitly disabled stay off even after a service is re-enabled, and
+        # tools the user explicitly enabled come back when the service is live.
+        ToolRegistry._apply_tool_settings()
 
         log.info("tool.device.sync", {
             "service_id": service_id,

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -1065,11 +1065,13 @@ class ToolRegistry:
 
     @classmethod
     def _sync_api_service_states(cls) -> None:
-        """Disable tools whose API service is disabled in flocks.json.
+        """Bi-directionally sync tool enabled state with their API service.
 
-        YAML plugin tools default to ``enabled=True``, but the corresponding
-        API service in ``api_services`` may be ``enabled: false``.  Without
-        this sync the runner exposes disabled-service tools to the LLM.
+        - Service disabled  → force tool off.
+        - Service enabled   → restore the tool to its factory/YAML default so
+          that re-enabling a service (e.g. after adding a device) brings its
+          tools back automatically.  User-level overrides stored in
+          ``tool_settings`` are applied afterwards by :meth:`_apply_tool_settings`.
         """
         try:
             from flocks.config.config_writer import ConfigWriter
@@ -1078,22 +1080,34 @@ class ToolRegistry:
             return
 
         disabled_count = 0
+        restored_count = 0
         for tool in cls._tools.values():
             provider = tool.info.provider
             if not provider:
                 continue
             svc = api_services.get(provider, {})
-            if not svc.get("enabled", False):
+            svc_enabled = svc.get("enabled", False)
+            if not svc_enabled:
                 tool.info.enabled = False
                 disabled_count += 1
+            else:
+                # Restore to factory default so tools re-appear when their
+                # service is re-enabled (e.g. after a device is re-added).
+                # _apply_tool_settings() runs after and can flip back to False
+                # when the user has explicitly disabled a specific tool.
+                default = cls._enabled_defaults.get(tool.info.name, True)
+                if not tool.info.enabled and default:
+                    tool.info.enabled = True
+                    restored_count += 1
 
-        if disabled_count:
+        if disabled_count or restored_count:
             disabled_providers = [
                 p for p, svc in api_services.items()
                 if not svc.get("enabled", False)
             ]
             log.debug("tool_registry.api_service_sync", {
                 "disabled_tools": disabled_count,
+                "restored_tools": restored_count,
                 "disabled_providers": disabled_providers,
             })
 

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -1070,8 +1070,23 @@ class ToolRegistry:
         - Service disabled  → force tool off.
         - Service enabled   → restore the tool to its factory/YAML default so
           that re-enabling a service (e.g. after adding a device) brings its
-          tools back automatically.  User-level overrides stored in
-          ``tool_settings`` are applied afterwards by :meth:`_apply_tool_settings`.
+          tools back automatically.
+
+        Calling contract — IMPORTANT:
+            This method overwrites ``tool.info.enabled`` with the factory
+            default whenever a service becomes enabled.  That would silently
+            re-open any tool the user had explicitly disabled via the
+            ``tool_settings`` overlay.  **Every call site that may flip a
+            service's enabled flag MUST pair the call with
+            :meth:`_apply_tool_settings` afterwards**, so the user overlay
+            wins the final write::
+
+                ToolRegistry._sync_api_service_states()
+                ToolRegistry._apply_tool_settings()
+
+            The bootstrap path (:meth:`_load_plugin_tools`) and the device
+            sync helper (:func:`flocks.tool.device.sync.sync_service_tool_state`)
+            already follow this discipline.
         """
         try:
             from flocks.config.config_writer import ConfigWriter

--- a/tests/server/routes/test_device_routes.py
+++ b/tests/server/routes/test_device_routes.py
@@ -1,0 +1,198 @@
+"""Route-level tests for ``POST /api/devices/{id}/test``.
+
+Covers the connectivity-probe behaviour added when host+port providers
+(e.g. Sangfor SIP) were brought into scope:
+
+  * empty ``base_url`` but populated ``host``/``port`` → probe targets
+    ``https://{host}:{port}``;
+  * ``host`` field already carries a scheme → respect it (no double
+    ``https://http://...``);
+  * neither ``base_url`` nor ``host`` set → user-facing error mentions
+    *both* fields, not just ``base_url``.
+"""
+from __future__ import annotations
+
+import json
+from typing import Dict, Optional
+
+import pytest
+from httpx import AsyncClient
+
+from flocks.server.routes import device as device_routes
+from flocks.tool.device.models import DeviceTestResult
+
+
+def _fake_row(*, fields: Dict[str, str], verify_ssl: bool = False) -> dict:
+    """Return a dict shaped like the aiosqlite.Row that
+    ``fetch_device`` would normally yield.  Route code accesses it with
+    ``row["fields"]`` / ``row["verify_ssl"]`` style indexing so a plain
+    ``dict`` is enough.
+    """
+    return {
+        "id": "dev-test",
+        "fields": json.dumps(fields),
+        "verify_ssl": int(bool(verify_ssl)),
+    }
+
+
+def _install_route_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    row: Optional[dict],
+    probe_result: DeviceTestResult,
+    captured: dict,
+) -> None:
+    """Stub out fetch_device, _probe and record_test_result on the
+    routes module so the test stays isolated from DB / network."""
+
+    async def fake_fetch_device(device_id: str):
+        captured["device_id"] = device_id
+        return row
+
+    async def fake_probe(base_url: str, *, verify_ssl: bool):
+        captured["probed_base_url"] = base_url
+        captured["probed_verify_ssl"] = verify_ssl
+        return probe_result
+
+    async def fake_record(device_id, *, success, message, latency_ms):
+        captured.setdefault("record_calls", []).append(
+            {"device_id": device_id, "success": success, "message": message}
+        )
+
+    monkeypatch.setattr(device_routes, "fetch_device", fake_fetch_device)
+    monkeypatch.setattr(device_routes, "_probe", fake_probe)
+    monkeypatch.setattr(device_routes, "record_test_result", fake_record)
+    # secrets resolution: return the persisted dict untouched so tests can
+    # drive the field values directly.
+    monkeypatch.setattr(
+        device_routes,
+        "resolve_for_runtime",
+        lambda db_fields: dict(db_fields),
+    )
+
+
+class TestDeviceTestEndpoint:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_host_and_port_when_base_url_missing(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Sangfor SIP-style providers (host=192.168.1.100 + port=7443)
+        must produce ``https://192.168.1.100:7443`` even though the
+        device has no ``base_url`` field at all.
+        """
+        captured: dict = {}
+        _install_route_stubs(
+            monkeypatch,
+            row=_fake_row(fields={"host": "192.168.1.100", "port": "7443"}),
+            probe_result=DeviceTestResult(success=True, message="HTTP 200, 12ms", latency_ms=12),
+            captured=captured,
+        )
+
+        resp = await client.post("/api/devices/dev-test/test", json={})
+
+        assert resp.status_code == 200, resp.text
+        assert captured["probed_base_url"] == "https://192.168.1.100:7443"
+
+    @pytest.mark.asyncio
+    async def test_host_only_defaults_to_https_without_port(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Port is optional; when absent the probe should still build a
+        well-formed ``https://{host}`` URL rather than dangling a trailing
+        colon."""
+        captured: dict = {}
+        _install_route_stubs(
+            monkeypatch,
+            row=_fake_row(fields={"host": "console.example.com"}),
+            probe_result=DeviceTestResult(success=True, message="ok"),
+            captured=captured,
+        )
+
+        resp = await client.post("/api/devices/dev-test/test", json={})
+
+        assert resp.status_code == 200, resp.text
+        assert captured["probed_base_url"] == "https://console.example.com"
+
+    @pytest.mark.asyncio
+    async def test_host_already_with_scheme_is_not_double_prefixed(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Defensive: an operator that typed ``http://10.1.2.3`` into the
+        ``host`` field must not produce ``https://http://10.1.2.3``."""
+        captured: dict = {}
+        _install_route_stubs(
+            monkeypatch,
+            row=_fake_row(fields={"host": "http://10.1.2.3", "port": "8080"}),
+            probe_result=DeviceTestResult(success=True, message="ok"),
+            captured=captured,
+        )
+
+        resp = await client.post("/api/devices/dev-test/test", json={})
+
+        assert resp.status_code == 200, resp.text
+        assert captured["probed_base_url"] == "http://10.1.2.3:8080"
+
+    @pytest.mark.asyncio
+    async def test_form_override_base_url_wins_over_persisted_host(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """If the WebUI sends an unsaved ``base_url`` it must take priority
+        over the persisted ``host`` field — that's the whole point of the
+        override path."""
+        captured: dict = {}
+        _install_route_stubs(
+            monkeypatch,
+            row=_fake_row(fields={"host": "192.168.1.100", "port": "7443"}),
+            probe_result=DeviceTestResult(success=True, message="ok"),
+            captured=captured,
+        )
+
+        resp = await client.post(
+            "/api/devices/dev-test/test",
+            json={"base_url": "https://staging.example.com"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert captured["probed_base_url"] == "https://staging.example.com"
+
+    @pytest.mark.asyncio
+    async def test_error_message_mentions_both_base_url_and_host(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When neither ``base_url`` nor ``host`` is configured, the error
+        text must tell the operator BOTH field names — otherwise users on
+        host+port providers (SIP) get a misleading "base_url" message even
+        though that field isn't on their form."""
+        captured: dict = {}
+        _install_route_stubs(
+            monkeypatch,
+            row=_fake_row(fields={}),
+            # Probe should never run when address is missing — keep a
+            # sentinel that would fail loudly if it did.
+            probe_result=DeviceTestResult(
+                success=True, message="UNREACHABLE: probe ran without an address"
+            ),
+            captured=captured,
+        )
+
+        resp = await client.post("/api/devices/dev-test/test", json={})
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is False
+        assert "base_url" in data["message"]
+        assert "host" in data["message"]
+        assert "probed_base_url" not in captured, "probe must not run when no address resolved"
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_unknown_device(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        async def fake_fetch_device(device_id: str):
+            return None
+
+        monkeypatch.setattr(device_routes, "fetch_device", fake_fetch_device)
+
+        resp = await client.post("/api/devices/missing-id/test", json={})
+
+        assert resp.status_code == 404

--- a/tests/server/routes/test_mcp_routes.py
+++ b/tests/server/routes/test_mcp_routes.py
@@ -721,6 +721,191 @@ class TestMcpRoutes:
         )
         assert stored_configs["demo-mcp"]["headers"]["X-Client"] == "flocks-web"
 
+    # ---------------------------------------------------------------------
+    # should_reconnect: the contract for ``PUT /api/mcp/{name}`` is that
+    # any save where the new config asks the server to be enabled AND the
+    # config is complete enough to dial must trigger a fresh connect — not
+    # just the "was already connected" case.  These tests cover the three
+    # flows the production fix needs to keep working:
+    #   * first enable (no runtime status entry at all);
+    #   * fixing credentials after a previous FAILED connect;
+    #   * blocked configs (pending {secret:...}) must NOT auto-connect.
+    # ---------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_update_mcp_server_connects_on_first_enable_without_prior_status(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        stored_configs: dict[str, dict] = {}
+        attempted_connects: list[str] = []
+
+        async def fake_status() -> dict[str, McpStatusInfo]:
+            # No runtime status — server has never been touched in this
+            # process (the catalog-install + later-enable flow).
+            return {}
+
+        async def fake_connect(name: str, config: dict) -> bool:
+            attempted_connects.append(name)
+            return True
+
+        async def fake_remove(name: str) -> bool:
+            raise AssertionError("remove must not run when there is no runtime state")
+
+        monkeypatch.setattr(
+            mcp_routes.ConfigWriter,
+            "get_mcp_server",
+            lambda name: {
+                "type": "local",
+                "command": ["python", "-m", "mcp_panther"],
+                "enabled": False,
+            },
+        )
+        monkeypatch.setattr(mcp_routes.MCP, "status", fake_status)
+        monkeypatch.setattr(mcp_routes.MCP, "remove", fake_remove)
+        monkeypatch.setattr(mcp_routes.MCP, "connect", fake_connect)
+        monkeypatch.setattr(
+            mcp_routes.ConfigWriter,
+            "add_mcp_server",
+            lambda name, config: stored_configs.__setitem__(name, config),
+        )
+        monkeypatch.setattr(tool_loader, "save_mcp_config", lambda name, config: None)
+
+        resp = await client.put(
+            "/api/mcp/panther",
+            json={"config": {"enabled": True}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["reconnected"] is True
+        assert data["reconnect_error"] is None
+        assert attempted_connects == ["panther"], (
+            "first enable must trigger a connect — otherwise the user has "
+            "to restart the process for a freshly-enabled server's tools "
+            "to register"
+        )
+        assert stored_configs["panther"]["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_mcp_server_reconnects_after_previous_failure(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """User fixed credentials, saves the config — the route must dial
+        again even though the prior status was FAILED rather than CONNECTED."""
+        stored_configs: dict[str, dict] = {}
+        attempted_connects: list[str] = []
+        removed: list[str] = []
+
+        async def fake_status() -> dict[str, McpStatusInfo]:
+            return {
+                "panther": McpStatusInfo(
+                    status=McpStatus.FAILED,
+                    error="Authentication failed",
+                )
+            }
+
+        async def fake_connect(name: str, config: dict) -> bool:
+            attempted_connects.append(name)
+            return True
+
+        async def fake_remove(name: str) -> bool:
+            removed.append(name)
+            return True
+
+        monkeypatch.setattr(
+            mcp_routes.ConfigWriter,
+            "get_mcp_server",
+            lambda name: {
+                "type": "local",
+                "command": ["python", "-m", "mcp_panther"],
+                "enabled": True,
+            },
+        )
+        monkeypatch.setattr(mcp_routes.MCP, "status", fake_status)
+        monkeypatch.setattr(mcp_routes.MCP, "remove", fake_remove)
+        monkeypatch.setattr(mcp_routes.MCP, "connect", fake_connect)
+        monkeypatch.setattr(
+            mcp_routes.ConfigWriter,
+            "add_mcp_server",
+            lambda name, config: stored_configs.__setitem__(name, config),
+        )
+        monkeypatch.setattr(tool_loader, "save_mcp_config", lambda name, config: None)
+
+        resp = await client.put(
+            "/api/mcp/panther",
+            json={"config": {"command": ["python", "-m", "mcp_panther", "--fixed"]}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["reconnected"] is True
+        assert attempted_connects == ["panther"], (
+            "saving a config when the server was FAILED must re-dial — "
+            "otherwise the user has to manually click Connect after fixing "
+            "credentials"
+        )
+        assert removed == ["panther"]
+
+    @pytest.mark.asyncio
+    async def test_update_mcp_server_skips_connect_when_credentials_blank(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When the saved config leaves an apikey auth ``value`` blank —
+        which is how the UI represents "I have not entered credentials
+        yet" — ``get_connect_block_reason`` flags the config as pending.
+        The route must NOT auto-connect in that case; those connects
+        would always fail and waste cycles.
+        """
+        stored_configs: dict[str, dict] = {}
+        attempted_connects: list[str] = []
+
+        async def fake_status() -> dict[str, McpStatusInfo]:
+            return {}
+
+        async def fake_connect(name: str, config: dict) -> bool:
+            attempted_connects.append(name)
+            return True
+
+        monkeypatch.setattr(
+            mcp_routes.ConfigWriter,
+            "get_mcp_server",
+            lambda name: {
+                "type": "remote",
+                "url": "https://example.com/mcp",
+                "auth": {
+                    "type": "apikey",
+                    "location": "header",
+                    "param_name": "Authorization",
+                    # Blank value — UI representation for "no credentials
+                    # entered yet"; flagged as pending by
+                    # ``config_has_pending_credentials``.
+                    "value": "",
+                },
+                "enabled": False,
+            },
+        )
+        monkeypatch.setattr(mcp_routes.MCP, "status", fake_status)
+        monkeypatch.setattr(mcp_routes.MCP, "connect", fake_connect)
+        monkeypatch.setattr(
+            mcp_routes.ConfigWriter,
+            "add_mcp_server",
+            lambda name, config: stored_configs.__setitem__(name, config),
+        )
+        monkeypatch.setattr(tool_loader, "save_mcp_config", lambda name, config: None)
+
+        resp = await client.put(
+            "/api/mcp/blocked-mcp",
+            json={"config": {"enabled": True}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert attempted_connects == [], (
+            "configs with blank credential slots must not be auto-connected "
+            "— that would just generate failed login attempts"
+        )
+        assert data["reconnected"] is False
+
     @pytest.mark.asyncio
     async def test_catalog_install_defaults_to_disabled_without_connecting(
         self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch

--- a/tests/tool/test_apply_tool_settings.py
+++ b/tests/tool/test_apply_tool_settings.py
@@ -409,3 +409,91 @@ def test_unregister_dynamic_tools_drops_enabled_default(temp_config, isolated_re
         "_unregister_dynamic_tools must pop the snapshot entry to keep "
         "the factory-default lifecycle symmetric with plugin tools"
     )
+
+
+# ---------------------------------------------------------------------------
+# Bi-directional sync: re-enabling a service must restore its tools to the
+# factory default. Without this, deleting and re-adding a device would leave
+# its tools silently disabled because ``_sync_api_service_states`` used to
+# only flip ``enabled = False`` and never flip back to True.
+# ---------------------------------------------------------------------------
+
+def test_sync_restores_tool_when_service_re_enabled(
+    temp_config, isolated_registry
+):
+    """Regression: tool whose factory default is True should bounce back
+    to True after the owning service is re-enabled."""
+    tool = _stub_api_tool("onesec_dns", enabled=True, provider="onesec_api")
+    ToolRegistry.register(tool)
+    assert ToolRegistry.get_default_enabled("onesec_dns") is True
+
+    _set_api_service("onesec_api", enabled=False)
+    ToolRegistry._sync_api_service_states()
+    assert tool.info.enabled is False
+
+    _set_api_service("onesec_api", enabled=True)
+    ToolRegistry._sync_api_service_states()
+    assert tool.info.enabled is True, (
+        "service flipping enabled=False→True must restore the tool to its "
+        "factory default — otherwise re-adding a device leaves its tools "
+        "permanently off"
+    )
+
+
+def test_sync_does_not_resurrect_user_disabled_tool(
+    temp_config, isolated_registry
+):
+    """A user that explicitly turned a tool off via ``tool_settings`` must
+    keep that choice across service-state flips.  ``_sync_api_service_states``
+    restores the YAML default, then ``_apply_tool_settings`` re-applies
+    the user's disable; the net result is still disabled."""
+    from flocks.config.config_writer import ConfigWriter
+
+    tool = _stub_api_tool("onesec_dns", enabled=True, provider="onesec_api")
+    ToolRegistry.register(tool)
+    ConfigWriter.set_tool_setting("onesec_dns", {"enabled": False})
+
+    _set_api_service("onesec_api", enabled=False)
+    ToolRegistry._sync_api_service_states()
+    ToolRegistry._apply_tool_settings()
+    assert tool.info.enabled is False
+
+    _set_api_service("onesec_api", enabled=True)
+    ToolRegistry._sync_api_service_states()
+    ToolRegistry._apply_tool_settings()
+    assert tool.info.enabled is False, (
+        "the user's explicit disable in tool_settings must win over "
+        "service-state bounce-back"
+    )
+
+
+def test_sync_does_not_flip_factory_disabled_tool(
+    temp_config, isolated_registry
+):
+    """A tool whose factory default is ``enabled=False`` must NOT be
+    flipped on by ``_sync_api_service_states`` when the service is
+    enabled — the sync's job is to honour the YAML default, not to
+    re-enable everything blindly."""
+    tool = _stub_api_tool("onesec_admin", enabled=False, provider="onesec_api")
+    ToolRegistry.register(tool)
+    assert ToolRegistry.get_default_enabled("onesec_admin") is False
+
+    _set_api_service("onesec_api", enabled=True)
+    ToolRegistry._sync_api_service_states()
+    assert tool.info.enabled is False, (
+        "tools whose YAML default is enabled=false must stay off when "
+        "the service is enabled — only an explicit user overlay can open them"
+    )
+
+
+def test_sync_leaves_already_enabled_tool_alone(
+    temp_config, isolated_registry
+):
+    """When a tool is already enabled and its service is enabled, the
+    sync must be a true no-op for it — no spurious writes or log spam."""
+    tool = _stub_api_tool("onesec_dns", enabled=True, provider="onesec_api")
+    ToolRegistry.register(tool)
+
+    _set_api_service("onesec_api", enabled=True)
+    ToolRegistry._sync_api_service_states()
+    assert tool.info.enabled is True

--- a/tests/tool/test_device_startup_sync.py
+++ b/tests/tool/test_device_startup_sync.py
@@ -1,0 +1,243 @@
+"""Regression tests for ``flocks.tool.device.startup._sync_all``.
+
+The startup sync must NOT touch pure-API integrations
+(``integration_type: api``).  Doing so was the root cause of a
+production incident where every restart silently flipped
+``api_services[<tdp_api>].enabled`` to ``False``: those services have
+no rows in ``device_integrations``, so the device-centric sync judged
+them as "0 enabled devices" and disabled them.
+
+These tests pin the behavioural contract:
+  * ``_device_type_storage_keys()`` returns only device-type keys,
+    regardless of how many api-type plugins are also installed.
+  * ``_sync_all()`` only calls ``sync_service_tool_state`` for
+    storage_keys whose plugin declares ``integration_type: device``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pytest
+import yaml
+
+from flocks.tool.device import startup
+
+
+@pytest.fixture
+def isolated_plugins(monkeypatch, tmp_path):
+    """Point plugin discovery at an empty tmp HOME so production plugins
+    on disk don't bleed into the test."""
+    from flocks.config import api_versioning as versioning
+
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(project)
+    versioning._reset_descriptor_cache()
+    yield home
+    versioning._reset_descriptor_cache()
+
+
+def _drop_plugin(
+    home: Path,
+    *,
+    integration_type: str,
+    plugin_id: str,
+    service_id: str,
+    version: str = "1.0.0",
+) -> str:
+    """Write a minimal ``_provider.yaml`` for either api/ or device/ and
+    return the resulting storage_key."""
+    subdir = "device" if integration_type == "device" else "api"
+    plugin_dir = home / ".flocks" / "plugins" / "tools" / subdir / plugin_id
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "_provider.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": plugin_id,
+                "service_id": service_id,
+                "version": version,
+                "integration_type": integration_type,
+                "credential_fields": [{"key": "base_url", "label": "Base URL"}],
+            },
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+    from flocks.config.api_versioning import derive_storage_key
+
+    return derive_storage_key(service_id, version)
+
+
+# ---------------------------------------------------------------------------
+# _device_type_storage_keys
+# ---------------------------------------------------------------------------
+
+class TestDeviceTypeStorageKeys:
+    def test_empty_when_no_plugins(self, isolated_plugins):
+        assert startup._device_type_storage_keys() == set()
+
+    def test_includes_device_excludes_api(self, isolated_plugins):
+        device_sk = _drop_plugin(
+            isolated_plugins,
+            integration_type="device",
+            plugin_id="sangfor_sip_v92",
+            service_id="sangfor_sip",
+            version="9.2",
+        )
+        api_sk = _drop_plugin(
+            isolated_plugins,
+            integration_type="api",
+            plugin_id="tdp_api_v3_3_10",
+            service_id="tdp_api",
+            version="3.3.10",
+        )
+        from flocks.config.api_versioning import (
+            discover_api_service_descriptors,
+        )
+
+        discover_api_service_descriptors(refresh=True)
+
+        keys = startup._device_type_storage_keys()
+        assert device_sk in keys
+        assert api_sk not in keys, (
+            "pure-API plugins must be excluded so the device sync loop "
+            "never touches their api_services entry"
+        )
+
+    def test_handles_unreadable_yaml(self, isolated_plugins, monkeypatch):
+        """A broken YAML must not crash the whole sweep."""
+        ok_sk = _drop_plugin(
+            isolated_plugins,
+            integration_type="device",
+            plugin_id="ok_device",
+            service_id="ok_device",
+            version="1.0.0",
+        )
+        broken_dir = (
+            isolated_plugins
+            / ".flocks" / "plugins" / "tools" / "device" / "broken_plugin"
+        )
+        broken_dir.mkdir(parents=True)
+        (broken_dir / "_provider.yaml").write_text(":\nthis is not yaml\n: : :", encoding="utf-8")
+        from flocks.config.api_versioning import (
+            discover_api_service_descriptors,
+        )
+
+        discover_api_service_descriptors(refresh=True)
+
+        keys = startup._device_type_storage_keys()
+        assert ok_sk in keys
+
+    def test_treats_unknown_type_as_non_device(self, isolated_plugins):
+        """Anything other than the literal ``"device"`` is excluded."""
+        _drop_plugin(
+            isolated_plugins,
+            integration_type="proxy",  # not a recognised type
+            plugin_id="weird_plugin",
+            service_id="weird_plugin",
+            version="1.0.0",
+        )
+        from flocks.config.api_versioning import (
+            discover_api_service_descriptors,
+        )
+
+        discover_api_service_descriptors(refresh=True)
+
+        assert startup._device_type_storage_keys() == set()
+
+
+# ---------------------------------------------------------------------------
+# _sync_all integration check via stubbing
+# ---------------------------------------------------------------------------
+
+class TestSyncAllScope:
+    @pytest.mark.asyncio
+    async def test_skips_pure_api_services_with_no_db_rows(
+        self, isolated_plugins, monkeypatch
+    ):
+        """End-to-end style: ``_sync_all`` must NOT invoke
+        ``sync_service_tool_state`` for storage_keys whose plugin is
+        pure-API.
+
+        We stub ``sync_service_tool_state`` to record invocations and
+        also stub ``Storage.connect`` + ``ConfigWriter.list_api_services_raw``
+        so we don't need a real DB or config file to drive the test.
+        """
+        device_sk = _drop_plugin(
+            isolated_plugins,
+            integration_type="device",
+            plugin_id="sangfor_sip_v92",
+            service_id="sangfor_sip",
+            version="9.2",
+        )
+        api_sk = _drop_plugin(
+            isolated_plugins,
+            integration_type="api",
+            plugin_id="tdp_api_v3_3_10",
+            service_id="tdp_api",
+            version="3.3.10",
+        )
+        from flocks.config.api_versioning import (
+            discover_api_service_descriptors,
+        )
+
+        discover_api_service_descriptors(refresh=True)
+
+        # Both keys exist in the api_services config, but only the device
+        # one should make it into the sync loop.
+        monkeypatch.setattr(
+            "flocks.config.config_writer.ConfigWriter.list_api_services_raw",
+            staticmethod(lambda: {device_sk: {"enabled": True}, api_sk: {"enabled": True}}),
+        )
+
+        # No DB rows exist (simulating: user deleted the last device of the
+        # device-type service, and the api-type service never had any rows).
+        class _FakeCursor:
+            def __init__(self, rows):
+                self._rows = rows
+
+            async def fetchall(self):
+                return self._rows
+
+        class _FakeDB:
+            async def execute(self, *_args, **_kwargs):
+                return _FakeCursor([])
+
+        class _CtxMgr:
+            async def __aenter__(self):
+                return _FakeDB()
+
+            async def __aexit__(self, *_args):
+                return False
+
+        monkeypatch.setattr(
+            "flocks.tool.device.startup.Storage.connect",
+            staticmethod(lambda *_a, **_kw: _CtxMgr()),
+        )
+        monkeypatch.setattr(
+            "flocks.tool.device.startup.Storage.get_db_path",
+            staticmethod(lambda: ":memory:"),
+        )
+
+        called_with: List[str] = []
+
+        async def _fake_sync(sid, deleted_storage_keys=None):
+            called_with.append(sid)
+
+        monkeypatch.setattr(
+            "flocks.tool.device.startup.sync_service_tool_state",
+            _fake_sync,
+        )
+
+        await startup._sync_all()
+
+        # sangfor_sip (device-type) must be synced; tdp_api must NOT be.
+        assert "sangfor_sip" in called_with
+        assert "tdp_api" not in called_with, (
+            "pure-API service tdp_api was synced by the device subsystem — "
+            "this would silently disable its tools on every restart"
+        )

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -442,7 +442,20 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
       // Probe with the form's current SSL toggle / base_url so the user can
       // validate unsaved changes immediately. Empty base_url means "fall
       // back to whatever is already in the DB".
-      const candidateBaseUrl = (fields.base_url ?? fields.baseUrl ?? '').trim();
+      // For providers that use host + port (e.g. Sangfor SIP) instead of
+      // base_url, construct the URL from those fields when available.
+      // If the operator already typed a scheme into ``host``, respect it
+      // instead of double-prefixing.
+      let candidateBaseUrl = (fields.base_url ?? fields.baseUrl ?? '').trim();
+      if (!candidateBaseUrl) {
+        const host = (fields.host ?? '').trim();
+        const port = (fields.port ?? '').trim();
+        if (host) {
+          const hasScheme = host.includes('://');
+          const prefix = hasScheme ? host : `https://${host}`;
+          candidateBaseUrl = port ? `${prefix}:${port}` : prefix;
+        }
+      }
       setTestResult(await onTest({
         verify_ssl: verifySsl,
         base_url: candidateBaseUrl || undefined,


### PR DESCRIPTION
fix(mcp): connect on first enable when server is absent from runtime

``PUT /api/mcp/{name}`` decided whether to reconnect the server based
solely on ``was_connected``. When the user installed a catalog entry
with ``enabled=false`` and then later flipped it to ``enabled=true``
via this endpoint, the runtime status dict had no entry for the server
at all, so ``was_connected`` was False and the reconnect step was
skipped. The result: the server's tools never registered into
``ToolRegistry`` and stayed invisible until the next process restart.

The new ``should_reconnect`` condition reconnects in two cases:
  1. Was already connected (existing behaviour — config change).
  2. Was not present in the runtime status at all AND the new config
     has ``enabled != False`` AND ``get_connect_block_reason`` reports
     no credential/config gap. This covers the first-enable flow
     without surprising operators by auto-connecting servers that the
     handler intentionally left in a non-running state.