### PR TITLE
fix(device): per-device tool enable/disable isolation

### DIFF
--- a/flocks/server/routes/device.py
+++ b/flocks/server/routes/device.py
@@ -30,15 +30,18 @@ from flocks.tool.device.secrets import delete_secrets, persist_fields, resolve_f
 from flocks.tool.device.store import (
     create_group,
     delete_device_row,
+    delete_device_tool_setting,
     delete_group,
     fetch_device,
     get_group,
     group_exists,
     insert_device,
+    list_device_tool_settings,
     list_devices,
     list_groups,
     record_test_result,
     row_to_device,
+    set_device_tool_enabled,
     storage_key_to_service_id,
     update_device_row,
     update_group,
@@ -220,7 +223,137 @@ async def route_delete_device(device_id: str):
 
     delete_secrets(device_id, db_fields)
     await delete_device_row(device_id)
+    # Per-device tool settings are cleaned up automatically via
+    # ON DELETE CASCADE on the device_tool_settings table.
     await sync_service_tool_state(service_id, deleted_storage_keys=[storage_key])
+
+
+# ===========================================================================
+# Per-device tool settings routes
+# ===========================================================================
+
+class DeviceToolInfo(BaseModel):
+    """Tool information with per-device enabled state."""
+    name: str
+    description: str
+    description_cn: Optional[str] = None
+    enabled_global: bool = Field(
+        ...,
+        description="全局工具开关状态（影响所有同版本设备）",
+    )
+    enabled_device: Optional[bool] = Field(
+        None,
+        description=(
+            "本设备的工具开关覆盖值。null 表示未设置覆盖，遵从全局状态；"
+            "true/false 表示该设备有独立的启用/禁用设置。"
+        ),
+    )
+    enabled_effective: bool = Field(
+        ...,
+        description="最终生效状态（per-device 覆盖 > 全局 > 出厂默认）",
+    )
+
+
+class DeviceToolUpdateRequest(BaseModel):
+    enabled: bool = Field(..., description="启用或禁用此设备上的工具")
+
+
+@router.get("/{device_id}/tools", response_model=List[DeviceToolInfo])
+async def route_list_device_tools(device_id: str):
+    """列出设备对应插件的所有工具，并附带该设备的独立开关状态。
+
+    返回的 ``enabled_effective`` 字段反映实际执行时的生效状态：
+    - 若存在 per-device 覆盖（enabled_device 非 null），以它为准；
+    - 否则沿用全局 tool_settings（enabled_global）。
+    """
+    row = await fetch_device(device_id)
+    if row is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND, detail="Device not found"
+        )
+
+    from flocks.tool.registry import ToolRegistry
+
+    storage_key: str = row["storage_key"]
+    ToolRegistry.init()
+
+    # Collect tools that belong to this device's plugin (matching provider).
+    device_tools = [
+        t for t in ToolRegistry.list_tools()
+        if t.provider == storage_key and t.source == "device"
+    ]
+
+    # Read per-device overrides once: {tool_name: enabled_bool}.
+    per_device = await list_device_tool_settings(device_id)
+
+    result: List[DeviceToolInfo] = []
+    for t in device_tools:
+        enabled_device: Optional[bool] = per_device.get(t.name)
+
+        enabled_global = t.enabled
+        enabled_effective = (
+            enabled_device if enabled_device is not None else enabled_global
+        )
+        result.append(
+            DeviceToolInfo(
+                name=t.name,
+                description=t.description,
+                description_cn=t.description_cn,
+                enabled_global=enabled_global,
+                enabled_device=enabled_device,
+                enabled_effective=enabled_effective,
+            )
+        )
+
+    return result
+
+
+@router.patch("/{device_id}/tools/{tool_name}", response_model=DeviceToolInfo)
+async def route_update_device_tool(
+    device_id: str, tool_name: str, body: DeviceToolUpdateRequest
+):
+    """设置或清除某工具在指定设备上的独立开关。
+
+    - ``enabled=false`` → 仅在该设备上禁用工具，不影响同版本其他设备；
+    - ``enabled=true``  → 移除 per-device 覆盖，恢复遵从全局工具开关。
+    """
+    row = await fetch_device(device_id)
+    if row is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND, detail="Device not found"
+        )
+
+    from flocks.tool.registry import ToolRegistry
+
+    ToolRegistry.init()
+    storage_key: str = row["storage_key"]
+    tool = ToolRegistry.get(tool_name)
+    if tool is None or tool.info.provider != storage_key:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"Tool '{tool_name}' does not belong to this device",
+        )
+
+    if body.enabled:
+        # Removing the override restores global behaviour.
+        await delete_device_tool_setting(device_id, tool_name)
+        enabled_device = None
+    else:
+        await set_device_tool_enabled(device_id, tool_name, False)
+        enabled_device = False
+
+    enabled_global = tool.info.enabled
+    enabled_effective = (
+        enabled_device if enabled_device is not None else enabled_global
+    )
+    return DeviceToolInfo(
+        name=tool_name,
+        description=tool.info.description,
+        description_cn=tool.info.description_cn,
+        enabled_global=enabled_global,
+        enabled_device=enabled_device,
+        enabled_effective=enabled_effective,
+    )
 
 
 class DeviceTestRequest(BaseModel):

--- a/flocks/server/routes/tool.py
+++ b/flocks/server/routes/tool.py
@@ -5,7 +5,7 @@ Tool routes - API endpoints for tool management and execution
 import asyncio
 import time
 from typing import List, Optional, Dict, Any
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from flocks.server.auth import require_admin
@@ -506,18 +506,34 @@ async def get_tool(tool_name: str):
     response_model=ToolInfoResponse,
     summary="Update tool settings",
 )
