### PR TITLE
fix(session): reject tool-call title payloads

### DIFF
--- a/flocks/session/lifecycle/title.py
+++ b/flocks/session/lifecycle/title.py
@@ -7,6 +7,8 @@ Based on Flocks' ported src/session/title.ts
 
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 import asyncio
+import json
+import re
 
 from flocks.utils.log import Log
 from flocks.provider.provider import ChatMessage
@@ -22,6 +24,14 @@ from flocks.session.prompt_strings import PROMPT_TITLE as _CANONICAL_TITLE_PROMP
 
 class SessionTitle:
     """Session title generation"""
+
+    _TOOL_CALL_TITLE_PATTERNS = (
+        re.compile(r"^\s*\[TOOL_CALL\]", re.IGNORECASE),
+        re.compile(r"^\s*<tool[_ -]?call", re.IGNORECASE),
+        re.compile(r"\btool\s*=>", re.IGNORECASE),
+        re.compile(r"\bargs\s*=>", re.IGNORECASE),
+        re.compile(r"^\s*\{?\s*(tool|name)\s*=>", re.IGNORECASE),
+    )
     
     @classmethod
     async def generate_title_after_first_message(
@@ -138,13 +148,8 @@ class SessionTitle:
                     "error": str(llm_err),
                 })
             
-            # Clean up the generated title
-            title = title.strip().strip('"').strip("'").strip()
-            
-            # Validate title length
-            if len(title) > 50:
-                title = title[:47] + "..."
-            
+            title = cls._sanitize_generated_title(title)
+
             if not title:
                 title = cls._generate_simple_title(question)
             
@@ -233,3 +238,70 @@ class SessionTitle:
             title = "New Chat"
         
         return title
+
+    @classmethod
+    def _sanitize_generated_title(cls, title: str, max_length: int = 50) -> str:
+        """Clean and validate a model-generated title candidate."""
+        title = title.strip().strip('"').strip("'").strip()
+        if not title:
+            return ""
+
+        if cls._looks_like_tool_call_title(title):
+            log.warn("title.rejected_tool_call_candidate", {
+                "candidate": title[:120],
+            })
+            return ""
+
+        if len(title) > max_length:
+            title = title[:max_length - 3] + "..."
+        return title
+
+    @classmethod
+    def _looks_like_tool_call_title(cls, title: str) -> bool:
+        """Return True when a title candidate is actually a tool-call payload."""
+        candidate = title.strip()
+        if not candidate:
+            return False
+
+        for pattern in cls._TOOL_CALL_TITLE_PATTERNS:
+            if pattern.search(candidate):
+                return True
+
+        json_candidate = cls._strip_code_fence(candidate)
+        if not json_candidate.startswith(("{", "[")):
+            return False
+
+        try:
+            parsed = json.loads(json_candidate)
+        except (TypeError, ValueError):
+            return False
+
+        return cls._json_has_tool_call_shape(parsed)
+
+    @staticmethod
+    def _strip_code_fence(text: str) -> str:
+        stripped = text.strip()
+        if not stripped.startswith("```"):
+            return stripped
+
+        lines = stripped.splitlines()
+        if len(lines) >= 2 and lines[-1].strip() == "```":
+            return "\n".join(lines[1:-1]).strip()
+        return stripped
+
+    @classmethod
+    def _json_has_tool_call_shape(cls, value: Any) -> bool:
+        if isinstance(value, dict):
+            keys = {str(key).lower() for key in value.keys()}
+            if {"tool", "args"} <= keys:
+                return True
+            if {"name", "arguments"} <= keys:
+                return True
+            if "function" in keys and ("arguments" in keys or "name" in keys):
+                return True
+            return any(cls._json_has_tool_call_shape(item) for item in value.values())
+
+        if isinstance(value, list):
+            return any(cls._json_has_tool_call_shape(item) for item in value)
+
+        return False

--- a/tests/session/test_cli_title_generation.py
+++ b/tests/session/test_cli_title_generation.py
@@ -81,6 +81,48 @@ class TestGenerateTitleAfterFirstMessage:
         mock_update.assert_awaited_once_with("proj-1", "sess-1", title="Debug Python")
 
     @pytest.mark.asyncio
+    async def test_rejects_tool_call_payload_title_and_falls_back(self):
+        """Tool-call payloads from the title model are not persisted as titles."""
+        from flocks.session.lifecycle.title import SessionTitle
+
+        question = (
+            "based on ThreatBook Threat Intelligence, please give me reports for "
+            "cyber news related to Hong Kong for the past 7 days"
+        )
+        mock_session = _make_session()
+        msg, part = _make_user_msg(question)
+        mock_provider = MagicMock()
+
+        async def fake_stream(*args, **kwargs):
+            yield MagicMock(delta='[TOOL_CALL]\n{tool => "news", args => {\n  --query: "Hong Kong"\n}}')
+
+        mock_provider.chat_stream = fake_stream
+        mock_update = AsyncMock()
+
+        patches = _patch_title_deps(mock_session, [msg], [part], mock_provider, mock_update)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            title = await SessionTitle.generate_title_after_first_message(
+                session_id="sess-1",
+                model_id="minimax-m2.7",
+                provider_id="threatbook-cn-llm",
+            )
+
+        expected = SessionTitle._generate_simple_title(question)
+        assert title == expected
+        assert "TOOL_CALL" not in title
+        mock_update.assert_awaited_once_with("proj-1", "sess-1", title=expected)
+
+    def test_rejects_json_function_call_title_candidate(self):
+        """Structured function-call shaped JSON is invalid as a thread title."""
+        from flocks.session.lifecycle.title import SessionTitle
+
+        title = SessionTitle._sanitize_generated_title(
+            '{"name": "news", "arguments": {"query": "Hong Kong"}}'
+        )
+
+        assert title == ""
+
+    @pytest.mark.asyncio
     async def test_skips_when_more_than_one_user_message(self):
         """Returns None when there are 2+ user messages (not the first turn)."""
         from flocks.session.lifecycle.title import SessionTitle


### PR DESCRIPTION
## Summary
- Prevent title-generation responses like `[TOOL_CALL]...` from being persisted as session titles.
- Add validation for tool-call shaped title candidates and fall back to the first user prompt summary.
- Cover malformed tool-call and JSON function-call title outputs with regression tests.

## Test plan
- `source .venv/bin/activate && pytest tests/session/test_cli_title_generation.py`
- Verified the original minimal repro no longer stores `TOOL_CALL` in the generated title.