### PR TITLE
fix(tool): force-close HTTP tool sockets to prevent CLOSE_WAIT buildup

### DIFF
--- a/flocks/tool/tool_loader.py
+++ b/flocks/tool/tool_loader.py
@@ -17,6 +17,7 @@ import ast
 import importlib.util
 import inspect
 import re
+import sys
 import urllib.parse
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -308,6 +309,33 @@ def _build_handler(raw_handler: dict, yaml_path: Path) -> ToolHandler:
         raise ValueError(f"Unknown handler type: {handler_type}")
 
 
+def _build_tcp_connector(verify_ssl: bool) -> "Any":
+    """Create a per-request aiohttp TCPConnector that tears down sockets promptly.
+
+    Declarative HTTP tools (skyeye / tdp / onesec / qingteng / threatbook 等) build a
+    fresh ``ClientSession`` + connector for every call, so connection pooling brings no
+    benefit. Leaving keep-alive enabled lets the remote (often a self-signed HTTPS
+    appliance) send FIN while our socket lingers in ``CLOSE_WAIT``; under rapid back-to-back
+    tool calls — e.g. ``run_workflow`` / ``run_workflow_node`` driving dozens of nodes —
+    these half-closed sockets accumulate (60+ observed) and eventually starve the event loop.
+
+    Mitigations:
+    - ``force_close=True``: close the underlying connection right after each request
+      instead of returning it to the pool, so no idle keep-alive socket can rot into
+      ``CLOSE_WAIT``.
+    - ``enable_cleanup_closed=True``: on CPython < 3.12.7 the asyncio SSL transport leak
+      means TLS sockets are not fully torn down; this aborts them after a short grace
+      period. The flag was made a no-op (with a DeprecationWarning) once the CPython bug
+      was fixed, so we only pass it on the affected interpreters.
+    """
+    import aiohttp
+
+    kwargs: Dict[str, Any] = {"ssl": verify_ssl, "force_close": True}
+    if sys.version_info < (3, 12, 7):
+        kwargs["enable_cleanup_closed"] = True
+    return aiohttp.TCPConnector(**kwargs)
+
+
 def _build_http_handler(cfg: dict) -> ToolHandler:
     """Build an async HTTP request handler from declarative config."""
     method = cfg.get("method", "GET").upper()
@@ -363,7 +391,7 @@ def _build_http_handler(cfg: dict) -> ToolHandler:
 
         try:
             client_timeout = aiohttp.ClientTimeout(total=timeout)
-            connector = aiohttp.TCPConnector(ssl=verify_ssl)
+            connector = _build_tcp_connector(verify_ssl)
             async with aiohttp.ClientSession(timeout=client_timeout, connector=connector) as session:
                 req_kwargs: Dict[str, Any] = {"headers": headers}
                 if query_params:

--- a/tests/tool/test_tool_plugin.py
+++ b/tests/tool/test_tool_plugin.py
@@ -13,6 +13,7 @@ import yaml
 from flocks.tool.tool_loader import (
     _build_execution_handler,
     _build_http_handler,
+    _build_tcp_connector,
     _extract_response,
     _json_schema_to_params,
     _merge_provider_defaults,
@@ -1131,6 +1132,80 @@ class TestHttpHandler:
 
         assert result.success is True
         assert result.output == [1, 2]
+
+
+class TestTcpConnector:
+    """Regression tests for CLOSE_WAIT socket accumulation under rapid tool calls."""
+
+    def test_connector_forces_socket_close(self):
+        """force_close must be True so per-request sockets don't linger in CLOSE_WAIT."""
+        captured: Dict[str, Any] = {}
+
+        def _fake_connector(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("aiohttp.TCPConnector", side_effect=_fake_connector):
+            _build_tcp_connector(verify_ssl=False)
+
+        assert captured["force_close"] is True
+        assert captured["ssl"] is False
+
+    def test_connector_enables_cleanup_closed_only_on_affected_python(self):
+        """enable_cleanup_closed is only meaningful before the CPython 3.12.7 SSL fix."""
+        import sys as _sys
+
+        captured: Dict[str, Any] = {}
+
+        def _fake_connector(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("aiohttp.TCPConnector", side_effect=_fake_connector):
+            _build_tcp_connector(verify_ssl=True)
+
+        if _sys.version_info < (3, 12, 7):
+            assert captured.get("enable_cleanup_closed") is True
+        else:
+            assert "enable_cleanup_closed" not in captured
+
+    @pytest.mark.asyncio
+    async def test_http_handler_uses_hardened_connector(self):
+        """The declarative HTTP handler must build its session with the hardened connector."""
+        cfg = {
+            "type": "http",
+            "method": "GET",
+            "url": "https://appliance.example.com/api",
+            "timeout": 10,
+        }
+        handler = _build_http_handler(cfg)
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"ok": True})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.request = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        captured: Dict[str, Any] = {}
+
+        def _fake_connector(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        ctx = ToolContext(session_id="test", message_id="test")
+
+        with patch("aiohttp.TCPConnector", side_effect=_fake_connector), patch(
+            "aiohttp.ClientSession", return_value=mock_session
+        ):
+            result = await handler(ctx)
+
+        assert result.success is True
+        assert captured["force_close"] is True
 
 
 class TestExecutionHandler:


### PR DESCRIPTION
## Summary

- Add `_build_tcp_connector()` for declarative HTTP tools (skyeye / tdp / onesec / qingteng / threatbook, etc.) with `force_close=True` so per-request sockets are torn down immediately instead of lingering in `CLOSE_WAIT`.
- On CPython < 3.12.7, pass `enable_cleanup_closed=True` to mitigate the asyncio SSL transport leak; skip the flag on newer interpreters where it is a no-op.
- Add regression tests covering connector kwargs and HTTP handler integration.