-async def update_tool(tool_name: str, request: ToolUpdateRequest, _admin: object = Depends(require_admin)):
+async def update_tool(
+    tool_name: str,
+    request: ToolUpdateRequest,
+    device_id: Optional[str] = Query(
+        None,
+        description=(
+            "设备实例 UUID。提供时仅修改该设备的工具开关（per-device 覆盖），"
+            "不影响其他同版本设备；省略时修改全局 tool_settings（影响所有设备）。"
+        ),
+    ),
+    _admin: object = Depends(require_admin),
+):
     """
     Update tool settings (e.g., enable or disable).
 
-    The ``enabled`` flag is persisted to the user-level overlay in
-    ``flocks.json`` (``tool_settings.<tool_name>.enabled``) instead of
-    mutating the YAML plugin file.  This keeps project-level YAML files
-    (which may be tracked by git and overwritten on upgrade) clean and
-    treats the YAML's ``enabled:`` field as the factory default that the
-    overlay can selectively customise.
+    **Global mode** (``device_id`` omitted):
+    Persists to ``flocks.json`` → ``tool_settings.<tool_name>.enabled``.
+    Affects all device instances that share this tool.
 
-    Two behaviours of note:
+    **Per-device mode** (``device_id`` provided):
+    Persists to the SQLite ``device_tool_settings`` table (one row per
+    device_id × tool_name).  Only affects tool execution when ``device_id``
+    is explicitly targeted, allowing Device A and Device B (same plugin
+    version, different names) to carry independent tool enabled/disabled
+    states.  Rows are removed automatically via ON DELETE CASCADE when the
+    parent device row is deleted.
+
+    Two behaviours of note (global mode only):
 
     * If ``request.enabled`` matches the registration-time default we
       *delete* the overlay entry instead of writing one — the tool is
@@ -538,6 +554,34 @@ async def update_tool(tool_name: str, request: ToolUpdateRequest, _admin: object
         )
 
     desired = bool(request.enabled)
+
+    # --- Per-device mode ---
+    if device_id:
+        from flocks.tool.device.store import (
+            delete_device_tool_setting,
+            set_device_tool_enabled,
+        )
+        if desired:
+            # "Enable" in per-device mode means removing the per-device
+            # override so the global/factory default takes effect again.
+            removed = await delete_device_tool_setting(device_id, tool_name)
+            log.info("tool.device.updated.reset_to_global", {
+                "name": tool_name,
+                "device_id": device_id,
+                "removed_override": removed,
+            })
+        else:
+            await set_device_tool_enabled(device_id, tool_name, False)
+            log.info("tool.device.updated", {
+                "name": tool_name,
+                "device_id": device_id,
+                "enabled": False,
+            })
+        # The in-memory ToolInfo.enabled is NOT changed; it reflects global
+        # state.  Per-device gating happens at ToolRegistry.execute time.
+        return _build_tool_response(tool.info)
+
+    # --- Global mode (original behaviour) ---
     default = _get_default_enabled(tool.info)
     # Service gate: only matters when the user is trying to enable.
     # Disabling is always honoured.

--- a/flocks/tool/device/models.py
+++ b/flocks/tool/device/models.py
@@ -64,6 +64,26 @@ Storage.register_ddl(
     "ALTER TABLE device_integrations ADD COLUMN group_id TEXT NOT NULL DEFAULT '';"
 )
 
+# Per-device tool enabled/disabled overrides.
+#
+# Each row disables (enabled=0) or re-enables (enabled=1) a specific tool
+# for a specific device instance, independent of the shared global
+# tool_settings overlay and other device instances that share the same
+# storage_key (same plugin version, different names).
+#
+# ON DELETE CASCADE removes all per-device settings automatically when the
+# parent device row is deleted, so no manual cleanup is needed.
+Storage.register_ddl("""
+CREATE TABLE IF NOT EXISTS device_tool_settings (
+    device_id  TEXT NOT NULL REFERENCES device_integrations(id) ON DELETE CASCADE,
+    tool_name  TEXT NOT NULL,
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (device_id, tool_name)
+);
+CREATE INDEX IF NOT EXISTS idx_dts_device ON device_tool_settings(device_id);
+""")
+
 
 # ---------------------------------------------------------------------------
 # Pydantic models

--- a/flocks/tool/device/prompt.py
+++ b/flocks/tool/device/prompt.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 from flocks.utils.log import Log
 
 from .models import DeviceGroup, DeviceIntegration
-from .store import list_devices, list_groups
+from .store import list_all_device_tool_settings, list_devices, list_groups
 
 log = Log.create(service="tool.device.prompt")
 
@@ -27,6 +27,10 @@ async def build_device_context_section() -> Optional[str]:
     same type are connected, the per-tool description and action list appear
     only once in a shared "工具说明" section, keeping the prompt size O(tools)
     rather than O(tools × devices).
+
+    Per-device tool overrides (stored in ``device_tool_settings`` DB table) are
+    loaded per device so the Agent knows which tools are individually disabled
+    on a given device and will not waste a round-trip trying to call them.
     """
     try:
         groups = await list_groups()
@@ -37,6 +41,14 @@ async def build_device_context_section() -> Optional[str]:
 
     if not devices:
         return None
+
+    # Load per-device tool overrides for all devices upfront in ONE query
+    # (avoids N+1 connections when many devices are registered).
+    try:
+        per_device_overrides: Dict[str, Dict[str, bool]] = await list_all_device_tool_settings()
+    except Exception as exc:
+        log.warn("tool.device.prompt.per_device_load_failed", {"error": str(exc)})
+        per_device_overrides = {}
 
     tool_map = _build_tool_map()
     group_map: Dict[str, DeviceGroup] = {g.id: g for g in groups}
@@ -80,6 +92,17 @@ async def build_device_context_section() -> Optional[str]:
             if d.enabled and tools:
                 lines.append(f"  tool_set_id: `{d.storage_key}`")
                 lines.append(f"  调用方式: 附带 `device_id=\"{d.id}\"` 参数")
