### PR TITLE
fix(kafka): tighten ingest backpressure and compact execution storage

### DIFF
--- a/flocks/ingest/kafka/manager.py
+++ b/flocks/ingest/kafka/manager.py
@@ -15,8 +15,6 @@ Differences from the syslog manager:
   consumer pause naturally. Because ``aiokafka`` auto-commits fetched offsets,
   the current crash semantics are still best-effort / at-most-once rather than
   fully durable at-least-once delivery.
-* When an output broker/topic is configured, the successful run result is
-  produced back to Kafka via a per-workflow ``AIOKafkaProducer``.
 """
 
 from __future__ import annotations
@@ -572,6 +570,7 @@ class KafkaManager:
                 workflow=workflow_json,
                 inputs=inputs,
                 trace=False,
+                history_mode="summary",
             )
             status, error_msg = resolve_execution_outcome(result)
             duration = time.time() - start_time

--- a/flocks/ingest/kafka/manager.py
+++ b/flocks/ingest/kafka/manager.py
@@ -22,13 +22,16 @@ Differences from the syslog manager:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import time
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 from flocks.workflow.execution_store import (
+    DEFAULT_LARGE_LIST_KEYS,
     compact_history_for_storage,
     compact_outputs_for_storage,
     create_execution_record,
@@ -44,11 +47,13 @@ log = Log.create(service="kafka.manager")
 
 
 # Maximum concurrent workflow executions per workflow to avoid FD exhaustion and
-# SQLite write contention (mirrors the syslog manager).
-_MAX_CONCURRENT_EXECUTIONS = 8
+# SQLite write contention. Kafka messages can carry large JSON payloads, so keep
+# this lower than syslog to avoid several full workflow histories being resident
+# at the same time.
+_MAX_CONCURRENT_EXECUTIONS = 2
 # Maximum number of buffered Kafka messages per workflow.  Unlike syslog we do
 # not drop on overflow; a full queue applies backpressure to the consumer loop.
-_MAX_QUEUE_SIZE = 1000
+_MAX_QUEUE_SIZE = 100
 # Maximum time we wait for the consumer to either connect successfully or fail
 # during ``restart_workflow`` so the HTTP save endpoint can surface connection
 # errors instead of pretending the consumer is running.
@@ -56,6 +61,31 @@ _CONNECT_WAIT_TIMEOUT_S = 8.0
 # Kafka client request timeout; kept short so an unreachable broker fails fast
 # within the connect-wait window above.
 _REQUEST_TIMEOUT_MS = 5000
+# Bound aiokafka's internal fetch buffers. The explicit queue below provides the
+# main backpressure; these caps stop the client from prefetching a large burst
+# before the workflow workers can drain it.
+_FETCH_MAX_BYTES = 8 * 1024 * 1024
+_MAX_PARTITION_FETCH_BYTES = 4 * 1024 * 1024
+_MAX_POLL_RECORDS = 16
+
+_KAFKA_STORAGE_LIST_KEYS = DEFAULT_LARGE_LIST_KEYS | frozenset(
+    {
+        "duplicate_alerts",
+        "triage_candidate_alerts",
+        "enriched_alerts_with_triage",
+        "kafka_messages",
+    }
+)
+_KAFKA_RAW_INPUT_KEYS = frozenset({"kafka_message", "kafka_value", "kafka_record"})
+_STORAGE_PREVIEW_CHARS = 512
+
+
+@dataclass(frozen=True)
+class _QueuedKafkaMessage:
+    """Raw Kafka value kept in the queue until a worker is ready to process it."""
+
+    raw_value: Optional[bytes]
+    size_bytes: int
 
 
 def _decode_message(raw: Optional[bytes]) -> Any:
@@ -76,6 +106,90 @@ def _decode_message(raw: Optional[bytes]) -> Any:
         return text
 
 
+def _summarize_large_value(value: Any) -> Any:
+    """Return a bounded representation suitable for execution history storage."""
+    if isinstance(value, bytes):
+        return {
+            "_type": "bytes",
+            "sizeBytes": len(value),
+            "sha256": hashlib.sha256(value).hexdigest(),
+        }
+    if isinstance(value, str):
+        if len(value) <= _STORAGE_PREVIEW_CHARS:
+            return value
+        return {
+            "_type": "string",
+            "chars": len(value),
+            "sha256": hashlib.sha256(value.encode("utf-8", errors="ignore")).hexdigest(),
+            "preview": value[:_STORAGE_PREVIEW_CHARS],
+        }
+    if isinstance(value, (list, tuple)):
+        return {
+            "_type": "list",
+            "count": len(value),
+            "preview": [_summarize_large_value(item) for item in list(value)[:3]],
+        }
+    if isinstance(value, dict):
+        compacted: Dict[str, Any] = {
+            "_type": "dict",
+            "keys": list(value.keys())[:50],
+        }
+        for key in (
+            "id",
+            "_id",
+            "log_id",
+            "raw_log_id",
+            "event_id",
+            "message_id",
+            "source",
+            "product_type",
+            "hostname",
+        ):
+            if key in value:
+                compacted[key] = _summarize_large_value(value[key])
+        if "alarmData" in value:
+            compacted["alarmData"] = _summarize_large_value(value["alarmData"])
+        return compacted
+    return value
+
+
+def _compact_for_kafka_storage(outputs: Any) -> Dict[str, Any]:
+    """Compact all known large workflow lists for high-frequency Kafka runs."""
+    compacted = compact_outputs_for_storage(
+        outputs,
+        keys=_KAFKA_STORAGE_LIST_KEYS,
+        size_threshold=0,
+    )
+    for key, value in list(compacted.items()):
+        if key == "kafka_output" or (
+            isinstance(value, str) and len(value) > _STORAGE_PREVIEW_CHARS
+        ):
+            compacted[key] = _summarize_large_value(value)
+    return compacted
+
+
+def _compact_history_for_kafka_storage(history: Any, *, input_key: str) -> List[Any]:
+    compacted = compact_history_for_storage(
+        history,
+        keys=_KAFKA_STORAGE_LIST_KEYS,
+        size_threshold=0,
+    )
+    raw_input_keys = _KAFKA_RAW_INPUT_KEYS | frozenset({input_key})
+    for step in compacted:
+        if not isinstance(step, dict):
+            continue
+        for field in ("inputs", "outputs"):
+            payload = step.get(field)
+            if not isinstance(payload, dict):
+                continue
+            for key, value in list(payload.items()):
+                if key in raw_input_keys or key == "kafka_output" or (
+                    isinstance(value, str) and len(value) > _STORAGE_PREVIEW_CHARS
+                ):
+                    payload[key] = _summarize_large_value(value)
+    return compacted
+
+
 class KafkaManager:
     """One async consumer task per workflow id (when enabled)."""
 
@@ -92,10 +206,6 @@ class KafkaManager:
         # Per-workflow event signalled once the consumer has either connected
         # successfully or failed; used by ``restart_workflow``.
         self._ready: dict[str, asyncio.Event] = {}
-        # Per-workflow output producer (only when output is configured)
-        self._producers: dict[str, Any] = {}
-        self._producer_brokers: dict[str, str] = {}
-        self._producer_locks: dict[str, asyncio.Lock] = {}
 
     @staticmethod
     def _config_key(workflow_id: str) -> str:
@@ -126,38 +236,6 @@ class KafkaManager:
         for workflow_id in list(self._tasks.keys()):
             await self.stop_workflow(workflow_id)
 
-    def _producer_lock(self, workflow_id: str) -> asyncio.Lock:
-        lock = self._producer_locks.get(workflow_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._producer_locks[workflow_id] = lock
-        return lock
-
-    async def _drop_output_producer(self, workflow_id: str) -> None:
-        producer = self._producers.pop(workflow_id, None)
-        self._producer_brokers.pop(workflow_id, None)
-        if producer is not None:
-            try:
-                await producer.stop()
-            except Exception:
-                pass
-
-    async def _ensure_output_producer(self, workflow_id: str, broker: str) -> Any:
-        broker = broker.strip()
-        if not broker:
-            return None
-
-        async with self._producer_lock(workflow_id):
-            current = self._producers.get(workflow_id)
-            if current is not None and self._producer_brokers.get(workflow_id) == broker:
-                return current
-
-            await self._drop_output_producer(workflow_id)
-            producer = await self._create_producer(broker)
-            self._producers[workflow_id] = producer
-            self._producer_brokers[workflow_id] = broker
-            return producer
-
     async def _cleanup_runtime_resources(self, workflow_id: str) -> None:
         # Cancel all worker pool tasks; pop first so callers observing a stopped
         # consumer see an empty pool immediately.
@@ -174,7 +252,6 @@ class KafkaManager:
             except (asyncio.TimeoutError, asyncio.CancelledError):
                 pass
 
-        await self._drop_output_producer(workflow_id)
         self._queues.pop(workflow_id, None)
         self._abort_events.pop(workflow_id, None)
         self._ready.pop(workflow_id, None)
@@ -258,9 +335,6 @@ class KafkaManager:
 
         group_id = str(data.get("inputGroupId") or "").strip() or f"flocks-consumer-{workflow_id}"
         input_key = str(data.get("inputKey") or "kafka_message")
-        output_broker = str(data.get("outputBroker") or "").strip()
-        output_topic = str(data.get("outputTopic") or "").strip()
-        output_enabled = bool(data.get("outputEnabled"))
 
         queue: asyncio.Queue = asyncio.Queue(maxsize=_MAX_QUEUE_SIZE)
         self._queues[workflow_id] = queue
@@ -279,19 +353,6 @@ class KafkaManager:
             "groupId": group_id,
         }
 
-        # Optionally start an output producer up-front so failures are visible.
-        producer = None
-        if output_enabled and output_broker and output_topic:
-            try:
-                producer = await self._ensure_output_producer(workflow_id, output_broker)
-            except Exception as exc:
-                log.warning(
-                    "kafka.producer_start_failed",
-                    {"workflow_id": workflow_id, "error": str(exc)},
-                )
-        else:
-            await self._drop_output_producer(workflow_id)
-
         # Fixed worker pool drains the queue (at most _MAX_CONCURRENT_EXECUTIONS
         # concurrent runs).
         workers: List[asyncio.Task] = []
@@ -300,7 +361,6 @@ class KafkaManager:
                 asyncio.create_task(
                     self._worker_loop(
                         workflow_id, workflow_json, input_key, queue, abort,
-                        producer, output_topic,
                     ),
                     name=f"kafka-worker-{workflow_id}-{i}",
                 )
@@ -346,54 +406,6 @@ class KafkaManager:
         log.info("kafka.consumer_scheduled", {"workflow_id": workflow_id})
         return self.get_consumer_status(workflow_id)
 
-    async def _create_producer(self, broker: str) -> Any:
-        from aiokafka import AIOKafkaProducer
-
-        producer = AIOKafkaProducer(
-            bootstrap_servers=broker,
-            request_timeout_ms=_REQUEST_TIMEOUT_MS,
-        )
-        await producer.start()
-        return producer
-
-    async def publish_execution_result(self, workflow_id: str, exec_id: str, outputs: Any) -> bool:
-        """Publish a successful workflow execution to the configured output topic.
-
-        This intentionally does not require the Kafka consumer to be enabled, so
-        workflows can be configured as output-only producers.
-        """
-        try:
-            data = await Storage.read(self._config_key(workflow_id))
-        except Exception as exc:
-            log.warning(
-                "kafka.output_config_read_failed",
-                {"workflow_id": workflow_id, "exec_id": exec_id, "error": str(exc)},
-            )
-            return False
-        if not isinstance(data, dict):
-            return False
-
-        output_broker = str(data.get("outputBroker") or "").strip()
-        output_topic = str(data.get("outputTopic") or "").strip()
-        if not data.get("outputEnabled") or not output_broker or not output_topic:
-            await self._drop_output_producer(workflow_id)
-            return False
-
-        try:
-            producer = await self._ensure_output_producer(workflow_id, output_broker)
-            value = json.dumps(
-                {"workflowId": workflow_id, "executionId": exec_id, "outputs": outputs},
-                default=str,
-            ).encode("utf-8")
-            await producer.send_and_wait(output_topic, value)
-            return True
-        except Exception as exc:
-            log.warning(
-                "kafka.produce_failed",
-                {"workflow_id": workflow_id, "exec_id": exec_id, "error": str(exc)},
-            )
-            return False
-
     async def _consumer_loop(
         self,
         workflow_id: str,
@@ -430,6 +442,9 @@ class KafkaManager:
             enable_auto_commit=True,
             auto_offset_reset=auto_offset_reset if auto_offset_reset in ("latest", "earliest") else "latest",
             request_timeout_ms=_REQUEST_TIMEOUT_MS,
+            fetch_max_bytes=_FETCH_MAX_BYTES,
+            max_partition_fetch_bytes=_MAX_PARTITION_FETCH_BYTES,
+            max_poll_records=_MAX_POLL_RECORDS,
         )
 
         try:
@@ -474,9 +489,13 @@ class KafkaManager:
             async for msg in consumer:
                 if abort.is_set():
                     break
-                payload = _decode_message(msg.value)
+                raw_value = msg.value
+                queued = _QueuedKafkaMessage(
+                    raw_value=raw_value,
+                    size_bytes=len(raw_value) if raw_value is not None else 0,
+                )
                 # Blocking put applies backpressure instead of dropping messages.
-                await queue.put(payload)
+                await queue.put(queued)
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -505,8 +524,6 @@ class KafkaManager:
         input_key: str,
         queue: asyncio.Queue,
         abort: asyncio.Event,
-        producer: Any,
-        output_topic: str,
     ) -> None:
         while not abort.is_set():
             try:
@@ -516,8 +533,10 @@ class KafkaManager:
             except asyncio.CancelledError:
                 return
             try:
+                if isinstance(msg, _QueuedKafkaMessage):
+                    msg = _decode_message(msg.raw_value)
                 await self._trigger_workflow(
-                    workflow_id, workflow_json, msg, input_key, producer, output_topic,
+                    workflow_id, workflow_json, msg, input_key,
                 )
             except asyncio.CancelledError:
                 return
@@ -533,14 +552,15 @@ class KafkaManager:
         workflow_json: Any,
         message: Any,
         input_key: str,
-        producer: Any = None,
-        output_topic: str = "",
     ) -> None:
         inputs = {input_key: message}
 
         exec_data = await create_execution_record(
             workflow_id,
-            input_params={"_trigger": "kafka", **inputs},
+            input_params={
+                "_trigger": "kafka",
+                input_key: _summarize_large_value(message),
+            },
         )
         exec_id = exec_data["id"]
         start_time = time.time()
@@ -557,11 +577,14 @@ class KafkaManager:
             duration = time.time() - start_time
             exec_data.update({
                 "status": status,
-                "outputResults": compact_outputs_for_storage(result.outputs),
+                "outputResults": _compact_for_kafka_storage(result.outputs),
                 "finishedAt": int(time.time() * 1000),
                 "duration": duration,
                 "errorMessage": error_msg,
-                "executionLog": compact_history_for_storage(result.history),
+                "executionLog": _compact_history_for_kafka_storage(
+                    result.history,
+                    input_key=input_key,
+                ),
                 "currentNodeId": result.last_node_id,
                 "currentPhase": status,
                 "currentStepIndex": result.steps,
@@ -584,25 +607,6 @@ class KafkaManager:
                 await record_execution_result(workflow_id, exec_id, exec_data)
             except Exception as exc:
                 log.warning("kafka.exec_record_failed", {"exec_id": exec_id, "error": str(exc)})
-
-        # Produce the result back to Kafka on success when configured.
-        if (
-            producer is not None
-            and output_topic
-            and result is not None
-            and exec_data.get("status") == "success"
-        ):
-            try:
-                value = json.dumps(
-                    {"workflowId": workflow_id, "executionId": exec_id, "outputs": result.outputs},
-                    default=str,
-                ).encode("utf-8")
-                await producer.send_and_wait(output_topic, value)
-            except Exception as exc:
-                log.warning(
-                    "kafka.produce_failed",
-                    {"workflow_id": workflow_id, "exec_id": exec_id, "error": str(exc)},
-                )
 
 
 default_manager = KafkaManager()

--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -79,19 +79,6 @@ class ActiveWorkflowExecution:
 _active_workflow_executions: Dict[str, ActiveWorkflowExecution] = {}
 
 
-async def _publish_kafka_execution_result(workflow_id: str, exec_id: str, outputs: Any) -> None:
-    """Best-effort Kafka output publishing for successful workflow executions."""
-    try:
-        from flocks.ingest.kafka.manager import default_manager as _kafka_default_manager
-
-        await _kafka_default_manager.publish_execution_result(workflow_id, exec_id, outputs)
-    except Exception as exc:
-        log.warning(
-            "workflow.kafka_output.publish_failed",
-            {"id": workflow_id, "exec_id": exec_id, "error": str(exc)},
-        )
-
-
 # =============================================================================
 # Request/Response Models
 # =============================================================================
@@ -515,8 +502,6 @@ async def _run_workflow_execution_task(
         })
 
         await _record_execution_result(workflow_id, exec_id, current_data)
-        if status_value == "success":
-            await _publish_kafka_execution_result(workflow_id, exec_id, result.outputs)
         log.info("workflow.executed", {
             "id": workflow_id,
             "exec_id": exec_id,
@@ -1080,9 +1065,6 @@ async def workflow_center_invoke(workflow_id: str, req: WorkflowCenterInvokeRequ
             "currentPhase": status_value,
         })
         await _record_execution_result(workflow_id, exec_id, exec_data)
-        if success:
-            outputs = result.get("outputs", {}) if isinstance(result, dict) else {}
-            await _publish_kafka_execution_result(workflow_id, exec_id, outputs)
         return result
     except (WorkflowNotFoundError, WorkflowNotPublishedError) as e:
         duration = time.time() - started
@@ -1403,7 +1385,7 @@ class WorkflowServiceResponse(BaseModel):
 
 
 class KafkaConfigRequest(BaseModel):
-    """Per-workflow Kafka consumer/producer configuration (experimental)."""
+    """Per-workflow Kafka consumer configuration."""
 
     enabled: bool = False
     inputBroker: Optional[str] = None
@@ -1411,9 +1393,6 @@ class KafkaConfigRequest(BaseModel):
     inputGroupId: Optional[str] = None
     inputKey: str = "kafka_message"
     autoOffsetReset: str = "latest"
-    outputEnabled: bool = False
-    outputBroker: Optional[str] = None
-    outputTopic: Optional[str] = None
 
 
 class WorkflowPollerConfigRequest(BaseModel):
@@ -1593,7 +1572,7 @@ async def list_workflow_services():
 @router.post("/workflow/{workflow_id}/kafka-config")
 async def save_kafka_config(workflow_id: str, req: KafkaConfigRequest):
     """
