### PR TITLE
fix(channel): support /clear slash command

### DIFF
--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -673,6 +673,24 @@ class InboundDispatcher:
                 f"命令 `{display_text or prompt_text}` 暂不支持在当前渠道中以 slash 形式执行。"
             )
 
+        async def _clear_history() -> None:
+            try:
+                from flocks.server.routes.session import _clear_session_history
+
+                deleted_count = await _clear_session_history(binding.session_id)
+            except Exception as exc:
+                log.error("dispatcher.clear_command_failed", {
+                    "session_id": binding.session_id,
+                    "channel_id": msg.channel_id,
+                    "error": str(exc),
+                })
+                await callbacks.deliver_text(f"清空当前会话失败：{type(exc).__name__}")
+                return
+
+            await callbacks.deliver_text(
+                f"已清空当前会话历史，共删除 {deleted_count} 条消息。"
+            )
+
         async def _run_session_control(_event, parsed) -> bool:
             if parsed.canonical_name == "status":
                 await self._handle_status_command(binding, msg, callbacks)
@@ -718,6 +736,7 @@ class InboundDispatcher:
                 direct_response=_publish_direct_response,
                 run_llm=_run_llm,
                 session_control=_run_session_control,
+                clear_history=_clear_history,
             ),
         )
         return True

--- a/flocks/command/command.py
+++ b/flocks/command/command.py
@@ -249,6 +249,8 @@ class Command:
                 template="Clear all messages in the current session.",
                 execution_kind="direct",
                 allow_attachments=False,
+                visible_surfaces=ALL_SURFACES,
+                channel_safe=True,
             ),
             CommandDef(
                 name="bug",

--- a/tests/channel/test_channel.py
+++ b/tests/channel/test_channel.py
@@ -735,6 +735,61 @@ class TestFeishuNativeCommands:
         assert "Available / commands:" in delivered[0]
 
     @pytest.mark.asyncio
+    async def test_clear_command_clears_channel_session_history(self, monkeypatch):
+        from flocks.channel.inbound.dispatcher import InboundDispatcher
+        from flocks.channel.inbound.session_binding import SessionBinding
+
+        dispatcher = InboundDispatcher()
+        binding = SessionBinding(
+            channel_id="wecom",
+            account_id="default",
+            chat_id="room_1",
+            chat_type=ChatType.DIRECT,
+            thread_id=None,
+            session_id="session_1",
+            agent_id="rex",
+            created_at=0,
+            last_message_at=0,
+        )
+        msg = InboundMessage(
+            channel_id="wecom",
+            account_id="default",
+            message_id="msg_1",
+            sender_id="user_1",
+            chat_id="room_1",
+            chat_type=ChatType.DIRECT,
+            text="/clear",
+            mention_text="/clear",
+        )
+
+        delivered: list[str] = []
+        clear_history = AsyncMock(return_value=3)
+
+        async def fake_deliver(ctx, session_id=None):
+            delivered.append(ctx.text)
+
+        monkeypatch.setattr(
+            "flocks.channel.outbound.deliver.OutboundDelivery.deliver",
+            fake_deliver,
+        )
+        monkeypatch.setattr(
+            "flocks.server.routes.session._clear_session_history",
+            clear_history,
+        )
+
+        handled = await dispatcher._handle_feishu_native_command(
+            binding=binding,
+            msg=msg,
+            channel_config=ChannelConfig(enabled=True),
+            user_text="/clear",
+            scope_override=None,
+        )
+
+        assert handled is True
+        clear_history.assert_awaited_once_with("session_1")
+        assert delivered == ["已清空当前会话历史，共删除 3 条消息。"]
+
+    @pytest.mark.asyncio
     async def test_append_user_message_stores_feishu_media_part(self, monkeypatch):
         from flocks.channel.inbound.dispatcher import InboundDispatcher
         from flocks.config.config import ChannelConfig

--- a/tests/server/test_input_dispatcher.py
+++ b/tests/server/test_input_dispatcher.py
@@ -75,6 +75,31 @@ class TestDispatchUserInput:
         assert not llm
 
     @pytest.mark.asyncio
+    async def test_clear_is_allowed_on_channel_surface(self):
+        direct = []
+        llm = []
+        clear_history_calls = []
+        sink = CallbackOutputSink(
+            "channel",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append(llm, (prompt, display)),
+            clear_history=lambda: _append(clear_history_calls, "cleared"),
+        )
+        event = UserInputEvent(
+            source_type="wecom",
+            sessionID="ses_test",
+            text="/clear",
+            parts=[{"type": "text", "text": "/clear"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "direct"
+        assert clear_history_calls == ["cleared"]
+        assert not direct
+        assert not llm
+
+    @pytest.mark.asyncio
     async def test_llm_command_routes_raw_slash_text(self):
         direct = []
         llm = []


### PR DESCRIPTION
## Summary
- allow `/clear` to be recognized on channel surfaces by marking the command as channel-safe and visible there
- wire channel slash dispatch to the existing session history clear flow and return a user-facing confirmation message
- add regression tests for dispatcher routing and channel-side clear execution

## Test plan
- [x] `uv run pytest tests/server/test_input_dispatcher.py tests/channel/test_channel.py -q`
- [ ] Full test suite

Made with [Cursor](https://cursor.com)