### PR TITLE
fix(webui): enforce workflow session cap on all localStorage writes

### DIFF
--- a/webui/src/pages/WorkflowDetail/index.test.tsx
+++ b/webui/src/pages/WorkflowDetail/index.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { buildSessionsPath, resolveWorkflowSessionId } from './index';
-import { pushStoredSession } from './sessionStorage';
+import { getStoredSessions, pushStoredSession, setStoredSessions } from './sessionStorage';
 
 describe('WorkflowDetail', () => {
   beforeEach(() => {
@@ -25,5 +25,21 @@ describe('WorkflowDetail', () => {
 
     const sessionId = resolveWorkflowSessionId(null, 'wf-1');
     expect(buildSessionsPath(sessionId)).toBe('/sessions?session=session-123');
+  });
+
+  it('覆盖本地历史时会限制最大会话数量', () => {
+    setStoredSessions(
+      'wf-1',
+      Array.from({ length: 20 }, (_, index) => ({
+        id: `session-${index}`,
+        title: `会话 ${index}`,
+        createdAt: index,
+      })),
+    );
+
+    const sessions = getStoredSessions('wf-1');
+    expect(sessions).toHaveLength(15);
+    expect(sessions[0]?.id).toBe('session-0');
+    expect(sessions[14]?.id).toBe('session-14');
   });
 });

--- a/webui/src/pages/WorkflowDetail/sessionStorage.ts
+++ b/webui/src/pages/WorkflowDetail/sessionStorage.ts
@@ -10,6 +10,13 @@ function lsKey(workflowId: string) {
   return `wf-sessions-${workflowId}`;
 }
 
+export function setStoredSessions(workflowId: string, sessions: StoredSession[]) {
+  localStorage.setItem(
+    lsKey(workflowId),
+    JSON.stringify(sessions.slice(0, MAX_STORED_SESSIONS)),
+  );
+}
+
 export function getStoredSessions(workflowId: string): StoredSession[] {
   try {
     const raw = localStorage.getItem(lsKey(workflowId));
@@ -27,8 +34,5 @@ export function getLatestStoredSessionId(workflowId: string): string | null {
 
 export function pushStoredSession(workflowId: string, session: StoredSession) {
   const existing = getStoredSessions(workflowId).filter((stored) => stored.id !== session.id);
-  localStorage.setItem(
-    lsKey(workflowId),
-    JSON.stringify([session, ...existing].slice(0, MAX_STORED_SESSIONS)),
-  );
+  setStoredSessions(workflowId, [session, ...existing]);
 }

--- a/webui/src/pages/WorkflowDetail/tabs/ChatTab.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/ChatTab.tsx
@@ -8,7 +8,12 @@ import type { ImagePartData } from '@/utils/imageUpload';
 import { workflowAPI, Workflow, WorkflowExecution, WorkflowNode } from '@/api/workflow';
 import { formatSessionDate } from '@/utils/time';
 import client from '@/api/client';
-import { getStoredSessions, pushStoredSession, type StoredSession } from '../sessionStorage';
+import {
+  getStoredSessions,
+  pushStoredSession,
+  setStoredSessions,
+  type StoredSession,
+} from '../sessionStorage';
 
 const FALLBACK_POLL_MS = 30_000;
 
@@ -102,7 +107,7 @@ export default function ChatTab({
             break; // found a valid one, stop
           } catch { /* continue */ }
         }
-        localStorage.setItem(lsKey(workflow.id), JSON.stringify(valid));
+        setStoredSessions(workflow.id, valid);
         setSessions(valid);
         if (valid.length > 0) {
           setActiveSessionId(valid[0].id);


### PR DESCRIPTION
## Summary
- Add `setStoredSessions` so every workflow session list write applies `MAX_STORED_SESSIONS` (15).
- Route `pushStoredSession` and ChatTab validation persistence through the shared helper instead of direct `localStorage.setItem`.
- Add a unit test that bulk overwrites are trimmed to the cap.