### PR TITLE
fix(log): restructure log directory retention

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,50 @@
+# Flocks Logging Layout
+
+Flocks writes logs under `FLOCKS_LOG_DIR`, or `FLOCKS_ROOT/logs`, or `~/.flocks/logs`.
+
+## Directory Layout
+
+The log root contains only process logs and daily log directories:
+
+```text
+logs/
+  backend.log
+  webui.log
+  YYYY-MM-DD/
+    flocks.log
+    errors.log
+```
+
+- `backend.log`: backend process stdout/stderr, appended as a single root-level file.
+- `webui.log`: WebUI process stdout/stderr, appended as a single root-level file.
+- `YYYY-MM-DD/flocks.log`: main structured application log for that day.
+- `YYYY-MM-DD/errors.log`: WARN/ERROR lines for quick troubleshooting.
+
+Daily `flocks.log` and `errors.log` files are not size-rotated. Flocks retains daily directories for 30 days by default and deletes older `YYYY-MM-DD/` directories during logging startup and day rollover.
+
+## Environment Variables
+
+Current logging variable:
+
+- `FLOCKS_LOG_RETENTION_DAYS`: number of days to keep daily directories and legacy timestamp logs. Default: `30`.
+
+Removed rotation variables:
+
+- `FLOCKS_LOG_MAX_BYTES`
+- `FLOCKS_LOG_MAX_MB`
+- `FLOCKS_LOG_BACKUP_COUNT`
+
+These variables no longer affect structured log files because daily logs are append-only and do not create `.log.1` / `.log.2` backup files.
+
+## Migration Notes
+
+- `dev.log` is no longer created. `Log.init(dev=True)` is kept for compatibility, but file output uses the same daily `flocks.log` / `errors.log` layout.
+- `workflow.log` is no longer created by workflow logging. Workflow logs should be emitted through structured Flocks logging or stderr.
+- `update.log` is no longer created. Upgrade journal lines are appended to that day's `errors.log`.
+- Legacy root timestamp logs like `YYYY-MM-DDTHHMMSS.log` and their `.log.N` backups are retained until they are older than `FLOCKS_LOG_RETENTION_DAYS`, then cleaned up.
+
+## Process Log Growth
+
+`backend.log` and `webui.log` intentionally do not rotate because the log layout avoids `.log.N` suffixes and avoids automatic truncation. In normal local usage, `backend.log` has been observed at about 0.5 MB/day and `webui.log` is negligible, but noisy stdout/stderr or repeated exceptions can grow `backend.log` much faster.
+
+If `backend.log` becomes large, archive or delete it manually while the service is stopped.

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -26,7 +26,6 @@ from typing import Iterable, Sequence
 import httpx
 
 from flocks.browser.admin import stop_all_daemons as stop_all_browser_daemons
-from flocks.utils.log import rotate_log_file
 
 try:
     import fcntl