+
+                # Show per-device disabled tools so the Agent knows not to call them.
+                overrides = per_device_overrides.get(d.id, {})
+                disabled_tools = sorted(
+                    name for name, enabled in overrides.items() if not enabled
+                )
+                if disabled_tools:
+                    lines.append(
+                        f"  以下工具在设备「{d.name}」(device_id=`{d.id}`) 上已单独禁用，禁止调用: "
+                        + ", ".join(f"`{t}`" for t in disabled_tools)
+                    )
             elif not d.enabled:
                 lines.append(f"  tool_set_id: `{d.storage_key}`")
                 lines.append("  可用工具: (已禁用，不可调用)")

--- a/flocks/tool/device/store.py
+++ b/flocks/tool/device/store.py
@@ -390,6 +390,109 @@ async def ensure_default_group() -> None:
 # Public helper for downstream callers (Agent tools, etc.)
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Per-device tool settings (device_tool_settings table)
+# ---------------------------------------------------------------------------
+
+async def get_device_tool_enabled(device_id: str, tool_name: str) -> Optional[bool]:
+    """Return the per-device enabled override for *tool_name*, or None if not set.
+
+    None  → no per-device override; fall back to global tool_settings / factory default.
+    True  → explicitly enabled for this device.
+    False → explicitly disabled for this device.
+    """
+    async with Storage.connect(Storage.get_db_path()) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT enabled FROM device_tool_settings WHERE device_id = ? AND tool_name = ?",
+            (device_id, tool_name),
+        ) as cur:
+            row = await cur.fetchone()
+    if row is None:
+        return None
+    return bool(row["enabled"])
+
+
+async def set_device_tool_enabled(
+    device_id: str, tool_name: str, enabled: bool
+) -> None:
+    """Upsert the per-device tool override for *tool_name*.
+
+    Bumps the device revision so the session runner's system-prompt cache
+    invalidates and rebuilds the DeviceAssetContext section — otherwise the
+    Agent would keep seeing the pre-toggle tool list until the cache TTL.
+    """
+    now = _now_ms()
+    async with Storage.connect(Storage.get_db_path()) as db:
+        await db.execute(
+            """
+            INSERT INTO device_tool_settings (device_id, tool_name, enabled, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(device_id, tool_name) DO UPDATE SET
+                enabled    = excluded.enabled,
+                updated_at = excluded.updated_at
+            """,
+            (device_id, tool_name, int(enabled), now),
+        )
+        await db.commit()
+    _bump_revision()
+    log.info("tool.device.tool_setting.set", {
+        "device_id": device_id, "tool": tool_name, "enabled": enabled,
+    })
+
+
+async def delete_device_tool_setting(device_id: str, tool_name: str) -> bool:
+    """Remove the per-device override for *tool_name*.
+
+    Returns True if a row existed and was deleted.  Bumps the device
+    revision on actual deletion so cached prompts get rebuilt.
+    """
+    async with Storage.connect(Storage.get_db_path()) as db:
+        cur = await db.execute(
+            "DELETE FROM device_tool_settings WHERE device_id = ? AND tool_name = ?",
+            (device_id, tool_name),
+        )
+        await db.commit()
+    removed = cur.rowcount > 0
+    if removed:
+        _bump_revision()
+        log.info("tool.device.tool_setting.removed", {
+            "device_id": device_id, "tool": tool_name,
+        })
+    return removed
+
+
+async def list_device_tool_settings(
+    device_id: str,
+) -> Dict[str, bool]:
+    """Return {tool_name: enabled} for all per-device overrides of *device_id*."""
+    async with Storage.connect(Storage.get_db_path()) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT tool_name, enabled FROM device_tool_settings WHERE device_id = ?",
+            (device_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+    return {row["tool_name"]: bool(row["enabled"]) for row in rows}
+
+
+async def list_all_device_tool_settings() -> Dict[str, Dict[str, bool]]:
+    """Return {device_id: {tool_name: enabled}} for ALL devices in one query.
+
+    Avoids the N+1 pattern when building artefacts (e.g. the DeviceAssetContext
+    prompt section) that need per-device overrides for many devices at once.
+    """
+    result: Dict[str, Dict[str, bool]] = {}
+    async with Storage.connect(Storage.get_db_path()) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT device_id, tool_name, enabled FROM device_tool_settings"
+        ) as cur:
+            async for row in cur:
+                result.setdefault(row["device_id"], {})[row["tool_name"]] = bool(row["enabled"])
+    return result
+
+
 async def get_device_credentials(device_id: str) -> Optional[Dict[str, Any]]:
     """Return plaintext credentials for *device_id*, or None if not found / disabled.
 

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -816,6 +816,27 @@ class ToolRegistry:
             device_id = resolved_device_id
 
         if device_id:
+            # Per-device tool enable gate: an individual device instance may
+            # have its own enabled=False override independent of the shared
+            # global tool_settings.  This prevents toggling a tool "for
+            # Device A" from affecting Device B when both share the same
+            # storage_key (same plugin version, different names).
+            try:
+                from flocks.tool.device.store import get_device_tool_enabled
+                per_device_enabled = await get_device_tool_enabled(device_id, tool_name)
+                if per_device_enabled is False:
+                    return ToolResult(
+                        success=False,
+                        error=(
+                            f"工具 {tool_name!r} 在设备 {device_id!r} 上已禁用。"
+                            "如需启用，请在设备管理页面打开对应工具开关。"
+                        ),
+                    )
+            except Exception as _gate_err:
+                log.debug("tool.device.per_device_gate_error", {
+                    "tool": tool_name, "device_id": device_id, "error": str(_gate_err),
+                })
+
             from flocks.tool.credential_context import activate_device_credentials
             async with activate_device_credentials(device_id) as activated:
                 if not activated:

--- a/tests/tool/test_device_context_prompt.py
+++ b/tests/tool/test_device_context_prompt.py
@@ -7,6 +7,31 @@ from flocks.tool.device.prompt import build_device_context_section
 from flocks.tool.registry import ParameterType, ToolCategory, ToolInfo, ToolParameter
 
 
+def _stub_groups(monkeypatch: pytest.MonkeyPatch, groups):
+    monkeypatch.setattr(
+        "flocks.tool.device.prompt.list_groups", AsyncMock(return_value=groups)
+    )
+
+
+def _stub_devices(monkeypatch: pytest.MonkeyPatch, devices):
+    monkeypatch.setattr(
+        "flocks.tool.device.prompt.list_devices", AsyncMock(return_value=devices)
+    )
+
+
+def _stub_per_device(monkeypatch: pytest.MonkeyPatch, mapping):
+    monkeypatch.setattr(
+        "flocks.tool.device.prompt.list_all_device_tool_settings",
+        AsyncMock(return_value=mapping),
+    )
+
+
+def _stub_tools(monkeypatch: pytest.MonkeyPatch, tools):
+    monkeypatch.setattr(
+        "flocks.tool.registry.ToolRegistry.list_tools", lambda: tools
+    )
+
+
 @pytest.mark.asyncio
 async def test_device_context_deduplicates_tool_sets_and_references_them_from_devices(
     monkeypatch: pytest.MonkeyPatch,
@@ -81,3 +106,86 @@ async def test_device_context_deduplicates_tool_sets_and_references_them_from_de
     assert "`tdp_alert_list`" in content
     assert "**TDP-A**" in content
     assert "**TDP-B**" in content
+
+
+@pytest.mark.asyncio
+async def test_device_context_shows_per_device_disabled_tools_only_for_their_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-device disabled tools must be annotated only under the device that
+    has the override — not under sibling devices sharing the same storage_key.
+    """
+    _stub_groups(monkeypatch, [SimpleNamespace(id="room-1", name="上海机房")])
+    _stub_devices(monkeypatch, [
+        SimpleNamespace(
+            id="dev-a", group_id="room-1", name="TDP-A",
+            storage_key="tdp_v3_3_10", enabled=True,
+        ),
+        SimpleNamespace(
+            id="dev-b", group_id="room-1", name="TDP-B",
+            storage_key="tdp_v3_3_10", enabled=True,
+        ),
+    ])
+    # Per-device override: TDP-A has tdp_alert_list disabled; TDP-B has no overrides.
+    _stub_per_device(monkeypatch, {
+        "dev-a": {"tdp_alert_list": False},
+    })
+    _stub_tools(monkeypatch, [
+        ToolInfo(
+            name="tdp_event_list", description="List TDP events.",
+            category=ToolCategory.CUSTOM, parameters=[],
+            enabled=True, source="device", provider="tdp_v3_3_10",
+        ),
+        ToolInfo(
+            name="tdp_alert_list", description="List TDP alerts.",
+            category=ToolCategory.CUSTOM, parameters=[],
+            enabled=True, source="device", provider="tdp_v3_3_10",
+        ),
+    ])
+
+    content = await build_device_context_section()
+    assert content is not None
+
+    # Locate the per-device blocks by anchoring on the device name line.
+    a_block_start = content.index("**TDP-A**")
+    b_block_start = content.index("**TDP-B**")
+    a_block = content[a_block_start:b_block_start]
+    b_block = content[b_block_start:]
+
+    # TDP-A block must mention the disabled tool with its OWN device name & id.
+    assert "已单独禁用" in a_block
+    assert "`tdp_alert_list`" in a_block
+    assert "TDP-A" in a_block
+    assert "dev-a" in a_block
+
+    # TDP-B block must NOT mention any per-device disable.
+    assert "已单独禁用" not in b_block
+
+    # Defence-in-depth: TDP-A's notice must not leak the wrong device name.
+    assert "TDP-B" not in a_block.split("已单独禁用", 1)[1].split("\n", 1)[0]
+
+
+@pytest.mark.asyncio
+async def test_device_context_omits_notice_when_no_per_device_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No notice line should appear when a device has no per-device overrides."""
+    _stub_groups(monkeypatch, [SimpleNamespace(id="room-1", name="上海机房")])
+    _stub_devices(monkeypatch, [
+        SimpleNamespace(
+            id="dev-a", group_id="room-1", name="TDP-A",
+            storage_key="tdp_v3_3_10", enabled=True,
+        ),
+    ])
+    _stub_per_device(monkeypatch, {})
+    _stub_tools(monkeypatch, [
+        ToolInfo(
+            name="tdp_event_list", description="List TDP events.",
+            category=ToolCategory.CUSTOM, parameters=[],
+            enabled=True, source="device", provider="tdp_v3_3_10",
+        ),
+    ])
+
+    content = await build_device_context_section()
+    assert content is not None
+    assert "已单独禁用" not in content

--- a/tests/tool/test_device_tool_isolation.py
+++ b/tests/tool/test_device_tool_isolation.py
@@ -1,0 +1,392 @@
+"""Tests for per-device tool enable/disable isolation (DB-backed).
+
+Regression suite for the bug where two device instances sharing the same
+``storage_key`` (same product version, different names) would have their
+tool on/off state coupled — toggling a tool "for Device A" also affected
+Device B.
+
+Fix: store per-device tool overrides in the ``device_tool_settings`` SQLite
+table (ON DELETE CASCADE cleans up automatically on device removal).  The
+override is checked at ToolRegistry.execute() time, AFTER the shared global
+tool_settings have been applied.  The in-memory ToolInfo.enabled remains a
+global/shared concept; per-device gates live exclusively in the execution path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import AsyncMock
+
+import pytest
+
+from flocks.tool.registry import Tool, ToolCategory, ToolContext, ToolInfo, ToolRegistry, ToolResult
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def db_env(tmp_path: Path, monkeypatch):
+    """Isolated SQLite DB for each test.
+
+    Importing ``flocks.tool.device.models`` ensures all DDLs (including
+    device_tool_settings) are registered before Storage.init() runs.
+    """
+    from flocks.config.config import Config
+    from flocks.storage.storage import Storage
+    import flocks.tool.device.models  # noqa: F401 — registers DDLs
+
+    data_dir = tmp_path / "flocks_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("FLOCKS_DATA_DIR", str(data_dir))
+
+    Config._global_config = None
+    Config._cached_config = None
+    Storage._db_path = None
+    Storage._initialized = False
+
+    await Storage.init()
+    yield data_dir
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    saved_tools = dict(ToolRegistry._tools)
+    saved_defaults = dict(ToolRegistry._enabled_defaults)
+    saved_plugin_names = list(ToolRegistry._plugin_tool_names)
+    saved_dynamic = dict(ToolRegistry._dynamic_tools_by_module)
+    monkeypatch.setattr(ToolRegistry, "_tools", {})
+    monkeypatch.setattr(ToolRegistry, "_enabled_defaults", {})
+    monkeypatch.setattr(ToolRegistry, "_plugin_tool_names", [])
+    monkeypatch.setattr(ToolRegistry, "_dynamic_tools_by_module", {})
+    yield
+    ToolRegistry._tools = saved_tools
+    ToolRegistry._enabled_defaults = saved_defaults
+    ToolRegistry._plugin_tool_names = saved_plugin_names
+    ToolRegistry._dynamic_tools_by_module = saved_dynamic
+
+
+def _device_tool(name: str, storage_key: str, *, enabled: bool = True) -> Tool:
+    async def _handler(_ctx: ToolContext, **_kwargs) -> ToolResult:
+        return ToolResult(success=True, output="ok")
+
+    return Tool(
+        info=ToolInfo(
+            name=name,
+            description=f"stub device tool {name}",
+            category=ToolCategory.CUSTOM,
+            enabled=enabled,
+            source="device",
+            provider=storage_key,
+        ),
+        handler=_handler,
+    )
+
+
+async def _insert_stub_device(device_id: str, storage_key: str) -> None:
+    """Insert a minimal device row so FK constraints on device_tool_settings pass."""
+    from flocks.storage.storage import Storage
+
+    now = 1_700_000_000_000
+    async with Storage.connect(Storage.get_db_path()) as db:
+        await db.execute("""
+            INSERT OR IGNORE INTO device_groups (id, name, sort_order, created_at, updated_at)
+            VALUES ('default-room', '默认机房', 0, ?, ?)
+        """, (now, now))
+        await db.execute("""
+            INSERT OR IGNORE INTO device_integrations
+                (id, group_id, name, storage_key, service_id, enabled,
+                 verify_ssl, fields, status, created_at, updated_at)
+            VALUES (?, 'default-room', ?, ?, ?, 1, 0, '{}', 'unknown', ?, ?)
+        """, (device_id, f"dev-{device_id[:4]}", storage_key, storage_key, now, now))
+        await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# store.py: device_tool_settings CRUD
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestStoreDeviceToolSettings:
+    async def test_get_returns_none_when_absent(self, db_env):
+        from flocks.tool.device.store import get_device_tool_enabled
+        result = await get_device_tool_enabled("dev-a", "sangfor_af_login")
+        assert result is None
+
+    async def test_set_and_get_roundtrip(self, db_env):
+        from flocks.tool.device.store import get_device_tool_enabled, set_device_tool_enabled
+        dev_id = str(uuid.uuid4())
+        await _insert_stub_device(dev_id, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_id, "sangfor_af_login", False)
+        result = await get_device_tool_enabled(dev_id, "sangfor_af_login")
+        assert result is False
+
+    async def test_set_does_not_affect_other_device(self, db_env):
+        from flocks.tool.device.store import get_device_tool_enabled, set_device_tool_enabled
+        dev_a = str(uuid.uuid4())
+        dev_b = str(uuid.uuid4())
+        await _insert_stub_device(dev_a, "sangfor_af_v8_0_106")
+        await _insert_stub_device(dev_b, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_a, "sangfor_af_login", False)
+        result_b = await get_device_tool_enabled(dev_b, "sangfor_af_login")
+        assert result_b is None
+
+    async def test_set_does_not_affect_other_tool(self, db_env):
+        from flocks.tool.device.store import get_device_tool_enabled, set_device_tool_enabled
+        dev_id = str(uuid.uuid4())
+        await _insert_stub_device(dev_id, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_id, "sangfor_af_login", False)
+        other = await get_device_tool_enabled(dev_id, "sangfor_af_query")
+        assert other is None
+
+    async def test_delete_returns_true_when_entry_existed(self, db_env):
+        from flocks.tool.device.store import (
+            delete_device_tool_setting,
+            get_device_tool_enabled,
+            set_device_tool_enabled,
+        )
+        dev_id = str(uuid.uuid4())
+        await _insert_stub_device(dev_id, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_id, "sangfor_af_login", False)
+        removed = await delete_device_tool_setting(dev_id, "sangfor_af_login")
+        assert removed is True
+        assert await get_device_tool_enabled(dev_id, "sangfor_af_login") is None
+
+    async def test_delete_returns_false_when_absent(self, db_env):
+        from flocks.tool.device.store import delete_device_tool_setting
+        removed = await delete_device_tool_setting("non-existent", "some_tool")
+        assert removed is False
+
+    async def test_list_returns_all_settings_for_device(self, db_env):
+        from flocks.tool.device.store import list_device_tool_settings, set_device_tool_enabled
+        dev_id = str(uuid.uuid4())
+        await _insert_stub_device(dev_id, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_id, "tool_x", False)
+        await set_device_tool_enabled(dev_id, "tool_y", False)
+        settings = await list_device_tool_settings(dev_id)
+        assert set(settings.keys()) == {"tool_x", "tool_y"}
+        assert settings["tool_x"] is False
+        assert settings["tool_y"] is False
+
+    async def test_delete_does_not_affect_other_device(self, db_env):
+        from flocks.tool.device.store import (
+            delete_device_tool_setting,
+            get_device_tool_enabled,
+            set_device_tool_enabled,
+        )
+        dev_a = str(uuid.uuid4())
+        dev_b = str(uuid.uuid4())
+        await _insert_stub_device(dev_a, "sangfor_af_v8_0_106")
+        await _insert_stub_device(dev_b, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_a, "tool_x", False)
+        await set_device_tool_enabled(dev_b, "tool_x", False)
+        await delete_device_tool_setting(dev_a, "tool_x")
+        assert await get_device_tool_enabled(dev_b, "tool_x") is False
+
+    async def test_cascade_delete_on_device_removal(self, db_env):
+        """Removing the parent device row must cascade to device_tool_settings."""
+        from flocks.storage.storage import Storage
+        from flocks.tool.device.store import get_device_tool_enabled, set_device_tool_enabled
+
+        dev_id = str(uuid.uuid4())
+        await _insert_stub_device(dev_id, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_id, "sangfor_af_login", False)
+
+        async with Storage.connect(Storage.get_db_path()) as db:
+            await db.execute(
+                "DELETE FROM device_integrations WHERE id = ?", (dev_id,)
+            )
+            await db.commit()
+
+        result = await get_device_tool_enabled(dev_id, "sangfor_af_login")
+        assert result is None
+
+    async def test_global_tool_settings_unaffected(self, db_env):
+        """device_tool_settings must not touch flocks.json tool_settings."""
+        from flocks.config.config_writer import ConfigWriter
+        from flocks.tool.device.store import set_device_tool_enabled
+
+        dev_id = str(uuid.uuid4())
+        await _insert_stub_device(dev_id, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_id, "sangfor_af_login", False)
+
+        global_setting = ConfigWriter.get_tool_setting("sangfor_af_login")
+        assert global_setting is None
+
+    async def test_set_bumps_device_revision(self, db_env):
+        """Cache-invalidation contract: setting a per-device override must bump
+        the device_revision so the session runner rebuilds the DeviceAssetContext
+        section in the system prompt.
+        """
+        from flocks.tool.device.store import device_revision, set_device_tool_enabled
+
+        dev_id = str(uuid.uuid4())
+        await _insert_stub_device(dev_id, "sangfor_af_v8_0_106")
+        before = device_revision()
+        await set_device_tool_enabled(dev_id, "sangfor_af_login", False)
+        assert device_revision() > before
+
+    async def test_delete_bumps_device_revision_only_on_real_removal(self, db_env):
+        """Deleting a non-existent override must NOT bump the revision."""
+        from flocks.tool.device.store import (
+            delete_device_tool_setting,
+            device_revision,
+            set_device_tool_enabled,
+        )
+
+        dev_id = str(uuid.uuid4())
+        await _insert_stub_device(dev_id, "sangfor_af_v8_0_106")
+
+        # No-op delete: revision unchanged.
+        rev_a = device_revision()
+        await delete_device_tool_setting(dev_id, "missing_tool")
+        assert device_revision() == rev_a
+
+        # Real delete after a set: revision bumps.
+        await set_device_tool_enabled(dev_id, "sangfor_af_login", False)
+        rev_b = device_revision()
+        removed = await delete_device_tool_setting(dev_id, "sangfor_af_login")
+        assert removed is True
+        assert device_revision() > rev_b
+
+    async def test_list_all_returns_grouped_by_device(self, db_env):
+        """Batch helper used by the system-prompt builder to avoid N+1."""
+        from flocks.tool.device.store import (
+            list_all_device_tool_settings,
+            set_device_tool_enabled,
+        )
+
+        dev_a = str(uuid.uuid4())
+        dev_b = str(uuid.uuid4())
+        await _insert_stub_device(dev_a, "sangfor_af_v8_0_106")
+        await _insert_stub_device(dev_b, "sangfor_af_v8_0_106")
+        await set_device_tool_enabled(dev_a, "tool_x", False)
+        await set_device_tool_enabled(dev_a, "tool_y", True)
+        await set_device_tool_enabled(dev_b, "tool_x", False)
+
+        all_settings = await list_all_device_tool_settings()
+        assert all_settings[dev_a] == {"tool_x": False, "tool_y": True}
+        assert all_settings[dev_b] == {"tool_x": False}
+
+    async def test_list_all_returns_empty_dict_when_no_overrides(self, db_env):
+        from flocks.tool.device.store import list_all_device_tool_settings
+
+        result = await list_all_device_tool_settings()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry.execute: per-device gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestDeviceToolIsolationExecution:
+    async def _run_tool(
+        self,
+        monkeypatch,
+        db_env,
+        *,
+        storage_key: str,
+        device_id: str,
+        tool_name: str = "sangfor_af_login",
+        enabled_in_registry: bool = True,
+        per_device_enabled: Optional[bool] = None,
+    ) -> ToolResult:
+        """Helper: stub the registry + device store, then call execute()."""
+        tool = _device_tool(tool_name, storage_key, enabled=enabled_in_registry)
+        monkeypatch.setattr(
+            "flocks.tool.registry.ToolRegistry.get", lambda _name: tool
+        )
+
+        monkeypatch.setattr(
+            "flocks.tool.device.store.list_devices",
+            AsyncMock(return_value=[
+                SimpleNamespace(id=device_id, storage_key=storage_key, enabled=True),
+            ]),
+        )
+
+        @asynccontextmanager
+        async def _activate(did: str):
+            yield True
+
+        monkeypatch.setattr(
+            "flocks.tool.credential_context.activate_device_credentials", _activate
+        )
+
+        # Apply per-device DB setting.
+        from flocks.tool.device.store import (
+            delete_device_tool_setting,
+            set_device_tool_enabled,
+        )
+        await _insert_stub_device(device_id, storage_key)
+        if per_device_enabled is False:
+            await set_device_tool_enabled(device_id, tool_name, False)
+        elif per_device_enabled is True:
+            await delete_device_tool_setting(device_id, tool_name)
+
+        return await ToolRegistry.execute(tool_name, device_id=device_id)
+
+    async def test_tool_executes_when_no_per_device_override(
+        self, monkeypatch, db_env
+    ):
+        result = await self._run_tool(
+            monkeypatch, db_env,
+            storage_key="sangfor_af_v8_0_106",
+            device_id=str(uuid.uuid4()),
+            per_device_enabled=None,
+        )
+        assert result.success is True
+
+    async def test_tool_blocked_by_per_device_disable(
+        self, monkeypatch, db_env
+    ):
+        result = await self._run_tool(
+            monkeypatch, db_env,
+            storage_key="sangfor_af_v8_0_106",
+            device_id=str(uuid.uuid4()),
+            per_device_enabled=False,
+        )
+        assert result.success is False
+        assert "已禁用" in (result.error or "")
+
+    async def test_per_device_disable_does_not_affect_other_device(
+        self, monkeypatch, db_env
+    ):
+        """Core regression: disabling tool for dev-a must NOT affect dev-b."""
+        from flocks.tool.device.store import set_device_tool_enabled
+
+        dev_a = str(uuid.uuid4())
+        dev_b = str(uuid.uuid4())
+        storage_key = "sangfor_af_v8_0_106"
+
+        await _insert_stub_device(dev_a, storage_key)
+        await set_device_tool_enabled(dev_a, "sangfor_af_login", False)
+
+        result = await self._run_tool(
+            monkeypatch, db_env,
+            storage_key=storage_key,
+            device_id=dev_b,
+            per_device_enabled=None,
+        )
+        assert result.success is True, (
+            "Disabling a tool for dev-a must not affect dev-b even if they "
+            "share the same storage_key (same plugin version)."
+        )
+
+    async def test_global_disable_still_blocks_all_devices(
+        self, monkeypatch, db_env, isolated_registry
+    ):
+        """Global tool_settings (enabled=False in registry) must still block ALL devices."""
+        tool = _device_tool("sangfor_af_login", "sangfor_af_v8_0_106", enabled=False)
+        monkeypatch.setattr(
+            "flocks.tool.registry.ToolRegistry.get", lambda _name: tool
+        )
+
+        result = await ToolRegistry.execute("sangfor_af_login", device_id=str(uuid.uuid4()))
+        assert result.success is False
+        assert "disabled" in (result.error or "").lower()

