### PR TITLE
feat(provider): add minimax-m3 and update model limits in catalog

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -52,6 +52,30 @@
       "THREATBOOK_CN_LLM_API_KEY"
     ],
     "models": {
+      "minimax-m3": {
+        "name": "minimax-m3",
+        "family": "minimax",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "interleaved": {
+            "field": "reasoning_details",
+            "echo": "tool_calls",
+            "cross_provider_policy": "promote"
+          },
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 1000000,
+          "max_output_tokens": 128000
+        },
+        "pricing": {
+          "input": 4.2,
+          "output": 16.8,
+          "currency": "CNY",
+          "note": "≤512k input: ¥4.20/M tokens output: ¥16.80/M tokens; >512k input: ¥8.40/M tokens output: ¥33.60/M tokens"
+        }
+      },
       "minimax-m2.7": {
         "name": "minimax-m2.7",
         "family": "minimax",
@@ -203,8 +227,8 @@
           "supports_streaming": true
         },
         "limits": {
-          "context_window": 200000,
-          "max_output_tokens": 128000
+          "context_window": 1000000,
+          "max_output_tokens": 384000
         },
         "pricing": {
           "input": 1.0,
@@ -237,6 +261,30 @@
       "THREATBOOK_IO_LLM_API_KEY"
     ],
     "models": {
+      "minimax-m3": {
+        "name": "minimax-m3",
+        "family": "minimax",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "interleaved": {
+            "field": "reasoning_details",
+            "echo": "tool_calls",
+            "cross_provider_policy": "promote"
+          },
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 1000000,
+          "max_output_tokens": 128000
+        },
+        "pricing": {
+          "input": 4.2,
+          "output": 16.8,
+          "currency": "CNY",
+          "note": "≤512k input: ¥4.20/M tokens output: ¥16.80/M tokens; >512k input: ¥8.40/M tokens output: ¥33.60/M tokens"
+        }
+      },
       "minimax-m2.7": {
         "name": "minimax-m2.7",
         "family": "minimax",
@@ -361,8 +409,8 @@
           "supports_streaming": true
         },
         "limits": {
-          "context_window": 200000,
-          "max_output_tokens": 128000
+          "context_window": 1000000,
+          "max_output_tokens": 384000
         },
         "pricing": {
           "input": 1.0,
@@ -1346,7 +1394,7 @@
     "models": {
       "minimax-m3": {
         "name": "MiniMax M3",
-        "family": "minimax-m3",
+        "family": "minimax",
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
@@ -1358,8 +1406,14 @@
           "supports_streaming": true
         },
         "limits": {
-          "context_window": 512000,
-          "max_output_tokens": 512000
+          "context_window": 1000000,
+          "max_output_tokens": 128000
+        },
+        "pricing": {
+          "input": 4.2,
+          "output": 16.8,
+          "currency": "CNY",
+          "note": "≤512k input: ¥4.20/M tokens, output: ¥16.80/M tokens; >512k input: ¥8.40/M tokens, output: ¥33.60/M tokens"
         }
       },
       "minimax-m2.7": {


### PR DESCRIPTION
- Add minimax-m3 (1M context, 128K output) to threatbook-cn-llm, threatbook-io-llm, and minimax providers
- Update deepseek-v4-flash context window 200K→1M, max output 128K→384K in both threatbook-cn-llm and threatbook-io-llm
- Reorder ThreatBook provider models: minimax group (m3/m2.7/m2.5) first
- Fix minimax provider: align minimax-m3 family field and add pricing