-    Save Kafka input/output configuration for a workflow.
+    Save Kafka input configuration for a workflow.
 
     When ``enabled`` is true this also (re)starts the Kafka consumer and blocks
     until it has either connected to the broker or failed.  Connection failures
@@ -1612,9 +1591,6 @@ async def save_kafka_config(workflow_id: str, req: KafkaConfigRequest):
             "inputGroupId": req.inputGroupId,
             "inputKey": req.inputKey,
             "autoOffsetReset": req.autoOffsetReset,
-            "outputEnabled": req.outputEnabled,
-            "outputBroker": req.outputBroker,
-            "outputTopic": req.outputTopic,
             "updatedAt": int(time.time() * 1000),
         }
         await Storage.write(_kafka_config_key(workflow_id), config)

--- a/flocks/workflow/engine.py
+++ b/flocks/workflow/engine.py
@@ -9,7 +9,7 @@ import time
 import traceback
 import uuid
 import json
-from typing import Any, Callable, Deque, Dict, List, NamedTuple, Optional, Set, Tuple, TypeVar
+from typing import Any, Callable, Deque, Dict, List, Literal, NamedTuple, Optional, Set, Tuple, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -39,12 +39,45 @@ class _ExecOutcome(NamedTuple):
     is_cancelled: bool = False
 
 
