### PR TITLE
feat(device): add multi-room support and i18n for device integration

### DIFF
--- a/flocks/tool/device/models.py
+++ b/flocks/tool/device/models.py
@@ -12,10 +12,10 @@ from flocks.storage.storage import Storage
 # Feature flags
 # ---------------------------------------------------------------------------
 
-#: Flip to True (or set env FLOCKS_DEVICE_MULTI_GROUP=1) to unlock multi-group
-#: routes. The data layer is already multi-group ready; this is UI/API gating only.
+#: Multi-group (多机房) is on by default. Set env FLOCKS_DEVICE_MULTI_GROUP=0
+#: to fall back to single-room mode.
 MULTI_GROUP_ENABLED: bool = (
-    os.environ.get("FLOCKS_DEVICE_MULTI_GROUP", "").lower() in {"1", "true", "yes"}
+    os.environ.get("FLOCKS_DEVICE_MULTI_GROUP", "1").lower() not in {"0", "false", "no"}
 )
 
 DEFAULT_GROUP_ID = "default-room"

--- a/webui/src/components/layout/Layout.tsx
+++ b/webui/src/components/layout/Layout.tsx
@@ -455,7 +455,8 @@ export default function Layout() {
     matchPath('/workflows/create', location.pathname) ||
     matchPath('/workflows/:id/edit', location.pathname) ||
     matchPath('/workflows/:id', location.pathname) ||
-    matchPath('/sessions', location.pathname);
+    matchPath('/sessions', location.pathname) ||
+    matchPath('/devices', location.pathname);
   const productName = isFlocksproActive ? 'Flocks Pro' : 'Flocks';
   const displayVersion = isFlocksproActive
     ? flocksproVersion || (currentVersion ? formatProVersion(currentVersion) : null)
@@ -675,7 +676,7 @@ export default function Layout() {
             <Outlet />
           ) : (
             <div className="h-full overflow-y-auto">
-              <div className="min-h-full p-6">
+              <div className="min-h-full p-6 flex flex-col">
                 <Outlet />
               </div>
             </div>

--- a/webui/src/i18n.ts
+++ b/webui/src/i18n.ts
@@ -22,6 +22,7 @@ import enWorkspace from './locales/en-US/workspace.json';
 import enAuth from './locales/en-US/auth.json';
 import enNotification from './locales/en-US/notification.json';
 import enFlocksPro from './locales/en-US/flockspro.json';
+import enDevice from './locales/en-US/device.json';
 
 import zhCommon from './locales/zh-CN/common.json';
 import zhNav from './locales/zh-CN/nav.json';
@@ -43,6 +44,7 @@ import zhWorkspace from './locales/zh-CN/workspace.json';
 import zhAuth from './locales/zh-CN/auth.json';
 import zhNotification from './locales/zh-CN/notification.json';
 import zhFlocksPro from './locales/zh-CN/flockspro.json';
+import zhDevice from './locales/zh-CN/device.json';
 
 i18n
   .use(LanguageDetector)
@@ -70,6 +72,7 @@ i18n
         auth: enAuth,
         notification: enNotification,
         flockspro: enFlocksPro,
+        device: enDevice,
       },
       'zh-CN': {
         common: zhCommon,
@@ -92,11 +95,12 @@ i18n
         auth: zhAuth,
         notification: zhNotification,
         flockspro: zhFlocksPro,
+        device: zhDevice,
       },
     },
     fallbackLng: 'en-US',
     defaultNS: 'common',