@@ -1682,7 +1681,6 @@ def _spawn_process(
         kwargs["start_new_session"] = True
 
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    rotate_log_file(log_path)
     handle = log_path.open("a", encoding="utf-8")
     try:
         return subprocess.Popen(

--- a/flocks/server/routes/logs.py
+++ b/flocks/server/routes/logs.py
@@ -68,18 +68,18 @@ async def read_latest_log(
 
     today_log = log_dir / date.today().isoformat() / "flocks.log"
     if today_log.is_file():
-        return _read_log_file(today_log, tail)
+        return _read_log_file(today_log, tail, filename=_relative_log_name(log_dir, today_log))
 
     for day_dir in sorted(_iter_date_dirs(log_dir), reverse=True):
         main_log = day_dir / "flocks.log"
         if main_log.is_file():
-            return _read_log_file(main_log, tail)
+            return _read_log_file(main_log, tail, filename=_relative_log_name(log_dir, main_log))
 
     log_files = sorted(_iter_log_files(log_dir), key=lambda f: f.stat().st_mtime, reverse=True)
     if not log_files:
         raise HTTPException(status_code=404, detail="No log files found")
 
-    return _read_log_file(log_files[0], tail)
+    return _read_log_file(log_files[0], tail, filename=_relative_log_name(log_dir, log_files[0]))
 
 
 @router.get(
@@ -101,7 +101,7 @@ async def read_log(
     if not log_path.resolve().is_relative_to(log_dir.resolve()):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    return _read_log_file(log_path, tail)
+    return _read_log_file(log_path, tail, filename=filename)
 
 
 def _is_date_dir(path: Path) -> bool:
@@ -148,7 +148,11 @@ def _iter_log_files(log_dir: Path) -> List[Path]:
     return files
 
 
-def _read_log_file(path: Path, tail: int) -> LogContentResponse:
+def _relative_log_name(log_dir: Path, path: Path) -> str:
+    return path.relative_to(log_dir).as_posix()
+
+
+def _read_log_file(path: Path, tail: int, filename: str | None = None) -> LogContentResponse:
     try:
         lines: deque[str] = deque(maxlen=tail)
         total = 0
@@ -163,7 +167,7 @@ def _read_log_file(path: Path, tail: int) -> LogContentResponse:
     content = "\n".join(lines)
 
     return LogContentResponse(
-        filename=path.name,
+        filename=filename or path.name,
         content=content,
         total_lines=total,
         truncated=truncated,

--- a/flocks/server/routes/logs.py
+++ b/flocks/server/routes/logs.py
@@ -5,6 +5,7 @@ Provides endpoints to list and read log files from ~/.flocks/logs.
 """
 
 from collections import deque
+from datetime import date, datetime
 from pathlib import Path
 from typing import List
 
@@ -46,9 +47,9 @@ async def list_logs():
         return LogListResponse(files=[], log_dir=str(log_dir))
 
     files: List[LogFileInfo] = []
-    for p in sorted(log_dir.glob("*.log"), key=lambda f: f.stat().st_mtime, reverse=True):
+    for p in sorted(_iter_log_files(log_dir), key=lambda f: f.stat().st_mtime, reverse=True):
         stat = p.stat()
-        files.append(LogFileInfo(name=p.name, size=stat.st_size, modified=stat.st_mtime))
+        files.append(LogFileInfo(name=p.relative_to(log_dir).as_posix(), size=stat.st_size, modified=stat.st_mtime))
     return LogListResponse(files=files, log_dir=str(log_dir))
 
 
@@ -65,7 +66,16 @@ async def read_latest_log(
     if not log_dir.is_dir():
         raise HTTPException(status_code=404, detail="Log directory not found")
 
-    log_files = sorted(log_dir.glob("*.log"), key=lambda f: f.stat().st_mtime, reverse=True)
+    today_log = log_dir / date.today().isoformat() / "flocks.log"
+    if today_log.is_file():
+        return _read_log_file(today_log, tail)
+
+    for day_dir in sorted(_iter_date_dirs(log_dir), reverse=True):
+        main_log = day_dir / "flocks.log"
+        if main_log.is_file():
+            return _read_log_file(main_log, tail)
+
+    log_files = sorted(_iter_log_files(log_dir), key=lambda f: f.stat().st_mtime, reverse=True)
     if not log_files:
         raise HTTPException(status_code=404, detail="No log files found")
 
@@ -73,7 +83,7 @@ async def read_latest_log(
 
 
 @router.get(
-    "/{filename}",
+    "/{filename:path}",
     response_model=LogContentResponse,
     summary="Read a specific log file",
 )
@@ -85,13 +95,57 @@ async def read_log(
     log_dir = get_log_dir()
     log_path = log_dir / filename
 
-    if not log_path.is_file() or not log_path.suffix == ".log":
+    if not log_path.is_file() or not _is_allowed_log_path(log_dir, log_path):
         raise HTTPException(status_code=404, detail=f"Log file not found: {filename}")
 
     if not log_path.resolve().is_relative_to(log_dir.resolve()):
         raise HTTPException(status_code=403, detail="Access denied")
 
     return _read_log_file(log_path, tail)
+
+
+def _is_date_dir(path: Path) -> bool:
+    try:
+        datetime.strptime(path.name, "%Y-%m-%d")
+    except ValueError:
+        return False
+    return path.is_dir()
+
+
+def _iter_date_dirs(log_dir: Path) -> List[Path]:
+    return [p for p in log_dir.iterdir() if _is_date_dir(p)]
+
+
+def _is_allowed_log_path(log_dir: Path, path: Path) -> bool:
+    try:
+        relative = path.relative_to(log_dir)
+    except ValueError:
+        return False
+    parts = relative.parts
+    if len(parts) == 1:
+        return parts[0] in {"backend.log", "webui.log"}
+    if len(parts) == 2:
+        day, filename = parts
+        try:
+            datetime.strptime(day, "%Y-%m-%d")
+        except ValueError:
+            return False
+        return filename in {"flocks.log", "errors.log"}
+    return False
+
+
+def _iter_log_files(log_dir: Path) -> List[Path]:
+    files = []
+    for name in ("backend.log", "webui.log"):
+        path = log_dir / name
+        if path.is_file():
+            files.append(path)
+    for day_dir in _iter_date_dirs(log_dir):
+        for name in ("flocks.log", "errors.log"):
+            path = day_dir / name
+            if path.is_file():
+                files.append(path)
+    return files
 
 
 def _read_log_file(path: Path, tail: int) -> LogContentResponse:

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -81,7 +81,7 @@ class ConsoleManifestRelease:
 
 
 def _record_update_journal(message: str) -> None:
-    """Append a human-readable line to ``update.log`` (see ``append_upgrade_text_log``)."""
+    """Append a human-readable upgrade line to today's errors log."""
     from flocks.utils.log import append_upgrade_text_log
 
     append_upgrade_text_log(message)

--- a/flocks/utils/log.py
+++ b/flocks/utils/log.py
@@ -11,6 +11,7 @@ import os
 import sys
 import time
 import threading
+import shutil
 from pathlib import Path
 from typing import Any, Dict, Optional, TextIO
 from datetime import date, datetime, timedelta
@@ -51,7 +52,7 @@ def _env_int(name: str, default: int) -> int:
 
 
 def get_log_retention_days(default: int = _DEFAULT_LOG_RETENTION_DAYS) -> int:
-    """Return how long legacy timestamp logs are retained."""
+    """Return how long daily log directories and legacy timestamp logs are retained."""
     return _env_int("FLOCKS_LOG_RETENTION_DAYS", default)
 
 
@@ -462,6 +463,7 @@ class Log:
         cls._writer = None
         cls._error_writer = None
         cls._open_daily_writers()
+        cls._cleanup_sync(cls._log_dir_path)
     
     @classmethod
     async def _cleanup(cls, log_dir: Path, retention_days: Optional[int] = None) -> None:
@@ -470,6 +472,11 @@ class Log:
         Args:
             log_dir: Directory containing log files
         """
+        cls._cleanup_sync(log_dir, retention_days=retention_days)
+
+    @classmethod
+    def _cleanup_sync(cls, log_dir: Path, retention_days: Optional[int] = None) -> None:
+        """Clean up date directories and legacy timestamp logs by age."""
         days = get_log_retention_days() if retention_days is None else retention_days
         if days <= 0:
             return
@@ -495,7 +502,6 @@ class Log:
                 day = _date_from_dir(path)
                 if day is not None and day < cutoff.date():
                     try:
-                        import shutil
                         shutil.rmtree(path)
                     except Exception:
                         pass

--- a/flocks/utils/log.py
+++ b/flocks/utils/log.py
@@ -13,13 +13,12 @@ import time
 import threading
 from pathlib import Path
 from typing import Any, Dict, Optional, TextIO
-from datetime import datetime
+from datetime import date, datetime, timedelta
 import json
 import glob as file_glob
 
 
-_DEFAULT_LOG_MAX_BYTES = 5 * 1024 * 1024
-_DEFAULT_LOG_BACKUP_COUNT = 3
+_DEFAULT_LOG_RETENTION_DAYS = 30
 _DEFAULT_LOG_VALUE_MAX_CHARS = 8 * 1024
 _MAX_STRUCTURED_ITEMS = 50
 _MAX_STRUCTURED_DEPTH = 4
@@ -37,7 +36,7 @@ def _log_dir() -> Path:
 
 
 def get_log_dir() -> Path:
-    """Return the log directory for file handlers (e.g. workflow). Same as Log.init() uses."""
+    """Return the root log directory used by Flocks."""
     return _log_dir()
 
 
@@ -51,99 +50,29 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-def get_log_max_bytes(default: int = _DEFAULT_LOG_MAX_BYTES) -> int:
-    """Return the per-file log size limit in bytes.
-
-    ``FLOCKS_LOG_MAX_BYTES`` is exact; ``FLOCKS_LOG_MAX_MB`` is a convenient
-    human-facing override. When both are set, bytes wins. Values <= 0 disable
-    rotation.
-    """
-    if os.getenv("FLOCKS_LOG_MAX_BYTES") is not None:
-        return _env_int("FLOCKS_LOG_MAX_BYTES", default)
-    max_mb = os.getenv("FLOCKS_LOG_MAX_MB")
-    if max_mb is not None:
-        try:
-            return int(float(max_mb) * 1024 * 1024)
-        except ValueError:
-            return default
-    return default
+def get_log_retention_days(default: int = _DEFAULT_LOG_RETENTION_DAYS) -> int:
+    """Return how long legacy timestamp logs are retained."""
+    return _env_int("FLOCKS_LOG_RETENTION_DAYS", default)
 
 
-def get_log_backup_count(default: int = _DEFAULT_LOG_BACKUP_COUNT) -> int:
-    """Return how many rotated backups to keep for long-lived log files."""
-    return max(0, _env_int("FLOCKS_LOG_BACKUP_COUNT", default))
+class _AppendTextWriter:
+    """Small line-buffered writer for Flocks daily logs."""
 
-
-def rotate_log_file(
-    path: Path,
-    *,
-    max_bytes: Optional[int] = None,
-    backup_count: Optional[int] = None,
-    force: bool = False,
-) -> None:
-    """Rotate ``path`` if it is already over the configured size limit."""
-    limit = get_log_max_bytes() if max_bytes is None else max_bytes
-    backups = get_log_backup_count() if backup_count is None else backup_count
-    if limit <= 0 or not path.exists():
-        return
-    try:
-        if not force and path.stat().st_size < limit:
-            return
-        if backups <= 0:
-            path.unlink(missing_ok=True)
-            return
-        for index in range(backups - 1, 0, -1):
-            src = path.with_name(f"{path.name}.{index}")
-            dst = path.with_name(f"{path.name}.{index + 1}")
-            if src.exists():
-                src.replace(dst)
-        path.replace(path.with_name(f"{path.name}.1"))
-    except OSError:
-        return
-
-
-class _RotatingTextWriter:
-    """Small line-buffered writer with size-based rotation for Flocks logs."""
-
-    def __init__(self, path: Path, *, max_bytes: int, backup_count: int):
+    def __init__(self, path: Path):
         self.path = path
-        self.max_bytes = max_bytes
-        self.backup_count = backup_count
         self._handle: Optional[TextIO] = None
-        self._bytes_written = 0
         self._lock = threading.RLock()
         self._open()
 
     def _open(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._handle = open(self.path, "a", buffering=1, encoding="utf-8")
-        try:
-            self._bytes_written = self.path.stat().st_size
-        except OSError:
-            self._bytes_written = 0
-
-    def _should_rotate(self, message: str) -> bool:
-        if self.max_bytes <= 0:
-            return False
-        return self._bytes_written + len(message.encode("utf-8")) > self.max_bytes
 
     def write(self, message: str) -> int:
-        encoded_len = len(message.encode("utf-8"))
         with self._lock:
-            if self._should_rotate(message):
-                self.close()
-                rotate_log_file(
-                    self.path,
-                    max_bytes=self.max_bytes,
-                    backup_count=self.backup_count,
-                    force=True,
-                )
-                self._open()
             if self._handle is None:
                 self._open()
-            written = self._handle.write(message)
-            self._bytes_written += encoded_len
-            return written
+            return self._handle.write(message)
 
     def flush(self) -> None:
         with self._lock:
@@ -213,15 +142,16 @@ def _format_log_value(value: Any) -> str:
 
 
 def append_upgrade_text_log(message: str) -> None:
-    """Append timestamped lines to ``update.log`` under the configured log directory.
+    """Append timestamped upgrade lines to today's ``errors.log``.
 
     Used for upgrade flows so errors remain on disk when the process had no TTY
-    or when structured ``Log`` output went to a different file than ``backend.log``.
+    or when structured ``Log`` output was not initialized.
     """
     try:
         log_dir = _log_dir()
-        log_dir.mkdir(parents=True, exist_ok=True)
-        path = log_dir / "update.log"
+        day_dir = log_dir / date.today().isoformat()
+        day_dir.mkdir(parents=True, exist_ok=True)
+        path = day_dir / "errors.log"
         stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         normalized = message.replace("\r\n", "\n").replace("\r", "\n")
         with path.open("a", encoding="utf-8") as handle:
@@ -310,12 +240,12 @@ class Logger:
     def warn(self, message: Any = None, extra: Optional[Dict[str, Any]] = None) -> None:
         """Log warning message"""
         if Log._should_log(LogLevel.WARN):
-            Log._write("WARN  " + self._build_message(message, extra))
+            Log._write("WARN  " + self._build_message(message, extra), error=True)
     
     def error(self, message: Any = None, extra: Optional[Dict[str, Any]] = None) -> None:
         """Log error message"""
         if Log._should_log(LogLevel.ERROR):
-            Log._write("ERROR " + self._build_message(message, extra))
+            Log._write("ERROR " + self._build_message(message, extra), error=True)
     
     # Alias for compatibility with standard logging library
     warning = warn
@@ -403,6 +333,10 @@ class Log:
     _last_time: int = int(time.time() * 1000)
     _log_file: Optional[Path] = None
     _writer: Optional[TextIO] = None
+    _error_writer: Optional[TextIO] = None
+    _log_dir_path: Optional[Path] = None
+    _log_date: Optional[str] = None
+    _state_lock = threading.RLock()
     
     # Default logger instance
     Default: Logger = None  # Will be initialized
@@ -413,16 +347,21 @@ class Log:
         return _LEVEL_PRIORITY.get(level, 0) >= _LEVEL_PRIORITY.get(cls._level, 1)
     
     @classmethod
-    def _write(cls, message: str) -> int:
+    def _write(cls, message: str, *, error: bool = False) -> int:
         """Write log message to file and/or stderr"""
         try:
-            if cls._writer:
-                cls._writer.write(message)
-                cls._writer.flush()
-            else:
-                # Fallback to stderr
-                sys.stderr.write(message)
-                sys.stderr.flush()
+            with cls._state_lock:
+                cls._ensure_current_day()
+                if cls._writer:
+                    cls._writer.write(message)
+                    cls._writer.flush()
+                else:
+                    # Fallback to stderr
+                    sys.stderr.write(message)
+                    sys.stderr.flush()
+                if error and cls._error_writer:
+                    cls._error_writer.write(message)
+                    cls._error_writer.flush()
             return len(message)
         except Exception:
             # Silently fail - logging should never break the app
@@ -457,7 +396,7 @@ class Log:
         
         Args:
             print: Whether to print logs to stderr (if False, logs to file)
-            dev: Whether in development mode (affects filename)
+            dev: Kept for compatibility; file output always uses daily logs
             level: Log level (DEBUG, INFO, WARN, ERROR)
         """
         cls._level = level
@@ -469,53 +408,107 @@ class Log:
         # Cleanup old logs
         await cls._cleanup(log_dir)
         
-        if print:
-            # Print to stderr
+        with cls._state_lock:
+            if print:
+                # Print to stderr
+                if cls._writer:
+                    cls._writer.close()
+                if cls._error_writer:
+                    cls._error_writer.close()
+                cls._writer = None
+                cls._error_writer = None
+                cls._log_file = None
+                cls._log_dir_path = None
+                cls._log_date = None
+                return
+
+            if cls._writer:
+                cls._writer.close()
+            if cls._error_writer:
+                cls._error_writer.close()
+
+            cls._log_dir_path = log_dir
             cls._writer = None
-            return
-        
-        # Setup log file
-        if dev:
-            filename = "dev.log"
-        else:
-            # Format: YYYY-MM-DDTHHMMSS.log
-            filename = datetime.now().strftime("%Y-%m-%dT%H%M%S") + ".log"
-        
-        cls._log_file = log_dir / filename
-        
-        # Truncate if exists
-        if cls._log_file.exists():
-            cls._log_file.write_text("")
-        
-        # Open for writing with size-based rotation for long-running sessions.
-        cls._writer = _RotatingTextWriter(
-            cls._log_file,
-            max_bytes=get_log_max_bytes(),
-            backup_count=get_log_backup_count(),
-        )
+            cls._error_writer = None
+            cls._log_date = None
+            cls._open_daily_writers()
         
         # Create default logger
         cls.Default = cls.create(service="default")
+
+    @classmethod
+    def _open_daily_writers(cls) -> None:
+        if cls._log_dir_path is None:
+            return
+        today = date.today().isoformat()
+        day_dir = cls._log_dir_path / today
+        day_dir.mkdir(parents=True, exist_ok=True)
+        cls._log_date = today
+        cls._log_file = day_dir / "flocks.log"
+        cls._writer = _AppendTextWriter(cls._log_file)
+        cls._error_writer = _AppendTextWriter(day_dir / "errors.log")
+
+    @classmethod
+    def _ensure_current_day(cls) -> None:
+        if cls._writer is None or cls._log_dir_path is None:
+            return
+        today = date.today().isoformat()
+        if cls._log_date == today:
+            return
+        if cls._writer:
+            cls._writer.close()
+        if cls._error_writer:
+            cls._error_writer.close()
+        cls._writer = None
+        cls._error_writer = None
+        cls._open_daily_writers()
     
     @classmethod
-    async def _cleanup(cls, log_dir: Path) -> None:
-        """
-        Clean up old log files, keeping only the 10 most recent
+    async def _cleanup(cls, log_dir: Path, retention_days: Optional[int] = None) -> None:
+        """Clean up date directories and legacy timestamp logs by age.
         
         Args:
             log_dir: Directory containing log files
         """
+        days = get_log_retention_days() if retention_days is None else retention_days
+        if days <= 0:
+            return
+        cutoff = datetime.now() - timedelta(days=days)
+
+        def _timestamp_from_name(path: Path) -> Optional[datetime]:
+            stem = path.name.split(".log", 1)[0]
+            try:
+                return datetime.strptime(stem, "%Y-%m-%dT%H%M%S")
+            except ValueError:
+                return None
+
+        def _date_from_dir(path: Path) -> Optional[date]:
+            try:
+                return datetime.strptime(path.name, "%Y-%m-%d").date()
+            except ValueError:
+                return None
+
         try:
+            for path in log_dir.iterdir():
+                if not path.is_dir():
+                    continue
+                day = _date_from_dir(path)
+                if day is not None and day < cutoff.date():
+                    try:
+                        import shutil
+                        shutil.rmtree(path)
+                    except Exception:
+                        pass
+
             # Find base log files matching pattern YYYY-MM-DDTHHMMSS.log.
             # Rotated siblings are deleted together with their base file so
             # old ``.log.1``/``.log.2`` files do not leak forever.
             pattern = str(log_dir / "????-??-??T??????.log")
             files = [Path(path) for path in sorted(file_glob.glob(pattern))]
-            
-            # Keep only the 10 most recent
-            if len(files) > 10:
-                files_to_delete = files[:-10]
-                for path in files_to_delete:
+
+            for path in files:
+                timestamp = _timestamp_from_name(path)
+                if timestamp is not None and timestamp < cutoff:
                     try:
                         path.unlink(missing_ok=True)
                         for rotated in path.parent.glob(f"{path.name}.*"):
@@ -523,12 +516,12 @@ class Log:
                     except Exception:
                         pass  # Silently ignore deletion errors
 
-            kept_files = set(files[-10:])
             rotated_pattern = str(log_dir / "????-??-??T??????.log.*")
             for rotated_path in (Path(path) for path in file_glob.glob(rotated_pattern)):
                 base_name = rotated_path.name.split(".log.", 1)[0] + ".log"
                 base_path = rotated_path.with_name(base_name)
-                if base_path not in kept_files and not base_path.exists():
+                timestamp = _timestamp_from_name(base_path)
+                if not base_path.exists() and timestamp is not None and timestamp < cutoff:
                     try:
                         rotated_path.unlink(missing_ok=True)
                     except Exception:
@@ -571,7 +564,7 @@ class Log:
         """Get the current log file path"""
         if cls._log_file:
             return str(cls._log_file)
-        return str(_log_dir() / "flocks.log")
+        return str(_log_dir() / date.today().isoformat() / "flocks.log")
 
 
 # Initialize Default logger on module import

--- a/flocks/workflow/logging_config.py
+++ b/flocks/workflow/logging_config.py
@@ -1,15 +1,12 @@
 """Logging configuration for flocks.workflow.
 
-Workflow logs go to stderr and, when file logging is enabled, to
-~/.flocks/logs/workflow.log (or FLOCKS_LOG_DIR/workflow.log).
+Workflow logs go to stderr. File logging is intentionally disabled so the
+Flocks log directory only contains backend.log, webui.log, and date folders.
 """
 
 import logging
 import sys
-from logging.handlers import RotatingFileHandler
 from typing import Optional
-
-from flocks.utils.log import get_log_backup_count, get_log_dir, get_log_max_bytes
 
 
 def setup_workflow_logging(
@@ -18,13 +15,13 @@ def setup_workflow_logging(
     stream=None,
     file: bool = True,
 ) -> None:
-    """配置 flocks.workflow 的日志输出（控制台 + 可选文件）。
+    """配置 flocks.workflow 的日志输出（控制台）。
 
     Args:
         level: 日志级别，默认为 INFO
         format_string: 日志格式字符串，如果为 None 则使用默认格式
         stream: 输出流，默认为 sys.stderr
-        file: 是否同时写入 ~/.flocks/logs/workflow.log（与主 Log 同目录）
+        file: 兼容旧参数；当前不会创建 workflow.log 文件
 
     Example:
         >>> from flocks.workflow import setup_workflow_logging
@@ -49,22 +46,9 @@ def setup_workflow_logging(
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
-    # File (same directory as flocks.utils.log)
-    if file:
-        try:
-            log_dir = get_log_dir()
-            log_dir.mkdir(parents=True, exist_ok=True)
-            file_handler = RotatingFileHandler(
-                log_dir / "workflow.log",
-                maxBytes=get_log_max_bytes(),
-                backupCount=get_log_backup_count(),
-                encoding="utf-8",
-            )
-            file_handler.setLevel(level)
-            file_handler.setFormatter(formatter)
-            logger.addHandler(file_handler)
-        except OSError:
-            pass  # Do not break if log dir is read-only or missing
+    # Workflow file logging is intentionally disabled. Structured workflow
+    # activity should be emitted through ``flocks.utils.log`` so the log
+    # directory only contains backend.log, webui.log, and date folders.
 
     logger.propagate = False
 

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -1357,7 +1357,7 @@ def test_spawn_process_uses_new_session_on_non_windows(monkeypatch, tmp_path: Pa
     assert "startupinfo" not in captured["kwargs"]
 
 
-def test_spawn_process_rotates_large_log_before_append(monkeypatch, tmp_path: Path) -> None:
+def test_spawn_process_appends_without_rotated_suffix(monkeypatch, tmp_path: Path) -> None:
     log_path = tmp_path / "logs" / "backend.log"
     log_path.parent.mkdir(parents=True)
     log_path.write_text("x" * 20, encoding="utf-8")
@@ -1367,15 +1367,13 @@ def test_spawn_process_rotates_large_log_before_append(monkeypatch, tmp_path: Pa
         kwargs["stdout"].flush()
         return SimpleNamespace(pid=9876)
 
-    monkeypatch.setenv("FLOCKS_LOG_MAX_BYTES", "10")
-    monkeypatch.setenv("FLOCKS_LOG_BACKUP_COUNT", "1")
     monkeypatch.setattr(service_manager.sys, "platform", "darwin")
     monkeypatch.setattr(service_manager.subprocess, "Popen", fake_popen)
 
     service_manager._spawn_process(["python", "-m", "uvicorn"], cwd=tmp_path, log_path=log_path)
 
-    assert log_path.read_text(encoding="utf-8") == "new\n"
-    assert (tmp_path / "logs" / "backend.log.1").read_text(encoding="utf-8") == "x" * 20
+    assert log_path.read_text(encoding="utf-8") == "x" * 20 + "new\n"
+    assert not (tmp_path / "logs" / "backend.log.1").exists()
 
 
 def test_spawn_process_passes_custom_environment(monkeypatch, tmp_path: Path) -> None:

--- a/tests/server/test_log_routes.py
+++ b/tests/server/test_log_routes.py
@@ -1,6 +1,9 @@
 """Log route helpers."""
 
 from pathlib import Path
+from datetime import date
+
+import pytest
 
 from flocks.server.routes import logs as log_routes
 
@@ -34,3 +37,65 @@ def test_read_log_file_reports_untruncated_small_file(tmp_path: Path) -> None:
     assert response.content == "one\ntwo"
     assert response.total_lines == 2
     assert response.truncated is False
+
+
+@pytest.mark.asyncio
+async def test_list_logs_includes_root_and_date_log_files(tmp_path: Path, monkeypatch) -> None:
+    today = date.today().isoformat()
+    day_dir = tmp_path / today
+    day_dir.mkdir()
+    (tmp_path / "backend.log").write_text("backend\n", encoding="utf-8")
+    (tmp_path / "webui.log").write_text("webui\n", encoding="utf-8")
+    (day_dir / "flocks.log").write_text("main\n", encoding="utf-8")
+    (day_dir / "errors.log").write_text("errors\n", encoding="utf-8")
+    (tmp_path / "flocks.log.1").write_text("rotated\n", encoding="utf-8")
+    (tmp_path / "not-a-log.txt").write_text("ignore\n", encoding="utf-8")
+    monkeypatch.setattr(log_routes, "get_log_dir", lambda: tmp_path)
+
+    response = await log_routes.list_logs()
+
+    names = {item.name for item in response.files}
+    assert "backend.log" in names
+    assert "webui.log" in names
+    assert f"{today}/flocks.log" in names
+    assert f"{today}/errors.log" in names
+    assert "flocks.log.1" not in names
+    assert "not-a-log.txt" not in names
+
+
+@pytest.mark.asyncio
+async def test_latest_log_prefers_main_flocks_log(tmp_path: Path, monkeypatch) -> None:
+    today = date.today().isoformat()
+    day_dir = tmp_path / today
+    day_dir.mkdir()
+    (tmp_path / "backend.log").write_text("backend\n", encoding="utf-8")
+    (day_dir / "flocks.log").write_text("main\n", encoding="utf-8")
+    monkeypatch.setattr(log_routes, "get_log_dir", lambda: tmp_path)
+
+    response = await log_routes.read_latest_log(tail=10)
+
+    assert response.filename == "flocks.log"
+    assert response.content == "main"
+
+
+@pytest.mark.asyncio
+async def test_read_log_allows_daily_log_files(tmp_path: Path, monkeypatch) -> None:
+    today = date.today().isoformat()
+    day_dir = tmp_path / today
+    day_dir.mkdir()
+    (day_dir / "flocks.log").write_text("main\n", encoding="utf-8")
+    monkeypatch.setattr(log_routes, "get_log_dir", lambda: tmp_path)
+
+    response = await log_routes.read_log(f"{today}/flocks.log", tail=10)
+
+    assert response.filename == "flocks.log"
+    assert response.content == "main"
+
+
+@pytest.mark.asyncio
+async def test_read_log_rejects_rotated_suffix_files(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "backend.log.1").write_text("rotated\n", encoding="utf-8")
+    monkeypatch.setattr(log_routes, "get_log_dir", lambda: tmp_path)
+
+    with pytest.raises(Exception):
+        await log_routes.read_log("backend.log.1", tail=10)

--- a/tests/server/test_log_routes.py
+++ b/tests/server/test_log_routes.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from datetime import date
 
 import pytest
+from fastapi import HTTPException
 
 from flocks.server.routes import logs as log_routes
 
@@ -74,7 +75,7 @@ async def test_latest_log_prefers_main_flocks_log(tmp_path: Path, monkeypatch) -
 
     response = await log_routes.read_latest_log(tail=10)
 
-    assert response.filename == "flocks.log"
+    assert response.filename == f"{today}/flocks.log"
     assert response.content == "main"
 
 
@@ -88,7 +89,7 @@ async def test_read_log_allows_daily_log_files(tmp_path: Path, monkeypatch) -> N
 
     response = await log_routes.read_log(f"{today}/flocks.log", tail=10)
 
-    assert response.filename == "flocks.log"
+    assert response.filename == f"{today}/flocks.log"
     assert response.content == "main"
 
 
@@ -97,5 +98,23 @@ async def test_read_log_rejects_rotated_suffix_files(tmp_path: Path, monkeypatch
     (tmp_path / "backend.log.1").write_text("rotated\n", encoding="utf-8")
     monkeypatch.setattr(log_routes, "get_log_dir", lambda: tmp_path)
 
-    with pytest.raises(Exception):
+    with pytest.raises(HTTPException) as exc_info:
         await log_routes.read_log("backend.log.1", tail=10)
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_read_log_returns_same_nested_filename_as_list(tmp_path: Path, monkeypatch) -> None:
+    today = date.today().isoformat()
+    day_dir = tmp_path / today
+    day_dir.mkdir()
+    (day_dir / "errors.log").write_text("warn\n", encoding="utf-8")
+    monkeypatch.setattr(log_routes, "get_log_dir", lambda: tmp_path)
+
+    listed = await log_routes.list_logs()
+    listed_name = next(item.name for item in listed.files if item.name.endswith("errors.log"))
+    response = await log_routes.read_log(listed_name, tail=10)
+
+    assert listed_name == f"{today}/errors.log"
+    assert response.filename == listed_name
+    assert response.content == "warn"

--- a/tests/utils/test_append_upgrade_log.py
+++ b/tests/utils/test_append_upgrade_log.py
@@ -2,6 +2,7 @@
 
 import re
 from pathlib import Path
+from datetime import date
 
 from flocks.utils.log import append_upgrade_text_log
 
@@ -10,8 +11,9 @@ def test_append_upgrade_text_log_writes_timestamped_lines(monkeypatch, tmp_path:
     monkeypatch.setenv("FLOCKS_LOG_DIR", str(tmp_path))
     append_upgrade_text_log("first line")
     append_upgrade_text_log("a\nb")
-    text = (tmp_path / "update.log").read_text(encoding="utf-8")
+    text = (tmp_path / date.today().isoformat() / "errors.log").read_text(encoding="utf-8")
     lines = text.strip().splitlines()
+    assert not (tmp_path / "update.log").exists()
     assert len(lines) == 3
     assert re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| first line$", lines[0])
     assert re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \| a$", lines[1])

--- a/tests/utils/test_log_compatibility.py
+++ b/tests/utils/test_log_compatibility.py
@@ -7,6 +7,7 @@ import time
 import tempfile
 from pathlib import Path
 from datetime import datetime, timedelta
+import flocks.utils.log as log_module
 from flocks.utils.log import Log, Logger, LogLevel
 
 
@@ -435,6 +436,51 @@ class TestLogInitialization:
 
         assert not old_dir.exists()
         assert recent_dir.exists()
+
+    async def test_day_rollover_switches_writer_and_runs_cleanup(self, tmp_path: Path, monkeypatch):
+        """Test long-running processes move to the new daily log and clean old days."""
+        old_day = (datetime.now() - timedelta(days=31)).date().isoformat()
+        first_day = (datetime.now() - timedelta(days=1)).date()
+        second_day = datetime.now().date()
+        old_dir = tmp_path / old_day
+        old_dir.mkdir()
+        (old_dir / "flocks.log").write_text("old", encoding="utf-8")
+
+        class FakeDate:
+            current = first_day
+
+            @classmethod
+            def today(cls):
+                return cls.current
+
+        monkeypatch.setenv("FLOCKS_LOG_DIR", str(tmp_path))
+        monkeypatch.setattr(log_module, "date", FakeDate)
+
+        try:
+            await Log.init(print=False, dev=False, level=LogLevel.INFO)
+            Log.Default.info("first day")
+            first_file = Path(Log.file())
+
+            FakeDate.current = second_day
+            Log.Default.warn("second day")
+            second_file = Path(Log.file())
+
+            assert first_file == tmp_path / first_day.isoformat() / "flocks.log"
+            assert second_file == tmp_path / second_day.isoformat() / "flocks.log"
+            assert "first day" in first_file.read_text(encoding="utf-8")
+            assert "second day" in second_file.read_text(encoding="utf-8")
+            assert "second day" in (tmp_path / second_day.isoformat() / "errors.log").read_text(encoding="utf-8")
+            assert not old_dir.exists()
+        finally:
+            if Log._writer:
+                Log._writer.close()
+                Log._writer = None
+            if Log._error_writer:
+                Log._error_writer.close()
+                Log._error_writer = None
+            Log._log_file = None
+            Log._log_dir_path = None
+            Log._log_date = None
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_log_compatibility.py
+++ b/tests/utils/test_log_compatibility.py
@@ -6,7 +6,8 @@ import pytest
 import time
 import tempfile
 from pathlib import Path
-from flocks.utils.log import Log, Logger, LogLevel, _RotatingTextWriter, rotate_log_file
+from datetime import datetime, timedelta
+from flocks.utils.log import Log, Logger, LogLevel
 
 
 class TestLoggerCompatibility:
@@ -245,38 +246,6 @@ class TestLoggerCompatibility:
         finally:
             Log._writer = old_stderr
 
-    def test_rotate_log_file_keeps_bounded_backups(self, tmp_path: Path):
-        """Test oversized runtime logs rotate before another process appends."""
-        log_path = tmp_path / "backend.log"
-        log_path.write_text("x" * 20, encoding="utf-8")
-
-        rotate_log_file(log_path, max_bytes=10, backup_count=2)
-
-        assert not log_path.exists()
-        assert (tmp_path / "backend.log.1").read_text(encoding="utf-8") == "x" * 20
-
-        log_path.write_text("y" * 20, encoding="utf-8")
-        rotate_log_file(log_path, max_bytes=10, backup_count=2)
-
-        assert (tmp_path / "backend.log.1").read_text(encoding="utf-8") == "y" * 20
-        assert (tmp_path / "backend.log.2").read_text(encoding="utf-8") == "x" * 20
-
-    def test_rotating_text_writer_rotates_during_log_writes(self, tmp_path: Path):
-        """Test Log's writer rotates when the next line would exceed the limit."""
-        log_path = tmp_path / "session.log"
-        writer = _RotatingTextWriter(log_path, max_bytes=12, backup_count=1)
-
-        try:
-            writer.write("first\n")
-            writer.flush()
-            writer.write("second\n")
-            writer.flush()
-        finally:
-            writer.close()
-
-        assert log_path.read_text(encoding="utf-8") == "second\n"
-        assert (tmp_path / "session.log.1").read_text(encoding="utf-8") == "first\n"
-    
     def test_time_diff_calculation(self):
         """Test time difference calculation between logs"""
         logger = Log.create(service="test")
@@ -342,14 +311,84 @@ class TestLogInitialization:
                 log_dir = Path(tmpdir) / ".flocks" / "logs"
                 assert log_dir.exists()
                 
-                dev_log = log_dir / "dev.log"
-                assert dev_log.exists()
+                today_dir = log_dir / datetime.now().date().isoformat()
+                assert (today_dir / "flocks.log").exists()
+                assert (today_dir / "errors.log").exists()
+                assert not (log_dir / "dev.log").exists()
             finally:
                 # Restore
                 os.environ["HOME"] = str(old_home)
                 if Log._writer:
                     Log._writer.close()
                     Log._writer = None
+                if Log._error_writer:
+                    Log._error_writer.close()
+                    Log._error_writer = None
+
+    async def test_init_uses_stable_main_log_file(self):
+        """Test production logging appends to the daily flocks.log."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_home = Path.home()
+            import os
+            os.environ["HOME"] = tmpdir
+
+            try:
+                await Log.init(print=False, dev=False, level=LogLevel.INFO)
+                Log.Default.info("first")
+                first_file = Path(Log.file())
+                await Log.init(print=False, dev=False, level=LogLevel.INFO)
+                Log.Default.info("second")
+
+                log_dir = Path(tmpdir) / ".flocks" / "logs"
+                today_dir = log_dir / datetime.now().date().isoformat()
+                assert first_file == today_dir / "flocks.log"
+                assert Path(Log.file()) == first_file
+                assert not list(log_dir.glob("????-??-??T??????.log"))
+                assert not list(log_dir.glob("*.log.1"))
+                content = first_file.read_text(encoding="utf-8")
+                assert "first" in content
+                assert "second" in content
+            finally:
+                os.environ["HOME"] = str(old_home)
+                if Log._writer:
+                    Log._writer.close()
+                    Log._writer = None
+                if Log._error_writer:
+                    Log._error_writer.close()
+                    Log._error_writer = None
+
+    async def test_warn_and_error_are_copied_to_errors_log(self):
+        """Test warning and error lines are available in errors.log for quick triage."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_home = Path.home()
+            import os
+            os.environ["HOME"] = tmpdir
+
+            try:
+                await Log.init(print=False, dev=False, level=LogLevel.INFO)
+                logger = Log.create(service="error-copy")
+                logger.info("info")
+                logger.warn("warn")
+                logger.error("error")
+
+                log_dir = Path(tmpdir) / ".flocks" / "logs"
+                today_dir = log_dir / datetime.now().date().isoformat()
+                main_content = (today_dir / "flocks.log").read_text(encoding="utf-8")
+                error_content = (today_dir / "errors.log").read_text(encoding="utf-8")
+                assert "info" in main_content
+                assert "warn" in main_content
+                assert "error" in main_content
+                assert "info" not in error_content
+                assert "warn" in error_content
+                assert "error" in error_content
+            finally:
+                os.environ["HOME"] = str(old_home)
+                if Log._writer:
+                    Log._writer.close()
+                    Log._writer = None
+                if Log._error_writer:
+                    Log._error_writer.close()
+                    Log._error_writer = None
     
     async def test_init_print_mode(self):
         """Test that init with print=True uses stderr"""
@@ -357,6 +396,7 @@ class TestLogInitialization:
         
         # Should not create a file writer
         assert Log._writer is None
+        assert Log._error_writer is None
     
     async def test_log_file_path(self):
         """Test log file path method"""
@@ -364,18 +404,37 @@ class TestLogInitialization:
         assert file_path.endswith("flocks.log") or "flocks" in file_path
 
     async def test_cleanup_removes_rotated_siblings_for_old_timestamp_logs(self, tmp_path: Path):
-        """Test cleanup deletes rotated backups for base files outside retention."""
-        for day in range(11):
-            base = tmp_path / f"2026-05-{day + 1:02d}T010203.log"
-            base.write_text("base", encoding="utf-8")
-            (tmp_path / f"{base.name}.1").write_text("rotated", encoding="utf-8")
+        """Test cleanup deletes legacy timestamp logs by age, not by file count."""
+        old_stamp = (datetime.now() - timedelta(days=31)).strftime("%Y-%m-%dT%H%M%S")
+        recent_stamp = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%dT%H%M%S")
+        old_base = tmp_path / f"{old_stamp}.log"
+        recent_base = tmp_path / f"{recent_stamp}.log"
+        old_base.write_text("old", encoding="utf-8")
+        (tmp_path / f"{old_base.name}.1").write_text("old rotated", encoding="utf-8")
+        recent_base.write_text("recent", encoding="utf-8")
+        (tmp_path / f"{recent_base.name}.1").write_text("recent rotated", encoding="utf-8")
 
-        await Log._cleanup(tmp_path)
+        await Log._cleanup(tmp_path, retention_days=30)
 
-        assert not (tmp_path / "2026-05-01T010203.log").exists()
-        assert not (tmp_path / "2026-05-01T010203.log.1").exists()
-        assert (tmp_path / "2026-05-02T010203.log").exists()
-        assert (tmp_path / "2026-05-02T010203.log.1").exists()
+        assert not old_base.exists()
+        assert not (tmp_path / f"{old_base.name}.1").exists()
+        assert recent_base.exists()
+        assert (tmp_path / f"{recent_base.name}.1").exists()
+
+    async def test_cleanup_removes_old_date_directories(self, tmp_path: Path):
+        old_day = (datetime.now() - timedelta(days=31)).date().isoformat()
+        recent_day = (datetime.now() - timedelta(days=1)).date().isoformat()
+        old_dir = tmp_path / old_day
+        recent_dir = tmp_path / recent_day
+        old_dir.mkdir()
+        recent_dir.mkdir()
+        (old_dir / "flocks.log").write_text("old", encoding="utf-8")
+        (recent_dir / "flocks.log").write_text("recent", encoding="utf-8")
+
+        await Log._cleanup(tmp_path, retention_days=30)
+
+        assert not old_dir.exists()
+        assert recent_dir.exists()
 
 
 if __name__ == "__main__":

--- a/tests/workflow/test_logging_config.py
+++ b/tests/workflow/test_logging_config.py
@@ -1,24 +1,19 @@
 import logging
-from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 from flocks.workflow.logging_config import setup_workflow_logging
 
 
-def test_workflow_file_logging_uses_rotating_handler(monkeypatch, tmp_path: Path) -> None:
+def test_workflow_file_logging_is_disabled(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("FLOCKS_LOG_DIR", str(tmp_path))
-    monkeypatch.setenv("FLOCKS_LOG_MAX_BYTES", "1234")
-    monkeypatch.setenv("FLOCKS_LOG_BACKUP_COUNT", "2")
 
     setup_workflow_logging(stream=None)
 
     logger = logging.getLogger("flocks.workflow")
-    handlers = [handler for handler in logger.handlers if isinstance(handler, RotatingFileHandler)]
 
     try:
-        assert len(handlers) == 1
-        assert handlers[0].baseFilename == str(tmp_path / "workflow.log")
-        assert handlers[0].maxBytes == 1234
-        assert handlers[0].backupCount == 2
+        assert len(logger.handlers) == 1
+        assert isinstance(logger.handlers[0], logging.StreamHandler)
+        assert not (tmp_path / "workflow.log").exists()
     finally:
         logger.handlers.clear()

--- a/tui/flocks/util/log.ts
+++ b/tui/flocks/util/log.ts
@@ -47,44 +47,70 @@ export namespace Log {
   }
 
   let logpath = ""
+  let errorLogpath = ""
+  let logDate = ""
   export function file() {
     return logpath
   }
-  let write = (msg: any) => {
+  let write = async (msg: any, error = false) => {
     process.stderr.write(msg)
     return msg.length
   }
 
   export async function init(options: Options) {
     if (options.level) level = options.level
-    cleanup(Global.Path.log)
+    await cleanup(Global.Path.log)
     if (options.print) return
-    logpath = path.join(
-      Global.Path.log,
-      options.dev ? "dev.log" : new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
-    )
-    const logfile = Bun.file(logpath)
-    await fs.truncate(logpath).catch(() => {})
-    const writer = logfile.writer()
-    write = async (msg: any) => {
-      const num = writer.write(msg)
-      writer.flush()
-      return num
+    await openDailyLogs()
+    write = async (msg: any, error = false) => {
+      await ensureCurrentDay()
+      await fs.appendFile(logpath, msg)
+      if (error) await fs.appendFile(errorLogpath, msg)
+      return msg.length
     }
   }
 
+  function todayString() {
+    return new Date().toISOString().split("T")[0]
+  }
+
+  async function openDailyLogs() {
+    logDate = todayString()
+    const dir = path.join(Global.Path.log, logDate)
+    await fs.mkdir(dir, { recursive: true })
+    logpath = path.join(dir, "flocks.log")
+    errorLogpath = path.join(dir, "errors.log")
+  }
+
+  async function ensureCurrentDay() {
+    if (logDate === todayString()) return
+    await openDailyLogs()
+    await cleanup(Global.Path.log)
+  }
+
   async function cleanup(dir: string) {
-    const glob = new Bun.Glob("????-??-??T??????.log")
-    const files = await Array.fromAsync(
-      glob.scan({
-        cwd: dir,
-        absolute: true,
+    const retentionDays = Number.parseInt(process.env.FLOCKS_LOG_RETENTION_DAYS || "30", 10)
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return
+    const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000
+    const cutoffDay = new Date(cutoff).toISOString().split("T")[0]
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    await Promise.all(
+      entries.map(async (entry) => {
+        const target = path.join(dir, entry.name)
+        if (entry.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(entry.name)) {
+          if (entry.name < cutoffDay) {
+            await fs.rm(target, { recursive: true, force: true }).catch(() => {})
+          }
+          return
+        }
+        if (entry.isFile() && /^\d{4}-\d{2}-\d{2}T\d{6}\.log(\.\d+)?$/.test(entry.name)) {
+          const stamp = entry.name.split(".log")[0]
+          if (new Date(stamp.replace(/T(\d{2})(\d{2})(\d{2})$/, "T$1:$2:$3")).getTime() < cutoff) {
+            await fs.unlink(target).catch(() => {})
+          }
+        }
       }),
     )
-    if (files.length <= 5) return
-
-    const filesToDelete = files.slice(0, -10)
-    await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})))
   }
 
   function formatError(error: Error, depth = 0): string {
@@ -137,12 +163,12 @@ export namespace Log {
       },
       error(message?: any, extra?: Record<string, any>) {
         if (shouldLog("ERROR")) {
-          write("ERROR " + build(message, extra))
+          write("ERROR " + build(message, extra), true)
         }
       },
       warn(message?: any, extra?: Record<string, any>) {
         if (shouldLog("WARN")) {
-          write("WARN  " + build(message, extra))
+          write("WARN  " + build(message, extra), true)
         }
       },
       tag(key: string, value: string) {


### PR DESCRIPTION
## 概要

- 将 Flocks 日志重构为稳定的日期目录结构：
  - 日志根目录只保留 `backend.log`、`webui.log`
  - 每个 `YYYY-MM-DD/` 日期目录只保留 `flocks.log` 和 `errors.log`
- 移除结构化日志和 backend/webui 进程日志的 `.log.1` / `.log.2` 小标轮转。
- `WARN` / `ERROR` 日志同步写入当天 `errors.log`，主结构化业务日志写入当天 `flocks.log`。
- 按 30 天清理过期日期目录，并兼容清理旧版时间戳日志。
- 更新 WebUI 日志接口，支持安全列出和读取日期目录日志，`/latest` 优先读取当天 `flocks.log`。
- 停用额外根目录日志文件，如 `workflow.log`、`dev.log`、`update.log`，保持日志目录结构稳定。

## 日志大小评估

- 当前本机 `backend.log` 约 `32.42 MB`，跨度约 `62` 天，平均约 `0.52 MB/天`。
- 当前本机 `webui.log` 约 `0.02 MB`，体积很小，基本可忽略。
- `backend.log` 仍可能在 stdout/stderr 或异常堆栈频繁输出时增长；本次不做自动截断或轮转，避免日志丢失和再次出现 `.log.N` 小标。

## 测试

已运行：

```bash
source /Users/yinzhongchao/repository/project/flocks/.venv/bin/activate && python -m pytest tests/utils/test_log_compatibility.py tests/server/test_log_routes.py tests/cli/test_service_manager.py::test_spawn_process_appends_without_rotated_suffix tests/workflow/test_logging_config.py tests/utils/test_append_upgrade_log.py