+def _summarize_for_observability(value: Any, *, depth: int = 0) -> Any:
+    """Return a bounded, non-retaining summary for logs and lightweight history."""
+    if depth >= 2:
+        if isinstance(value, (list, tuple, set)):
+            return {"_type": type(value).__name__, "count": len(value)}
+        if isinstance(value, dict):
+            return {"_type": "dict", "keys": list(value.keys())[:20]}
+        if isinstance(value, str) and len(value) > 200:
+            return {"_type": "string", "chars": len(value), "preview": value[:200]}
+        return value
+    if isinstance(value, dict):
+        return {
+            key: _summarize_for_observability(item, depth=depth + 1)
+            for key, item in list(value.items())[:50]
+        }
+    if isinstance(value, (list, tuple, set)):
+        return {
+            "_type": type(value).__name__,
+            "count": len(value),
+            "preview": [
+                _summarize_for_observability(item, depth=depth + 1)
+                for item in list(value)[:3]
+            ],
+        }
+    if isinstance(value, str) and len(value) > 200:
+        return {"_type": "string", "chars": len(value), "preview": value[:200]}
+    return value
+
+
 def _outputs_for_log(outputs: Dict[str, Any], *, max_chars: int = 4000) -> str:
-    """Serialize outputs for logs with bounded size."""
+    """Serialize an output summary for logs with bounded size."""
     try:
-        text = json.dumps(outputs, ensure_ascii=False, default=str)
+        text = json.dumps(
+            _summarize_for_observability(outputs),
+            ensure_ascii=False,
+            default=str,
+        )
     except Exception:
-        text = repr(outputs)
+        text = repr(_summarize_for_observability(outputs))
     if len(text) <= max_chars:
         return text
     return text[:max_chars] + f"...[truncated:{len(text) - max_chars}]"
@@ -64,6 +97,7 @@ class ExecutionResult(BaseModel):
     steps: int
     history: list[StepResult] = Field(default_factory=list)
     last_node_id: Optional[str] = None
+    outputs: Dict[str, Any] = Field(default_factory=dict)
     run_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
 
 
@@ -110,6 +144,7 @@ class WorkflowEngine:
     mutate_workflow: bool = False
     workflow_path: Optional[str] = None
     node_timeout_s: Optional[float] = 300.0
+    history_mode: Literal["full", "summary"] = "full"
     _depth: int = 0
     max_parallel_workers: int = 4
     workflow_loader: Optional[Callable[[str], "Workflow"]] = field(default=None, repr=False)
@@ -119,6 +154,8 @@ class WorkflowEngine:
             raise ValueError("max_steps must be > 0")
         if self.max_parallel_workers < 1:
             raise ValueError("max_parallel_workers must be >= 1")