-    ns: ['common', 'nav', 'home', 'session', 'agent', 'task', 'workflow', 'tool', 'skill', 'model', 'mcp', 'config', 'channel', 'permission', 'monitoring', 'update', 'workspace', 'auth', 'notification', 'flockspro'],
+    ns: ['common', 'nav', 'home', 'session', 'agent', 'task', 'workflow', 'tool', 'skill', 'model', 'mcp', 'config', 'channel', 'permission', 'monitoring', 'update', 'workspace', 'auth', 'notification', 'flockspro', 'device'],
     detection: {
       order: ['localStorage', 'navigator'],
       lookupLocalStorage: 'flocks-language',

--- a/webui/src/locales/en-US/device.json
+++ b/webui/src/locales/en-US/device.json
@@ -1,0 +1,125 @@
+{
+  "pageTitle": "Device Integration",
+  "pageDescription": "Configure security device API connections so Flocks agents can call and control them directly",
+
+  "status": {
+    "disabled": "Disabled",
+    "connected": "Connected",
+    "error": "Connection failed",
+    "unknown": "Not checked"
+  },
+
+  "vendor": {
+    "unspecified": "Unspecified vendor"
+  },
+
+  "sidebar": {
+    "heading": "Rooms",
+    "addRoom": "New room",
+    "allRooms": "All Rooms",
+    "rename": "Rename",
+    "deleteRoom": "Delete room",
+    "deleteDisabled": "{{count}} device(s) present — cannot delete",
+    "roomNamePlaceholder": "Room name...",
+    "deleteHasDevices": "Room \"{{name}}\" still has {{count}} device(s). Move or delete them first."
+  },
+
+  "toolbar": {
+    "refresh": "Refresh",
+    "addDevice": "Add Device",
+    "collapseAll": "Collapse all",
+    "expandAll": "Expand all"
+  },
+
+  "header": {
+    "allRooms": "All Rooms",
+    "deviceCount": "{{count}} device(s) · {{rooms}} room(s)",
+    "connected": "{{count}} connected",
+    "failed": "{{count}} failed",
+    "devices": "{{count}} device(s)"
+  },
+
+  "empty": {
+    "noDevices": "No devices integrated yet",
+    "noDevicesHint": "Once you add a device, Flocks agents can call its tools",
+    "addNow": "Add device now",
+    "roomEmpty": "No devices in this room",
+    "roomEmptyHint": "Click \"Add Device\" to integrate a device into this room"
+  },
+
+  "section": {
+    "activeDevices": "Integrated Devices",
+    "ungrouped": "Ungrouped Devices",
+    "ungroupedHint": "Room not found — edit the device to reassign it"
+  },
+
+  "wizard": {
+    "title": "Add Device",
+    "closeAriaLabel": "Close add-device panel",
+    "step1": "1 Select vendor",
+    "step2": "2 Select device",
+    "step3": "3 Fill in config",
+    "selectVendorTitle": "Select {{vendor}} device",
+    "vendorHint": "Choose a vendor — {{count}} available",
+    "productCount": "{{count}} product(s)",
+    "instanceCount": "{{count}} integrated",
+    "productHint": "{{count}} product(s) — the same type can be added multiple times"
+  },
+
+  "config": {
+    "closeAriaLabel": "Close device config panel",
+    "newDeviceTitle": "Fill in config",
+    "tabConfig": "Config",
+    "tabTools": "Tools",
+    "tabToolsCount": "Tools ({{count}})",
+    "tabOverview": "Overview",
+    "nameLabel": "Device name",
+    "namePlaceholder": "e.g. HQ AF Firewall",
+    "roomLabel": "Room",
+    "connectionParams": "Connection parameters",
+    "secretConfigured": "Already set · Leave unchanged to keep it, clear to remove",
+    "sslLabel": "SSL verification",
+    "sslHint": "Disable to reach internal devices with self-signed certificates",
+    "enabledLabel": "Enable device",
+    "enabledHint": "When disabled, agents will not call tools from this device",
+    "testBtn": "Test connection",
+    "saveBtn": "Save config",
+    "addBtn": "Confirm integration",
+    "deleteBtn": "Delete device",
+    "confirmDelete": "Confirm delete this device config?"
+  },
+
+  "tools": {
+    "empty": "No associated tools",
+    "colName": "Tool name",
+    "colDesc": "Description",
+    "colStatus": "Status",
+    "colAction": "Action",
+    "detail": "Test / Details"
+  },
+
+  "overview": {
+    "serviceName": "Service name",
+    "version": "Version",
+    "toolCount": "Tools",
+    "vendor": "Vendor",
+    "serviceDesc": "Service description",
+    "viewDocs": "View API docs"
+  },
+
+  "toast": {
+    "loadFailed": "Failed to load",
+    "nameRequired": "Please enter a device name",
+    "saveDone": "Config saved",
+    "addDone": "Device added",
+    "saveFailed": "Save failed",
+    "sslOn": "SSL verification enabled",
+    "sslOff": "SSL verification disabled",
+    "rollback": "Save failed — changes rolled back",
+    "enabledOn": "Device enabled",
+    "enabledOff": "Device disabled",
+    "deleteDone": "Device deleted",
+    "deleteFailed": "Delete failed",
+    "actionFailed": "Action failed"
+  }
+}

--- a/webui/src/locales/zh-CN/device.json
+++ b/webui/src/locales/zh-CN/device.json
@@ -1,0 +1,125 @@
+{
+  "pageTitle": "设备接入",
+  "pageDescription": "配置安全设备 API 连接，使 Flocks 能够直接调用和控制这些设备",
+
+  "status": {
+    "disabled": "已禁用",
+    "connected": "已连接",
+    "error": "连接失败",
+    "unknown": "未检测"
+  },
+
+  "vendor": {
+    "unspecified": "未指定厂商"
+  },
+
+  "sidebar": {
+    "heading": "机房",
+    "addRoom": "新建机房",
+    "allRooms": "全部机房",
+    "rename": "重命名",
+    "deleteRoom": "删除机房",
+    "deleteDisabled": "有 {{count}} 台设备，无法删除",
+    "roomNamePlaceholder": "机房名称...",
+    "deleteHasDevices": "机房「{{name}}」还有 {{count}} 台设备，请先转移或删除后再操作"
+  },
+
+  "toolbar": {
+    "refresh": "刷新",
+    "addDevice": "添加设备",
+    "collapseAll": "折叠全部",
+    "expandAll": "展开全部"
+  },
+
+  "header": {
+    "allRooms": "全部机房",
+    "deviceCount": "{{count}} 台设备 · {{rooms}} 个机房",
+    "connected": "{{count}} 已连接",
+    "failed": "{{count}} 失败",
+    "devices": "{{count}} 台设备"
+  },
+
+  "empty": {
+    "noDevices": "暂无已接入的设备",
+    "noDevicesHint": "添加设备后，Flocks Agent 即可调用对应工具",
+    "addNow": "立即添加设备",
+    "roomEmpty": "此机房暂无设备",
+    "roomEmptyHint": "点击「添加设备」将设备接入此机房"
+  },
+
+  "section": {
+    "activeDevices": "已接入设备",
+    "ungrouped": "未分组设备",
+    "ungroupedHint": "所属机房不存在，请编辑后重新指定"
+  },
+
+  "wizard": {
+    "title": "添加设备",
+    "closeAriaLabel": "关闭添加设备面板",
+    "step1": "1 选择厂商",
+    "step2": "2 选择设备",
+    "step3": "3 填写配置",
+    "selectVendorTitle": "选择 {{vendor}} 设备",
+    "vendorHint": "选择设备所属厂商，共 {{count}} 家",
+    "productCount": "{{count}} 种设备",
+    "instanceCount": "已接入 {{count}} 台",
+    "productHint": "共 {{count}} 款设备，同款设备可多次接入"
+  },
+
+  "config": {
+    "closeAriaLabel": "关闭设备配置面板",
+    "newDeviceTitle": "填写配置",
+    "tabConfig": "配置",
+    "tabTools": "工具",
+    "tabToolsCount": "工具 ({{count}})",
+    "tabOverview": "概览",
+    "nameLabel": "设备名称",
+    "namePlaceholder": "例如：总部 AF 防火墙",
+    "roomLabel": "所属机房",
+    "connectionParams": "连接参数",
+    "secretConfigured": "已配置 · 保持不变请勿修改，清空则删除",
+    "sslLabel": "SSL 验证",
+    "sslHint": "关闭可访问自签名证书的内网设备",
+    "enabledLabel": "启用设备",
+    "enabledHint": "关闭后 Agent 不会调用此设备的工具",
+    "testBtn": "连通测试",
+    "saveBtn": "保存配置",
+    "addBtn": "确认接入",
+    "deleteBtn": "删除设备",
+    "confirmDelete": "确认删除此设备配置？"
+  },
+
+  "tools": {
+    "empty": "暂无关联工具",
+    "colName": "工具名称",
+    "colDesc": "描述",
+    "colStatus": "状态",
+    "colAction": "操作",
+    "detail": "测试 / 详情"
+  },
+
+  "overview": {
+    "serviceName": "服务名称",
+    "version": "版本",
+    "toolCount": "工具数量",
+    "vendor": "厂商",
+    "serviceDesc": "服务简介",
+    "viewDocs": "查看 API 文档"
+  },
+
+  "toast": {
+    "loadFailed": "加载失败",
+    "nameRequired": "请填写设备名称",
+    "saveDone": "配置已保存",
+    "addDone": "设备已添加",
+    "saveFailed": "保存失败",
+    "sslOn": "已开启 SSL 验证",
+    "sslOff": "已关闭 SSL 验证",
+    "rollback": "保存失败，已回滚",
+    "enabledOn": "设备已启用",
+    "enabledOff": "设备已停用",
+    "deleteDone": "已删除设备",
+    "deleteFailed": "删除失败",
+    "actionFailed": "操作失败"
+  }
+}

--- a/webui/src/pages/DeviceIntegration/index.test.tsx
+++ b/webui/src/pages/DeviceIntegration/index.test.tsx
@@ -12,7 +12,11 @@ const mocks = vi.hoisted(() => ({
   deleteDevice: vi.fn(),
   testDevice: vi.fn(),
   listGroups: vi.fn(),
+  createGroup: vi.fn(),
   updateGroup: vi.fn(),
+  deleteGroup: vi.fn(),
+  listDeviceTools: vi.fn(),
+  updateDeviceTool: vi.fn(),
   listApiServices: vi.fn(),
   getServiceMetadata: vi.fn(),
   listTools: vi.fn(),
@@ -30,7 +34,11 @@ vi.mock('@/api/device', () => ({
     delete: mocks.deleteDevice,
     test: mocks.testDevice,
     listGroups: mocks.listGroups,
+    createGroup: mocks.createGroup,
     updateGroup: mocks.updateGroup,
+    deleteGroup: mocks.deleteGroup,
+    listDeviceTools: mocks.listDeviceTools,
+    updateDeviceTool: mocks.updateDeviceTool,
   },
 }));
 
@@ -157,6 +165,8 @@ describe('DeviceIntegrationPage', () => {
     });
     mocks.listTools.mockResolvedValue({ data: [] });
     mocks.setToolEnabled.mockResolvedValue({ data: {} });
+    mocks.listDeviceTools.mockResolvedValue({ data: [] });
+    mocks.updateDeviceTool.mockResolvedValue({ data: {} });
   });
 
   it('clicking the blank backdrop closes the config panel', async () => {

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Shield, CheckCircle, XCircle, AlertTriangle, RefreshCw,
   Plug, PlugZap, WifiOff, Plus, Settings, Loader2,
   Eye, EyeOff, Save, Trash2, Activity, X, Server, Pencil, Check,
-  Wrench, ChevronRight, ChevronLeft,
+  Wrench, ChevronRight, ChevronLeft, ChevronDown, Building2, ServerCog,
 } from 'lucide-react';
 import PageHeader from '@/components/common/PageHeader';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
@@ -13,6 +14,20 @@ import { deviceAPI, type DeviceIntegration, type DeviceGroup, type DeviceToolInf
 import type { APIServiceSummary, APIServiceCredentialField, Tool } from '@/types';
 import { toolAPI } from '@/api/tool';
 import ToolDetailModal from '../Tool/components/ToolDetailModal';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_GROUP_ID = 'default-room';
+
+/** Pull the backend's human-readable error detail (e.g. "机房名称已存在")
+ *  out of an axios error, falling back to a generic message. */
+function errDetail(err: unknown, fallback: string): string {
+  return (
+    (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail || fallback
+  );
+}
 
 // ============================================================================
 // Vendor catalog
@@ -43,8 +58,6 @@ const VENDOR_PRESENTATION: Record<string, Omit<DeviceVendor, 'id'>> = {
 function vendorPresentation(vendorKey: string): DeviceVendor {
   const preset = VENDOR_PRESENTATION[vendorKey];
   if (preset) return { id: vendorKey, ...preset };
-  // Unknown vendor key: surface it as-is so the operator notices the gap
-  // instead of inheriting a wrong-but-pretty bucket.
   return {
     id: vendorKey,
     nameCn: vendorKey,
@@ -58,17 +71,18 @@ function vendorPresentation(vendorKey: string): DeviceVendor {
 // ============================================================================
 
 function StatusBadge({ status, enabled }: { status: string; enabled: boolean }) {
+  const { t } = useTranslation('device');
   if (!enabled) return (
-    <span className="inline-flex items-center gap-1 text-xs text-zinc-400"><WifiOff className="w-3 h-3" />已禁用</span>
+    <span className="inline-flex items-center gap-1 text-xs text-zinc-400"><WifiOff className="w-3 h-3" />{t('status.disabled')}</span>
   );
   if (status === 'ok' || status === 'connected') return (
-    <span className="inline-flex items-center gap-1 text-xs text-green-600"><CheckCircle className="w-3 h-3" />已连接</span>
+    <span className="inline-flex items-center gap-1 text-xs text-green-600"><CheckCircle className="w-3 h-3" />{t('status.connected')}</span>
   );
   if (status === 'error') return (
-    <span className="inline-flex items-center gap-1 text-xs text-red-500"><XCircle className="w-3 h-3" />连接失败</span>
+    <span className="inline-flex items-center gap-1 text-xs text-red-500"><XCircle className="w-3 h-3" />{t('status.error')}</span>
   );
   return (
-    <span className="inline-flex items-center gap-1 text-xs text-zinc-400"><AlertTriangle className="w-3 h-3" />未检测</span>
+    <span className="inline-flex items-center gap-1 text-xs text-zinc-400"><AlertTriangle className="w-3 h-3" />{t('status.unknown')}</span>
   );
 }
 
@@ -82,7 +96,9 @@ function ActiveCard({ device, vendorKey, selected, onClick }: {
   selected: boolean;
   onClick: () => void;
 }) {
+  const { i18n } = useTranslation('device');
   const vendor = vendorKey ? vendorPresentation(vendorKey) : undefined;
+  const vendorLabel = vendor ? (i18n.language.startsWith('zh') ? vendor.nameCn : vendor.nameEn) : undefined;
   return (
     <button
       onClick={onClick}
@@ -112,7 +128,7 @@ function ActiveCard({ device, vendorKey, selected, onClick }: {
             {vendor && (
               <>
                 <span className="text-zinc-200">·</span>
-                <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-md ${vendor.color}`}>{vendor.nameCn}</span>
+                <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-md ${vendor.color}`}>{vendorLabel}</span>
               </>
             )}
           </div>
@@ -133,14 +149,9 @@ function AddDeviceWizardPanel({ templates, instanceCounts, initialVendor, onSele
   onSelect: (template: APIServiceSummary) => void;
   onClose: () => void;
 }) {
+  const { t, i18n } = useTranslation('device');
   const [selectedVendor, setSelectedVendor] = useState<DeviceVendor | null>(initialVendor ?? null);
 
-  // Distinct vendor keys from the live template list. Templates whose YAML
-  // omits `vendor` are bucketed under the special "(未指定)" key so they
-  // remain visible (and obviously misconfigured) instead of disappearing.
-  //
-  // Order: pinned vendors first (threatbook 微步 is our default), then any
-  // other known vendor in catalog order, then unknown/unspecified last.
   const availableVendors = useMemo<DeviceVendor[]>(() => {
     const seen: string[] = [];
     for (const t of templates) {
@@ -160,7 +171,7 @@ function AddDeviceWizardPanel({ templates, instanceCounts, initialVendor, onSele
     });
     return seen.map((key) =>
       key === '__unspecified__'
-        ? { id: '__unspecified__', nameCn: '未指定厂商', nameEn: 'Unspecified', color: 'bg-zinc-100 text-zinc-600' }
+        ? { id: '__unspecified__', nameCn: t('vendor.unspecified'), nameEn: 'Unspecified', color: 'bg-zinc-100 text-zinc-600' }
         : vendorPresentation(key),
     );
   }, [templates]);
@@ -181,10 +192,10 @@ function AddDeviceWizardPanel({ templates, instanceCounts, initialVendor, onSele
 
   return (
     <div className="fixed inset-0 z-40 pointer-events-none">
-      <button
-        type="button"
-        aria-label="关闭添加设备面板"
-        onClick={onClose}
+        <button
+          type="button"
+          aria-label={t('wizard.closeAriaLabel')}
+          onClick={onClose}
         className="pointer-events-auto absolute left-0 bottom-0 bg-transparent"
         style={{ top: 64, right: 440 }}
       />
@@ -205,20 +216,21 @@ function AddDeviceWizardPanel({ templates, instanceCounts, initialVendor, onSele
             )}
             <div>
               <h3 className="text-sm font-semibold text-zinc-900">
-                {selectedVendor ? `选择 ${selectedVendor.nameCn} 设备` : '添加设备'}
+                {selectedVendor
+                  ? t('wizard.selectVendorTitle', { vendor: i18n.language.startsWith('zh') ? selectedVendor.nameCn : selectedVendor.nameEn })
+                  : t('wizard.title')}
               </h3>
               <div className="flex items-center gap-1.5 mt-0.5">
-                {/* Breadcrumb */}
                 <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ${!selectedVendor ? 'bg-blue-100 text-blue-700' : 'bg-zinc-100 text-zinc-500'}`}>
-                  1 选择厂商
+                  {t('wizard.step1')}
                 </span>
                 <ChevronRight className="w-2.5 h-2.5 text-zinc-300" />
                 <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ${selectedVendor ? 'bg-blue-100 text-blue-700' : 'bg-zinc-100 text-zinc-400'}`}>
-                  2 选择设备
+                  {t('wizard.step2')}
                 </span>
                 <ChevronRight className="w-2.5 h-2.5 text-zinc-300" />
                 <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-zinc-100 text-zinc-400">
-                  3 填写配置
+                  {t('wizard.step3')}
                 </span>
               </div>
             </div>
@@ -231,9 +243,8 @@ function AddDeviceWizardPanel({ templates, instanceCounts, initialVendor, onSele
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-5">
           {!selectedVendor ? (
-            /* Step 1: Vendor selection */
             <>
-              <p className="text-xs text-zinc-400 mb-4">选择设备所属厂商，共 {availableVendors.length} 家</p>
+              <p className="text-xs text-zinc-400 mb-4">{t('wizard.vendorHint', { count: availableVendors.length })}</p>
               <div className="grid grid-cols-2 gap-3">
                 {availableVendors.map((vendor) => {
                   const count = vendorTotalCounts[vendor.id] ?? 0;
@@ -250,11 +261,11 @@ function AddDeviceWizardPanel({ templates, instanceCounts, initialVendor, onSele
                         {vendor.nameCn[0]}
                       </div>
                       <div className="text-center">
-                        <p className="text-sm font-semibold text-zinc-800">{vendor.nameCn}</p>
+                        <p className="text-sm font-semibold text-zinc-800">{i18n.language.startsWith('zh') ? vendor.nameCn : vendor.nameEn}</p>
                         <p className="text-xs text-zinc-400">{vendor.nameEn}</p>
                         <p className="text-[10px] text-zinc-400 mt-0.5">
-                          {productCount} 种设备
-                          {count > 0 && <span className="text-blue-600 font-medium"> · 已接入 {count} 台</span>}
+                          {t('wizard.productCount', { count: productCount })}
+                          {count > 0 && <span className="text-blue-600 font-medium"> · {t('wizard.instanceCount', { count })}</span>}
                         </p>
                       </div>
                       <ChevronRight className="w-3.5 h-3.5 text-zinc-300 group-hover:text-blue-400 transition-colors" />
@@ -264,10 +275,9 @@ function AddDeviceWizardPanel({ templates, instanceCounts, initialVendor, onSele
               </div>
             </>
           ) : (
-            /* Step 2: Product selection */
             <>
               <p className="text-xs text-zinc-400 mb-4">
-                共 {vendorTemplates.length} 款设备，同款设备可多次接入
+                {t('wizard.productHint', { count: vendorTemplates.length })}
               </p>
               <div className="space-y-2">
                 {vendorTemplates.map((tpl) => {
@@ -297,7 +307,7 @@ function AddDeviceWizardPanel({ templates, instanceCounts, initialVendor, onSele
                         )}
                         {count > 0 && (
                           <span className="inline-block mt-1.5 text-[10px] text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded-md font-medium">
-                            已接入 {count} 台
+                            {t('wizard.instanceCount', { count })}
                           </span>
                         )}
                       </div>
@@ -332,26 +342,36 @@ function Toggle({ on, onToggle }: { on: boolean; onToggle: () => void }) {
   );
 }
 
-function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onClose, onTest, onToggleVerifySsl, onToggleEnabled, onBack }: {
+function DeviceConfigPanel({
+  device, template, vendorKey, initialGroupId, groups, groupLocked,
+  onSave, onDelete, onClose, onTest, onToggleVerifySsl, onToggleEnabled, onBack,
+}: {
   device?: DeviceIntegration;
   template?: APIServiceSummary;
   vendorKey?: string;
-  onSave: (data: { name: string; fields: Record<string, string>; enabled: boolean; verify_ssl: boolean }) => Promise<void>;
+  initialGroupId: string;
+  groups: DeviceGroup[];
+  /** true = room is determined by the sidebar selection and cannot be changed here */
+  groupLocked: boolean;
+  onSave: (data: {
+    name: string;
+    fields: Record<string, string>;
+    enabled: boolean;
+    verify_ssl: boolean;
+    group_id: string;
+  }) => Promise<void>;
   onDelete?: () => Promise<void>;
   onClose: () => void;
-  /** Receives the current (unsaved) form values so the probe reflects the
-   *  on-screen toggle state instead of whatever was last persisted. */
   onTest?: (overrides: { verify_ssl: boolean; base_url?: string }) => Promise<{ success: boolean; message: string }>;
-  /** Persist the SSL toggle immediately (without requiring "保存"). Only
-   *  meaningful when editing an existing device — for the "Add device"
-   *  wizard the value is held in local state until the row is created. */
   onToggleVerifySsl?: (next: boolean) => Promise<void>;
   onToggleEnabled?: (next: boolean) => Promise<void>;
   onBack?: () => void;
 }) {
   const toast = useToast();
+  const { t, i18n } = useTranslation('device');
   const [tab, setTab] = useState<PanelTab>('config');
   const [name, setName] = useState(device?.name ?? '');
+  const [groupId, setGroupId] = useState(device?.group_id ?? initialGroupId);
   const [fields, setFields] = useState<Record<string, string>>(() => device ? { ...device.fields } : {});
   const [enabled, setEnabled] = useState(device?.enabled ?? true);
   const [verifySsl, setVerifySsl] = useState(device?.verify_ssl ?? false);
@@ -365,22 +385,10 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
   const [serviceTools, setServiceTools] = useState<Tool[]>([]);
   const [toolModal, setToolModal] = useState<Tool | null>(null);
   const [metadata, setMetadata] = useState<{ name?: string; version?: string; description?: string; description_cn?: string; docs_url?: string } | null>(null);
-  // per-device effective enabled state; keyed by tool name.
-  // When viewing an existing device we load this from the per-device API so
-  // the toggle reflects the device-specific override, not the global state.
   const [toolEnabled, setToolEnabled] = useState<Record<string, boolean>>({});
   const originalMasked = useRef<Record<string, string>>({});
 
   const serviceId = device?.service_id ?? template?.id ?? '';
-  // ``storage_key`` is the versioned, unambiguous identifier
-  // (e.g. ``onesig_api_v2_5_3_D20260321``) that tool registrations
-  // surface as ``ToolInfoResponse.source_name``. Use it directly for
-  // tool filtering so two devices that happen to share a service_id
-  // prefix (``onesig`` vs ``onesig_pro``) — or a plugin whose
-  // ``service_id`` already contains a ``_v…`` token — never bleed each
-  // other's tools into the device-edit panel. ``template?.id`` is also
-  // the storage_key (set by the wizard), so the create-mode form
-  // resolves to the right key too.
   const storageKey = device?.storage_key ?? template?.id ?? '';
   const vendor = vendorKey ? vendorPresentation(vendorKey) : undefined;
 
@@ -409,9 +417,6 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
       })
       .catch(() => {});
 
-    // Only existing devices have a "工具" tab (the wizard hides it because
-    // there's no device_id yet — see TABS comment).  So loading the tool list
-    // and per-device enabled overrides only matters when ``device`` exists.
     if (device) {
       Promise.all([
         toolAPI.list(),
@@ -422,7 +427,6 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
             (t) => !!storageKey && t.source_name === storageKey,
           );
           setServiceTools(matched);
-          // Effective enabled state = per-device override (if any) else global.
           const perDevice: Record<string, DeviceToolInfo> = {};
           (deviceToolsRes.data || []).forEach((dt) => { perDevice[dt.name] = dt; });
           const initEnabled: Record<string, boolean> = {};
@@ -436,17 +440,17 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
   }, [device, serviceId, storageKey]);
 
   const handleSave = async () => {
-    if (!name.trim()) { toast.error('请填写设备名称'); return; }
+    if (!name.trim()) { toast.error(t('toast.nameRequired')); return; }
     setSaving(true);
     try {
       const payload: Record<string, string> = { ...fields };
       Object.entries(originalMasked.current).forEach(([k, masked]) => {
         if (payload[k] === masked) payload[k] = '';
       });
-      await onSave({ name: name.trim(), fields: payload, enabled, verify_ssl: verifySsl });
-      toast.success(device ? '配置已保存' : '设备已添加');
+      await onSave({ name: name.trim(), fields: payload, enabled, verify_ssl: verifySsl, group_id: groupId });
+      toast.success(device ? t('toast.saveDone') : t('toast.addDone'));
     } catch {
-      toast.error('保存失败');
+      toast.error(t('toast.saveFailed'));
     } finally {
       setSaving(false);
     }
@@ -457,13 +461,6 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
     setTesting(true);
     setTestResult(null);
     try {
-      // Probe with the form's current SSL toggle / base_url so the user can
-      // validate unsaved changes immediately. Empty base_url means "fall
-      // back to whatever is already in the DB".
-      // For providers that use host + port (e.g. Sangfor SIP) instead of
-      // base_url, construct the URL from those fields when available.
-      // If the operator already typed a scheme into ``host``, respect it
-      // instead of double-prefixing.
       let candidateBaseUrl = (fields.base_url ?? fields.baseUrl ?? '').trim();
       if (!candidateBaseUrl) {
         const host = (fields.host ?? '').trim();
@@ -483,37 +480,29 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
     }
   };
 
-  // Toggle SSL on/off and persist immediately (no need to click 保存).
-  // Optimistic update with rollback on failure so the UI stays in sync
-  // with the backend even when the request errors out.
   const handleToggleSsl = async () => {
     const next = !verifySsl;
     setVerifySsl(next);
-    if (!device || !onToggleVerifySsl) {
-      return;
-    }
+    if (!device || !onToggleVerifySsl) return;
     try {
       await onToggleVerifySsl(next);
-      toast.success(next ? '已开启 SSL 验证' : '已关闭 SSL 验证');
+      toast.success(next ? t('toast.sslOn') : t('toast.sslOff'));
     } catch {
       setVerifySsl(!next);
-      toast.error('保存失败，已回滚');
+      toast.error(t('toast.rollback'));
     }
   };
 
-  // Same immediate-persist pattern for the "启用设备" toggle.
   const handleToggleEnabled = async () => {
     const next = !enabled;
     setEnabled(next);
-    if (!device || !onToggleEnabled) {
-      return;
-    }
+    if (!device || !onToggleEnabled) return;
     try {
       await onToggleEnabled(next);
-      toast.success(next ? '设备已启用' : '设备已停用');
+      toast.success(next ? t('toast.enabledOn') : t('toast.enabledOff'));
     } catch {
       setEnabled(!next);
-      toast.error('保存失败，已回滚');
+      toast.error(t('toast.rollback'));
     }
   };
 
@@ -525,36 +514,27 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
     }
     if (!onDelete) return;
     setDeleting(true);
-    try { await onDelete(); toast.success('已删除设备'); }
-    catch { toast.error('删除失败'); }
+    try { await onDelete(); toast.success(t('toast.deleteDone')); }
+    catch { toast.error(t('toast.deleteFailed')); }
     finally { setDeleting(false); }
   };
 
   const handleToggleTool = async (toolName: string, next: boolean) => {
-    // 仅在已存在设备时可触发（工具 tab 在 wizard 模式下被隐藏，见 TABS 注释）。
     if (!device) return;
     try {
-      // Per-device toggle: only affects this specific device instance.
-      // Other devices sharing the same storage_key (same product version)
-      // are not affected.
       await deviceAPI.updateDeviceTool(device.id, toolName, next);
       setToolEnabled((p) => ({ ...p, [toolName]: next }));
     } catch {
-      toast.error('操作失败');
+      toast.error(t('toast.actionFailed'));
     }
   };
 
-  // The "工具" tab is hidden during the add-device wizard because per-device
-  // toggles can only be persisted after the device row exists (we have no
-  // device_id to target).  Showing the tab here would force any toggle to
-  // mutate the GLOBAL tool_settings — re-introducing the original cross-device
-  // coupling bug this whole feature exists to fix.
   const TABS: { key: PanelTab; label: string; icon: React.ReactNode }[] = [
-    { key: 'config', label: '配置', icon: <Settings className="w-3.5 h-3.5" /> },
+    { key: 'config', label: t('config.tabConfig'), icon: <Settings className="w-3.5 h-3.5" /> },
     ...(device
-      ? [{ key: 'tools' as PanelTab, label: `工具${serviceTools.length ? ` (${serviceTools.length})` : ''}`, icon: <Wrench className="w-3.5 h-3.5" /> }]
+      ? [{ key: 'tools' as PanelTab, label: serviceTools.length ? t('config.tabToolsCount', { count: serviceTools.length }) : t('config.tabTools'), icon: <Wrench className="w-3.5 h-3.5" /> }]
       : []),
-    { key: 'overview', label: '概览', icon: <AlertTriangle className="w-3.5 h-3.5 opacity-60" /> },
+    { key: 'overview', label: t('config.tabOverview'), icon: <AlertTriangle className="w-3.5 h-3.5 opacity-60" /> },
   ];
 
   return (
@@ -562,7 +542,7 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
       <div className="fixed inset-0 z-40 pointer-events-none">
         <button
           type="button"
-          aria-label="关闭设备配置面板"
+          aria-label={t('config.closeAriaLabel')}
           onClick={onClose}
           className="pointer-events-auto absolute left-0 bottom-0 bg-transparent"
           style={{ top: 64, right: 480 }}
@@ -583,9 +563,9 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                 {device ? <PlugZap className="w-4 h-4 text-blue-500" /> : <Plus className="w-4 h-4 text-zinc-400" />}
               </div>
               <div className="min-w-0">
-                <h3 className="text-sm font-semibold text-zinc-900 truncate">{device ? device.name : '填写配置'}</h3>
+                <h3 className="text-sm font-semibold text-zinc-900 truncate">{device ? device.name : t('config.newDeviceTitle')}</h3>
                 <div className="flex items-center gap-1.5 mt-0.5">
-                  {vendor && <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-md ${vendor.color}`}>{vendor.nameCn}</span>}
+                  {vendor && <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-md ${vendor.color}`}>{i18n.language.startsWith('zh') ? vendor.nameCn : vendor.nameEn}</span>}
                   <span className="text-xs text-zinc-400 truncate">{device?.storage_key ?? template?.id}</span>
                 </div>
               </div>
@@ -620,20 +600,44 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
               <div className="px-5 py-4 space-y-4">
                 <div>
                   <label className="block text-xs font-semibold text-zinc-500 mb-1.5">
-                    设备名称 <span className="text-red-500">*</span>
+                    {t('config.nameLabel')} <span className="text-red-500">*</span>
                   </label>
                   <input
                     type="text"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
-                    placeholder="例如：总部 AF 防火墙"
+                    placeholder={t('config.namePlaceholder')}
                     className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
                   />
                 </div>
 
+                <div>
+                  <label className="block text-xs font-semibold text-zinc-500 mb-1.5">
+                    {t('config.roomLabel')} <span className="text-red-500">*</span>
+                  </label>
+                  {groupLocked ? (
+                    <div className="flex items-center gap-2 rounded-lg border border-zinc-100 bg-zinc-50 px-3 py-2">
+                      <Server className="w-3.5 h-3.5 text-zinc-400 flex-shrink-0" />
+                      <span className="text-sm text-zinc-600">
+                        {groups.find((g) => g.id === groupId)?.name ?? groupId}
+                      </span>
+                    </div>
+                  ) : (
+                    <select
+                      value={groupId}
+                      onChange={(e) => setGroupId(e.target.value)}
+                      className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                    >
+                      {groups.map((g) => (
+                        <option key={g.id} value={g.id}>{g.name}</option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+
                 {credFields.length > 0 && (
                   <div className="space-y-3">
-                    <p className="text-xs font-semibold text-zinc-400 uppercase tracking-wide">连接参数</p>
+                    <p className="text-xs font-semibold text-zinc-400 uppercase tracking-wide">{t('config.connectionParams')}</p>
                     {credFields.map((f) => {
                       const isSecret = f.storage === 'secret' || f.input_type === 'password';
                       const show = !!visibility[f.key];
@@ -663,7 +667,7 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                             )}
                           </div>
                           {isSecret && device && hasExisting && (
-                            <p className="mt-0.5 text-[11px] text-zinc-400">已配置 · 保持不变请勿修改，清空则删除</p>
+                            <p className="mt-0.5 text-[11px] text-zinc-400">{t('config.secretConfigured')}</p>
                           )}
                           {f.description && <p className="mt-0.5 text-xs text-zinc-400">{f.description}</p>}
                         </div>
@@ -675,15 +679,15 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                 <div className="rounded-xl border border-zinc-100 divide-y divide-zinc-100">
                   <div className="flex items-center justify-between px-4 py-3">
                     <div>
-                      <p className="text-sm font-medium text-zinc-700">SSL 验证</p>
-                      <p className="text-[11px] text-zinc-400 mt-0.5">关闭可访问自签名证书的内网设备</p>
+                      <p className="text-sm font-medium text-zinc-700">{t('config.sslLabel')}</p>
+                      <p className="text-[11px] text-zinc-400 mt-0.5">{t('config.sslHint')}</p>
                     </div>
                     <Toggle on={verifySsl} onToggle={handleToggleSsl} />
                   </div>
                   <div className="flex items-center justify-between px-4 py-3">
                     <div>
-                      <p className="text-sm font-medium text-zinc-700">启用设备</p>
-                      <p className="text-[11px] text-zinc-400 mt-0.5">关闭后 Agent 不会调用此设备的工具</p>
+                      <p className="text-sm font-medium text-zinc-700">{t('config.enabledLabel')}</p>
+                      <p className="text-[11px] text-zinc-400 mt-0.5">{t('config.enabledHint')}</p>
                     </div>
                     <Toggle on={enabled} onToggle={handleToggleEnabled} />
                   </div>
@@ -709,7 +713,7 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                         className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg border border-zinc-200 text-zinc-600 hover:bg-zinc-50 disabled:opacity-50 transition-colors"
                       >
                         {testing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Activity className="w-3.5 h-3.5" />}
-                        连通测试
+                        {t('config.testBtn')}
                       </button>
                     )}
                     <button
@@ -718,7 +722,7 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                       className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
                     >
                       {saving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Save className="w-3.5 h-3.5" />}
-                      {device ? '保存配置' : '确认接入'}
+                      {device ? t('config.saveBtn') : t('config.addBtn')}
                     </button>
                   </div>
                   {device && onDelete && (
@@ -728,7 +732,7 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                       className="w-full flex items-center justify-center gap-1.5 py-2 text-sm rounded-lg border border-red-100 text-red-500 hover:bg-red-50 disabled:opacity-50 transition-colors"
                     >
                       {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
-                      {confirmDelete ? '确认删除此设备配置？' : '删除设备'}
+                      {confirmDelete ? t('config.confirmDelete') : t('config.deleteBtn')}
                     </button>
                   )}
                 </div>
@@ -741,17 +745,17 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                 {serviceTools.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-16 text-zinc-400 gap-2">
                     <Wrench className="w-8 h-8 opacity-30" />
-                    <p className="text-sm">暂无关联工具</p>
+                    <p className="text-sm">{t('tools.empty')}</p>
                   </div>
                 ) : (
                   <div className="rounded-xl border border-zinc-100 overflow-hidden">
                     <table className="w-full table-fixed divide-y divide-zinc-100">
                       <thead className="bg-zinc-50">
                         <tr>
-                          <th className="w-[38%] px-4 py-2.5 text-left text-xs font-medium text-zinc-500">工具名称</th>
-                          <th className="px-4 py-2.5 text-left text-xs font-medium text-zinc-500">描述</th>
-                          <th className="w-[72px] px-4 py-2.5 text-left text-xs font-medium text-zinc-500">状态</th>
-                          <th className="w-[80px] px-4 py-2.5 text-right text-xs font-medium text-zinc-500">操作</th>
+                          <th className="w-[38%] px-4 py-2.5 text-left text-xs font-medium text-zinc-500">{t('tools.colName')}</th>
+                          <th className="px-4 py-2.5 text-left text-xs font-medium text-zinc-500">{t('tools.colDesc')}</th>
+                          <th className="w-[72px] px-4 py-2.5 text-left text-xs font-medium text-zinc-500">{t('tools.colStatus')}</th>
+                          <th className="w-[80px] px-4 py-2.5 text-right text-xs font-medium text-zinc-500">{t('tools.colAction')}</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-zinc-100 bg-white">
@@ -775,7 +779,7 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                                   onClick={() => setToolModal(tool)}
                                   className="text-xs text-blue-600 hover:text-blue-800 font-medium"
                                 >
-                                  测试 / 详情
+                                  {t('tools.detail')}
                                 </button>
                               </td>
                             </tr>
@@ -793,10 +797,10 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
               <div className="px-5 py-4 space-y-3">
                 <div className="rounded-xl border border-zinc-100 divide-y divide-zinc-100 overflow-hidden">
                   {[
-                    { label: '服务名称', value: metadata?.name || serviceId },
-                    metadata?.version ? { label: '版本', value: metadata.version } : null,
-                    { label: '工具数量', value: String(serviceTools.length) },
-                    vendor ? { label: '厂商', value: vendor.nameCn } : null,
+                    { label: t('overview.serviceName'), value: metadata?.name || serviceId },
+                    metadata?.version ? { label: t('overview.version'), value: metadata.version } : null,
+                    { label: t('overview.toolCount'), value: String(serviceTools.length) },
+                    vendor ? { label: t('overview.vendor'), value: i18n.language.startsWith('zh') ? vendor.nameCn : vendor.nameEn } : null,
                     device?.storage_key ? { label: 'Storage Key', value: device.storage_key } : null,
                     device?.service_id ? { label: 'Service ID', value: device.service_id } : null,
                   ].filter(Boolean).map((row) => (
@@ -809,7 +813,7 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
 
                 {(metadata?.description_cn || metadata?.description) && (
                   <div className="rounded-xl border border-zinc-100 px-4 py-3">
-                    <p className="text-xs font-semibold text-zinc-400 mb-1.5 uppercase tracking-wide">服务简介</p>
+                    <p className="text-xs font-semibold text-zinc-400 mb-1.5 uppercase tracking-wide">{t('overview.serviceDesc')}</p>
                     <p className="text-sm text-zinc-600 leading-relaxed whitespace-pre-wrap">
                       {metadata?.description_cn || metadata?.description}
                     </p>
@@ -824,7 +828,7 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
                     className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800 px-1"
                   >
                     <ChevronRight className="w-4 h-4" />
-                    查看 API 文档
+                    {t('overview.viewDocs')}
                   </a>
                 )}
               </div>
@@ -845,87 +849,273 @@ function DeviceConfigPanel({ device, template, vendorKey, onSave, onDelete, onCl
 }
 
 // ============================================================================
-// Group banner (inline rename for the single default room)
+// Group sidebar — left panel for room navigation & management
 // ============================================================================
 
-function GroupBanner({ group, onRenamed }: {
-  group: DeviceGroup | undefined;
-  onRenamed: () => void;
+type RoomStatus = 'ok' | 'partial' | 'empty';
+
+function GroupSidebar({ groups, devices, selectedGroupId, onSelect, onRename, onDelete, onCreate }: {
+  groups: DeviceGroup[];
+  devices: DeviceIntegration[];
+  selectedGroupId: string | null;
+  onSelect: (id: string | null) => void;
+  onRename: (id: string, newName: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+  onCreate: (name: string) => Promise<void>;
 }) {
   const toast = useToast();
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(group?.name ?? '');
-  const [saving, setSaving] = useState(false);
+  const { t } = useTranslation('device');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createDraft, setCreateDraft] = useState('');
+  const [busy, setBusy] = useState(false);
 
-  useEffect(() => { setDraft(group?.name ?? ''); }, [group?.name]);
+  // Device counts per group
+  const deviceCounts = useMemo(() => {
+    const c: Record<string, number> = {};
+    devices.forEach((d) => { c[d.group_id] = (c[d.group_id] || 0) + 1; });
+    return c;
+  }, [devices]);
 
-  if (!group) return null;
+  // Room connectivity status
+  const groupStatuses = useMemo((): Record<string, RoomStatus> => {
+    const s: Record<string, RoomStatus> = {};
+    groups.forEach((g) => {
+      const gd = devices.filter((d) => d.group_id === g.id && d.enabled);
+      if (gd.length === 0) { s[g.id] = 'empty'; return; }
+      const ok = gd.filter((d) => d.status === 'ok' || d.status === 'connected').length;
+      s[g.id] = ok === gd.length ? 'ok' : 'partial';
+    });
+    return s;
+  }, [groups, devices]);
 
-  const startEdit = () => { setDraft(group.name); setEditing(true); };
-  const cancelEdit = () => { setDraft(group.name); setEditing(false); };
-  const saveEdit = async () => {
-    const next = draft.trim();
-    if (!next || next === group.name) { cancelEdit(); return; }
-    setSaving(true);
+  const statusDotClass: Record<RoomStatus, string> = {
+    ok: 'bg-green-500',
+    partial: 'bg-yellow-400',
+    empty: 'bg-zinc-300',
+  };
+
+  const startEdit = (g: DeviceGroup, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditingId(g.id);
+    setEditDraft(g.name);
+    setCreating(false);
+  };
+
+  const cancelEdit = () => { setEditingId(null); setEditDraft(''); };
+
+  const saveEdit = async (groupId: string) => {
+    const next = editDraft.trim();
+    const g = groups.find((x) => x.id === groupId);
+    if (!next || next === g?.name) { cancelEdit(); return; }
+    setBusy(true);
     try {
-      await deviceAPI.updateGroup(group.id, { name: next });
-      toast.success('机房名称已更新');
-      setEditing(false);
-      onRenamed();
+      await onRename(groupId, next);
+      setEditingId(null);
     } catch {
-      toast.error('更新失败');
+      // error already toasted by parent
     } finally {
-      setSaving(false);
+      setBusy(false);
     }
   };
 
+  const startCreate = () => {
+    setCreating(true);
+    setCreateDraft('');
+    setEditingId(null);
+  };
+
+  const cancelCreate = () => { setCreating(false); setCreateDraft(''); };
+
+  const saveCreate = async () => {
+    const name = createDraft.trim();
+    if (!name) { cancelCreate(); return; }
+    setBusy(true);
+    try {
+      await onCreate(name);
+      cancelCreate();
+    } catch {
+      // error already toasted by parent; keep input open so user can retry
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDeleteClick = async (group: DeviceGroup, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const count = deviceCounts[group.id] || 0;
+    if (count > 0) {
+      toast.error(t('sidebar.deleteHasDevices', { name: group.name, count }));
+      return;
+    }
+    await onDelete(group.id);
+  };
+
   return (
-    <div className="px-6 py-2.5 border-b border-zinc-100 bg-zinc-50/60 flex items-center gap-2">
-      <Server className="w-4 h-4 text-zinc-400 flex-shrink-0" />
-      <span className="text-xs text-zinc-400">当前机房</span>
-      {editing ? (
-        <>
-          <input
-            autoFocus
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') void saveEdit();
-              if (e.key === 'Escape') cancelEdit();
-            }}
-            disabled={saving}
-            maxLength={40}
-            className="text-sm font-medium text-zinc-800 bg-white border border-zinc-200 rounded-md px-2 py-1 focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100 w-48"
-          />
-          <button
-            onClick={() => void saveEdit()}
-            disabled={saving}
-            className="p-1 rounded-md text-blue-600 hover:bg-blue-50 disabled:opacity-50"
-            title="保存"
-          >
-            {saving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
-          </button>
-          <button
-            onClick={cancelEdit}
-            disabled={saving}
-            className="p-1 rounded-md text-zinc-400 hover:bg-zinc-100"
-            title="取消"
-          >
-            <X className="w-3.5 h-3.5" />
-          </button>
-        </>
-      ) : (
-        <>
-          <span className="text-sm font-medium text-zinc-800 truncate">{group.name}</span>
-          <button
-            onClick={startEdit}
-            className="p-1 rounded-md text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100"
-            title="重命名"
-          >
-            <Pencil className="w-3 h-3" />
-          </button>
-        </>
-      )}
+    // self-stretch ensures the panel fills the full flex-row height so the
+    // right border reaches the bottom even when there are few rooms.
+    <div className="w-52 flex-shrink-0 border-r border-zinc-200 flex flex-col h-full bg-zinc-50">
+      {/* Header */}
+      <div className="px-3 py-2.5 flex items-center justify-between flex-shrink-0">
+        <span className="text-[11px] font-semibold text-zinc-400 uppercase tracking-wider">{t('sidebar.heading')}</span>
+        <button
+          onClick={startCreate}
+          className="p-1 rounded text-zinc-400 hover:text-zinc-700 transition-colors"
+          title={t('sidebar.addRoom')}
+        >
+          <Plus className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Divider */}
+      <div className="h-px bg-zinc-200 mx-0" />
+
+      {/* Scrollable list */}
+      <div className="flex-1 overflow-y-auto py-1 px-2">
+        {/* "全部机房" item */}
+        <button
+          onClick={() => { onSelect(null); cancelEdit(); }}
+          className={`w-full flex items-center gap-2 px-2.5 py-2 text-left rounded transition-colors mt-1 ${
+            selectedGroupId === null
+              ? 'bg-blue-50 text-blue-700'
+              : 'text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700'
+          }`}
+        >
+          <Building2 className="w-3.5 h-3.5 flex-shrink-0" />
+          <span className="text-sm flex-1 font-medium truncate">{t('sidebar.allRooms')}</span>
+          <span className={`text-[11px] font-semibold tabular-nums ${
+            selectedGroupId === null ? 'text-blue-500' : 'text-zinc-400'
+          }`}>
+            {devices.length}
+          </span>
+        </button>
+
+        <div className="h-px my-1 bg-zinc-200" />
+
+        {/* Individual rooms */}
+        {groups.map((group) => {
+          const count = deviceCounts[group.id] || 0;
+          const st = groupStatuses[group.id] || 'empty';
+          const isSelected = selectedGroupId === group.id;
+          const isEditing = editingId === group.id;
+          const isDefault = group.id === DEFAULT_GROUP_ID;
+
+          return (
+            <div
+              key={group.id}
+              className={`group/room relative flex items-center gap-2 px-2.5 py-2 rounded cursor-pointer transition-colors ${
+                isSelected
+                  ? 'bg-blue-50 text-blue-700'
+                  : 'text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700'
+              }`}
+              onClick={() => { if (!isEditing) onSelect(group.id); }}
+            >
+              {/* Status dot */}
+              <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${statusDotClass[st]}`} />
+
+              {isEditing ? (
+                <>
+                  <input
+                    autoFocus
+                    value={editDraft}
+                    onChange={(e) => setEditDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') void saveEdit(group.id);
+                      if (e.key === 'Escape') cancelEdit();
+                      e.stopPropagation();
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    disabled={busy}
+                    maxLength={40}
+                    className="flex-1 min-w-0 text-sm text-zinc-900 bg-white border border-zinc-300 rounded px-1.5 py-0.5 focus:outline-none focus:border-blue-400"
+                  />
+                  <div className="flex items-center gap-0.5 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                    <button
+                      onClick={() => void saveEdit(group.id)}
+                      disabled={busy}
+                      className="p-1 rounded text-blue-600 hover:bg-blue-100 disabled:opacity-50"
+                    >
+                      {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
+                    </button>
+                    <button onClick={cancelEdit} className="p-1 rounded text-zinc-400 hover:bg-zinc-200">
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <span className="flex-1 text-sm truncate">{group.name}</span>
+                  <span className={`text-[11px] font-semibold tabular-nums flex-shrink-0 ${
+                    isSelected ? 'text-blue-500' : 'text-zinc-400'
+                  }`}>
+                    {count}
+                  </span>
+
+                  {/* Hover action buttons */}
+                  <div
+                    className="absolute right-1 inset-y-0 hidden group-hover/room:flex items-center gap-0.5 pl-4"
+                    style={{ background: `linear-gradient(to right, transparent, ${isSelected ? '#eff6ff' : '#f4f4f5'} 35%)` }}
+                  >
+                    <button
+                      onClick={(e) => startEdit(group, e)}
+                      className="p-1 rounded text-zinc-400 hover:text-zinc-600 transition-colors"
+                      title={t('sidebar.rename')}
+                    >
+                      <Pencil className="w-3 h-3" />
+                    </button>
+                    {!isDefault && (
+                      <button
+                        onClick={(e) => void handleDeleteClick(group, e)}
+                        className={`p-1 rounded transition-colors ${
+                          count > 0
+                            ? 'text-zinc-300 cursor-not-allowed'
+                            : 'text-zinc-400 hover:text-red-500'
+                        }`}
+                        title={count > 0 ? t('sidebar.deleteDisabled', { count }) : t('sidebar.deleteRoom')}
+                      >
+                        <Trash2 className="w-3 h-3" />
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Inline new room form */}
+        {creating && (
+          <div className="flex items-center gap-2 px-2.5 py-2 rounded bg-blue-50 mt-0.5">
+            <Server className="w-3.5 h-3.5 text-blue-400 flex-shrink-0" />
+            <input
+              autoFocus
+              value={createDraft}
+              onChange={(e) => setCreateDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void saveCreate();
+                if (e.key === 'Escape') cancelCreate();
+              }}
+              disabled={busy}
+              placeholder={t('sidebar.roomNamePlaceholder')}
+              maxLength={40}
+              className="flex-1 min-w-0 text-sm text-zinc-900 bg-white border border-zinc-300 rounded px-1.5 py-0.5 focus:outline-none focus:border-blue-400"
+            />
+            <div className="flex items-center gap-0.5 flex-shrink-0">
+              <button
+                onClick={() => void saveCreate()}
+                disabled={busy}
+                className="p-1 rounded text-blue-600 hover:bg-blue-100 disabled:opacity-50"
+              >
+                {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
+              </button>
+              <button onClick={cancelCreate} className="p-1 rounded text-zinc-400 hover:bg-zinc-200">
+                <X className="w-3 h-3" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -935,6 +1125,7 @@ function GroupBanner({ group, onRenamed }: {
 // ============================================================================
 
 type PanelMode =
+  | { kind: 'pick-group' }
   | { kind: 'wizard'; initialVendor?: DeviceVendor }
   | { kind: 'add'; template: APIServiceSummary }
   | { kind: 'edit'; device: DeviceIntegration }
@@ -942,14 +1133,38 @@ type PanelMode =
 
 export default function DeviceIntegrationPage() {
   const toast = useToast();
+  const { t } = useTranslation('device');
   const [devices, setDevices] = useState<DeviceIntegration[]>([]);
   const [templates, setTemplates] = useState<APIServiceSummary[]>([]);
   const [groups, setGroups] = useState<DeviceGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [panel, setPanel] = useState<PanelMode>(null);
+  // null = "全部机房" aggregate view; string = specific group id
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+  // Group ids whose section is collapsed in the "全部机房" view. Default
+  // (absent) = expanded, so brand-new rooms show their devices immediately.
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
 
-  const currentGroup: DeviceGroup | undefined = groups[0];
+  const toggleGroupCollapsed = useCallback((groupId: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }, []);
+
+  const selectedGroup = useMemo(
+    () => groups.find((g) => g.id === selectedGroupId) ?? null,
+    [groups, selectedGroupId],
+  );
+
+  // Devices shown in the main area (filtered by selected room)
+  const filteredDevices = useMemo(
+    () => selectedGroupId ? devices.filter((d) => d.group_id === selectedGroupId) : devices,
+    [devices, selectedGroupId],
+  );
 
   const fetchData = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
@@ -964,7 +1179,7 @@ export default function DeviceIntegrationPage() {
       setTemplates((tplRes.data || []).filter((s) => s.integration_type === 'device'));
       setGroups(grpRes.data || []);
     } catch {
-      toast.error('加载失败');
+      toast.error(t('toast.loadFailed'));
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -980,15 +1195,7 @@ export default function DeviceIntegrationPage() {
     return counts;
   }, [devices]);
 
-  // storage_key (and bare service_id) → vendor key, sourced from the backend
-  // template list. Used to resolve vendor for already-installed devices
-  // (whose `DeviceIntegration` row does not carry the vendor field directly).
-  //
-  // Legacy devices may have been installed before api_versioning shipped, so
-  // their `storage_key` is the bare service_id (e.g. "tdp_api") rather than
-  // the versioned form ("tdp_api_v3_3_10"). We additionally index each
-  // template by its bare service_id (regex matches the backend's
-  // `storage_key_to_service_id`) so those rows still resolve correctly.
+  // storage_key / service_id → vendor key mapping
   const vendorByKey = useMemo(() => {
     const map: Record<string, string> = {};
     templates.forEach((t) => {
@@ -1010,12 +1217,63 @@ export default function DeviceIntegrationPage() {
 
   const panelDeviceId = panel?.kind === 'edit' ? panel.device.id : null;
 
-  const handleSave = async (data: { name: string; fields: Record<string, string>; enabled: boolean; verify_ssl: boolean }) => {
+  // ──────────────────────────────────────────────────────────────────────────
+  // Group CRUD handlers
+  // ──────────────────────────────────────────────────────────────────────────
+
+  // These three re-throw on failure (after toasting) so GroupSidebar's inline
+  // edit/create forms know to stay open for a retry instead of silently
+  // closing on a 409 (duplicate name) etc.
+  const handleCreateGroup = async (name: string) => {
+    try {
+      const res = await deviceAPI.createGroup({ name });
+      await fetchData(true);
+      setSelectedGroupId(res.data.id); // auto-select the newly created room
+      toast.success(`机房「${name}」已创建`);
+    } catch (err: unknown) {
+      toast.error(errDetail(err, '创建机房失败'));
+      throw err;
+    }
+  };
+
+  const handleRenameGroup = async (id: string, newName: string) => {
+    try {
+      await deviceAPI.updateGroup(id, { name: newName });
+      await fetchData(true);
+      toast.success('机房名称已更新');
+    } catch (err: unknown) {
+      toast.error(errDetail(err, '重命名失败'));
+      throw err;
+    }
+  };
+
+  const handleDeleteGroup = async (id: string) => {
+    try {
+      await deviceAPI.deleteGroup(id);
+      if (selectedGroupId === id) setSelectedGroupId(null);
+      await fetchData(true);
+      toast.success('机房已删除');
+    } catch (err: unknown) {
+      toast.error(errDetail(err, '删除失败'));
+    }
+  };
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Device CRUD handlers
+  // ──────────────────────────────────────────────────────────────────────────
+
+  const handleSave = async (data: {
+    name: string;
+    fields: Record<string, string>;
+    enabled: boolean;
+    verify_ssl: boolean;
+    group_id: string;
+  }) => {
     if (panel?.kind === 'add') {
       await deviceAPI.create({
         name: data.name,
         storage_key: panel.template.id,
-        group_id: currentGroup?.id,
+        group_id: data.group_id,
         enabled: data.enabled,
         verify_ssl: data.verify_ssl,
         fields: data.fields,
@@ -1024,6 +1282,7 @@ export default function DeviceIntegrationPage() {
     } else if (panel?.kind === 'edit') {
       await deviceAPI.update(panel.device.id, {
         name: data.name,
+        group_id: data.group_id,
         enabled: data.enabled,
         verify_ssl: data.verify_ssl,
         fields: data.fields,
@@ -1054,8 +1313,6 @@ export default function DeviceIntegrationPage() {
     return res.data;
   };
 
-  // Persist the SSL toggle the moment it flips, without requiring 保存.
-  // Re-fetches the device so the open panel reflects the freshly stored row.
   const handleToggleVerifySsl = async (next: boolean) => {
     if (panel?.kind !== 'edit') return;
     await deviceAPI.update(panel.device.id, { verify_ssl: next });
@@ -1064,7 +1321,6 @@ export default function DeviceIntegrationPage() {
     await fetchData(true);
   };
 
-  // Same pattern for enabled — persists immediately without needing 保存.
   const handleToggleEnabled = async (next: boolean) => {
     if (panel?.kind !== 'edit') return;
     await deviceAPI.update(panel.device.id, { enabled: next });
@@ -1073,18 +1329,48 @@ export default function DeviceIntegrationPage() {
     await fetchData(true);
   };
 
+  // ──────────────────────────────────────────────────────────────────────────
+  // Group to use when adding a new device (follows sidebar selection).
+  // In "全部机房" view (null), pre-select the first available group so the
+  // dropdown has a sensible default; the user can change it in the panel.
+  // ──────────────────────────────────────────────────────────────────────────
+  const addDefaultGroupId = selectedGroupId ?? groups[0]?.id ?? DEFAULT_GROUP_ID;
+  // Whether the room field should be locked (read-only) in the config panel.
+  const groupLocked = selectedGroupId !== null;
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Stats for the main area header
+  // ──────────────────────────────────────────────────────────────────────────
+  const connectedCount = filteredDevices.filter(
+    (d) => d.enabled && (d.status === 'ok' || d.status === 'connected'),
+  ).length;
+  const errorCount = filteredDevices.filter((d) => d.enabled && d.status === 'error').length;
+
+  // Groups that actually render a section in the "全部机房" view (i.e. have at
+  // least one device) — drives the collapse-all toggle.
+  const nonEmptyGroupIds = useMemo(
+    () => groups.filter((g) => devices.some((d) => d.group_id === g.id)).map((g) => g.id),
+    [groups, devices],
+  );
+  const allCollapsed =
+    nonEmptyGroupIds.length > 0 && nonEmptyGroupIds.every((id) => collapsedGroups.has(id));
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Render
+  // ──────────────────────────────────────────────────────────────────────────
+
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col p-6 bg-gray-50 overflow-hidden">
       <PageHeader
-        title="设备接入"
-        description="配置安全设备 API 连接，使 Flocks 能够直接调用和控制这些设备"
-        icon={<Shield className="w-5 h-5" />}
+        title={t('pageTitle')}
+        description={t('pageDescription')}
+        icon={<ServerCog className="w-8 h-8" />}
         action={
           <div className="flex items-center gap-2">
             <button
               onClick={() => void fetchData(true)}
               disabled={refreshing}
-              title="刷新"
+              title={t('toolbar.refresh')}
               className="p-1.5 rounded-lg border border-zinc-200 text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700 disabled:opacity-50 transition-colors"
             >
               <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? 'animate-spin' : ''}`} />
@@ -1094,63 +1380,236 @@ export default function DeviceIntegrationPage() {
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors font-medium"
             >
               <Plus className="w-3.5 h-3.5" />
-              添加设备
+              {t('toolbar.addDevice')}
             </button>
           </div>
         }
       />
 
-      <GroupBanner group={currentGroup} onRenamed={() => void fetchData(true)} />
+      {/* Content: sidebar + main area */}
+      <div className="flex-1 min-h-0 flex overflow-hidden">
+        {/* Left: room sidebar */}
+        {!loading && (
+          <GroupSidebar
+            groups={groups}
+            devices={devices}
+            selectedGroupId={selectedGroupId}
+            onSelect={setSelectedGroupId}
+            onRename={handleRenameGroup}
+            onDelete={handleDeleteGroup}
+            onCreate={handleCreateGroup}
+          />
+        )}
 
-      {loading ? (
-        <div className="flex-1 flex items-center justify-center"><LoadingSpinner /></div>
-      ) : (
-        <div className="flex-1 overflow-y-auto px-6 py-6">
-          {devices.length === 0 ? (
-            /* Empty state */
-            <div className="flex flex-col items-center justify-center py-24 gap-4">
-              <div className="w-16 h-16 rounded-2xl bg-zinc-100 flex items-center justify-center">
-                <PlugZap className="w-7 h-7 text-zinc-300" />
-              </div>
-              <div className="text-center">
-                <p className="text-sm font-semibold text-zinc-700">暂无已接入的设备</p>
-                <p className="text-xs text-zinc-400 mt-1.5">添加设备后，Flocks Agent 即可调用对应工具</p>
-              </div>
-              <button
-                onClick={() => setPanel({ kind: 'wizard' })}
-                className="flex items-center gap-1.5 px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors font-medium"
-              >
-                <Plus className="w-3.5 h-3.5" />
-                立即添加设备
-              </button>
-            </div>
+        {/* Right: main device area */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {loading ? (
+            <div className="flex-1 flex items-center justify-center"><LoadingSpinner /></div>
           ) : (
-            <section>
-              <div className="flex items-center gap-2 mb-4">
-                <PlugZap className="w-4 h-4 text-blue-600" />
-                <h3 className="text-sm font-semibold text-zinc-800">已接入设备</h3>
-                <span className="text-xs text-zinc-400 bg-zinc-100 px-1.5 py-0.5 rounded-md">{devices.length}</span>
-                {devices.filter((d) => d.status === 'ok' || d.status === 'connected').length > 0 && (
-                  <span className="text-xs text-green-600">
-                    {devices.filter((d) => d.status === 'ok' || d.status === 'connected').length} 已连接
-                  </span>
+            <>
+              {/* Room / aggregate header bar */}
+              <div className="px-6 py-3 border-b border-zinc-100 flex items-center gap-3 flex-shrink-0">
+                {selectedGroup ? (
+                  <>
+                    <Server className="w-4 h-4 text-zinc-400 flex-shrink-0" />
+                    <span className="text-sm font-semibold text-zinc-800">{selectedGroup.name}</span>
+                    <span className="text-xs text-zinc-400">{t('header.devices', { count: filteredDevices.length })}</span>
+                    {connectedCount > 0 && (
+                      <span className="inline-flex items-center gap-1 text-xs text-green-600">
+                        <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
+                        {t('header.connected', { count: connectedCount })}
+                      </span>
+                    )}
+                    {errorCount > 0 && (
+                      <span className="inline-flex items-center gap-1 text-xs text-red-500">
+                        <span className="w-1.5 h-1.5 rounded-full bg-red-500 inline-block" />
+                        {t('header.failed', { count: errorCount })}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <Building2 className="w-4 h-4 text-zinc-400 flex-shrink-0" />
+                    <span className="text-sm font-semibold text-zinc-800">{t('header.allRooms')}</span>
+                    <span className="text-xs text-zinc-400">
+                      {t('header.deviceCount', { count: devices.length, rooms: groups.length })}
+                    </span>
+                    {connectedCount > 0 && (
+                      <span className="inline-flex items-center gap-1 text-xs text-green-600">
+                        <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
+                        {t('header.connected', { count: connectedCount })}
+                      </span>
+                    )}
+                    {errorCount > 0 && (
+                      <span className="inline-flex items-center gap-1 text-xs text-red-500">
+                        <span className="w-1.5 h-1.5 rounded-full bg-red-500 inline-block" />
+                        {t('header.failed', { count: errorCount })}
+                      </span>
+                    )}
+                    {nonEmptyGroupIds.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setCollapsedGroups(allCollapsed ? new Set() : new Set(nonEmptyGroupIds))
+                        }
+                        className="ml-auto flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-700 transition-colors"
+                      >
+                        <ChevronDown className={`w-3.5 h-3.5 transition-transform ${allCollapsed ? '-rotate-90' : ''}`} />
+                        {allCollapsed ? t('toolbar.expandAll') : t('toolbar.collapseAll')}
+                      </button>
+                    )}
+                  </>
                 )}
               </div>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                {devices.map((d) => (
-                  <ActiveCard
-                    key={d.id}
-                    device={d}
-                    vendorKey={vendorOf(d)}
-                    selected={panelDeviceId === d.id}
-                    onClick={() => setPanel({ kind: 'edit', device: d })}
-                  />
-                ))}
+
+              {/* Device content area */}
+              <div className="flex-1 overflow-y-auto px-6 py-6">
+                {devices.length === 0 ? (
+                  /* Global empty state — no devices at all */
+                  <div className="flex flex-col items-center justify-center py-24 gap-4">
+                    <div className="w-16 h-16 rounded-2xl bg-zinc-100 flex items-center justify-center">
+                      <PlugZap className="w-7 h-7 text-zinc-300" />
+                    </div>
+                    <div className="text-center">
+                      <p className="text-sm font-semibold text-zinc-700">{t('empty.noDevices')}</p>
+                      <p className="text-xs text-zinc-400 mt-1.5">{t('empty.noDevicesHint')}</p>
+                    </div>
+                    <button
+                      onClick={() => setPanel({ kind: 'wizard' })}
+                      className="flex items-center gap-1.5 px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors font-medium"
+                    >
+                      <Plus className="w-3.5 h-3.5" />
+                      {t('empty.addNow')}
+                    </button>
+                  </div>
+                ) : selectedGroupId === null ? (
+                  /* ── "全部机房" grouped view ── */
+                  <div className="space-y-8">
+                    {groups.map((group) => {
+                      const gDevices = devices.filter((d) => d.group_id === group.id);
+                      if (gDevices.length === 0) return null;
+                      const gConnected = gDevices.filter(
+                        (d) => d.enabled && (d.status === 'ok' || d.status === 'connected'),
+                      ).length;
+                      const collapsed = collapsedGroups.has(group.id);
+                      return (
+                        <section key={group.id}>
+                          <button
+                            type="button"
+                            onClick={() => toggleGroupCollapsed(group.id)}
+                            className="w-full flex items-center gap-2 mb-4 group/sec text-left"
+                            aria-expanded={!collapsed}
+                          >
+                            <ChevronDown
+                              className={`w-3.5 h-3.5 text-zinc-400 transition-transform ${collapsed ? '-rotate-90' : ''}`}
+                            />
+                            <Server className="w-4 h-4 text-zinc-400" />
+                            <h3 className="text-sm font-semibold text-zinc-700 group-hover/sec:text-zinc-900">{group.name}</h3>
+                            <span className="text-xs text-zinc-400 bg-zinc-100 px-1.5 py-0.5 rounded-md">
+                              {gDevices.length}
+                            </span>
+                            {gConnected > 0 && (
+                              <span className="text-xs text-green-600">{t('header.connected', { count: gConnected })}</span>
+                            )}
+                          </button>
+                          {!collapsed && (
+                            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                              {gDevices.map((d) => (
+                                <ActiveCard
+                                  key={d.id}
+                                  device={d}
+                                  vendorKey={vendorOf(d)}
+                                  selected={panelDeviceId === d.id}
+                                  onClick={() => setPanel({ kind: 'edit', device: d })}
+                                />
+                              ))}
+                            </div>
+                          )}
+                        </section>
+                      );
+                    })}
+
+                    {/* Orphan fallback: devices whose group_id matches no known
+                        room (data drift / migration leftovers) must still be
+                        reachable — the "全部机房" view should never hide a device. */}
+                    {(() => {
+                      const known = new Set(groups.map((g) => g.id));
+                      const orphans = devices.filter((d) => !known.has(d.group_id));
+                      if (orphans.length === 0) return null;
+                      return (
+                        <section>
+                          <div className="flex items-center gap-2 mb-4">
+                            <AlertTriangle className="w-4 h-4 text-yellow-500" />
+                            <h3 className="text-sm font-semibold text-zinc-700">{t('section.ungrouped')}</h3>
+                            <span className="text-xs text-zinc-400 bg-zinc-100 px-1.5 py-0.5 rounded-md">
+                              {orphans.length}
+                            </span>
+                            <span className="text-xs text-zinc-400">{t('section.ungroupedHint')}</span>
+                          </div>
+                          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                            {orphans.map((d) => (
+                              <ActiveCard
+                                key={d.id}
+                                device={d}
+                                vendorKey={vendorOf(d)}
+                                selected={panelDeviceId === d.id}
+                                onClick={() => setPanel({ kind: 'edit', device: d })}
+                              />
+                            ))}
+                          </div>
+                        </section>
+                      );
+                    })()}
+                  </div>
+                ) : filteredDevices.length === 0 ? (
+                  /* ── Specific room, no devices ── */
+                  <div className="flex flex-col items-center justify-center py-24 gap-4">
+                    <div className="w-16 h-16 rounded-2xl bg-zinc-100 flex items-center justify-center">
+                      <Server className="w-7 h-7 text-zinc-300" />
+                    </div>
+                    <div className="text-center">
+                      <p className="text-sm font-semibold text-zinc-700">{t('empty.roomEmpty')}</p>
+                      <p className="text-xs text-zinc-400 mt-1.5">{t('empty.roomEmptyHint')}</p>
+                    </div>
+                    <button
+                      onClick={() => setPanel({ kind: 'wizard' })}
+                      className="flex items-center gap-1.5 px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors font-medium"
+                    >
+                      <Plus className="w-3.5 h-3.5" />
+                      {t('empty.addNow')}
+                    </button>
+                  </div>
+                ) : (
+                  /* ── Specific room, has devices ── */
+                  <section>
+                    <div className="flex items-center gap-2 mb-4">
+                      <PlugZap className="w-4 h-4 text-blue-600" />
+                      <h3 className="text-sm font-semibold text-zinc-800">{t('section.activeDevices')}</h3>
+                      <span className="text-xs text-zinc-400 bg-zinc-100 px-1.5 py-0.5 rounded-md">
+                        {filteredDevices.length}
+                      </span>
+                      {connectedCount > 0 && (
+                        <span className="text-xs text-green-600">{t('header.connected', { count: connectedCount })}</span>
+                      )}
+                    </div>
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                      {filteredDevices.map((d) => (
+                        <ActiveCard
+                          key={d.id}
+                          device={d}
+                          vendorKey={vendorOf(d)}
+                          selected={panelDeviceId === d.id}
+                          onClick={() => setPanel({ kind: 'edit', device: d })}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                )}
               </div>
-            </section>
+            </>
           )}
         </div>
-      )}
+      </div>
 
       {/* Wizard panel (vendor → product selection) */}
       {panel?.kind === 'wizard' && (
@@ -1168,12 +1627,18 @@ export default function DeviceIntegrationPage() {
         const panelVendorKey = panel.kind === 'edit'
           ? vendorOf(panel.device)
           : panel.template.vendor;
+        const panelInitGroupId = panel.kind === 'edit'
+          ? panel.device.group_id
+          : addDefaultGroupId;
         return (
           <DeviceConfigPanel
             key={panel.kind === 'edit' ? panel.device.id : panel.template.id}
             device={panel.kind === 'edit' ? panel.device : undefined}
             template={panel.kind === 'add' ? panel.template : undefined}
             vendorKey={panelVendorKey}
+            initialGroupId={panelInitGroupId}
+            groups={groups}
+            groupLocked={panel.kind === 'edit' ? true : groupLocked}
             onSave={handleSave}
             onDelete={panel.kind === 'edit' ? handleDelete : undefined}
             onClose={() => setPanel(null)}


### PR DESCRIPTION
- Enable MULTI_GROUP_ENABLED by default in backend (env var to opt out)
- Refactor DeviceIntegration page with left sidebar for room navigation
  - GroupSidebar with inline create / rename / delete for rooms
  - "All Rooms" aggregate view with collapsible per-room sections
  - Collapse-all / expand-all toggle when multiple rooms are present
- Fix sidebar height: route /devices as fullscreen to bypass min-h-full wrapper that breaks flex height propagation chain
- Room assignment in DeviceConfigPanel: dropdown (editable) when viewing "All Rooms", read-only field when viewing a specific room or editing
- Add i18n (zh-CN / en-US) for all hardcoded strings in device page; register "device" namespace in i18n.ts
- Align page header icon with other pages (ServerCog w-8 h-8)
- Update index.test.tsx mocks to cover createGroup / deleteGroup / listDeviceTools / updateDeviceTool