### PR TITLE
fix(channel): archive previous session on IM /new command

### DIFF
--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -848,6 +848,26 @@ class InboundDispatcher:
             agent_id=new_session.agent,
             scope_override=scope_override,
         )
+        # Archive the previous session so it no longer shows up as an *active*
+        # IM session. The binding has already moved to ``new_session`` via
+        # ``rebind`` above, but the old session retains ``status="active"`` and
+        # the same ``[Feishu]/[Wecom]/[Dingtalk]`` title prefix. Without this,
+        # repeated ``/new`` leaves multiple active sessions for the same
+        # conversation, and unattended scheduled tasks (which resolve the IM
+        # target via ``session_list(status="active")`` + title prefix) can no
+        # longer tell which one is current — sending to the wrong session or
+        # failing outright. Best-effort: archiving failure must not abort /new.
+        try:
+            await Session.update(
+                session.project_id,
+                session.id,
+                status="archived",
+            )
+        except Exception as exc:
+            log.warning("dispatcher.archive_previous_session_failed", {
+                "session_id": session.id,
+                "error": str(exc),
+            })
         await self._trigger_command_hook(
             "new",
             session.id,

--- a/tests/channel/test_channel.py
+++ b/tests/channel/test_channel.py
@@ -570,6 +570,8 @@ class TestFeishuNativeCommands:
             )
         )
         monkeypatch.setattr("flocks.session.session.Session.create", create_mock)
+        update_mock = AsyncMock(return_value=None)
+        monkeypatch.setattr("flocks.session.session.Session.update", update_mock)
 
         handled = await dispatcher._handle_feishu_native_command(
             binding=binding,
@@ -587,6 +589,11 @@ class TestFeishuNativeCommands:
         assert create_kwargs["title"] == "[Feishu] oc_group"
         assert "session_new" in delivered[0]
         assert "已开始全新对话。" in delivered[0]
+        # The previous session must be archived so it no longer appears in the
+        # active IM session list used for scheduled-task target resolution.
+        update_mock.assert_awaited_once()
+        assert update_mock.await_args.args == ("channel", "session_old")
+        assert update_mock.await_args.kwargs["status"] == "archived"
 
     @pytest.mark.asyncio
     async def test_reset_alias_matches_new_semantics(self, monkeypatch):


### PR DESCRIPTION
## Summary

- After IM `/new` (Feishu/WeCom/DingTalk), archive the previous session so only the rebound session stays `active`.
- Prevents multiple active sessions sharing the same `[Channel]` title prefix, which broke scheduled-task target resolution via `session_list(status="active")`.
- Best-effort archive: failures are logged and do not abort `/new`.
- Extend Feishu native-command test to assert `Session.update(..., status="archived")`.

## Test plan

- [x] `uv run pytest tests/channel/test_channel.py::TestFeishuNativeCommands::test_new_command_rebinds_conversation -q`
- [ ] Manual: run `/new` twice in the same IM thread and confirm only one active session remains for that conversation
- [ ] Manual: verify scheduled tasks still resolve the correct IM session after `/new`


Made with [Cursor](https://cursor.com)