+        if self.history_mode not in ("full", "summary"):
+            raise ValueError("history_mode must be 'full' or 'summary'")
         if self.runtime is None:
             self.runtime = PythonExecRuntime()
         if self.code_gen is None:
@@ -169,6 +206,7 @@ class WorkflowEngine:
             [(self.workflow.start, initial_inputs or {}, None)]
         )
         history: list[StepResult] = []
+        last_outputs: Dict[str, Any] = {}
         step_count = 0
         last_node_id: Optional[str] = None
         rid = (run_id or uuid.uuid4().hex).strip() or uuid.uuid4().hex
@@ -191,6 +229,7 @@ class WorkflowEngine:
                     "run_id": rid,
                     "steps": step_count,
                     "last_node_id": last_node_id,
+                    "outputs": last_outputs,
                     "history": history,
                 }
 
@@ -266,15 +305,22 @@ class WorkflowEngine:
                         inputs = merged
                         join_seen_sources.pop(node_id, None)
 
-                    # Dedup: skip if same node already ran with identical inputs
-                    try:
-                        _hash_raw = json.dumps(
-                            {"n": node_id, "i": inputs},
-                            sort_keys=True, ensure_ascii=False, default=str,
-                        )
-                        _input_hash = hashlib.sha256(_hash_raw.encode()).hexdigest()[:16]
-                    except Exception:
+                    # Dedup: skip if same node already ran with identical inputs.
+                    # Lightweight history mode is used by high-throughput ingest
+                    # paths with large payloads; hashing full inputs there would
+                    # serialize the same large alert lists we are trying not to
+                    # retain.
+                    if self.history_mode == "summary":
                         _input_hash = ""
