### PR TITLE
fix(logs): bound local log growth

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -26,6 +26,7 @@ from typing import Iterable, Sequence
 import httpx
 
 from flocks.browser.admin import stop_all_daemons as stop_all_browser_daemons
+from flocks.utils.log import rotate_log_file
 
 try:
     import fcntl
@@ -1670,6 +1671,7 @@ def _spawn_process(
         kwargs["start_new_session"] = True
 
     log_path.parent.mkdir(parents=True, exist_ok=True)
+    rotate_log_file(log_path)
     handle = log_path.open("a", encoding="utf-8")
     try:
         return subprocess.Popen(

--- a/flocks/utils/log.py
+++ b/flocks/utils/log.py
@@ -10,6 +10,7 @@ for file output and is done by CLI or by server lifespan when run standalone.
 import os
 import sys
 import time
+import threading
 from pathlib import Path
 from typing import Any, Dict, Optional, TextIO
 from datetime import datetime
@@ -20,6 +21,8 @@ import glob as file_glob
 _DEFAULT_LOG_MAX_BYTES = 5 * 1024 * 1024
 _DEFAULT_LOG_BACKUP_COUNT = 3
 _DEFAULT_LOG_VALUE_MAX_CHARS = 8 * 1024
+_MAX_STRUCTURED_ITEMS = 50
+_MAX_STRUCTURED_DEPTH = 4
 
 
 def _log_dir() -> Path:
@@ -52,7 +55,8 @@ def get_log_max_bytes(default: int = _DEFAULT_LOG_MAX_BYTES) -> int:
     """Return the per-file log size limit in bytes.
 
     ``FLOCKS_LOG_MAX_BYTES`` is exact; ``FLOCKS_LOG_MAX_MB`` is a convenient
-    human-facing override. Values <= 0 disable rotation.
+    human-facing override. When both are set, bytes wins. Values <= 0 disable
+    rotation.
     """
     if os.getenv("FLOCKS_LOG_MAX_BYTES") is not None:
         return _env_int("FLOCKS_LOG_MAX_BYTES", default)
@@ -75,6 +79,7 @@ def rotate_log_file(
     *,
     max_bytes: Optional[int] = None,
     backup_count: Optional[int] = None,
+    force: bool = False,
 ) -> None:
     """Rotate ``path`` if it is already over the configured size limit."""
     limit = get_log_max_bytes() if max_bytes is None else max_bytes
@@ -82,7 +87,7 @@ def rotate_log_file(
     if limit <= 0 or not path.exists():
         return
     try:
-        if path.stat().st_size < limit:
+        if not force and path.stat().st_size < limit:
             return
         if backups <= 0:
             path.unlink(missing_ok=True)
@@ -105,41 +110,54 @@ class _RotatingTextWriter:
         self.max_bytes = max_bytes
         self.backup_count = backup_count
         self._handle: Optional[TextIO] = None
+        self._bytes_written = 0
+        self._lock = threading.RLock()
         self._open()
 
     def _open(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._handle = open(self.path, "a", buffering=1, encoding="utf-8")
+        try:
+            self._bytes_written = self.path.stat().st_size
+        except OSError:
+            self._bytes_written = 0
 
     def _should_rotate(self, message: str) -> bool:
         if self.max_bytes <= 0:
             return False
-        current_size = self.path.stat().st_size if self.path.exists() else 0
-        return current_size + len(message.encode("utf-8")) > self.max_bytes
+        return self._bytes_written + len(message.encode("utf-8")) > self.max_bytes
 
     def write(self, message: str) -> int:
-        if self._should_rotate(message):
-            self.close()
-            rotate_log_file(
-                self.path,
-                max_bytes=self.max_bytes,
-                backup_count=self.backup_count,
-            )
-            self._open()
-        assert self._handle is not None
-        return self._handle.write(message)
+        encoded_len = len(message.encode("utf-8"))
+        with self._lock:
+            if self._should_rotate(message):
+                self.close()
+                rotate_log_file(
+                    self.path,
+                    max_bytes=self.max_bytes,
+                    backup_count=self.backup_count,
+                    force=True,
+                )
+                self._open()
+            if self._handle is None:
+                self._open()
+            written = self._handle.write(message)
+            self._bytes_written += encoded_len
+            return written
 
     def flush(self) -> None:
-        if self._handle is not None:
-            self._handle.flush()
+        with self._lock:
+            if self._handle is not None:
+                self._handle.flush()
 
     def close(self) -> None:
-        if self._handle is not None:
-            self._handle.close()
-            self._handle = None
+        with self._lock:
+            if self._handle is not None:
+                self._handle.close()
+                self._handle = None
 
 
-def _truncate_text(value: str, max_chars: Optional[int] = None) -> str:
+def _truncate_for_log(value: str, max_chars: Optional[int] = None) -> str:
     limit = _env_int("FLOCKS_LOG_VALUE_MAX_CHARS", _DEFAULT_LOG_VALUE_MAX_CHARS) if max_chars is None else max_chars
     if limit <= 0 or len(value) <= limit:
         return value
@@ -147,15 +165,51 @@ def _truncate_text(value: str, max_chars: Optional[int] = None) -> str:
     return f"{value[:limit]}...<truncated {omitted} chars>"
 
 
+def _prepare_json_value(value: Any, *, depth: int = 0, seen: Optional[set[int]] = None) -> Any:
+    if isinstance(value, str):
+        return _truncate_for_log(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if seen is None:
+        seen = set()
+    value_id = id(value)
+    if value_id in seen:
+        return "<cycle>"
+    if depth >= _MAX_STRUCTURED_DEPTH:
+        return f"<{type(value).__name__}>"
+    if isinstance(value, dict):
+        seen.add(value_id)
+        prepared = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= _MAX_STRUCTURED_ITEMS:
+                prepared["__truncated__"] = f"{len(value) - _MAX_STRUCTURED_ITEMS} more keys"
+                break
+            prepared_key = key if key is None or isinstance(key, (str, int, float, bool)) else _truncate_for_log(str(key))
+            prepared[prepared_key] = _prepare_json_value(item, depth=depth + 1, seen=seen)
+        seen.remove(value_id)
+        return prepared
+    if isinstance(value, list):
+        seen.add(value_id)
+        prepared = [
+            _prepare_json_value(item, depth=depth + 1, seen=seen)
+            for item in value[:_MAX_STRUCTURED_ITEMS]
+        ]
+        if len(value) > _MAX_STRUCTURED_ITEMS:
+            prepared.append(f"<truncated {len(value) - _MAX_STRUCTURED_ITEMS} more items>")
+        seen.remove(value_id)
+        return prepared
+    return _truncate_for_log(str(value))
+
+
 def _format_log_value(value: Any) -> str:
     if isinstance(value, Exception):
-        return _truncate_text(Log._format_error(value))
+        return _truncate_for_log(Log._format_error(value))
     if isinstance(value, (dict, list)):
         try:
-            return _truncate_text(json.dumps(value))
+            return _truncate_for_log(json.dumps(_prepare_json_value(value)))
         except (TypeError, ValueError):
-            return _truncate_text(str(value))
-    return _truncate_text(str(value))
+            return _truncate_for_log(str(value))
+    return _truncate_for_log(str(value))
 
 
 def append_upgrade_text_log(message: str) -> None:
@@ -240,7 +294,7 @@ class Logger:
         Log._last_time = current_time_ms
         
         # Build full message
-        parts = [timestamp, f"+{diff_ms}ms", prefix, _truncate_text(str(message)) if message else ""]
+        parts = [timestamp, f"+{diff_ms}ms", prefix, _truncate_for_log(str(message)) if message else ""]
         return " ".join([p for p in parts if p]) + "\n"
     
     def debug(self, message: Any = None, extra: Optional[Dict[str, Any]] = None) -> None:
@@ -452,18 +506,33 @@ class Log:
             log_dir: Directory containing log files
         """
         try:
-            # Find all log files matching pattern YYYY-MM-DDTHHMMSS.log
+            # Find base log files matching pattern YYYY-MM-DDTHHMMSS.log.
+            # Rotated siblings are deleted together with their base file so
+            # old ``.log.1``/``.log.2`` files do not leak forever.
             pattern = str(log_dir / "????-??-??T??????.log")
-            files = sorted(file_glob.glob(pattern))
+            files = [Path(path) for path in sorted(file_glob.glob(pattern))]
             
             # Keep only the 10 most recent
             if len(files) > 10:
                 files_to_delete = files[:-10]
-                for file_path in files_to_delete:
+                for path in files_to_delete:
                     try:
-                        Path(file_path).unlink()
+                        path.unlink(missing_ok=True)
+                        for rotated in path.parent.glob(f"{path.name}.*"):
+                            rotated.unlink(missing_ok=True)
                     except Exception:
                         pass  # Silently ignore deletion errors
+
+            kept_files = set(files[-10:])
+            rotated_pattern = str(log_dir / "????-??-??T??????.log.*")
+            for rotated_path in (Path(path) for path in file_glob.glob(rotated_pattern)):
+                base_name = rotated_path.name.split(".log.", 1)[0] + ".log"
+                base_path = rotated_path.with_name(base_name)
+                if base_path not in kept_files and not base_path.exists():
+                    try:
+                        rotated_path.unlink(missing_ok=True)
+                    except Exception:
+                        pass
         except Exception:
             pass  # Silently ignore cleanup errors
     

--- a/flocks/utils/log.py
+++ b/flocks/utils/log.py
@@ -17,6 +17,11 @@ import json
 import glob as file_glob
 
 
+_DEFAULT_LOG_MAX_BYTES = 5 * 1024 * 1024
+_DEFAULT_LOG_BACKUP_COUNT = 3
+_DEFAULT_LOG_VALUE_MAX_CHARS = 8 * 1024
+
+
 def _log_dir() -> Path:
     """Log directory: FLOCKS_LOG_DIR, or FLOCKS_ROOT/logs, or ~/.flocks/logs. Matches config."""
     raw = os.getenv("FLOCKS_LOG_DIR")
@@ -31,6 +36,126 @@ def _log_dir() -> Path:
 def get_log_dir() -> Path:
     """Return the log directory for file handlers (e.g. workflow). Same as Log.init() uses."""
     return _log_dir()
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def get_log_max_bytes(default: int = _DEFAULT_LOG_MAX_BYTES) -> int:
+    """Return the per-file log size limit in bytes.
+
+    ``FLOCKS_LOG_MAX_BYTES`` is exact; ``FLOCKS_LOG_MAX_MB`` is a convenient
+    human-facing override. Values <= 0 disable rotation.
+    """
+    if os.getenv("FLOCKS_LOG_MAX_BYTES") is not None:
+        return _env_int("FLOCKS_LOG_MAX_BYTES", default)
+    max_mb = os.getenv("FLOCKS_LOG_MAX_MB")
+    if max_mb is not None:
+        try:
+            return int(float(max_mb) * 1024 * 1024)
+        except ValueError:
+            return default
+    return default
+
+
+def get_log_backup_count(default: int = _DEFAULT_LOG_BACKUP_COUNT) -> int:
+    """Return how many rotated backups to keep for long-lived log files."""
+    return max(0, _env_int("FLOCKS_LOG_BACKUP_COUNT", default))
+
+
+def rotate_log_file(
+    path: Path,
+    *,
+    max_bytes: Optional[int] = None,
+    backup_count: Optional[int] = None,
+) -> None:
+    """Rotate ``path`` if it is already over the configured size limit."""
+    limit = get_log_max_bytes() if max_bytes is None else max_bytes
+    backups = get_log_backup_count() if backup_count is None else backup_count
+    if limit <= 0 or not path.exists():
+        return
+    try:
+        if path.stat().st_size < limit:
+            return
+        if backups <= 0:
+            path.unlink(missing_ok=True)
+            return
+        for index in range(backups - 1, 0, -1):
+            src = path.with_name(f"{path.name}.{index}")
+            dst = path.with_name(f"{path.name}.{index + 1}")
+            if src.exists():
+                src.replace(dst)
+        path.replace(path.with_name(f"{path.name}.1"))
+    except OSError:
+        return
+
+
+class _RotatingTextWriter:
+    """Small line-buffered writer with size-based rotation for Flocks logs."""
+
+    def __init__(self, path: Path, *, max_bytes: int, backup_count: int):
+        self.path = path
+        self.max_bytes = max_bytes
+        self.backup_count = backup_count
+        self._handle: Optional[TextIO] = None
+        self._open()
+
+    def _open(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = open(self.path, "a", buffering=1, encoding="utf-8")
+
+    def _should_rotate(self, message: str) -> bool:
+        if self.max_bytes <= 0:
+            return False
+        current_size = self.path.stat().st_size if self.path.exists() else 0
+        return current_size + len(message.encode("utf-8")) > self.max_bytes
+
+    def write(self, message: str) -> int:
+        if self._should_rotate(message):
+            self.close()
+            rotate_log_file(
+                self.path,
+                max_bytes=self.max_bytes,
+                backup_count=self.backup_count,
+            )
+            self._open()
+        assert self._handle is not None
+        return self._handle.write(message)
+
+    def flush(self) -> None:
+        if self._handle is not None:
+            self._handle.flush()
+
+    def close(self) -> None:
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+
+def _truncate_text(value: str, max_chars: Optional[int] = None) -> str:
+    limit = _env_int("FLOCKS_LOG_VALUE_MAX_CHARS", _DEFAULT_LOG_VALUE_MAX_CHARS) if max_chars is None else max_chars
+    if limit <= 0 or len(value) <= limit:
+        return value
+    omitted = len(value) - limit
+    return f"{value[:limit]}...<truncated {omitted} chars>"
+
+
+def _format_log_value(value: Any) -> str:
+    if isinstance(value, Exception):
+        return _truncate_text(Log._format_error(value))
+    if isinstance(value, (dict, list)):
+        try:
+            return _truncate_text(json.dumps(value))
+        except (TypeError, ValueError):
+            return _truncate_text(str(value))
+    return _truncate_text(str(value))
 
 
 def append_upgrade_text_log(message: str) -> None:
@@ -101,14 +226,7 @@ class Logger:
         # Build prefix (key=value pairs)
         prefix_parts = []
         for key, value in all_tags.items():
-            if isinstance(value, Exception):
-                # Format error with message and cause chain
-                prefix_parts.append(f"{key}={Log._format_error(value)}")
-            elif isinstance(value, dict):
-                # JSON stringify objects
-                prefix_parts.append(f"{key}={json.dumps(value)}")
-            else:
-                prefix_parts.append(f"{key}={value}")
+            prefix_parts.append(f"{key}={_format_log_value(value)}")
         
         prefix = " ".join(prefix_parts)
         
@@ -122,7 +240,7 @@ class Logger:
         Log._last_time = current_time_ms
         
         # Build full message
-        parts = [timestamp, f"+{diff_ms}ms", prefix, str(message) if message else ""]
+        parts = [timestamp, f"+{diff_ms}ms", prefix, _truncate_text(str(message)) if message else ""]
         return " ".join([p for p in parts if p]) + "\n"
     
     def debug(self, message: Any = None, extra: Optional[Dict[str, Any]] = None) -> None:
@@ -315,8 +433,12 @@ class Log:
         if cls._log_file.exists():
             cls._log_file.write_text("")
         
-        # Open for writing
-        cls._writer = open(cls._log_file, "a", buffering=1)  # Line buffered
+        # Open for writing with size-based rotation for long-running sessions.
+        cls._writer = _RotatingTextWriter(
+            cls._log_file,
+            max_bytes=get_log_max_bytes(),
+            backup_count=get_log_backup_count(),
+        )
         
         # Create default logger
         cls.Default = cls.create(service="default")

--- a/flocks/workflow/logging_config.py
+++ b/flocks/workflow/logging_config.py
@@ -6,10 +6,10 @@ Workflow logs go to stderr and, when file logging is enabled, to
 
 import logging
 import sys
-from pathlib import Path
+from logging.handlers import RotatingFileHandler
 from typing import Optional
 
-from flocks.utils.log import get_log_dir
+from flocks.utils.log import get_log_backup_count, get_log_dir, get_log_max_bytes
 
 
 def setup_workflow_logging(
@@ -54,8 +54,11 @@ def setup_workflow_logging(
         try:
             log_dir = get_log_dir()
             log_dir.mkdir(parents=True, exist_ok=True)
-            file_handler = logging.FileHandler(
-                log_dir / "workflow.log", mode="a", encoding="utf-8"
+            file_handler = RotatingFileHandler(
+                log_dir / "workflow.log",
+                maxBytes=get_log_max_bytes(),
+                backupCount=get_log_backup_count(),
+                encoding="utf-8",
             )
             file_handler.setLevel(level)
             file_handler.setFormatter(formatter)

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -1282,6 +1282,27 @@ def test_spawn_process_uses_new_session_on_non_windows(monkeypatch, tmp_path: Pa
     assert "startupinfo" not in captured["kwargs"]
 
 
+def test_spawn_process_rotates_large_log_before_append(monkeypatch, tmp_path: Path) -> None:
+    log_path = tmp_path / "logs" / "backend.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("x" * 20, encoding="utf-8")
+
+    def fake_popen(*args, **kwargs):
+        kwargs["stdout"].write("new\n")
+        kwargs["stdout"].flush()
+        return SimpleNamespace(pid=9876)
+
+    monkeypatch.setenv("FLOCKS_LOG_MAX_BYTES", "10")
+    monkeypatch.setenv("FLOCKS_LOG_BACKUP_COUNT", "1")
+    monkeypatch.setattr(service_manager.sys, "platform", "darwin")
+    monkeypatch.setattr(service_manager.subprocess, "Popen", fake_popen)
+
+    service_manager._spawn_process(["python", "-m", "uvicorn"], cwd=tmp_path, log_path=log_path)
+
+    assert log_path.read_text(encoding="utf-8") == "new\n"
+    assert (tmp_path / "logs" / "backend.log.1").read_text(encoding="utf-8") == "x" * 20
+
+
 def test_spawn_process_passes_custom_environment(monkeypatch, tmp_path: Path) -> None:
     captured = {}
     log_path = tmp_path / "logs" / "backend.log"

--- a/tests/tool/test_logging_noise.py
+++ b/tests/tool/test_logging_noise.py
@@ -121,7 +121,11 @@ def test_tool_registry_api_service_sync_logs_at_debug(monkeypatch) -> None:
     assert tool.info.enabled is False
     event, payload = logger.debug.call_args.args
     assert event == "tool_registry.api_service_sync"
-    assert payload == {"disabled_tools": 1, "disabled_providers": ["svc"]}
+    assert payload == {
+        "disabled_tools": 1,
+        "disabled_providers": ["svc"],
+        "restored_tools": 0,
+    }
     logger.info.assert_not_called()
 
 

--- a/tests/utils/test_log_compatibility.py
+++ b/tests/utils/test_log_compatibility.py
@@ -6,7 +6,7 @@ import pytest
 import time
 import tempfile
 from pathlib import Path
-from flocks.utils.log import Log, Logger, LogLevel, rotate_log_file
+from flocks.utils.log import Log, Logger, LogLevel, _RotatingTextWriter, rotate_log_file
 
 
 class TestLoggerCompatibility:
@@ -260,6 +260,22 @@ class TestLoggerCompatibility:
 
         assert (tmp_path / "backend.log.1").read_text(encoding="utf-8") == "y" * 20
         assert (tmp_path / "backend.log.2").read_text(encoding="utf-8") == "x" * 20
+
+    def test_rotating_text_writer_rotates_during_log_writes(self, tmp_path: Path):
+        """Test Log's writer rotates when the next line would exceed the limit."""
+        log_path = tmp_path / "session.log"
+        writer = _RotatingTextWriter(log_path, max_bytes=12, backup_count=1)
+
+        try:
+            writer.write("first\n")
+            writer.flush()
+            writer.write("second\n")
+            writer.flush()
+        finally:
+            writer.close()
+
+        assert log_path.read_text(encoding="utf-8") == "second\n"
+        assert (tmp_path / "session.log.1").read_text(encoding="utf-8") == "first\n"
     
     def test_time_diff_calculation(self):
         """Test time difference calculation between logs"""
@@ -346,6 +362,20 @@ class TestLogInitialization:
         """Test log file path method"""
         file_path = Log.file()
         assert file_path.endswith("flocks.log") or "flocks" in file_path
+
+    async def test_cleanup_removes_rotated_siblings_for_old_timestamp_logs(self, tmp_path: Path):
+        """Test cleanup deletes rotated backups for base files outside retention."""
+        for day in range(11):
+            base = tmp_path / f"2026-05-{day + 1:02d}T010203.log"
+            base.write_text("base", encoding="utf-8")
+            (tmp_path / f"{base.name}.1").write_text("rotated", encoding="utf-8")
+
+        await Log._cleanup(tmp_path)
+
+        assert not (tmp_path / "2026-05-01T010203.log").exists()
+        assert not (tmp_path / "2026-05-01T010203.log.1").exists()
+        assert (tmp_path / "2026-05-02T010203.log").exists()
+        assert (tmp_path / "2026-05-02T010203.log.1").exists()
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_log_compatibility.py
+++ b/tests/utils/test_log_compatibility.py
@@ -6,7 +6,7 @@ import pytest
 import time
 import tempfile
 from pathlib import Path
-from flocks.utils.log import Log, Logger, LogLevel
+from flocks.utils.log import Log, Logger, LogLevel, rotate_log_file
 
 
 class TestLoggerCompatibility:
@@ -225,6 +225,41 @@ class TestLoggerCompatibility:
             assert 'data={"nested": "value"}' in output or 'data={"nested":"value"}' in output
         finally:
             Log._writer = old_stderr
+
+    def test_large_object_values_are_truncated(self, monkeypatch):
+        """Test large objects are bounded before being written to logs."""
+        logger = Log.create(service="test")
+
+        import io
+        old_stderr = Log._writer
+        Log._writer = io.StringIO()
+        monkeypatch.setenv("FLOCKS_LOG_VALUE_MAX_CHARS", "20")
+
+        try:
+            logger.info("message", {"data": {"payload": "x" * 100}})
+            output = Log._writer.getvalue()
+
+            assert "data=" in output
+            assert "<truncated" in output
+            assert len(output) < 200
+        finally:
+            Log._writer = old_stderr
+
+    def test_rotate_log_file_keeps_bounded_backups(self, tmp_path: Path):
+        """Test oversized runtime logs rotate before another process appends."""
+        log_path = tmp_path / "backend.log"
+        log_path.write_text("x" * 20, encoding="utf-8")
+
+        rotate_log_file(log_path, max_bytes=10, backup_count=2)
+
+        assert not log_path.exists()
+        assert (tmp_path / "backend.log.1").read_text(encoding="utf-8") == "x" * 20
+
+        log_path.write_text("y" * 20, encoding="utf-8")
+        rotate_log_file(log_path, max_bytes=10, backup_count=2)
+
+        assert (tmp_path / "backend.log.1").read_text(encoding="utf-8") == "y" * 20
+        assert (tmp_path / "backend.log.2").read_text(encoding="utf-8") == "x" * 20
     
     def test_time_diff_calculation(self):
         """Test time difference calculation between logs"""
@@ -233,6 +268,7 @@ class TestLoggerCompatibility:
         import io
         old_stderr = Log._writer
         Log._writer = io.StringIO()
+        Log._last_time = int(time.time() * 1000)
         
         try:
             logger.info("first")

--- a/tests/workflow/test_logging_config.py
+++ b/tests/workflow/test_logging_config.py
@@ -1,0 +1,24 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from flocks.workflow.logging_config import setup_workflow_logging
+
+
+def test_workflow_file_logging_uses_rotating_handler(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("FLOCKS_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("FLOCKS_LOG_MAX_BYTES", "1234")
+    monkeypatch.setenv("FLOCKS_LOG_BACKUP_COUNT", "2")
+
+    setup_workflow_logging(stream=None)
+
+    logger = logging.getLogger("flocks.workflow")
+    handlers = [handler for handler in logger.handlers if isinstance(handler, RotatingFileHandler)]
+
+    try:
+        assert len(handlers) == 1
+        assert handlers[0].baseFilename == str(tmp_path / "workflow.log")
+        assert handlers[0].maxBytes == 1234
+        assert handlers[0].backupCount == 2
+    finally:
+        logger.handlers.clear()


### PR DESCRIPTION
Add size-based rotation and payload truncation so long-running local services cannot grow log files without limit.