### PR TITLE
fix(webui): remove stale workflow detail session sync

### DIFF
--- a/webui/src/pages/WorkflowDetail/index.tsx
+++ b/webui/src/pages/WorkflowDetail/index.tsx
@@ -119,14 +119,6 @@ export default function WorkflowDetail() {
     void loadWorkflow();
   }, [id, loadWorkflow]);
 
-  useEffect(() => {
-    if (!workflow?.id) {
-      setChatSessionId(null);
-      return;
-    }
-    setChatSessionId(getLatestStoredSessionId(workflow.id));
-  }, [workflow?.id]);
-
   const refreshWorkflowStats = useCallback(() => {
     void loadWorkflow({ preserveExecution: true, silent: true });
   }, [loadWorkflow]);


### PR DESCRIPTION
## Summary
- remove the orphaned session sync effect from `WorkflowDetail`
- fix the WebUI TypeScript build failure caused by undefined `setChatSessionId` and `getLatestStoredSessionId` references
- keep the change minimal by deleting stale logic that no longer has state or consumers in the page

## Test plan
- [x] Run `npm --prefix /Users/zgy/workspace/flocks-2/webui run build`

Made with [Cursor](https://cursor.com)