+                    else:
+                        try:
+                            _hash_raw = json.dumps(
+                                {"n": node_id, "i": inputs},
+                                sort_keys=True, ensure_ascii=False, default=str,
+                            )
+                            _input_hash = hashlib.sha256(_hash_raw.encode()).hexdigest()[:16]
+                        except Exception:
+                            _input_hash = ""
                     if _input_hash and node_id in _dedup_hashes and _dedup_hashes[node_id] == _input_hash:
                         _logger.info(
                             "wf.step.dedup_skip node=%s (identical input hash %s)",
@@ -413,12 +459,41 @@ class WorkflowEngine:
                     _nid, _nd, _inp, _src = ready[_eo.idx]
                     _sn = step_count + _eo.idx + 1
                     last_node_id = _nid
+                    last_outputs = _eo.outputs
+
+                    def _build_step_result(
+                        *,
+                        outputs: Dict[str, Any],
+                        stdout: str,
+                        error: Optional[str],
+                        traceback_text: Optional[str] = None,
+                    ) -> StepResult:
+                        if self.history_mode == "summary":
+                            return StepResult(
+                                node_id=_nid,
+                                inputs=_summarize_for_observability(_inp),
+                                outputs=_summarize_for_observability(outputs),
+                                stdout=stdout,
+                                error=error,
+                                traceback=traceback_text,
+                                duration_ms=_eo.duration_ms,
+                            )
+                        return StepResult(
+                            node_id=_nid,
+                            inputs=_inp,
+                            outputs=outputs,
+                            stdout=stdout,
+                            error=error,
+                            traceback=traceback_text,
+                            duration_ms=_eo.duration_ms,
+                        )
 
                     if _eo.is_cancelled:
-                        step_res = StepResult(
-                            node_id=_nid, inputs=_inp, outputs={},
-                            stdout=_eo.stdout, error=_eo.error or "Run cancelled",
-                            traceback=_eo.traceback, duration_ms=_eo.duration_ms,
+                        step_res = _build_step_result(
+                            outputs={},
+                            stdout=_eo.stdout,
+                            error=_eo.error or "Run cancelled",
+                            traceback_text=_eo.traceback,
                         )
                         history.append(step_res)
                         if on_step_end is not None and _eo.idx in step_tokens:
@@ -440,10 +515,11 @@ class WorkflowEngine:
                             if _eo.traceback:
                                 print("[WF] traceback:")
                                 print(_eo.traceback.rstrip())
-                        step_res = StepResult(
-                            node_id=_nid, inputs=_inp, outputs=_eo.outputs,
-                            stdout=_eo.stdout, error=_eo.error, traceback=_eo.traceback,
-                            duration_ms=_eo.duration_ms,
+                        step_res = _build_step_result(
+                            outputs=_eo.outputs,
+                            stdout=_eo.stdout,
+                            error=_eo.error,
+                            traceback_text=_eo.traceback,
                         )
                         history.append(step_res)
                         _status = "timeout" if _eo.is_timeout else "error"
@@ -495,9 +571,10 @@ class WorkflowEngine:
                                 print("[WF] outputs=" + json.dumps(_eo.outputs, ensure_ascii=False, default=str))
                             except Exception:
                                 print(f"[WF] outputs=<unserializable> {_eo.outputs!r}")
-                        step_res = StepResult(
-                            node_id=_nid, inputs=_inp, outputs=_eo.outputs,
-                            stdout=_eo.stdout, error=None, duration_ms=_eo.duration_ms,
+                        step_res = _build_step_result(
+                            outputs=_eo.outputs,
+                            stdout=_eo.stdout,
+                            error=None,
                         )
                         history.append(step_res)
                         _logger.info(
@@ -545,7 +622,13 @@ class WorkflowEngine:
                     f"{nid} expected={expected} seen={seen}" for nid, expected, seen in pending_joins
                 )
                 raise NodeExecutionError(node_id=pending_joins[0][0], message=msg)
-            return ExecutionResult(steps=step_count, history=history, last_node_id=last_node_id, run_id=rid)
+            return ExecutionResult(
+                steps=step_count,
+                history=history,
+                last_node_id=last_node_id,
+                outputs=last_outputs,
+                run_id=rid,
+            )
         finally:
             if isinstance(self.runtime, PythonExecRuntime):
                 self.runtime.cancel_checker = previous_cancel_checker
@@ -775,6 +858,7 @@ class WorkflowEngine:
             use_llm=self.use_llm,
             trace=self.trace,
             node_timeout_s=self.node_timeout_s,
+            history_mode=self.history_mode,
             _depth=self._depth + 1,
             workflow_loader=self.workflow_loader,
         )

--- a/flocks/workflow/engine.py
+++ b/flocks/workflow/engine.py
@@ -459,7 +459,11 @@ class WorkflowEngine:
                     _nid, _nd, _inp, _src = ready[_eo.idx]
                     _sn = step_count + _eo.idx + 1
                     last_node_id = _nid
-                    last_outputs = _eo.outputs
+                    last_outputs = (
+                        _summarize_for_observability(_eo.outputs)
+                        if self.history_mode == "summary"
+                        else _eo.outputs
+                    )
 
                     def _build_step_result(
                         *,

--- a/flocks/workflow/repl_runtime.py
+++ b/flocks/workflow/repl_runtime.py
@@ -14,7 +14,7 @@ import traceback
 import uuid
 from concurrent.futures import TimeoutError as _FuturesTimeoutError
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional, TextIO, Tuple
+from typing import Any, Callable, ClassVar, Dict, Optional, TextIO, Tuple
 
 from .errors import NodeExecutionError, RunCancelledError
 from .llm import get_lazy_llm
@@ -49,6 +49,20 @@ class PythonExecRuntime(Runtime):
     globals: Dict[str, Any] = field(default_factory=dict)
     tool_registry: Optional[Any] = None  # FlocksToolAdapter or compatible
     cancel_checker: Optional[Callable[[], bool]] = None
+    cleanup_globals_after_execute: bool = False
+
+    _RUNTIME_GLOBAL_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "__builtins__",
+            "inputs",
+            "outputs",
+            "cancelled",
+            "is_cancelled",
+            "llm",
+            "tool",
+            "get_path",
+        }
+    )
 
     def execute(self, code: str, inputs: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
         if not isinstance(code, str):
@@ -189,6 +203,10 @@ class PythonExecRuntime(Runtime):
             out_obj = {}
         if not isinstance(out_obj, dict):
             raise NodeExecutionError(node_id="<runtime>", message="`outputs` must be a dict")
+        if self.cleanup_globals_after_execute:
+            for key in list(g.keys()):
+                if key not in self._RUNTIME_GLOBAL_KEYS:
+                    g.pop(key, None)
         return out_obj, buf.getvalue()
 
     def reset(self) -> None:

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -296,6 +296,7 @@ def run_workflow(
     on_step_start: Optional[Any] = None,
     on_step_complete: Optional[Any] = None,
     max_parallel_workers: int = 4,
+    history_mode: Literal["full", "summary"] = "full",
     cancel: Optional[Callable[[], bool]] = None,
 ) -> RunWorkflowResult:
     # 确保日志已配置
@@ -417,11 +418,12 @@ def run_workflow(
         rt = PythonExecRuntime(tool_registry=registry)
     
     _logger.info(
-        "创建执行引擎 (use_llm=%s, trace=%s, node_timeout=%ss, parallel_workers=%s)",
+        "创建执行引擎 (use_llm=%s, trace=%s, node_timeout=%ss, parallel_workers=%s, history_mode=%s)",
         effective_use_llm,
         trace,
         effective_node_timeout_s,
         max_parallel_workers,
+        history_mode,
     )
     engine = WorkflowEngine(
         wf,
@@ -431,6 +433,7 @@ def run_workflow(
         workflow_path=workflow_path_for_engine,
         node_timeout_s=effective_node_timeout_s,
         max_parallel_workers=max_parallel_workers,
+        history_mode=history_mode,
     )
     
     initial_inputs = _build_initial_inputs(inputs, workflow_path_for_engine)
@@ -469,7 +472,9 @@ def run_workflow(
         if history_from_error and hasattr(history_from_error[0], 'model_dump'):
             history_from_error = [s.model_dump(mode="json") for s in history_from_error]
         
-        last_outputs = history_from_error[-1].get('outputs', {}) if history_from_error else {}
+        last_outputs = exec_ctx.get('outputs') or (
+            history_from_error[-1].get('outputs', {}) if history_from_error else {}
+        )
         
         status = "FAILED"
         if isinstance(e, RunCancelledError):
@@ -488,7 +493,7 @@ def run_workflow(
         )
 
     history = [s.model_dump(mode="json") for s in result.history]
-    last_outputs = result.history[-1].outputs if result.history else {}
+    last_outputs = result.outputs if result.outputs else (result.history[-1].outputs if result.history else {})
 
     if cancel is not None and cancel():
         return RunWorkflowResult(

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -415,7 +415,10 @@ def run_workflow(
             _logger.info("workflow runtime: host forced by sandbox.mode=off or runtime override")
         if ensure_requirements and reqs:
             (requirements_installer or RequirementsInstaller(installer="auto")).ensure_installed(reqs)
-        rt = PythonExecRuntime(tool_registry=registry)
+        rt = PythonExecRuntime(
+            tool_registry=registry,
+            cleanup_globals_after_execute=(history_mode == "summary"),
+        )
     
     _logger.info(
         "创建执行引擎 (use_llm=%s, trace=%s, node_timeout=%ss, parallel_workers=%s, history_mode=%s)",

--- a/tests/ingest/test_kafka_manager.py
+++ b/tests/ingest/test_kafka_manager.py
@@ -246,6 +246,7 @@ async def test_trigger_workflow_compacts_kafka_execution_record(
     manager = kafka_manager.KafkaManager()
     captured_input_params: dict = {}
     captured_exec_data: dict = {}
+    captured_run_kwargs: dict = {}
 
     async def _fake_create_execution_record(workflow_id, *, input_params=None, exec_id=None):  # noqa: ANN001
         captured_input_params.update(input_params or {})
@@ -255,6 +256,7 @@ async def test_trigger_workflow_compacts_kafka_execution_record(
         captured_exec_data.update(exec_data)
 
     def _fake_run_workflow(**kwargs):  # noqa: ANN003
+        captured_run_kwargs.update(kwargs)
         large_alert = {"raw_log_id": "alert-1", "req_body": "x" * 50_000}
         return SimpleNamespace(
             status="SUCCEEDED",
@@ -292,6 +294,7 @@ async def test_trigger_workflow_compacts_kafka_execution_record(
 
     assert captured_input_params["kafka_message"]["alarmData"]["_type"] == "string"
     assert captured_input_params["kafka_message"]["alarmData"]["chars"] == 50_000
+    assert captured_run_kwargs["history_mode"] == "summary"
     assert captured_exec_data["outputResults"] == {
         "_enriched_alerts_count": 1,
         "_kafka_messages_count": 1,

--- a/tests/ingest/test_kafka_manager.py
+++ b/tests/ingest/test_kafka_manager.py
@@ -56,7 +56,7 @@ async def test_worker_pool_bounds_in_flight_dispatches(monkeypatch: pytest.Monke
     manager._abort_events[workflow_id] = abort
     workers = [
         asyncio.create_task(
-            manager._worker_loop(workflow_id, {}, "kafka_message", queue, abort, None, ""),
+            manager._worker_loop(workflow_id, {}, "kafka_message", queue, abort),
             name=f"test-worker-{i}",
         )
         for i in range(pool_size)
@@ -84,6 +84,37 @@ async def test_worker_pool_bounds_in_flight_dispatches(monkeypatch: pytest.Monke
 
 
 @pytest.mark.asyncio
+async def test_worker_decodes_queued_raw_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Kafka workers should decode raw bytes only when a worker is ready."""
+
+    manager = kafka_manager.KafkaManager()
+    workflow_id = "test-wf-raw-queue"
+    queue: asyncio.Queue = asyncio.Queue(maxsize=8)
+    abort = asyncio.Event()
+    captured: list[dict] = []
+
+    async def _fake_trigger(workflow_id, workflow_json, msg, input_key, producer=None, output_topic=""):  # noqa: ANN001
+        captured.append(msg)
+        abort.set()
+
+    monkeypatch.setattr(manager, "_trigger_workflow", _fake_trigger)
+    queue.put_nowait(
+        kafka_manager._QueuedKafkaMessage(  # noqa: SLF001
+            raw_value=b'{"ok": true}',
+            size_bytes=len(b'{"ok": true}'),
+        )
+    )
+
+    worker = asyncio.create_task(
+        manager._worker_loop(workflow_id, {}, "kafka_message", queue, abort),
+        name="test-worker-raw-queue",
+    )
+    await asyncio.wait_for(worker, timeout=1.0)
+
+    assert captured == [{"ok": True}]
+
+
+@pytest.mark.asyncio
 async def test_stop_workflow_cancels_worker_pool() -> None:
     """``stop_workflow`` must cancel and drain the worker pool cleanly."""
 
@@ -102,7 +133,7 @@ async def test_stop_workflow_cancels_worker_pool() -> None:
 
     workers = [
         asyncio.create_task(
-            manager._worker_loop(workflow_id, {}, "kafka_message", queue, abort, None, ""),
+            manager._worker_loop(workflow_id, {}, "kafka_message", queue, abort),
             name=f"stop-worker-{i}",
         )
         for i in range(3)
@@ -151,92 +182,6 @@ async def test_restart_missing_broker_reports_failed(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
-async def test_publish_execution_result_allows_output_only_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Kafka output publishing must not require consumer input configuration."""
-
-    manager = kafka_manager.KafkaManager()
-
-    class _Producer:
-        def __init__(self) -> None:
-            self.sent: list[tuple[str, bytes]] = []
-            self.stopped = False
-
-        async def send_and_wait(self, topic: str, value: bytes) -> None:
-            self.sent.append((topic, value))
-
-        async def stop(self) -> None:
-            self.stopped = True
-
-    producer = _Producer()
-    create_calls: list[str] = []
-
-    async def _fake_read(key):  # noqa: ANN001
-        return {
-            "enabled": False,
-            "inputBroker": "",
-            "inputTopic": "",
-            "outputEnabled": True,
-            "outputBroker": "localhost:9092",
-            "outputTopic": "workflow-output",
-        }
-
-    async def _fake_create_producer(broker: str):  # noqa: ANN001
-        create_calls.append(broker)
-        assert broker == "localhost:9092"
-        return producer
-
-    monkeypatch.setattr(kafka_manager.Storage, "read", _fake_read)
-    monkeypatch.setattr(manager, "_create_producer", _fake_create_producer)
-
-    published = await manager.publish_execution_result("wf-output", "exec-1", {"ok": True})
-    published_again = await manager.publish_execution_result("wf-output", "exec-2", {"ok": "again"})
-
-    assert published is True
-    assert published_again is True
-    assert create_calls == ["localhost:9092"]
-    assert len(producer.sent) == 2
-    topic, value = producer.sent[0]
-    assert topic == "workflow-output"
-    assert json.loads(value.decode("utf-8")) == {
-        "workflowId": "wf-output",
-        "executionId": "exec-1",
-        "outputs": {"ok": True},
-    }
-    assert producer.stopped is False
-
-    await manager.stop_workflow("wf-output")
-    assert producer.stopped is True
-
-
-@pytest.mark.asyncio
-async def test_publish_execution_result_skips_when_output_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Configured output broker/topic should not publish when the output toggle is off."""
-
-    manager = kafka_manager.KafkaManager()
-    create_producer_called = False
-
-    async def _fake_read(key):  # noqa: ANN001
-        return {
-            "enabled": False,
-            "outputEnabled": False,
-            "outputBroker": "localhost:9092",
-            "outputTopic": "workflow-output",
-        }
-
-    async def _fake_create_producer(broker: str):  # noqa: ANN001
-        nonlocal create_producer_called
-        create_producer_called = True
-
-    monkeypatch.setattr(kafka_manager.Storage, "read", _fake_read)
-    monkeypatch.setattr(manager, "_create_producer", _fake_create_producer)
-
-    published = await manager.publish_execution_result("wf-output", "exec-1", {"ok": True})
-
-    assert published is False
-    assert create_producer_called is False
-
-
-@pytest.mark.asyncio
 async def test_restart_workflow_cleans_resources_after_connect_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -252,17 +197,7 @@ async def test_restart_workflow_cleans_resources_after_connect_failure(
             "inputTopic": "workflow-input",
             "inputGroupId": "wf-group",
             "inputKey": "kafka_message",
-            "outputEnabled": True,
-            "outputBroker": "localhost:9092",
-            "outputTopic": "workflow-output",
         }
-
-    class _Producer:
-        def __init__(self) -> None:
-            self.stopped = False
-
-        async def stop(self) -> None:
-            self.stopped = True
 
     class _Consumer:
         def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
@@ -274,19 +209,12 @@ async def test_restart_workflow_cleans_resources_after_connect_failure(
         async def stop(self) -> None:
             self.stopped = True
 
-    producer = _Producer()
-
-    async def _fake_create_producer(broker: str):  # noqa: ANN001
-        assert broker == "localhost:9092"
-        return producer
-
     monkeypatch.setattr(kafka_manager.Storage, "read", _fake_read)
     monkeypatch.setattr(
         kafka_manager,
         "read_workflow_from_fs",
         lambda _workflow_id: {"workflowJson": {"start": "n1", "nodes": [], "edges": []}},
     )
-    monkeypatch.setattr(manager, "_create_producer", _fake_create_producer)
     monkeypatch.setitem(sys.modules, "aiokafka", SimpleNamespace(AIOKafkaConsumer=_Consumer))
 
     status = await manager.restart_workflow(workflow_id)
@@ -297,8 +225,6 @@ async def test_restart_workflow_cleans_resources_after_connect_failure(
     assert workflow_id not in manager._worker_pools
     assert workflow_id not in manager._queues
     assert workflow_id not in manager._abort_events
-    assert workflow_id not in manager._producers
-    assert producer.stopped is True
 
 
 def test_decode_message_variants() -> None:
@@ -309,3 +235,67 @@ def test_decode_message_variants() -> None:
     assert kafka_manager._decode_message(None) is None
     # Invalid UTF-8 bytes fall back to a hex repr.
     assert kafka_manager._decode_message(b"\xff\xfe") == "fffe"
+
+
+@pytest.mark.asyncio
+async def test_trigger_workflow_compacts_kafka_execution_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Kafka-triggered execution rows should not retain full raw alert bodies."""
+
+    manager = kafka_manager.KafkaManager()
+    captured_input_params: dict = {}
+    captured_exec_data: dict = {}
+
+    async def _fake_create_execution_record(workflow_id, *, input_params=None, exec_id=None):  # noqa: ANN001
+        captured_input_params.update(input_params or {})
+        return {"id": "exec-compact", "workflowId": workflow_id, "inputParams": input_params}
+
+    async def _fake_record_execution_result(workflow_id, exec_id, exec_data):  # noqa: ANN001
+        captured_exec_data.update(exec_data)
+
+    def _fake_run_workflow(**kwargs):  # noqa: ANN003
+        large_alert = {"raw_log_id": "alert-1", "req_body": "x" * 50_000}
+        return SimpleNamespace(
+            status="SUCCEEDED",
+            error=None,
+            outputs={
+                "enriched_alerts": [large_alert],
+                "kafka_messages": [{"raw_log_id": "alert-1"}],
+            },
+            history=[
+                {
+                    "node_id": "receive_alert",
+                    "inputs": {"kafka_message": {"alarmData": "x" * 50_000}},
+                    "outputs": {"raw_alerts": [large_alert]},
+                },
+                {
+                    "node_id": "dedup_and_write",
+                    "inputs": {"filtered_alerts": [large_alert]},
+                    "outputs": {"enriched_alerts": [large_alert]},
+                },
+            ],
+            last_node_id="done",
+            steps=2,
+        )
+
+    monkeypatch.setattr(kafka_manager, "create_execution_record", _fake_create_execution_record)
+    monkeypatch.setattr(kafka_manager, "record_execution_result", _fake_record_execution_result)
+    monkeypatch.setattr(kafka_manager, "run_workflow", _fake_run_workflow)
+
+    await manager._trigger_workflow(
+        "wf-compact",
+        {"start": "receive_alert", "nodes": [], "edges": []},
+        {"alarmData": "x" * 50_000},
+        "kafka_message",
+    )
+
+    assert captured_input_params["kafka_message"]["alarmData"]["_type"] == "string"
+    assert captured_input_params["kafka_message"]["alarmData"]["chars"] == 50_000
+    assert captured_exec_data["outputResults"] == {
+        "_enriched_alerts_count": 1,
+        "_kafka_messages_count": 1,
+    }
+    assert captured_exec_data["executionLog"][0]["outputs"] == {"_raw_alerts_count": 1}
+    assert captured_exec_data["executionLog"][1]["inputs"] == {"_filtered_alerts_count": 1}
+    assert len(json.dumps(captured_exec_data, ensure_ascii=False)) < 10_000

--- a/tests/server/routes/test_workflow_run_route.py
+++ b/tests/server/routes/test_workflow_run_route.py
@@ -59,82 +59,37 @@ async def test_run_workflow_execution_task_reuses_existing_mcp_without_reinit(
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_execution_task_publishes_kafka_output_on_success(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    run_mock = Mock(
-        return_value=SimpleNamespace(
-            outputs={"ok": True},
-            history=[],
-            last_node_id="node-1",
-            steps=1,
-        )
-    )
-    record_result = AsyncMock(return_value=None)
-    publish_output = AsyncMock(return_value=None)
-
-    monkeypatch.setattr(workflow_module, "run_workflow", run_mock)
-    monkeypatch.setattr(workflow_module, "_resolve_execution_outcome", lambda _result: ("success", None))
-    monkeypatch.setattr(workflow_module, "_record_execution_result", record_result)
-    monkeypatch.setattr(workflow_module, "_publish_kafka_execution_result", publish_output)
-    monkeypatch.setattr(
-        workflow_module.Storage,
-        "read",
-        AsyncMock(
-            return_value={
-                "id": "exec-1",
-                "workflowId": "wf-1",
-                "currentNodeType": "tool",
-                "executionLog": [],
-            }
-        ),
-    )
-    monkeypatch.setattr(workflow_module.Storage, "write", AsyncMock(return_value=None))
-    monkeypatch.setattr(workflow_module, "compact_outputs_for_storage", lambda value: value)
-    monkeypatch.setattr(workflow_module, "compact_history_for_storage", lambda value: value)
-
-    req = workflow_module.WorkflowRunRequest(inputs={"ip": "8.8.8.8"}, trace=False)
-
-    await workflow_module._run_workflow_execution_task(
-        workflow_id="wf-1",
-        workflow_json={"id": "wf-1", "start": "node-1", "nodes": [], "edges": []},
-        req=req,
-        exec_id="exec-1",
-        cancel_event=workflow_module.threading.Event(),
-    )
-
-    record_result.assert_awaited_once()
-    publish_output.assert_awaited_once_with("wf-1", "exec-1", {"ok": True})
-
-
-@pytest.mark.asyncio
-async def test_save_kafka_config_accepts_output_only_without_consumer(
+async def test_save_kafka_config_persists_consumer_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from flocks.ingest.kafka import manager as kafka_manager
 
     storage_write = AsyncMock(return_value=None)
-    restart_workflow = AsyncMock(return_value={"state": "stopped", "error": None})
+    restart_workflow = AsyncMock(return_value={"state": "running", "error": None})
 
     monkeypatch.setattr(workflow_module, "_read_workflow_from_fs", lambda _workflow_id: {"workflowJson": {}})
     monkeypatch.setattr(workflow_module.Storage, "write", storage_write)
     monkeypatch.setattr(kafka_manager.default_manager, "restart_workflow", restart_workflow)
 
     req = workflow_module.KafkaConfigRequest(
-        enabled=False,
-        outputEnabled=True,
-        outputBroker="localhost:9092",
-        outputTopic="workflow-output",
+        enabled=True,
+        inputBroker="localhost:9092",
+        inputTopic="workflow-input",
+        inputGroupId="wf-group",
+        inputKey="kafka_message",
     )
 
-    response = await workflow_module.save_kafka_config("wf-output", req)
+    response = await workflow_module.save_kafka_config("wf-input", req)
 
-    assert response == {"ok": True, "consumer": {"state": "stopped", "error": None}}
+    assert response == {"ok": True, "consumer": {"state": "running", "error": None}}
     storage_write.assert_awaited_once()
     _, saved_config = storage_write.await_args.args
-    assert saved_config["enabled"] is False
-    assert saved_config["outputEnabled"] is True
-    assert saved_config["inputTopic"] is None
-    assert saved_config["outputBroker"] == "localhost:9092"
-    assert saved_config["outputTopic"] == "workflow-output"
-    restart_workflow.assert_awaited_once_with("wf-output")
+    assert saved_config["enabled"] is True
+    assert saved_config["inputBroker"] == "localhost:9092"
+    assert saved_config["inputTopic"] == "workflow-input"
+    assert saved_config["inputGroupId"] == "wf-group"
+    assert saved_config["inputKey"] == "kafka_message"
+    assert "outputEnabled" not in saved_config
+    assert "outputBroker" not in saved_config
+    assert "outputTopic" not in saved_config
+    restart_workflow.assert_awaited_once_with("wf-input")

--- a/tests/workflow/test_workflow_history_mode.py
+++ b/tests/workflow/test_workflow_history_mode.py
@@ -1,0 +1,50 @@
+from flocks.workflow.runner import run_workflow
+
+
+def test_run_workflow_summary_history_does_not_retain_large_step_payloads() -> None:
+    workflow = {
+        "start": "produce",
+        "nodes": [
+            {
+                "id": "produce",
+                "type": "python",
+                "code": "\n".join(
+                    [
+                        "outputs['raw_alerts'] = [{'id': i, 'body': 'x' * 1000} for i in range(200)]",
+                        "outputs['count'] = len(outputs['raw_alerts'])",
+                    ]
+                ),
+            },
+            {
+                "id": "consume",
+                "type": "python",
+                "code": "\n".join(
+                    [
+                        "alerts = inputs.get('raw_alerts', [])",
+                        "outputs['final_count'] = len(alerts)",
+                    ]
+                ),
+            },
+        ],
+        "edges": [{"from": "produce", "to": "consume"}],
+    }
+
+    result = run_workflow(
+        workflow=workflow,
+        history_mode="summary",
+        ensure_requirements=False,
+    )
+
+    assert result.status == "SUCCEEDED"
+    assert result.outputs == {"final_count": 200}
+    assert result.history[0]["outputs"]["raw_alerts"] == {
+        "_type": "list",
+        "count": 200,
+        "preview": [
+            {"_type": "dict", "keys": ["id", "body"]},
+            {"_type": "dict", "keys": ["id", "body"]},
+            {"_type": "dict", "keys": ["id", "body"]},
+        ],
+    }
+    assert result.history[1]["inputs"]["raw_alerts"]["count"] == 200
+

--- a/tests/workflow/test_workflow_history_mode.py
+++ b/tests/workflow/test_workflow_history_mode.py
@@ -1,4 +1,5 @@
 from flocks.workflow.runner import run_workflow
+from flocks.workflow.repl_runtime import PythonExecRuntime
 
 
 def test_run_workflow_summary_history_does_not_retain_large_step_payloads() -> None:
@@ -71,4 +72,17 @@ def test_run_workflow_summary_outputs_do_not_retain_large_final_payloads() -> No
     assert result.status == "SUCCEEDED"
     assert result.outputs["items"]["_type"] == "list"
     assert result.outputs["items"]["count"] == 200
+
+
+def test_python_runtime_can_cleanup_node_globals_after_execute() -> None:
+    runtime = PythonExecRuntime(cleanup_globals_after_execute=True)
+
+    outputs, _stdout = runtime.execute(
+        "temporary_payload = 'x' * 1000\noutputs['ok'] = True",
+        {},
+    )
+
+    assert outputs == {"ok": True}
+    assert "temporary_payload" not in runtime.globals
+    assert runtime.globals["outputs"] == {"ok": True}
 

--- a/tests/workflow/test_workflow_history_mode.py
+++ b/tests/workflow/test_workflow_history_mode.py
@@ -48,3 +48,27 @@ def test_run_workflow_summary_history_does_not_retain_large_step_payloads() -> N
     }
     assert result.history[1]["inputs"]["raw_alerts"]["count"] == 200
 
+
+def test_run_workflow_summary_outputs_do_not_retain_large_final_payloads() -> None:
+    workflow = {
+        "start": "final",
+        "nodes": [
+            {
+                "id": "final",
+                "type": "python",
+                "code": "outputs['items'] = [{'body': 'x' * 1000} for _ in range(200)]",
+            },
+        ],
+        "edges": [],
+    }
+
+    result = run_workflow(
+        workflow=workflow,
+        history_mode="summary",
+        ensure_requirements=False,
+    )
+
+    assert result.status == "SUCCEEDED"
+    assert result.outputs["items"]["_type"] == "list"
+    assert result.outputs["items"]["count"] == 200
+

--- a/webui/src/api/workflow.ts
+++ b/webui/src/api/workflow.ts
@@ -182,9 +182,6 @@ export interface KafkaConfig {
   inputGroupId?: string;
   inputKey?: string;
   autoOffsetReset?: string;
-  outputEnabled?: boolean;
-  outputBroker?: string;
-  outputTopic?: string;
   updatedAt?: number;
 }
 
@@ -312,9 +309,6 @@ export const workflowAPI = {
     inputGroupId?: string;
     inputKey?: string;
     autoOffsetReset?: string;
-    outputEnabled?: boolean;
-    outputBroker?: string;
-    outputTopic?: string;
   }) =>
     client.post<{ ok: boolean; consumer?: KafkaConsumerStatus }>(
       `/api/workflow/${id}/kafka-config`,

--- a/webui/src/pages/WorkflowDetail/tabs/IntegrationTab.test.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/IntegrationTab.test.tsx
@@ -54,10 +54,8 @@ vi.mock('react-i18next', () => ({
         'detail.run.kafkaSection': 'Kafka 配置',
         'detail.run.kafkaExperimental': '实验性',
         'detail.run.kafkaEnabled': '启用消费',
-        'detail.run.kafkaOutputEnabled': '启用输出',
         'detail.run.kafkaInputKey': 'Inputs 键名',
         'detail.run.inputConfig': '输入配置',
-        'detail.run.outputConfig': '输出配置',
         'detail.run.savingConfig': '保存中',
         'detail.run.savedConfig': '已保存',
         'detail.run.saveConfig': '保存配置',
@@ -142,29 +140,27 @@ describe('IntegrationTab Kafka config', () => {
     expect(screen.queryByText('实验性')).not.toBeInTheDocument();
   });
 
-  it('saves output-only Kafka config without enabling consumer', async () => {
+  it('saves Kafka consumer config without output fields', async () => {
     const user = userEvent.setup();
     render(<IntegrationTab workflow={workflow} />);
 
     await user.click(await screen.findByRole('button', { name: /Kafka 配置/ }));
-    const brokerFields = screen.getAllByPlaceholderText('localhost:9092');
-    await user.type(brokerFields[1], 'localhost:9092');
-    await user.type(screen.getByPlaceholderText('workflow-output'), 'workflow-output');
-    await user.click(screen.getByLabelText('启用输出'));
+    await user.type(screen.getByPlaceholderText('localhost:9092'), 'localhost:9092');
+    await user.type(screen.getByPlaceholderText('workflow-input'), 'workflow-input');
+    await user.click(screen.getByLabelText('启用消费'));
     await user.click(screen.getByRole('button', { name: '保存配置' }));
 
     await waitFor(() => {
       expect(workflowAPI.saveKafkaConfig).toHaveBeenCalledWith('wf-1', {
-        enabled: false,
-        inputBroker: '',
-        inputTopic: '',
+        enabled: true,
+        inputBroker: 'localhost:9092',
+        inputTopic: 'workflow-input',
         inputGroupId: '',
         inputKey: 'kafka_message',
-        outputEnabled: true,
-        outputBroker: 'localhost:9092',
-        outputTopic: 'workflow-output',
       });
     });
+    expect(screen.queryByText('输出配置')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('启用输出')).not.toBeInTheDocument();
   });
 
   it('renders poller status badge when runtime is running', async () => {

--- a/webui/src/pages/WorkflowDetail/tabs/IntegrationTab.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/IntegrationTab.tsx
@@ -303,9 +303,6 @@ function KafkaSection({ workflowId }: { workflowId: string }) {
   const [inputTopic, setInputTopic] = useState('');
   const [inputGroupId, setInputGroupId] = useState('');
   const [inputKey, setInputKey] = useState('kafka_message');
-  const [outputEnabled, setOutputEnabled] = useState(false);
-  const [outputBroker, setOutputBroker] = useState('');
-  const [outputTopic, setOutputTopic] = useState('');
   // Runtime consumer state (independent from saved config) — only this should
   // drive the "Running" indicator, otherwise a connection failure leaves the UI
   // falsely showing the consumer as active.
@@ -356,9 +353,6 @@ function KafkaSection({ workflowId }: { workflowId: string }) {
         setInputTopic(res.data.inputTopic || '');
         setInputGroupId(res.data.inputGroupId || '');
         setInputKey(res.data.inputKey || 'kafka_message');
-        setOutputBroker(res.data.outputBroker || '');
-        setOutputTopic(res.data.outputTopic || '');
-        setOutputEnabled(!!res.data.outputEnabled);
       }
     }).catch(() => {});
     refreshStatus();
@@ -379,7 +373,7 @@ function KafkaSection({ workflowId }: { workflowId: string }) {
     setSaveError('');
     try {
       const res = await workflowAPI.saveKafkaConfig(workflowId, {
-        enabled, inputBroker, inputTopic, inputGroupId, inputKey, outputEnabled, outputBroker, outputTopic,
+        enabled, inputBroker, inputTopic, inputGroupId, inputKey,
       });
       if (res.data?.consumer) {
         setConsumer(res.data.consumer);
@@ -448,25 +442,12 @@ function KafkaSection({ workflowId }: { workflowId: string }) {
             {inputField('Consumer Group', inputGroupId, setInputGroupId, 'flocks-consumer')}
             {inputField(t('detail.run.kafkaInputKey'), inputKey, setInputKey, 'kafka_message')}
           </div>
-          <div className="space-y-2">
-            <p className="text-xs font-medium text-gray-600 flex items-center gap-1">
-              <Wifi className="w-3.5 h-3.5 rotate-180" /> {t('detail.run.outputConfig')}
-            </p>
-            {inputField('Broker', outputBroker, setOutputBroker, 'localhost:9092')}
-            {inputField('Topic', outputTopic, setOutputTopic, 'workflow-output')}
-          </div>
-          <div className="grid grid-cols-2 gap-2">
+          <div>
             {toggleOption(
               `kafka-enabled-${workflowId}`,
               t('detail.run.kafkaEnabled'),
               enabled,
               setEnabled,
-            )}
-            {toggleOption(
-              `kafka-output-enabled-${workflowId}`,
-              t('detail.run.kafkaOutputEnabled'),
-              outputEnabled,
-              setOutputEnabled,
             )}
           </div>
           <button


### PR DESCRIPTION
## Summary

- Tighten Kafka workflow ingest backpressure: lower concurrent runs (8→2), smaller per-workflow queue (1000→100), and cap aiokafka fetch/poll sizes so large message bursts do not prefetch unbounded memory.
- Defer message JSON decoding until a worker is ready (`_QueuedKafkaMessage` holds raw bytes in the queue).
- Compact Kafka-triggered execution records: summarize large raw inputs, alert lists, and history fields before persisting to storage.
- Remove experimental Kafka **output producer** configuration and publishing from the API, workflow run path, and WebUI integration tab (consumer-only Kafka config).

## Test plan

- [x] `uv run pytest tests/ingest/test_kafka_manager.py tests/server/routes/test_workflow_run_route.py`
- [ ] Save Kafka consumer config from Workflow → Integration tab and confirm consumer starts
- [ ] Trigger a high-volume Kafka workflow and verify execution history stays bounded without OOM


Made with [Cursor](https://cursor.com)