### PR TITLE
fix(session): merge per-message and legacy parts on read

### DIFF
--- a/flocks/session/message.py
+++ b/flocks/session/message.py
@@ -485,6 +485,91 @@ class Message:
         return serialized
 
     @classmethod
+    def _merge_serialized_parts(
+        cls,
+        primary_parts: Optional[List[Dict[str, Any]]],
+        fallback_parts: Optional[List[Dict[str, Any]]],
+    ) -> List[Dict[str, Any]]:
+        """Merge mixed-format part lists without rewriting storage.
+
+        ``primary_parts`` is the preferred source (per-message keys).  When it is
+        missing entries, ``fallback_parts`` (legacy blob) fills the gaps by part
+        ID while preserving the legacy order for shared entries.
+        """
+        if not isinstance(primary_parts, list) or not primary_parts:
+            return list(fallback_parts or [])
+        if not isinstance(fallback_parts, list) or not fallback_parts:
+            return list(primary_parts)
+
+        primary_by_id: Dict[str, Dict[str, Any]] = {}
+        for raw_part in primary_parts:
+            if not isinstance(raw_part, dict):
+                continue
+            part_id = raw_part.get("id")
+            if isinstance(part_id, str) and part_id:
+                primary_by_id[part_id] = dict(raw_part)
+
+        merged: List[Dict[str, Any]] = []
+        consumed_primary_ids: set[str] = set()
+
+        for raw_part in fallback_parts:
+            if not isinstance(raw_part, dict):
+                continue
+            part_id = raw_part.get("id")
+            if isinstance(part_id, str) and part_id in primary_by_id:
+                merged.append(primary_by_id[part_id])
+                consumed_primary_ids.add(part_id)
+            else:
+                merged.append(dict(raw_part))
+
+        for raw_part in primary_parts:
+            if not isinstance(raw_part, dict):
+                continue
+            part_id = raw_part.get("id")
+            if isinstance(part_id, str) and part_id:
+                if part_id in consumed_primary_ids:
+                    continue
+            merged.append(dict(raw_part))
+
+        return merged
+
+    @classmethod
+    def _deserialize_parts_list(
+        cls,
+        session_id: str,
+        message_id: str,
+        parts_data: List[Dict[str, Any]],
+    ) -> List[PartType]:
+        """Best-effort deserialize a message's stored parts."""
+        parts: List[PartType] = []
+        for index, raw_part in enumerate(parts_data):
+            if not isinstance(raw_part, dict):
+                log.debug("message.part.deserialize_skipped", {
+                    "session_id": session_id,
+                    "message_id": message_id,
+                    "index": index,
+                    "reason": "non_dict_part",
+                })
+                continue
+
+            normalized_part = dict(raw_part)
+            normalized_part["sessionID"] = session_id
+            normalized_part["messageID"] = message_id
+
+            try:
+                parts.append(cls.deserialize_part(normalized_part))
+            except Exception as exc:
+                log.warn("message.part.deserialize_failed", {
+                    "session_id": session_id,
+                    "message_id": message_id,
+                    "index": index,
+                    "part_id": normalized_part.get("id"),
+                    "type": normalized_part.get("type"),
+                    "error": str(exc),
+                })
+        return parts
+
+    @classmethod
     def _touch_parts_revision(cls, session_id: str, message_id: str) -> int:
         revisions = cls._parts_revision_cache.setdefault(session_id, {})
         next_revision = int(revisions.get(message_id, 0)) + 1
@@ -609,8 +694,8 @@ class Message:
                 cls._messages_cache[session_id] = []
             
             item_entries = await Storage.list_entries(prefix=cls._parts_item_prefix(session_id))
-            stored_parts: Dict[str, List[Dict[str, Any]]] = {}
-            persisted_mids: set[str] = set()
+            per_message_parts: Dict[str, List[Dict[str, Any]]] = {}
+            per_message_mids: set[str] = set()
 
             for key, value in item_entries:
                 if not cls._is_parts_item_key(key, session_id):
@@ -618,19 +703,38 @@ class Message:
                 if not isinstance(value, list):
                     continue
                 msg_id = key.rsplit(":", 1)[1]
-                stored_parts[msg_id] = value
-                persisted_mids.add(msg_id)
+                per_message_parts[msg_id] = value
+                per_message_mids.add(msg_id)
 
-            if stored_parts:
-                cls._parts_storage_format[session_id] = "per_message"
-            else:
-                legacy_parts = await Storage.get(cls._parts_blob_key(session_id))
-                if isinstance(legacy_parts, dict):
-                    stored_parts = legacy_parts
-                    persisted_mids = set(legacy_parts.keys())
+            legacy_parts: Dict[str, List[Dict[str, Any]]] = {}
+            cls._parts_storage_format[session_id] = "per_message"
+
+            legacy_blob = await Storage.get(cls._parts_blob_key(session_id))
+            if isinstance(legacy_blob, dict):
+                legacy_parts = {
+                    msg_id: parts_data
+                    for msg_id, parts_data in legacy_blob.items()
+                    if isinstance(parts_data, list)
+                }
+                if not per_message_parts:
                     cls._parts_storage_format[session_id] = "legacy"
