### PR TITLE
fix(updater): avoid Windows project install during dependency sync

### DIFF
--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -570,6 +570,16 @@ def _dependency_sync_timeout_seconds() -> int:
     return _DEPENDENCY_SYNC_TIMEOUT_SECONDS
 
 
+def _build_dependency_sync_command(uv_path: str, *, uv_default_index: str | None = None) -> list[str]:
+    """Build the ``uv sync`` command used by the self-updater."""
+    cmd = [uv_path, "sync"]
+    if sys.platform == "win32":
+        cmd.append("--no-install-project")
+    if uv_default_index:
+        cmd.extend(["--default-index", uv_default_index])
+    return cmd
+
+
 # ------------------------------------------------------------------ #
 # Async subprocess helpers
 # ------------------------------------------------------------------ #
@@ -2892,9 +2902,7 @@ async def perform_update(
         return
 
     log.info("updater.dependencies.sync", {"tool": "uv sync", "path": uv_path})
-    uv_cmd = [uv_path, "sync"]
-    if profile.uv_default_index:
-        uv_cmd.extend(["--default-index", profile.uv_default_index])
+    uv_cmd = _build_dependency_sync_command(uv_path, uv_default_index=profile.uv_default_index)
 
     sync_env = _build_uv_sync_env()
     sync_timeout = _dependency_sync_timeout_seconds()
@@ -2957,7 +2965,7 @@ async def perform_update(
             },
         )
         await asyncio.sleep(3)
-        uv_cmd = [uv_path, "sync"]
+        uv_cmd = _build_dependency_sync_command(uv_path)
         try:
             code, _, err = await _run_uv_sync(uv_cmd)
         except subprocess.TimeoutExpired:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,9 +108,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["flocks"]
 
-[tool.hatch.build.targets.wheel.force-include]
-".flocks/flockshub" = ".flocks/flockshub"
-
 [tool.ruff]
 line-length = 120
 target-version = "py312"

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import tarfile
+import tomllib
 from os import utime
 from pathlib import Path
 from types import SimpleNamespace
@@ -426,6 +427,36 @@ def test_build_uv_sync_env_returns_none_on_windows(
     assert updater._build_uv_sync_env() is None
 
 
+def test_build_dependency_sync_command_skips_project_install_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+
+    assert updater._build_dependency_sync_command("uv", uv_default_index="https://mirror.example/simple") == [
+        "uv",
+        "sync",
+        "--no-install-project",
+        "--default-index",
+        "https://mirror.example/simple",
+    ]
+
+
+def test_build_dependency_sync_command_keeps_project_install_on_non_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+
+    assert updater._build_dependency_sync_command("uv") == ["uv", "sync"]
+
+
+def test_wheel_build_config_does_not_force_include_flockshub() -> None:
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    wheel_config = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
+
+    assert ".flocks/flockshub" not in wheel_config.get("force-include", {})
+
+
 def test_build_frontend_subprocess_env_prepends_bundled_node_on_windows(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -539,6 +570,8 @@ async def test_download_archive_uses_curl_user_agent_for_gitee_web_archive(
     captured: dict[str, object] = {}
 
     class _FakeStreamResponse:
+        status_code = 200
+
         async def __aenter__(self):
             return self
 
@@ -593,6 +626,8 @@ async def test_download_archive_keeps_auth_header_for_non_gitee_sources(
     captured: dict[str, object] = {}
 
     class _FakeStreamResponse:
+        status_code = 200
+
         async def __aenter__(self):
             return self
 


### PR DESCRIPTION
## Summary
- Skip installing the current project during Windows self-upgrade dependency sync to avoid transient hatchling traversal failures.
- Remove flockshub from wheel force-include metadata so bundled hub resources are not processed during Python wheel builds.
- Add regression coverage for Windows dependency sync command construction and wheel build configuration.