--- a/webui/src/api/device.ts
+++ b/webui/src/api/device.ts
@@ -89,6 +89,22 @@ export interface DeviceTestRequest {
   verify_ssl?: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Per-device tool settings
+// ---------------------------------------------------------------------------
+
+export interface DeviceToolInfo {
+  name: string;
+  description: string;
+  description_cn?: string | null;
+  /** 全局工具开关（影响所有同版本设备） */
+  enabled_global: boolean;
+  /** 本设备的独立覆盖值；null = 未设置，遵从全局 */
+  enabled_device: boolean | null;
+  /** 最终生效状态 */
+  enabled_effective: boolean;
+}
+
 export const deviceAPI = {
   // groups
   listGroups: () =>
@@ -121,4 +137,11 @@ export const deviceAPI = {
 
   test: (id: string, body?: DeviceTestRequest) =>
     client.post<DeviceTestResult>(`/api/devices/${id}/test`, body ?? {}),
+
+  // per-device tool settings
+  listDeviceTools: (device_id: string) =>
+    client.get<DeviceToolInfo[]>(`/api/devices/${device_id}/tools`),
+
+  updateDeviceTool: (device_id: string, tool_name: string, enabled: boolean) =>
+    client.patch<DeviceToolInfo>(`/api/devices/${device_id}/tools/${tool_name}`, { enabled }),
 };

--- a/webui/src/api/tool.ts
+++ b/webui/src/api/tool.ts
@@ -41,8 +41,12 @@ export const toolAPI = {
   getStatistics: (name: string) =>
     client.get<ToolStatistics>(`/api/tools/${name}/statistics`),
 
-  setEnabled: (name: string, enabled: boolean) =>
-    client.patch<Tool>(`/api/tools/${name}`, { enabled }),
+  setEnabled: (name: string, enabled: boolean, options?: { device_id?: string }) =>
+    client.patch<Tool>(
+      `/api/tools/${name}`,
+      { enabled },
+      options?.device_id ? { params: { device_id: options.device_id } } : undefined,
+    ),
 
   /**
    * Remove the user-level setting and restore the YAML/registration default

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -9,7 +9,7 @@ import PageHeader from '@/components/common/PageHeader';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useToast } from '@/components/common/Toast';
 import { providerAPI } from '@/api/provider';
-import { deviceAPI, type DeviceIntegration, type DeviceGroup } from '@/api/device';
+import { deviceAPI, type DeviceIntegration, type DeviceGroup, type DeviceToolInfo } from '@/api/device';
 import type { APIServiceSummary, APIServiceCredentialField, Tool } from '@/types';
 import { toolAPI } from '@/api/tool';
 import ToolDetailModal from '../Tool/components/ToolDetailModal';
@@ -365,6 +365,9 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
   const [serviceTools, setServiceTools] = useState<Tool[]>([]);
   const [toolModal, setToolModal] = useState<Tool | null>(null);
   const [metadata, setMetadata] = useState<{ name?: string; version?: string; description?: string; description_cn?: string; docs_url?: string } | null>(null);
+  // per-device effective enabled state; keyed by tool name.
+  // When viewing an existing device we load this from the per-device API so
+  // the toggle reflects the device-specific override, not the global state.
   const [toolEnabled, setToolEnabled] = useState<Record<string, boolean>>({});
   const originalMasked = useRef<Record<string, string>>({});
 
@@ -406,22 +409,30 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
       })
       .catch(() => {});
 
-    toolAPI.list()
-      .then((res) => {
-        // Match against the device's storage_key exactly. The tool
-        // listing endpoint sets ``source_name = tool.provider``, which
-        // in turn equals the plugin's storage_key (see
-        // ``flocks/tool/tool_loader.py``). An exact comparison keeps
-        // multi-version installs of the same product cleanly isolated.
-        const matched = (res.data || []).filter(
-          (t) => !!storageKey && t.source_name === storageKey,
-        );
-        setServiceTools(matched);
-        const initEnabled: Record<string, boolean> = {};
-        matched.forEach((t) => { initEnabled[t.name] = t.enabled; });
-        setToolEnabled(initEnabled);
-      })
-      .catch(() => {});
+    // Only existing devices have a "工具" tab (the wizard hides it because
+    // there's no device_id yet — see TABS comment).  So loading the tool list
+    // and per-device enabled overrides only matters when ``device`` exists.
+    if (device) {
+      Promise.all([
+        toolAPI.list(),
+        deviceAPI.listDeviceTools(device.id),
+      ])
+        .then(([toolsRes, deviceToolsRes]) => {
+          const matched = (toolsRes.data || []).filter(
+            (t) => !!storageKey && t.source_name === storageKey,
+          );
+          setServiceTools(matched);
+          // Effective enabled state = per-device override (if any) else global.
+          const perDevice: Record<string, DeviceToolInfo> = {};
+          (deviceToolsRes.data || []).forEach((dt) => { perDevice[dt.name] = dt; });
+          const initEnabled: Record<string, boolean> = {};
+          matched.forEach((t) => {
+            initEnabled[t.name] = perDevice[t.name]?.enabled_effective ?? t.enabled;
+          });
+          setToolEnabled(initEnabled);
+        })
+        .catch(() => {});
+    }
   }, [device, serviceId, storageKey]);
 
   const handleSave = async () => {
@@ -520,18 +531,29 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
   };
 
   const handleToggleTool = async (toolName: string, next: boolean) => {
+    // 仅在已存在设备时可触发（工具 tab 在 wizard 模式下被隐藏，见 TABS 注释）。
+    if (!device) return;
     try {
-      await toolAPI.setEnabled(toolName, next);
+      // Per-device toggle: only affects this specific device instance.
+      // Other devices sharing the same storage_key (same product version)
+      // are not affected.
+      await deviceAPI.updateDeviceTool(device.id, toolName, next);
       setToolEnabled((p) => ({ ...p, [toolName]: next }));
-      setServiceTools((prev) => prev.map((t) => t.name === toolName ? { ...t, enabled: next } : t));
     } catch {
       toast.error('操作失败');
     }
   };
 
+  // The "工具" tab is hidden during the add-device wizard because per-device
+  // toggles can only be persisted after the device row exists (we have no
+  // device_id to target).  Showing the tab here would force any toggle to
+  // mutate the GLOBAL tool_settings — re-introducing the original cross-device
+  // coupling bug this whole feature exists to fix.
   const TABS: { key: PanelTab; label: string; icon: React.ReactNode }[] = [
     { key: 'config', label: '配置', icon: <Settings className="w-3.5 h-3.5" /> },
-    { key: 'tools',  label: `工具${serviceTools.length ? ` (${serviceTools.length})` : ''}`, icon: <Wrench className="w-3.5 h-3.5" /> },
+    ...(device
+      ? [{ key: 'tools' as PanelTab, label: `工具${serviceTools.length ? ` (${serviceTools.length})` : ''}`, icon: <Wrench className="w-3.5 h-3.5" /> }]
+      : []),
     { key: 'overview', label: '概览', icon: <AlertTriangle className="w-3.5 h-3.5 opacity-60" /> },
   ];
 


### PR DESCRIPTION
Root cause: tool_settings in flocks.json was keyed globally by tool name, so toggling a tool for Device A silently affected Device B when both shared the same storage_key (same product version, different instance names).

Solution: introduce a dedicated `device_tool_settings` SQLite table that stores per-device tool overrides independently of the shared global overlay.

Schema:
  PRIMARY KEY (device_id, tool_name)
  FOREIGN KEY device_id REFERENCES device_integrations(id) ON DELETE CASCADE

Changes:
- models.py: register DDL via Storage.register_ddl(); CASCADE handles cleanup automatically when a device row is deleted
- store.py: add get/set/delete/list/list_all async CRUD; set and delete bump _device_revision() so the session runner's system-prompt cache invalidates
- registry.py: ToolRegistry.execute() checks per-device DB override before activating credentials; gate is in try/except so a DB hiccup never blocks a tool that is globally enabled
- routes/tool.py: PATCH /api/tools/{name}?device_id= routes per-device toggles to the new DB table instead of flocks.json
- routes/device.py: GET /api/devices/{id}/tools and PATCH /api/devices/{id}/tools/{name} endpoints; DELETE /api/devices/{id} no longer needs manual cleanup (ON DELETE CASCADE)
- prompt.py: build_device_context_section() loads all per-device overrides in one SQL query (list_all_device_tool_settings) instead of N+1 calls; disabled tools are annotated with device name and device_id so the Agent knows not to attempt calling them
- webui: DeviceIntegration page loads per-device enabled state from GET /api/devices/{id}/tools and routes toggle to PATCH /api/devices/{id}/tools/{name}; wizard mode hides the tool tab entirely (no device_id exists yet, so a per-device toggle is impossible)
- tests: 52 passing (18 new); covers CRUD, CASCADE delete, cache-revision bumping, batch query correctness, Agent prompt display accuracy

Fixes: toggling a tool for one device no longer affects other devices of the same product version.