-                else:
-                    cls._parts_storage_format[session_id] = "per_message"
+
+            stored_parts: Dict[str, List[Dict[str, Any]]] = {}
+            all_message_ids = {
+                message.id for message in cls._messages_cache.get(session_id, [])
+            }
+            all_message_ids.update(per_message_parts.keys())
+            all_message_ids.update(legacy_parts.keys())
+
+            for msg_id in all_message_ids:
+                merged_parts = cls._merge_serialized_parts(
+                    per_message_parts.get(msg_id),
+                    legacy_parts.get(msg_id),
+                )
+                if merged_parts:
+                    stored_parts[msg_id] = merged_parts
+
+            persisted_mids = set(stored_parts.keys())
             
             if stored_parts:
                 cls._parts_cache[session_id] = {}
@@ -638,9 +742,11 @@ class Message:
                 for msg_id, parts_data in stored_parts.items():
                     if not isinstance(parts_data, list):
                         continue
-                    cls._parts_cache[session_id][msg_id] = [
-                        cls.deserialize_part(p) for p in parts_data
-                    ]
+                    cls._parts_cache[session_id][msg_id] = cls._deserialize_parts_list(
+                        session_id,
+                        msg_id,
+                        parts_data,
+                    )
                     cls._parts_revision_cache[session_id][msg_id] = 0
                 cls._parts_serialized_cache[session_id] = {
                     msg_id: list(parts_data)

--- a/tests/session/test_message_parts_persistence.py
+++ b/tests/session/test_message_parts_persistence.py
@@ -22,9 +22,15 @@ def _user_message(session_id: str, message_id: str) -> UserMessageInfo:
     )
 
 
-def _text_part(session_id: str, message_id: str, text: str) -> TextPart:
+def _text_part(
+    session_id: str,
+    message_id: str,
+    text: str,
+    *,
+    part_id: str | None = None,
+) -> TextPart:
     return TextPart(
-        id=f"part_{message_id}",
+        id=part_id or f"part_{message_id}",
         sessionID=session_id,
         messageID=message_id,
         text=text,
@@ -92,6 +98,47 @@ async def test_legacy_session_updates_continue_writing_legacy_blob() -> None:
     legacy_parts = await Storage.get(f"message_parts:{session_id}")
     assert legacy_parts["msg_a"][0]["text"] == "new"
     assert await Storage.list_keys(prefix=f"message_parts:{session_id}:") == []
+
+
+@pytest.mark.asyncio
+async def test_mixed_session_reads_per_message_and_legacy_fallback() -> None:
+    session_id = "ses_parts_mixed_read"
+    serialized_messages = [
+        _user_message(session_id, "msg_a").model_dump(),
+        _user_message(session_id, "msg_b").model_dump(),
+    ]
+    legacy_parts = {
+        "msg_a": [
+            _text_part(session_id, "msg_a", "legacy-a1", part_id="part_a1").model_dump(),
+            _text_part(session_id, "msg_a", "legacy-a2", part_id="part_a2").model_dump(),
+        ],
+        "msg_b": [
+            _text_part(session_id, "msg_b", "legacy-b1", part_id="part_b1").model_dump(),
+        ],
+    }
+    per_message_msg_a = [
+        _text_part(session_id, "msg_a", "new-a2", part_id="part_a2").model_dump(),
+    ]
+
+    await Storage.set(f"message:{session_id}", serialized_messages, "message")
+    await Storage.set(f"message_parts:{session_id}", legacy_parts, "message_parts")
+    await Storage.set(
+        f"message_parts:{session_id}:msg_a",
+        per_message_msg_a,
+        "message_part",
+    )
+    Message.invalidate_cache(session_id)
+
+    messages = await Message.list_with_parts(session_id)
+    by_id = {message.info.id: message for message in messages}
+
+    assert [part.id for part in by_id["msg_a"].parts] == ["part_a1", "part_a2"]
+    assert [part.text for part in by_id["msg_a"].parts] == ["legacy-a1", "new-a2"]
+    assert [part.id for part in by_id["msg_b"].parts] == ["part_b1"]
+    assert [part.text for part in by_id["msg_b"].parts] == ["legacy-b1"]
+
+    assert await Storage.get(f"message_parts:{session_id}") == legacy_parts
+    assert await Storage.get(f"message_parts:{session_id}:msg_a") == per_message_msg_a
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- When a session has both per-message `message_parts:{session}:{msg}` keys and a legacy `message_parts:{session}` blob, hydrate messages by merging parts by ID instead of preferring one storage format exclusively.
- Per-message entries win for shared part IDs; legacy order is preserved for the merged list; storage layout is not rewritten on read.
- Part cache loading uses best-effort deserialization with logging instead of failing the whole message on a single bad part.