### PR TITLE
feat(webui): improve workflow graph layout and editor edge UX

### DIFF
--- a/webui/src/api/workflow.ts
+++ b/webui/src/api/workflow.ts
@@ -18,6 +18,8 @@ export interface WorkflowNode {
   select_key?: string;
   join?: boolean;
   join_mode?: 'flat' | 'namespace';
+  join_conflict?: 'overwrite' | 'error';
+  join_namespace_key?: string;
   // tool node
   tool_name?: string;
   tool_args?: Record<string, unknown>;

--- a/webui/src/pages/WorkflowDetail/FlowCanvas.tsx
+++ b/webui/src/pages/WorkflowDetail/FlowCanvas.tsx
@@ -20,6 +20,13 @@ import {
 import '@xyflow/react/dist/style.css';
 import { Code2, Zap, GitBranch, RotateCw, X, ChevronRight, Wrench, Sparkles, Globe, Workflow } from 'lucide-react';
 import { WorkflowJSON, WorkflowNode as APINode } from '@/api/workflow';
+import {
+  buildWorkflowGraphLayout,
+  WORKFLOW_GRAPH_NODE_WIDTH,
+  workflowGraphEdgeId,
+  type WorkflowGraphEdgeRoute,
+  type WorkflowGraphOutputHandle,
+} from '@/utils/workflowGraphLayout';
 
 // ─────────────────────────────────────────────
 // Node type config
@@ -132,6 +139,9 @@ interface ViewNodeData {
   nodeType: string;
   description?: string;
   isStart?: boolean;
+  join?: boolean;
+  joinMode?: string;
+  outputHandles?: WorkflowGraphOutputHandle[];
   onNodeClick?: (nodeId: string) => void;
 }
 
@@ -141,12 +151,16 @@ const ViewNode = memo(function ViewNode({ data, selected }: NodeProps) {
   const cfg = TYPE_CONFIG[d.nodeType] ?? TYPE_CONFIG.python;
   const icon = TYPE_ICONS[d.nodeType];
   const typeLabel = TYPE_LABELS[d.nodeType] ?? d.nodeType;
+  const outputHandles =
+    d.outputHandles && d.outputHandles.length > 0
+      ? d.outputHandles
+      : [{ id: 'default', label: '', left: 50 }];
 
   return (
     <div
       className={`
         ${cfg.bg} ${cfg.border} border-2 rounded-xl shadow-sm
-        w-48 cursor-pointer select-none
+        w-[220px] cursor-pointer select-none
         transition-all duration-150
         ${selected ? 'shadow-md ring-2 ring-offset-1 ring-red-300' : 'hover:shadow-md'}
       `}
@@ -181,6 +195,11 @@ const ViewNode = memo(function ViewNode({ data, selected }: NodeProps) {
         ) : (
           <p className="text-xs text-gray-300 mt-1 italic">{t('detail.flow.noDescription')}</p>
         )}
+        {d.join && (
+          <div className="mt-2 inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700">
+            Join: {d.joinMode || 'flat'}
+          </div>
+        )}
       </div>
 
       {/* Click hint */}
@@ -190,11 +209,16 @@ const ViewNode = memo(function ViewNode({ data, selected }: NodeProps) {
         </span>
       </div>
 
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className={`!w-2.5 !h-2.5 ${cfg.handleColor} !border-2 !border-white`}
-      />
+      {outputHandles.map((handle) => (
+        <Handle
+          key={handle.id}
+          id={handle.id === 'default' ? undefined : handle.id}
+          type="source"
+          position={Position.Bottom}
+          className={`!w-2.5 !h-2.5 ${cfg.handleColor} !border-2 !border-white`}
+          style={{ left: `${handle.left}%` }}
+        />
+      ))}
     </div>
   );
 });
@@ -328,89 +352,95 @@ function NodeDetailModal({ node, isStart, onClose }: NodeDetailModalProps) {
 // Layout builder
 // ─────────────────────────────────────────────
 
+const EDGE_THEME: Record<WorkflowGraphEdgeRoute['kind'], {
+  stroke: string;
+  label: string;
+  labelBg: string;
+  strokeWidth: number;
+  strokeDasharray?: string;
+}> = {
+  default: {
+    stroke: '#94a3b8',
+    label: '#64748b',
+    labelBg: '#f8fafc',
+    strokeWidth: 1.7,
+  },
+  branch: {
+    stroke: '#d97706',
+    label: '#92400e',
+    labelBg: '#fffbeb',
+    strokeWidth: 2.2,
+  },
+  loop: {
+    stroke: '#8b5cf6',
+    label: '#6d28d9',
+    labelBg: '#f5f3ff',
+    strokeWidth: 2,
+  },
+  back: {
+    stroke: '#64748b',
+    label: '#475569',
+    labelBg: '#f8fafc',
+    strokeWidth: 1.8,
+    strokeDasharray: '6 5',
+  },
+};
+
 function buildLayout(
   workflowJson: WorkflowJSON,
   onNodeClick: (nodeId: string) => void
 ): { nodes: Node[]; edges: Edge[] } {
-  const children = new Map<string, string[]>();
-  const levels = new Map<string, number>();
-
-  for (const n of workflowJson.nodes) children.set(n.id, []);
-  for (const e of workflowJson.edges) children.get(e.from)?.push(e.to);
-
+  const diagram = buildWorkflowGraphLayout(workflowJson);
   const startId = workflowJson.start || workflowJson.nodes[0]?.id;
-  const queue: string[] = startId ? [startId] : [];
-  if (startId) levels.set(startId, 0);
-
-  while (queue.length > 0) {
-    const cur = queue.shift()!;
-    const curLevel = levels.get(cur) ?? 0;
-    for (const child of children.get(cur) ?? []) {
-      if (!levels.has(child)) {
-        levels.set(child, curLevel + 1);
-        queue.push(child);
-      }
-    }
-  }
-
-  let maxLevel = 0;
-  for (const v of levels.values()) maxLevel = Math.max(maxLevel, v);
-  for (const n of workflowJson.nodes) {
-    if (!levels.has(n.id)) {
-      maxLevel += 1;
-      levels.set(n.id, maxLevel);
-    }
-  }
-
-  const levelGroups = new Map<number, string[]>();
-  for (const [id, lv] of levels.entries()) {
-    if (!levelGroups.has(lv)) levelGroups.set(lv, []);
-    levelGroups.get(lv)!.push(id);
-  }
-
-  const NODE_W = 192; // w-48 = 12rem = 192px
-  const NODE_H = 110;
-  const H_GAP = 60;
-  const V_GAP = 70;
-
-  const positions = new Map<string, { x: number; y: number }>();
-  for (const [lv, ids] of levelGroups.entries()) {
-    const totalW = ids.length * NODE_W + (ids.length - 1) * H_GAP;
-    const startX = -totalW / 2;
-    ids.forEach((id, idx) => {
-      positions.set(id, {
-        x: startX + idx * (NODE_W + H_GAP),
-        y: lv * (NODE_H + V_GAP),
-      });
-    });
-  }
 
   const nodes: Node[] = workflowJson.nodes.map((node) => ({
     id: node.id,
     type: 'view',
-    position: positions.get(node.id) ?? { x: 0, y: 0 },
+    position: diagram.positions[node.id] ?? { x: 0, y: 0 },
     data: {
       label: node.id,
       nodeType: node.type,
       description: node.description,
       isStart: node.id === startId,
+      join: node.join,
+      joinMode: node.join_mode,
+      outputHandles: diagram.outputHandles[node.id],
       onNodeClick,
     },
+    style: { width: WORKFLOW_GRAPH_NODE_WIDTH },
   }));
 
-  const edges: Edge[] = workflowJson.edges.map((edge, idx) => ({
-    id: `e-${edge.from}-${edge.to}-${idx}`,
-    source: edge.from,
-    target: edge.to,
-    label: edge.label,
-    type: 'smoothstep',
-    animated: false,
-    markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
-    style: { stroke: '#cbd5e1', strokeWidth: 1.5 },
-    labelStyle: { fontSize: 10, fill: '#94a3b8' },
-    labelBgStyle: { fill: '#f8fafc', fillOpacity: 0.9 },
-    data: { order: edge.order, mapping: edge.mapping, const: edge.const },
-  }));
+  const edges: Edge[] = workflowJson.edges.map((edge, idx) => {
+    const id = workflowGraphEdgeId(edge, idx);
+    const route = diagram.edgeRoutes[id] ?? { kind: 'default' as const };
+    const theme = EDGE_THEME[route.kind];
+
+    return {
+      id,
+      source: edge.from,
+      target: edge.to,
+      sourceHandle: route.sourceHandle,
+      label: route.label ?? edge.label,
+      type: 'smoothstep',
+      animated: false,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 16,
+        height: 16,
+        color: theme.stroke,
+      },
+      style: {
+        stroke: theme.stroke,
+        strokeWidth: theme.strokeWidth,
+        strokeDasharray: theme.strokeDasharray,
+      },
+      labelStyle: { fontSize: 11, fontWeight: 600, fill: theme.label },
+      labelBgStyle: { fill: theme.labelBg, fillOpacity: 0.96 },
+      labelBgPadding: [8, 4],
+      labelBgBorderRadius: 8,
+      data: { order: edge.order, mapping: edge.mapping, const: edge.const },
+    };
+  });
 
   return { nodes, edges };
 }

--- a/webui/src/pages/WorkflowEditor/components/EdgePropertyPanel.tsx
+++ b/webui/src/pages/WorkflowEditor/components/EdgePropertyPanel.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react';
+import { Edge } from '@xyflow/react';
+import { AlertCircle, GitBranch, Hash, Settings, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface EdgeData {
+  label?: string;
+  order?: number;
+  mapping?: Record<string, string>;
+  const?: Record<string, unknown>;
+}
+
+interface EdgePropertyPanelProps {
+  selectedEdge: Edge | null;
+  onClose: () => void;
+  onUpdate: (edgeId: string, updates: {
+    label?: string;
+    order: number;
+    mapping?: Record<string, string>;
+    const?: Record<string, unknown>;
+  }) => void;
+}
+
+function parseJsonObject(raw: string, fieldName: string): Record<string, unknown> | undefined {
+  if (!raw.trim()) return undefined;
+
+  const parsed = JSON.parse(raw) as unknown;
+  if (parsed == null || Array.isArray(parsed) || typeof parsed !== 'object') {
+    throw new Error(`${fieldName} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export default function EdgePropertyPanel({ selectedEdge, onClose, onUpdate }: EdgePropertyPanelProps) {
+  const { t } = useTranslation('workflow');
+  const [label, setLabel] = useState('');
+  const [order, setOrder] = useState(0);
+  const [mappingRaw, setMappingRaw] = useState('');
+  const [constRaw, setConstRaw] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!selectedEdge) return;
+
+    const data = selectedEdge.data as EdgeData | undefined;
+    setLabel(data && Object.prototype.hasOwnProperty.call(data, 'label') ? data.label ?? '' : '');
+    setOrder(Number(data?.order ?? 0));
+    setMappingRaw(data?.mapping ? JSON.stringify(data.mapping, null, 2) : '');
+    setConstRaw(data?.const ? JSON.stringify(data.const, null, 2) : '');
+    setError('');
+  }, [selectedEdge]);
+
+  if (!selectedEdge) return null;
+
+  const handleSave = () => {
+    try {
+      const parsedMapping = parseJsonObject(mappingRaw, 'mapping') as Record<string, string> | undefined;
+      const parsedConst = parseJsonObject(constRaw, 'const');
+      onUpdate(selectedEdge.id, {
+        label: label.trim() || undefined,
+        order: Number.isFinite(order) && order >= 0 ? order : 0,
+        mapping: parsedMapping,
+        const: parsedConst,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'JSON format error');
+    }
+  };
+
+  return (
+    <div className="fixed right-0 top-0 h-full w-96 bg-white shadow-2xl border-l border-gray-200 z-50 flex flex-col">
+      <div className="flex items-center justify-between p-4 border-b border-gray-200 bg-gray-50">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Edge Properties</h2>
+          <p className="text-sm text-gray-500 font-mono">
+            {selectedEdge.source} → {selectedEdge.target}
+          </p>
+        </div>
+        <button onClick={onClose} className="p-2 hover:bg-gray-200 rounded-lg transition-colors">
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        <div>
+          <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+            <GitBranch className="w-4 h-4" />
+            Label
+          </label>
+          <input
+            type="text"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 font-mono text-sm"
+            placeholder="default / true / false / continue / exit"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            {t('editor.branchKey')} values from branch, loop, or logic nodes match this label. Empty label means default fallback.
+          </p>
+        </div>
+
+        <div>
+          <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+            <Hash className="w-4 h-4" />
+            Order
+          </label>
+          <input
+            type="number"
+            min={0}
+            value={order}
+            onChange={(event) => setOrder(Number(event.target.value))}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 font-mono text-sm"
+          />
+        </div>
+
+        <div>
+          <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+            <Settings className="w-4 h-4" />
+            Mapping
+          </label>
+          <textarea
+            value={mappingRaw}
+            onChange={(event) => setMappingRaw(event.target.value)}
+            rows={5}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 font-mono text-xs resize-none"
+            placeholder='{ "dstKey": "source.path" }'
+            spellCheck={false}
+          />
+        </div>
+
+        <div>
+          <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+            <Settings className="w-4 h-4" />
+            Const
+          </label>
+          <textarea
+            value={constRaw}
+            onChange={(event) => setConstRaw(event.target.value)}
+            rows={5}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 font-mono text-xs resize-none"
+            placeholder='{ "fixedKey": "fixed-value" }'
+            spellCheck={false}
+          />
+        </div>
+
+        {error && (
+          <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-xs text-red-700">
+            <AlertCircle className="w-4 h-4 flex-shrink-0" />
+            {error}
+          </div>
+        )}
+      </div>
+
+      <div className="p-4 border-t border-gray-200 bg-gray-50">
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-100 transition-colors"
+          >
+            {t('common:button.cancel')}
+          </button>
+          <button
+            onClick={handleSave}
+            className="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+          >
+            {t('editor.applyChanges')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/pages/WorkflowEditor/components/PropertyPanel.tsx
+++ b/webui/src/pages/WorkflowEditor/components/PropertyPanel.tsx
@@ -175,8 +175,8 @@ export default function PropertyPanel({
           </div>
         )}
 
-        {/* ── branch: select_key ── */}
-        {nodeType === 'branch' && (
+        {/* ── conditional routing: select_key ── */}
+        {['branch', 'loop', 'logic'].includes(nodeType) && (
           <div>
             <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
               <Settings className="w-4 h-4" />
@@ -187,30 +187,36 @@ export default function PropertyPanel({
               value={formData.select_key || ''}
               onChange={(e) => set('select_key', e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 font-mono text-sm"
-              placeholder={t('editor.branchKeyPlaceholder')}
+              placeholder={t('editor.branchKeyPlaceholder') || 'result'}
             />
+            <p className="text-xs text-gray-500 mt-1">
+              branch / loop / logic use this input path to choose the outgoing edge label.
+            </p>
           </div>
         )}
 
-        {/* ── branch / loop: join ── */}
-        {(nodeType === 'branch' || nodeType === 'loop') && (
-          <>
-            <div>
-              <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
-                <Settings className="w-4 h-4" />
-                {t('editor.joinMerge')}
-              </label>
-              <div className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={!!formData.join}
-                  onChange={(e) => set('join', e.target.checked)}
-                  className="w-4 h-4 text-red-600 border-gray-300 rounded"
-                />
-                <span className="text-sm text-gray-600">{t('editor.enableOutputMerge')}</span>
-              </div>
+        {/* ── join: applies to any downstream merge node ── */}
+        <div className="rounded-lg border border-sky-100 bg-sky-50/60 p-3 space-y-3">
+          <div>
+            <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+              <Settings className="w-4 h-4" />
+              {t('editor.joinMerge')}
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={!!formData.join}
+                onChange={(e) => set('join', e.target.checked)}
+                className="w-4 h-4 text-red-600 border-gray-300 rounded"
+              />
+              <span className="text-sm text-gray-600">{t('editor.enableOutputMerge')}</span>
             </div>
-            {formData.join && (
+            <p className="text-xs text-gray-500 mt-1">
+              Enable this on a node that merges multiple non-exclusive incoming paths.
+            </p>
+          </div>
+          {formData.join && (
+            <>
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
                   <Settings className="w-4 h-4" />
@@ -225,9 +231,38 @@ export default function PropertyPanel({
                   <option value="namespace">{t('editor.joinModeNamespace')}</option>
                 </select>
               </div>
-            )}
-          </>
-        )}
+              <div>
+                <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+                  <Settings className="w-4 h-4" />
+                  Join Conflict
+                </label>
+                <select
+                  value={formData.join_conflict || 'overwrite'}
+                  onChange={(e) => set('join_conflict', e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+                >
+                  <option value="overwrite">overwrite</option>
+                  <option value="error">error</option>
+                </select>
+              </div>
+              {formData.join_mode === 'namespace' && (
+                <div>
+                  <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+                    <Settings className="w-4 h-4" />
+                    Namespace Key
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.join_namespace_key || ''}
+                    onChange={(e) => set('join_namespace_key', e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 font-mono text-sm"
+                    placeholder="__by_source__"
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
 
         {/* ── tool node ── */}
         {nodeType === 'tool' && (

--- a/webui/src/pages/WorkflowEditor/index.tsx
+++ b/webui/src/pages/WorkflowEditor/index.tsx
@@ -33,6 +33,12 @@ import {
 } from 'lucide-react';
 import { workflowAPI, Workflow, WorkflowExecution, WorkflowJSON, WorkflowNode as APINode } from '@/api/workflow';
 import { extractErrorMessage } from '@/utils/error';
+import {
+  buildWorkflowGraphLayout,
+  workflowGraphEdgeId,
+  type WorkflowGraphEdgeRoute,
+  type WorkflowGraphOutputHandle,
+} from '@/utils/workflowGraphLayout';
 
 // 自定义节点组件
 import PythonNode from './nodes/PythonNode';
@@ -46,6 +52,7 @@ import SubworkflowNode from './nodes/SubworkflowNode';
 
 // 交互组件
 import PropertyPanel from './components/PropertyPanel';
+import EdgePropertyPanel from './components/EdgePropertyPanel';
 import NodeToolbar from './components/NodeToolbar';
 import ExecutionPanel from './components/ExecutionPanel';
 import ExecuteDialog from './components/ExecuteDialog';
@@ -63,22 +70,107 @@ const nodeTypes = {
 
 // 节点类型颜色配置
 const nodeColors: Record<string, { bg: string; border: string; text: string }> = {
-  python: { bg: 'bg-red-50', border: 'border-red-500', text: 'text-red-700' },
-  logic: { bg: 'bg-green-50', border: 'border-green-500', text: 'text-green-700' },
-  branch: { bg: 'bg-yellow-50', border: 'border-yellow-500', text: 'text-yellow-700' },
-  loop: { bg: 'bg-purple-50', border: 'border-purple-500', text: 'text-purple-700' },
-  tool: { bg: 'bg-violet-50', border: 'border-violet-500', text: 'text-violet-700' },
-  llm: { bg: 'bg-pink-50', border: 'border-pink-500', text: 'text-pink-700' },
-  http_request: { bg: 'bg-teal-50', border: 'border-teal-500', text: 'text-teal-700' },
-  subworkflow: { bg: 'bg-orange-50', border: 'border-orange-400', text: 'text-orange-700' },
+  python: { bg: 'bg-white', border: 'border-red-300', text: 'text-red-600' },
+  logic: { bg: 'bg-white', border: 'border-emerald-300', text: 'text-emerald-600' },
+  branch: { bg: 'bg-white', border: 'border-amber-300', text: 'text-amber-600' },
+  loop: { bg: 'bg-white', border: 'border-purple-300', text: 'text-purple-600' },
+  tool: { bg: 'bg-white', border: 'border-violet-300', text: 'text-violet-600' },
+  llm: { bg: 'bg-white', border: 'border-pink-300', text: 'text-pink-600' },
+  http_request: { bg: 'bg-white', border: 'border-teal-300', text: 'text-teal-600' },
+  subworkflow: { bg: 'bg-white', border: 'border-orange-300', text: 'text-orange-600' },
 };
+
+const nodeMiniMapColors: Record<string, string> = {
+  python: '#f87171',
+  logic: '#34d399',
+  branch: '#f59e0b',
+  loop: '#a78bfa',
+  tool: '#8b5cf6',
+  llm: '#f472b6',
+  http_request: '#2dd4bf',
+  subworkflow: '#fb923c',
+};
+
+const edgeTheme: Record<WorkflowGraphEdgeRoute['kind'], {
+  stroke: string;
+  label: string;
+  labelBg: string;
+  strokeWidth: number;
+  strokeDasharray?: string;
+}> = {
+  default: {
+    stroke: '#94a3b8',
+    label: '#64748b',
+    labelBg: '#f8fafc',
+    strokeWidth: 1.8,
+  },
+  branch: {
+    stroke: '#d97706',
+    label: '#92400e',
+    labelBg: '#fffbeb',
+    strokeWidth: 2.2,
+  },
+  loop: {
+    stroke: '#8b5cf6',
+    label: '#6d28d9',
+    labelBg: '#f5f3ff',
+    strokeWidth: 2,
+  },
+  back: {
+    stroke: '#64748b',
+    label: '#475569',
+    labelBg: '#f8fafc',
+    strokeWidth: 1.8,
+    strokeDasharray: '6 5',
+  },
+};
+
+function buildReactFlowEdge(
+  edge: WorkflowJSON['edges'][number],
+  index: number,
+  route: WorkflowGraphEdgeRoute = { kind: 'default' }
+): Edge {
+  const theme = edgeTheme[route.kind];
+
+  return {
+    id: workflowGraphEdgeId(edge, index),
+    source: edge.from,
+    target: edge.to,
+    sourceHandle: route.sourceHandle,
+    label: route.label ?? edge.label,
+    type: 'smoothstep',
+    animated: false,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 18,
+      height: 18,
+      color: theme.stroke,
+    },
+    style: {
+      stroke: theme.stroke,
+      strokeWidth: theme.strokeWidth,
+      strokeDasharray: theme.strokeDasharray,
+    },
+    labelStyle: { fontSize: 11, fontWeight: 600, fill: theme.label },
+    labelBgStyle: { fill: theme.labelBg, fillOpacity: 0.96 },
+    labelBgPadding: [8, 4],
+    labelBgBorderRadius: 8,
+    data: {
+      label: edge.label,
+      order: edge.order,
+      mapping: edge.mapping,
+      const: edge.const,
+    },
+  };
+}
 
 // 将后端数据转换为 ReactFlow 格式
 function convertToReactFlowFormat(workflowJson: WorkflowJSON): { nodes: Node[]; edges: Edge[] } {
-  const nodes: Node[] = workflowJson.nodes.map((node, index) => ({
+  const diagram = buildWorkflowGraphLayout(workflowJson);
+  const nodes: Node[] = workflowJson.nodes.map((node) => ({
     id: node.id,
     type: node.type,
-    position: { x: 100 + (index % 3) * 250, y: 100 + Math.floor(index / 3) * 150 },
+    position: diagram.positions[node.id] ?? { x: 0, y: 0 },
     data: {
       label: node.id,
       description: node.description,
@@ -86,6 +178,8 @@ function convertToReactFlowFormat(workflowJson: WorkflowJSON): { nodes: Node[]; 
       select_key: node.select_key,
       join: node.join,
       join_mode: node.join_mode,
+      join_conflict: node.join_conflict,
+      join_namespace_key: node.join_namespace_key,
       // tool
       tool_name: node.tool_name,
       tool_args: node.tool_args,
@@ -103,28 +197,14 @@ function convertToReactFlowFormat(workflowJson: WorkflowJSON): { nodes: Node[]; 
       workflow_id: node.workflow_id,
       inputs_mapping: node.inputs_mapping,
       inputs_const: node.inputs_const,
+      outputHandles: diagram.outputHandles[node.id],
       ...(nodeColors[node.type] ?? nodeColors.python),
     },
   }));
 
-  const edges: Edge[] = workflowJson.edges.map((edge, index) => ({
-    id: `e-${edge.from}-${edge.to}-${index}`,
-    source: edge.from,
-    target: edge.to,
-    label: edge.label,
-    type: 'smoothstep',
-    animated: true,
-    markerEnd: {
-      type: MarkerType.ArrowClosed,
-      width: 20,
-      height: 20,
-    },
-    data: {
-      order: edge.order,
-      mapping: edge.mapping,
-      const: edge.const,
-    },
-  }));
+  const edges: Edge[] = workflowJson.edges.map((edge, index) =>
+    buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)])
+  );
 
   return { nodes, edges };
 }
@@ -137,6 +217,8 @@ interface NodeData {
   select_key?: string;
   join?: boolean;
   join_mode?: string;
+  join_conflict?: string;
+  join_namespace_key?: string;
   bg?: string;
   border?: string;
   text?: string;
@@ -157,13 +239,32 @@ interface NodeData {
   workflow_id?: string;
   inputs_mapping?: Record<string, string>;
   inputs_const?: Record<string, unknown>;
+  outputHandles?: WorkflowGraphOutputHandle[];
 }
 
 // 定义边数据类型
 interface EdgeData {
+  label?: string;
   order?: number;
   mapping?: Record<string, string>;
   const?: Record<string, any>;
+}
+
+function applyGraphSemantics(nodes: Node[], edges: Edge[], workflow: Workflow): { nodes: Node[]; edges: Edge[] } {
+  const workflowJson = convertToWorkflowJSON(nodes, edges, workflow);
+  const diagram = buildWorkflowGraphLayout(workflowJson);
+  const updatedNodes = nodes.map((node) => ({
+    ...node,
+    data: {
+      ...node.data,
+      outputHandles: diagram.outputHandles[node.id],
+    },
+  }));
+  const updatedEdges = workflowJson.edges.map((edge, index) =>
+    buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)])
+  );
+
+  return { nodes: updatedNodes, edges: updatedEdges };
 }
 
 // 将 ReactFlow 格式转换回后端数据
@@ -178,6 +279,8 @@ function convertToWorkflowJSON(nodes: Node[], edges: Edge[], workflow: Workflow)
       select_key: data.select_key,
       join: data.join,
       join_mode: data.join_mode as any,
+      join_conflict: data.join_conflict as any,
+      join_namespace_key: data.join_namespace_key,
       // tool
       tool_name: data.tool_name,
       tool_args: data.tool_args,
@@ -204,7 +307,7 @@ function convertToWorkflowJSON(nodes: Node[], edges: Edge[], workflow: Workflow)
       from: edge.source,
       to: edge.target,
       order: data?.order || 0,
-      label: edge.label as string,
+      label: data && Object.prototype.hasOwnProperty.call(data, 'label') ? data.label : edge.label as string,
       mapping: data?.mapping,
       const: data?.const,
     };
@@ -227,12 +330,14 @@ export default function WorkflowEditor() {
 
   const [workflow, setWorkflow] = useState<Workflow | null>(null);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [edges, setEdges] = useEdgesState<Edge>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [validationResult, setValidationResult] = useState<{ valid: boolean; issues: any[] } | null>(null);
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
   const [showPropertyPanel, setShowPropertyPanel] = useState(false);
+  const [showEdgePropertyPanel, setShowEdgePropertyPanel] = useState(false);
   const [showNodeToolbar, setShowNodeToolbar] = useState(true);
   const [showExecuteDialog, setShowExecuteDialog] = useState(false);
   const [currentExecution, setCurrentExecution] = useState<WorkflowExecution | null>(null);
@@ -304,30 +409,81 @@ export default function WorkflowEditor() {
   // 连接节点
   const onConnect = useCallback(
     (params: Connection) => {
+      const sourceType = nodes.find((node) => node.id === params.source)?.type;
+      const route: WorkflowGraphEdgeRoute =
+        sourceType === 'branch'
+          ? { kind: 'branch', sourceHandle: params.sourceHandle ?? undefined }
+          : sourceType === 'loop'
+            ? { kind: 'loop', sourceHandle: params.sourceHandle ?? undefined }
+            : sourceType === 'logic'
+              ? { kind: 'branch', sourceHandle: params.sourceHandle ?? undefined }
+              : { kind: 'default', sourceHandle: params.sourceHandle ?? undefined };
+
       setEdges((eds) =>
-        addEdge(
+        {
+          const nextEdges = addEdge(
           {
             ...params,
             type: 'smoothstep',
-            animated: true,
+            animated: false,
             markerEnd: {
               type: MarkerType.ArrowClosed,
-              width: 20,
-              height: 20,
+              width: 18,
+              height: 18,
+              color: edgeTheme[route.kind].stroke,
             },
+            style: {
+              stroke: edgeTheme[route.kind].stroke,
+              strokeWidth: edgeTheme[route.kind].strokeWidth,
+            },
+            labelStyle: {
+              fontSize: 11,
+              fontWeight: 600,
+              fill: edgeTheme[route.kind].label,
+            },
+            labelBgStyle: { fill: edgeTheme[route.kind].labelBg, fillOpacity: 0.96 },
+            labelBgPadding: [8, 4],
+            labelBgBorderRadius: 8,
+            data: { label: undefined, order: 0 },
           },
           eds
-        )
+          );
+
+          if (!workflow) return nextEdges;
+          const refreshed = applyGraphSemantics(nodes, nextEdges, workflow);
+          setNodes(refreshed.nodes);
+          return refreshed.edges;
+        }
       );
     },
-    [setEdges]
+    [nodes, setEdges, setNodes, workflow]
   );
 
   // 节点点击事件 - 显示属性面板
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
     setSelectedNode(node);
+    setSelectedEdge(null);
     setShowPropertyPanel(true);
+    setShowEdgePropertyPanel(false);
   }, []);
+
+  const onEdgeClick = useCallback((_event: React.MouseEvent, edge: Edge) => {
+    setSelectedEdge(edge);
+    setSelectedNode(null);
+    setShowEdgePropertyPanel(true);
+    setShowPropertyPanel(false);
+  }, []);
+
+  const handleEdgesChange = useCallback((changes: EdgeChange<Edge>[]) => {
+    setEdges((eds) => {
+      const nextEdges = applyEdgeChanges(changes, eds);
+      if (!workflow) return nextEdges;
+
+      const refreshed = applyGraphSemantics(nodes, nextEdges, workflow);
+      setNodes(refreshed.nodes);
+      return refreshed.edges;
+    });
+  }, [nodes, setEdges, setNodes, workflow]);
 
   // 添加新节点
   const handleAddNode = useCallback((type: string) => {
@@ -366,6 +522,37 @@ export default function WorkflowEditor() {
     setSelectedNode(null);
   }, [setNodes]);
 
+  const handleUpdateEdge = useCallback((edgeId: string, updates: {
+    label?: string;
+    order: number;
+    mapping?: Record<string, string>;
+    const?: Record<string, unknown>;
+  }) => {
+    setEdges((eds) => {
+      const updatedEdges = eds.map((edge) => {
+        if (edge.id !== edgeId) return edge;
+        return {
+          ...edge,
+          label: updates.label,
+          data: {
+            ...(edge.data ?? {}),
+            label: updates.label,
+            order: updates.order,
+            mapping: updates.mapping,
+            const: updates.const,
+          },
+        };
+      });
+
+      if (!workflow) return updatedEdges;
+      const refreshed = applyGraphSemantics(nodes, updatedEdges, workflow);
+      setNodes(refreshed.nodes);
+      return refreshed.edges;
+    });
+    setShowEdgePropertyPanel(false);
+    setSelectedEdge(null);
+  }, [nodes, setEdges, setNodes, workflow]);
+
   // 删除选中的节点或边（键盘事件）
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -381,7 +568,16 @@ export default function WorkflowEditor() {
         // 删除选中的边
         const selectedEdges = edges.filter((edge) => edge.selected);
         if (selectedEdges.length > 0) {
-          setEdges((eds) => eds.filter((edge) => !edge.selected));
+          setEdges((eds) => {
+            const nextEdges = eds.filter((edge) => !edge.selected);
+            if (!workflow) return nextEdges;
+
+            const refreshed = applyGraphSemantics(nodes, nextEdges, workflow);
+            setNodes(refreshed.nodes);
+            return refreshed.edges;
+          });
+          setShowEdgePropertyPanel(false);
+          setSelectedEdge(null);
         }
       }
 
@@ -389,6 +585,8 @@ export default function WorkflowEditor() {
       if (event.key === 'Escape') {
         setShowPropertyPanel(false);
         setSelectedNode(null);
+        setShowEdgePropertyPanel(false);
+        setSelectedEdge(null);
       }
     };
 
@@ -396,19 +594,29 @@ export default function WorkflowEditor() {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [nodes, edges, setNodes, setEdges]);
+  }, [nodes, edges, setNodes, setEdges, workflow]);
 
   // 自动布局
   const handleAutoLayout = () => {
-    // 简单的网格布局
-    const updatedNodes = nodes.map((node, index) => ({
+    if (!workflow) return;
+
+    const workflowJson = convertToWorkflowJSON(nodes, edges, workflow);
+    const diagram = buildWorkflowGraphLayout(workflowJson);
+    const updatedNodes = nodes.map((node) => ({
       ...node,
-      position: {
-        x: 100 + (index % 3) * 300,
-        y: 100 + Math.floor(index / 3) * 200,
+      position: diagram.positions[node.id] ?? node.position,
+      data: {
+        ...node.data,
+        outputHandles: diagram.outputHandles[node.id],
       },
     }));
+
+    const updatedEdges = workflowJson.edges.map((edge, index) =>
+      buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)])
+    );
+
     setNodes(updatedNodes);
+    setEdges(updatedEdges);
   };
 
   // 保存工作流
@@ -630,6 +838,18 @@ export default function WorkflowEditor() {
           />
         )}
 
+        {/* 边属性面板 */}
+        {showEdgePropertyPanel && selectedEdge && (
+          <EdgePropertyPanel
+            selectedEdge={selectedEdge}
+            onClose={() => {
+              setShowEdgePropertyPanel(false);
+              setSelectedEdge(null);
+            }}
+            onUpdate={handleUpdateEdge}
+          />
+        )}
+
         {/* 执行对话框 */}
         {showExecuteDialog && (
           <ExecuteDialog
@@ -661,9 +881,10 @@ export default function WorkflowEditor() {
           nodes={nodes}
           edges={edges}
           onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
+          onEdgesChange={handleEdgesChange}
           onConnect={onConnect}
           onNodeClick={onNodeClick}
+          onEdgeClick={onEdgeClick}
           nodeTypes={nodeTypes}
           fitView
           attributionPosition="bottom-left"
@@ -673,8 +894,7 @@ export default function WorkflowEditor() {
           <Controls />
           <MiniMap
             nodeColor={(node) => {
-              const colors = nodeColors[node.type as keyof typeof nodeColors];
-              return colors ? colors.border.replace('border-', '#') : '#gray';
+              return nodeMiniMapColors[node.type as keyof typeof nodeMiniMapColors] ?? '#94a3b8';
             }}
             style={{ backgroundColor: '#f9fafb' }}
           />

--- a/webui/src/pages/WorkflowEditor/nodes/BranchNode.tsx
+++ b/webui/src/pages/WorkflowEditor/nodes/BranchNode.tsx
@@ -2,13 +2,15 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Handle, Position, NodeProps } from '@xyflow/react';
 import { GitBranch, Info } from 'lucide-react';
+import type { WorkflowGraphOutputHandle } from '@/utils/workflowGraphLayout';
 
 interface BranchNodeData {
   label?: string;
   description?: string;
   select_key?: string;
-  join?: string;
+  join?: boolean;
   join_mode?: string;
+  outputHandles?: WorkflowGraphOutputHandle[];
   bg?: string;
   border?: string;
   text?: string;
@@ -17,14 +19,21 @@ interface BranchNodeData {
 export default memo(function BranchNode({ data, selected }: NodeProps) {
   const { t } = useTranslation('workflow');
   const nodeData = data as BranchNodeData;
+  const outputHandles =
+    nodeData.outputHandles && nodeData.outputHandles.length > 0
+      ? nodeData.outputHandles
+      : [
+          { id: 'branch-0', label: 'out 1', left: 33 },
+          { id: 'branch-1', label: 'out 2', left: 66 },
+        ];
   
   return (
     <div
       className={`
-        px-4 py-3 rounded-lg border-2 shadow-md min-w-[180px]
+        relative px-4 py-3 rounded-xl border-2 shadow-sm min-w-[220px]
         ${nodeData.bg || ''} ${nodeData.border || ''}
         ${selected ? 'ring-2 ring-yellow-400 ring-offset-2' : ''}
-        transition-all duration-200
+        transition-all duration-200 hover:shadow-md
       `}
     >
       {/* Input Handle */}
@@ -68,21 +77,35 @@ export default memo(function BranchNode({ data, selected }: NodeProps) {
         </div>
       )}
 
+      {outputHandles.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {outputHandles.slice(0, 4).map((handle) => (
+            <span
+              key={handle.id}
+              className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700"
+            >
+              {handle.label}
+            </span>
+          ))}
+          {outputHandles.length > 4 && (
+            <span className="rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+              +{outputHandles.length - 4}
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Multiple Output Handles for branches */}
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="branch-1"
-        className="w-3 h-3 !bg-yellow-500 !border-2 !border-white"
-        style={{ left: '33%' }}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="branch-2"
-        className="w-3 h-3 !bg-yellow-500 !border-2 !border-white"
-        style={{ left: '66%' }}
-      />
+      {outputHandles.map((handle) => (
+        <Handle
+          key={handle.id}
+          type="source"
+          position={Position.Bottom}
+          id={handle.id}
+          className="w-3 h-3 !bg-yellow-500 !border-2 !border-white"
+          style={{ left: `${handle.left}%` }}
+        />
+      ))}
     </div>
   );
 });

--- a/webui/src/pages/WorkflowEditor/nodes/HttpRequestNode.tsx
+++ b/webui/src/pages/WorkflowEditor/nodes/HttpRequestNode.tsx
@@ -8,6 +8,8 @@ interface HttpRequestNodeData {
   description?: string;
   method?: string;
   url?: string;
+  join?: boolean;
+  join_mode?: string;
   bg?: string;
   border?: string;
   text?: string;
@@ -61,6 +63,11 @@ export default memo(function HttpRequestNode({ data, selected }: NodeProps) {
         <div className="flex items-start gap-1 mt-2 p-2 bg-white rounded border border-gray-200">
           <Info className="w-3 h-3 text-gray-400 flex-shrink-0 mt-0.5" />
           <p className="text-xs text-gray-600 line-clamp-2">{d.description}</p>
+        </div>
+      )}
+      {d.join && (
+        <div className="mt-2 inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700">
+          Join: {d.join_mode || 'flat'}
         </div>
       )}
       <Handle

--- a/webui/src/pages/WorkflowEditor/nodes/LlmNode.tsx
+++ b/webui/src/pages/WorkflowEditor/nodes/LlmNode.tsx
@@ -8,6 +8,8 @@ interface LlmNodeData {
   description?: string;
   prompt?: string;
   model?: string;
+  join?: boolean;
+  join_mode?: string;
   bg?: string;
   border?: string;
   text?: string;
@@ -52,6 +54,11 @@ export default memo(function LlmNode({ data, selected }: NodeProps) {
         <div className="flex items-start gap-1 mt-2 p-2 bg-white rounded border border-gray-200">
           <Info className="w-3 h-3 text-gray-400 flex-shrink-0 mt-0.5" />
           <p className="text-xs text-gray-600 line-clamp-2">{d.description}</p>
+        </div>
+      )}
+      {d.join && (
+        <div className="mt-2 inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700">
+          Join: {d.join_mode || 'flat'}
         </div>
       )}
       <Handle

--- a/webui/src/pages/WorkflowEditor/nodes/LogicNode.tsx
+++ b/webui/src/pages/WorkflowEditor/nodes/LogicNode.tsx
@@ -2,11 +2,16 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Handle, Position, NodeProps } from '@xyflow/react';
 import { Zap, Info } from 'lucide-react';
+import type { WorkflowGraphOutputHandle } from '@/utils/workflowGraphLayout';
 
 interface LogicNodeData {
   label?: string;
   description?: string;
   code?: string;
+  select_key?: string;
+  join?: boolean;
+  join_mode?: string;
+  outputHandles?: WorkflowGraphOutputHandle[];
   bg?: string;
   border?: string;
   text?: string;
@@ -15,11 +20,15 @@ interface LogicNodeData {
 export default memo(function LogicNode({ data, selected }: NodeProps) {
   const { t } = useTranslation('workflow');
   const nodeData = data as LogicNodeData;
+  const outputHandles =
+    nodeData.outputHandles && nodeData.outputHandles.length > 0
+      ? nodeData.outputHandles
+      : [{ id: 'default', label: '', left: 50 }];
   
   return (
     <div
       className={`
-        px-4 py-3 rounded-lg border-2 shadow-md min-w-[180px]
+        relative px-4 py-3 rounded-lg border-2 shadow-md min-w-[220px]
         ${nodeData.bg || ''} ${nodeData.border || ''}
         ${selected ? 'ring-2 ring-green-400 ring-offset-2' : ''}
         transition-all duration-200
@@ -49,6 +58,19 @@ export default memo(function LogicNode({ data, selected }: NodeProps) {
         </div>
       )}
 
+      {nodeData.select_key && (
+        <div className="mt-2 p-2 bg-white rounded border border-gray-200">
+          <div className="text-xs text-gray-500">{t('editor.branchKeyLabel')}</div>
+          <div className="text-xs font-mono text-gray-800 mt-0.5">{nodeData.select_key}</div>
+        </div>
+      )}
+
+      {nodeData.join && (
+        <div className="mt-2 inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700">
+          Join: {nodeData.join_mode || 'flat'}
+        </div>
+      )}
+
       {/* Code Preview */}
       {nodeData.code && (
         <div className="mt-2 p-2 bg-gray-900 rounded text-xs font-mono text-gray-300 overflow-hidden">
@@ -56,12 +78,35 @@ export default memo(function LogicNode({ data, selected }: NodeProps) {
         </div>
       )}
 
+      {outputHandles.length > 1 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {outputHandles.slice(0, 4).map((handle) => (
+            <span
+              key={handle.id}
+              className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[10px] font-medium text-emerald-700"
+            >
+              {handle.label}
+            </span>
+          ))}
+          {outputHandles.length > 4 && (
+            <span className="rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+              +{outputHandles.length - 4}
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Output Handle */}
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="w-3 h-3 !bg-green-500 !border-2 !border-white"
-      />
+      {outputHandles.map((handle) => (
+        <Handle
+          key={handle.id}
+          type="source"
+          position={Position.Bottom}
+          id={handle.id === 'default' ? undefined : handle.id}
+          className="w-3 h-3 !bg-green-500 !border-2 !border-white"
+          style={{ left: `${handle.left}%` }}
+        />
+      ))}
     </div>
   );
 });

--- a/webui/src/pages/WorkflowEditor/nodes/LoopNode.tsx
+++ b/webui/src/pages/WorkflowEditor/nodes/LoopNode.tsx
@@ -2,13 +2,16 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Handle, Position, NodeProps } from '@xyflow/react';
 import { RotateCw, Info } from 'lucide-react';
+import type { WorkflowGraphOutputHandle } from '@/utils/workflowGraphLayout';
 
 interface LoopNodeData {
   label?: string;
   description?: string;
   code?: string;
-  join?: string;
+  select_key?: string;
+  join?: boolean;
   join_mode?: string;
+  outputHandles?: WorkflowGraphOutputHandle[];
   bg?: string;
   border?: string;
   text?: string;
@@ -17,14 +20,21 @@ interface LoopNodeData {
 export default memo(function LoopNode({ data, selected }: NodeProps) {
   const { t } = useTranslation('workflow');
   const nodeData = data as LoopNodeData;
+  const outputHandles =
+    nodeData.outputHandles && nodeData.outputHandles.length > 0
+      ? nodeData.outputHandles
+      : [
+          { id: 'loop-0', label: 'continue', left: 33 },
+          { id: 'loop-1', label: 'exit', left: 66 },
+        ];
   
   return (
     <div
       className={`
-        px-4 py-3 rounded-lg border-2 shadow-md min-w-[180px]
+        relative px-4 py-3 rounded-xl border-2 shadow-sm min-w-[220px]
         ${nodeData.bg || ''} ${nodeData.border || ''}
         ${selected ? 'ring-2 ring-purple-400 ring-offset-2' : ''}
-        transition-all duration-200
+        transition-all duration-200 hover:shadow-md
       `}
     >
       {/* Input Handle */}
@@ -59,6 +69,14 @@ export default memo(function LoopNode({ data, selected }: NodeProps) {
       )}
 
       {/* Join Info */}
+      {nodeData.select_key && (
+        <div className="mt-2 p-2 bg-white rounded border border-gray-200">
+          <div className="text-xs text-gray-500">{t('editor.branchKeyLabel')}</div>
+          <div className="text-xs font-mono text-gray-800 mt-0.5">{nodeData.select_key}</div>
+        </div>
+      )}
+
+      {/* Join Info */}
       {nodeData.join && (
         <div className="mt-2 flex items-center gap-2 text-xs text-purple-700">
           <span className="px-2 py-0.5 bg-purple-200 rounded-full font-medium">
@@ -67,20 +85,35 @@ export default memo(function LoopNode({ data, selected }: NodeProps) {
         </div>
       )}
 
+      {outputHandles.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {outputHandles.slice(0, 4).map((handle) => (
+            <span
+              key={handle.id}
+              className="rounded-full border border-purple-200 bg-purple-50 px-2 py-0.5 text-[10px] font-medium text-purple-700"
+            >
+              {handle.label}
+            </span>
+          ))}
+          {outputHandles.length > 4 && (
+            <span className="rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+              +{outputHandles.length - 4}
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Output Handles */}
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="next"
-        className="w-3 h-3 !bg-purple-500 !border-2 !border-white"
-        style={{ left: '33%' }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="loop"
-        className="w-3 h-3 !bg-purple-500 !border-2 !border-white"
-      />
+      {outputHandles.map((handle) => (
+        <Handle
+          key={handle.id}
+          type="source"
+          position={Position.Bottom}
+          id={handle.id}
+          className="w-3 h-3 !bg-purple-500 !border-2 !border-white"
+          style={{ left: `${handle.left}%` }}
+        />
+      ))}
     </div>
   );
 });

--- a/webui/src/pages/WorkflowEditor/nodes/PythonNode.tsx
+++ b/webui/src/pages/WorkflowEditor/nodes/PythonNode.tsx
@@ -7,6 +7,8 @@ interface PythonNodeData {
   label?: string;
   description?: string;
   code?: string;
+  join?: boolean;
+  join_mode?: string;
   bg?: string;
   border?: string;
   text?: string;
@@ -46,6 +48,12 @@ export default memo(function PythonNode({ data, selected }: NodeProps) {
         <div className="flex items-start gap-1 mt-2 p-2 bg-white rounded border border-gray-200">
           <Info className="w-3 h-3 text-gray-400 flex-shrink-0 mt-0.5" />
           <p className="text-xs text-gray-600 line-clamp-2">{nodeData.description}</p>
+        </div>
+      )}
+
+      {nodeData.join && (
+        <div className="mt-2 inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700">
+          Join: {nodeData.join_mode || 'flat'}
         </div>
       )}
 

--- a/webui/src/pages/WorkflowEditor/nodes/SubworkflowNode.tsx
+++ b/webui/src/pages/WorkflowEditor/nodes/SubworkflowNode.tsx
@@ -7,6 +7,8 @@ interface SubworkflowNodeData {
   label?: string;
   description?: string;
   workflow_id?: string;
+  join?: boolean;
+  join_mode?: string;
   bg?: string;
   border?: string;
   text?: string;
@@ -46,6 +48,11 @@ export default memo(function SubworkflowNode({ data, selected }: NodeProps) {
         <div className="flex items-start gap-1 mt-2 p-2 bg-white rounded border border-gray-200">
           <Info className="w-3 h-3 text-gray-400 flex-shrink-0 mt-0.5" />
           <p className="text-xs text-gray-600 line-clamp-2">{d.description}</p>
+        </div>
+      )}
+      {d.join && (
+        <div className="mt-2 inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700">
+          Join: {d.join_mode || 'flat'}
         </div>
       )}
       <Handle

--- a/webui/src/pages/WorkflowEditor/nodes/ToolNode.tsx
+++ b/webui/src/pages/WorkflowEditor/nodes/ToolNode.tsx
@@ -7,6 +7,8 @@ interface ToolNodeData {
   label?: string;
   description?: string;
   tool_name?: string;
+  join?: boolean;
+  join_mode?: string;
   bg?: string;
   border?: string;
   text?: string;
@@ -46,6 +48,11 @@ export default memo(function ToolNode({ data, selected }: NodeProps) {
         <div className="flex items-start gap-1 mt-2 p-2 bg-white rounded border border-gray-200">
           <Info className="w-3 h-3 text-gray-400 flex-shrink-0 mt-0.5" />
           <p className="text-xs text-gray-600 line-clamp-2">{d.description}</p>
+        </div>
+      )}
+      {d.join && (
+        <div className="mt-2 inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700">
+          Join: {d.join_mode || 'flat'}
         </div>
       )}
       <Handle

--- a/webui/src/utils/workflowGraphLayout.test.ts
+++ b/webui/src/utils/workflowGraphLayout.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WorkflowJSON } from '@/api/workflow';
+import { buildWorkflowGraphLayout, workflowGraphEdgeId } from './workflowGraphLayout';
+
+describe('buildWorkflowGraphLayout', () => {
+  it('keeps branch children parallel and merge nodes after their parents', () => {
+    const workflowJson: WorkflowJSON = {
+      start: 'start',
+      nodes: [
+        { id: 'start', type: 'python' },
+        { id: 'choose', type: 'branch' },
+        { id: 'hit', type: 'python' },
+        { id: 'miss', type: 'python' },
+        { id: 'merge', type: 'python' },
+      ],
+      edges: [
+        { from: 'start', to: 'choose', order: 0 },
+        { from: 'choose', to: 'hit', order: 0, label: 'hit' },
+        { from: 'choose', to: 'miss', order: 1, label: 'miss' },
+        { from: 'hit', to: 'merge', order: 0 },
+        { from: 'miss', to: 'merge', order: 0 },
+      ],
+    };
+
+    const layout = buildWorkflowGraphLayout(workflowJson);
+
+    expect(layout.ranks.start).toBe(0);
+    expect(layout.ranks.choose).toBe(1);
+    expect(layout.ranks.hit).toBe(2);
+    expect(layout.ranks.miss).toBe(2);
+    expect(layout.ranks.merge).toBe(3);
+    expect(layout.positions.hit.x).toBeLessThan(layout.positions.miss.x);
+    expect(layout.positions.merge.y).toBeGreaterThan(layout.positions.hit.y);
+    expect(layout.outputHandles.choose).toEqual([
+      { id: 'branch-0', label: 'hit', left: expect.any(Number) },
+      { id: 'branch-1', label: 'miss', left: expect.any(Number) },
+    ]);
+  });
+
+  it('marks loop edges as back routes without moving the start behind the loop', () => {
+    const workflowJson: WorkflowJSON = {
+      start: 'start',
+      nodes: [
+        { id: 'start', type: 'python' },
+        { id: 'loop', type: 'loop' },
+        { id: 'done', type: 'python' },
+      ],
+      edges: [
+        { from: 'start', to: 'loop', order: 0 },
+        { from: 'loop', to: 'start', order: 0, label: 'loop' },
+        { from: 'loop', to: 'done', order: 1, label: 'done' },
+      ],
+    };
+
+    const layout = buildWorkflowGraphLayout(workflowJson);
+    const backEdgeId = workflowGraphEdgeId(workflowJson.edges[1], 1);
+
+    expect(layout.ranks.start).toBe(0);
+    expect(layout.ranks.loop).toBe(1);
+    expect(layout.ranks.done).toBe(2);
+    expect(layout.outputHandles.loop).toEqual([
+      { id: 'loop-0', label: 'loop', left: expect.any(Number) },
+      { id: 'loop-1', label: 'done', left: expect.any(Number) },
+    ]);
+    expect(layout.edgeRoutes[backEdgeId]).toEqual({
+      sourceHandle: 'loop-0',
+      kind: 'back',
+      label: 'loop',
+    });
+  });
+
+  it('assigns loop exit edges to real handles so they render in React Flow', () => {
+    const workflowJson: WorkflowJSON = {
+      start: 'init_hosts',
+      nodes: [
+        { id: 'init_hosts', type: 'python' },
+        { id: 'loop_check', type: 'loop' },
+        { id: 'inspect_host', type: 'python' },
+        { id: 'finalize_summary', type: 'python' },
+      ],
+      edges: [
+        { from: 'init_hosts', to: 'loop_check', order: 0 },
+        { from: 'loop_check', to: 'inspect_host', order: 0, label: 'continue' },
+        { from: 'loop_check', to: 'finalize_summary', order: 1, label: 'exit' },
+      ],
+    };
+
+    const layout = buildWorkflowGraphLayout(workflowJson);
+    const exitEdgeId = workflowGraphEdgeId(workflowJson.edges[2], 2);
+    const exitHandle = layout.outputHandles.loop_check.find(
+      (handle) => handle.id === layout.edgeRoutes[exitEdgeId].sourceHandle
+    );
+
+    expect(exitHandle?.label).toBe('exit');
+    expect(layout.edgeRoutes[exitEdgeId]).toEqual({
+      sourceHandle: 'loop-1',
+      kind: 'default',
+      label: 'exit',
+    });
+  });
+
+  it('orders outgoing handles like the backend adjacency order', () => {
+    const workflowJson: WorkflowJSON = {
+      start: 'choose',
+      nodes: [
+        { id: 'choose', type: 'branch' },
+        { id: 'a_target', type: 'python' },
+        { id: 'b_target', type: 'python' },
+        { id: 'default_target', type: 'python' },
+      ],
+      edges: [
+        { from: 'choose', to: 'b_target', order: 1, label: 'b' },
+        { from: 'choose', to: 'default_target', order: 0 },
+        { from: 'choose', to: 'a_target', order: 1, label: 'a' },
+      ],
+    };
+
+    const layout = buildWorkflowGraphLayout(workflowJson);
+
+    expect(layout.outputHandles.choose.map((handle) => handle.label)).toEqual([
+      'default',
+      'a',
+      'b',
+    ]);
+  });
+
+  it('treats logic nodes as conditional routers with labeled handles', () => {
+    const workflowJson: WorkflowJSON = {
+      start: 'decide',
+      nodes: [
+        { id: 'decide', type: 'logic', select_key: 'decision' },
+        { id: 'approve', type: 'python' },
+        { id: 'reject', type: 'python' },
+      ],
+      edges: [
+        { from: 'decide', to: 'approve', order: 0, label: 'approve' },
+        { from: 'decide', to: 'reject', order: 1, label: 'reject' },
+      ],
+    };
+
+    const layout = buildWorkflowGraphLayout(workflowJson);
+
+    expect(layout.outputHandles.decide.map((handle) => handle.id)).toEqual([
+      'logic-0',
+      'logic-1',
+    ]);
+    expect(layout.outputHandles.decide.map((handle) => handle.label)).toEqual([
+      'approve',
+      'reject',
+    ]);
+    expect(layout.edgeRoutes[workflowGraphEdgeId(workflowJson.edges[0], 0)]).toEqual({
+      sourceHandle: 'logic-0',
+      kind: 'branch',
+      label: 'approve',
+    });
+  });
+});

--- a/webui/src/utils/workflowGraphLayout.ts
+++ b/webui/src/utils/workflowGraphLayout.ts
@@ -1,0 +1,323 @@
+import type { WorkflowEdge, WorkflowJSON } from '@/api/workflow';
+
+export interface GraphPoint {
+  x: number;
+  y: number;
+}
+
+export interface WorkflowGraphOutputHandle {
+  id: string;
+  label: string;
+  left: number;
+}
+
+export interface WorkflowGraphEdgeRoute {
+  sourceHandle?: string;
+  kind: 'default' | 'branch' | 'loop' | 'back';
+  label?: string;
+}
+
+export interface WorkflowGraphLayout {
+  positions: Record<string, GraphPoint>;
+  ranks: Record<string, number>;
+  outputHandles: Record<string, WorkflowGraphOutputHandle[]>;
+  edgeRoutes: Record<string, WorkflowGraphEdgeRoute>;
+}
+
+export const WORKFLOW_GRAPH_NODE_WIDTH = 220;
+export const WORKFLOW_GRAPH_NODE_HEIGHT = 118;
+
+const HORIZONTAL_GAP = 96;
+const VERTICAL_GAP = 106;
+const FANOUT_GAP = WORKFLOW_GRAPH_NODE_WIDTH + HORIZONTAL_GAP;
+
+export function workflowGraphEdgeId(edge: WorkflowEdge, index: number): string {
+  return `e-${edge.from}-${edge.to}-${index}`;
+}
+
+function compareEdges(a: WorkflowEdge, b: WorkflowEdge): number {
+  const orderDiff = (a.order ?? 0) - (b.order ?? 0);
+  if (orderDiff !== 0) return orderDiff;
+
+  return a.to.localeCompare(b.to);
+}
+
+function getConditionalEdgeLabel(edge: WorkflowEdge): string {
+  return edge.label || 'default';
+}
+
+function getReachableDistances(startId: string | undefined, outgoing: Map<string, WorkflowEdge[]>): Map<string, number> {
+  const distances = new Map<string, number>();
+  if (!startId) return distances;
+
+  const queue = [startId];
+  distances.set(startId, 0);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const nextDistance = (distances.get(current) ?? 0) + 1;
+
+    for (const edge of outgoing.get(current) ?? []) {
+      if (distances.has(edge.to)) continue;
+      distances.set(edge.to, nextDistance);
+      queue.push(edge.to);
+    }
+  }
+
+  return distances;
+}
+
+function calculateRanks(workflowJson: WorkflowJSON, outgoing: Map<string, WorkflowEdge[]>): Record<string, number> {
+  const nodeIds = workflowJson.nodes.map((node) => node.id);
+  const idSet = new Set(nodeIds);
+  const startId = workflowJson.start || nodeIds[0];
+  const indegree = new Map<string, number>();
+  const ranks = new Map<string, number>();
+
+  for (const id of nodeIds) {
+    indegree.set(id, 0);
+  }
+
+  for (const edge of workflowJson.edges) {
+    if (!idSet.has(edge.from) || !idSet.has(edge.to)) continue;
+    if (edge.to === startId) continue;
+    indegree.set(edge.to, (indegree.get(edge.to) ?? 0) + 1);
+  }
+
+  if (startId) {
+    indegree.set(startId, 0);
+    ranks.set(startId, 0);
+  }
+
+  const queue = nodeIds
+    .filter((id) => (indegree.get(id) ?? 0) === 0)
+    .sort((a, b) => (a === startId ? -1 : b === startId ? 1 : nodeIds.indexOf(a) - nodeIds.indexOf(b)));
+  const processed = new Set<string>();
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (processed.has(current)) continue;
+    processed.add(current);
+
+    const currentRank = ranks.get(current) ?? 0;
+    for (const edge of outgoing.get(current) ?? []) {
+      if (!idSet.has(edge.to) || edge.to === startId) continue;
+
+      ranks.set(edge.to, Math.max(ranks.get(edge.to) ?? 0, currentRank + 1));
+      indegree.set(edge.to, Math.max((indegree.get(edge.to) ?? 0) - 1, 0));
+
+      if ((indegree.get(edge.to) ?? 0) === 0) {
+        queue.push(edge.to);
+      }
+    }
+  }
+
+  const distances = getReachableDistances(startId, outgoing);
+  let fallbackRank = Math.max(0, ...Array.from(ranks.values()));
+
+  for (const id of nodeIds) {
+    if (ranks.has(id)) continue;
+
+    const distance = distances.get(id);
+    if (distance !== undefined) {
+      ranks.set(id, distance);
+    } else {
+      fallbackRank += 1;
+      ranks.set(id, fallbackRank);
+    }
+  }
+
+  return Object.fromEntries(ranks.entries());
+}
+
+function getIncomingByNode(edges: WorkflowEdge[]): Map<string, WorkflowEdge[]> {
+  const incoming = new Map<string, WorkflowEdge[]>();
+  for (const edge of edges) {
+    if (!incoming.has(edge.to)) incoming.set(edge.to, []);
+    incoming.get(edge.to)!.push(edge);
+  }
+  return incoming;
+}
+
+function getDesiredX(
+  nodeId: string,
+  rank: number,
+  ranks: Record<string, number>,
+  positions: Record<string, GraphPoint>,
+  incoming: Map<string, WorkflowEdge[]>,
+  outgoing: Map<string, WorkflowEdge[]>,
+  originalIndex: Map<string, number>
+): number {
+  const parentTargets = (incoming.get(nodeId) ?? [])
+    .filter((edge) => ranks[edge.from] < rank && positions[edge.from])
+    .map((edge) => {
+      const parentOut = outgoing.get(edge.from) ?? [];
+      const edgeIndex = Math.max(parentOut.findIndex((candidate) => candidate === edge), 0);
+      const fanoutOffset = (edgeIndex - (parentOut.length - 1) / 2) * FANOUT_GAP;
+      return positions[edge.from].x + fanoutOffset;
+    });
+
+  if (parentTargets.length > 0) {
+    return parentTargets.reduce((sum, value) => sum + value, 0) / parentTargets.length;
+  }
+
+  return ((originalIndex.get(nodeId) ?? 0) % 7) * FANOUT_GAP;
+}
+
+function resolveRankPositions(
+  ids: string[],
+  rank: number,
+  ranks: Record<string, number>,
+  positions: Record<string, GraphPoint>,
+  incoming: Map<string, WorkflowEdge[]>,
+  outgoing: Map<string, WorkflowEdge[]>,
+  originalIndex: Map<string, number>
+): void {
+  const desired = ids
+    .map((id) => ({
+      id,
+      x: getDesiredX(id, rank, ranks, positions, incoming, outgoing, originalIndex),
+    }))
+    .sort((a, b) => a.x - b.x || (originalIndex.get(a.id) ?? 0) - (originalIndex.get(b.id) ?? 0));
+
+  const placed = desired.map((item, index) => ({
+    ...item,
+    x: index === 0 ? item.x : Math.max(item.x, desired[index - 1].x + FANOUT_GAP),
+  }));
+
+  for (let index = 1; index < placed.length; index += 1) {
+    placed[index].x = Math.max(placed[index].x, placed[index - 1].x + FANOUT_GAP);
+  }
+
+  const desiredCenter = desired.reduce((sum, item) => sum + item.x, 0) / Math.max(desired.length, 1);
+  const actualCenter =
+    placed.length > 0 ? (placed[0].x + placed[placed.length - 1].x) / 2 : 0;
+  const shift = desiredCenter - actualCenter;
+
+  for (const item of placed) {
+    positions[item.id] = {
+      x: item.x + shift,
+      y: rank * (WORKFLOW_GRAPH_NODE_HEIGHT + VERTICAL_GAP),
+    };
+  }
+}
+
+function buildOutputHandles(
+  workflowJson: WorkflowJSON,
+  outgoing: Map<string, WorkflowEdge[]>
+): Record<string, WorkflowGraphOutputHandle[]> {
+  const handles: Record<string, WorkflowGraphOutputHandle[]> = {};
+
+  for (const node of workflowJson.nodes) {
+    const edges = outgoing.get(node.id) ?? [];
+    if (!['branch', 'loop', 'logic'].includes(node.type) || edges.length === 0) continue;
+    const prefix = node.type === 'loop' ? 'loop' : node.type === 'logic' ? 'logic' : 'branch';
+
+    handles[node.id] = edges.map((edge, index) => ({
+      id: `${prefix}-${index}`,
+      label: getConditionalEdgeLabel(edge),
+      left: ((index + 1) / (edges.length + 1)) * 100,
+    }));
+  }
+
+  return handles;
+}
+
+function buildEdgeRoutes(
+  workflowJson: WorkflowJSON,
+  ranks: Record<string, number>,
+  outgoing: Map<string, WorkflowEdge[]>
+): Record<string, WorkflowGraphEdgeRoute> {
+  const nodeTypes = new Map(workflowJson.nodes.map((node) => [node.id, node.type]));
+  const routes: Record<string, WorkflowGraphEdgeRoute> = {};
+
+  workflowJson.edges.forEach((edge, index) => {
+    const sourceType = nodeTypes.get(edge.from);
+    const edgeIndex = outgoing.get(edge.from)?.findIndex((candidate) => candidate === edge) ?? -1;
+    const isBackEdge = (ranks[edge.to] ?? 0) <= (ranks[edge.from] ?? 0);
+    const label = (edge.label ?? '').toLowerCase();
+
+    if (sourceType === 'branch') {
+      routes[workflowGraphEdgeId(edge, index)] = {
+        sourceHandle: `branch-${Math.max(edgeIndex, 0)}`,
+        kind: isBackEdge ? 'back' : 'branch',
+        label: getConditionalEdgeLabel(edge),
+      };
+      return;
+    }
+
+    if (sourceType === 'loop') {
+      routes[workflowGraphEdgeId(edge, index)] = {
+        sourceHandle: `loop-${Math.max(edgeIndex, 0)}`,
+        kind: isBackEdge ? 'back' : label.includes('loop') || label.includes('continue') ? 'loop' : 'default',
+        label: getConditionalEdgeLabel(edge),
+      };
+      return;
+    }
+
+    if (sourceType === 'logic') {
+      routes[workflowGraphEdgeId(edge, index)] = {
+        sourceHandle: `logic-${Math.max(edgeIndex, 0)}`,
+        kind: isBackEdge ? 'back' : 'branch',
+        label: getConditionalEdgeLabel(edge),
+      };
+      return;
+    }
+
+    if (label.includes('loop') || label.includes('continue')) {
+      routes[workflowGraphEdgeId(edge, index)] = {
+        kind: isBackEdge ? 'back' : 'loop',
+      };
+      return;
+    }
+
+    routes[workflowGraphEdgeId(edge, index)] = {
+      kind: isBackEdge ? 'back' : 'default',
+    };
+  });
+
+  return routes;
+}
+
+export function buildWorkflowGraphLayout(workflowJson: WorkflowJSON): WorkflowGraphLayout {
+  const outgoing = new Map<string, WorkflowEdge[]>();
+  const originalIndex = new Map<string, number>();
+
+  workflowJson.nodes.forEach((node, index) => {
+    outgoing.set(node.id, []);
+    originalIndex.set(node.id, index);
+  });
+
+  for (const edge of workflowJson.edges) {
+    if (!outgoing.has(edge.from)) outgoing.set(edge.from, []);
+    outgoing.get(edge.from)!.push(edge);
+  }
+
+  for (const edges of outgoing.values()) {
+    edges.sort(compareEdges);
+  }
+
+  const ranks = calculateRanks(workflowJson, outgoing);
+  const incoming = getIncomingByNode(workflowJson.edges);
+  const rankGroups = new Map<number, string[]>();
+
+  for (const node of workflowJson.nodes) {
+    const rank = ranks[node.id] ?? 0;
+    if (!rankGroups.has(rank)) rankGroups.set(rank, []);
+    rankGroups.get(rank)!.push(node.id);
+  }
+
+  const positions: Record<string, GraphPoint> = {};
+  const sortedRanks = Array.from(rankGroups.keys()).sort((a, b) => a - b);
+
+  for (const rank of sortedRanks) {
+    resolveRankPositions(rankGroups.get(rank)!, rank, ranks, positions, incoming, outgoing, originalIndex);
+  }
+
+  return {
+    positions,
+    ranks,
+    outputHandles: buildOutputHandles(workflowJson, outgoing),
+    edgeRoutes: buildEdgeRoutes(workflowJson, ranks, outgoing),
+  };
+}


### PR DESCRIPTION
## Summary
- Extract shared `workflowGraphLayout` utility for editor and detail views, with branch/loop output handles, ranked layout, and edge route styling (default, branch, loop, back).
- Add `EdgePropertyPanel` for editing edge label, order, mapping, and const; expand node property panel with join conflict/namespace settings and conditional routing for logic nodes.
- Refresh workflow node visuals (multi-handle outputs, join badges) and add unit tests for graph layout.

## Test plan
- [x] `npm test -- --run workflowGraphLayout` (5 tests passed)


Made with [Cursor](https://cursor.com)