### PR TITLE
feat(device): auto-inject device_id into tool test params

### DIFF
--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -841,6 +841,7 @@ function DeviceConfigPanel({
         <ToolDetailModal
           tool={toolModal}
           initialSection="test"
+          deviceId={device?.id}
           onClose={() => setToolModal(null)}
         />
       )}

--- a/webui/src/pages/Tool/components/ToolDetailModal.tsx
+++ b/webui/src/pages/Tool/components/ToolDetailModal.tsx
@@ -12,26 +12,34 @@ import { EnabledBadge } from './badges';
 interface ToolDetailModalProps {
   tool: Tool;
   initialSection?: 'info' | 'test';
+  /** When opening from a specific device's panel, pass the device UUID so
+   *  it is pre-filled as `device_id` in the test params template. */
+  deviceId?: string;
   onClose: () => void;
 }
 
-function buildParamsTemplate(tool: Tool): string {
-  if (!tool.parameters || tool.parameters.length === 0) return '{}';
-  const obj: Record<string, string> = {};
-  for (const p of tool.parameters) {
-    if (p.required) {
-      obj[p.name] = p.type === 'number' || p.type === 'integer' ? '0' as any
-        : p.type === 'boolean' ? 'false' as any
-        : '';
+function buildParamsTemplate(tool: Tool, deviceId?: string): string {
+  const obj: Record<string, any> = {};
+  if (deviceId) {
+    obj['device_id'] = deviceId;
+  }
+  if (tool.parameters && tool.parameters.length > 0) {
+    for (const p of tool.parameters) {
+      if (p.name === 'device_id' && deviceId) continue; // injected value above wins
+      if (p.required) {
+        obj[p.name] = p.type === 'number' || p.type === 'integer' ? 0
+          : p.type === 'boolean' ? false
+          : '';
+      }
     }
   }
   return JSON.stringify(obj, null, 2);
 }
 
-export default function ToolDetailModal({ tool, initialSection, onClose }: ToolDetailModalProps) {
+export default function ToolDetailModal({ tool, initialSection, deviceId, onClose }: ToolDetailModalProps) {
   const { t, i18n } = useTranslation('tool');
   const [section, setSection] = useState<'info' | 'test'>(initialSection || 'info');
-  const defaultParams = useMemo(() => buildParamsTemplate(tool), [tool]);
+  const defaultParams = useMemo(() => buildParamsTemplate(tool, deviceId), [tool, deviceId]);
   const [testParams, setTestParams] = useState(defaultParams);
   const [testResult, setTestResult] = useState<any>(null);
   const [testing, setTesting] = useState(false);
@@ -240,6 +248,12 @@ export default function ToolDetailModal({ tool, initialSection, onClose }: ToolD
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">{t('toolDetail.testParams')}</label>
+                {deviceId && (
+                  <p className="text-xs text-blue-600 mb-1.5 flex items-center gap-1">
+                    <span className="inline-block w-1.5 h-1.5 rounded-full bg-blue-400 flex-shrink-0" />
+                    已自动填入当前设备 ID（<code className="font-mono">{deviceId}</code>）
+                  </p>
+                )}
                 <textarea
                   value={testParams}
                   onChange={(e) => setTestParams(e.target.value)}


### PR DESCRIPTION
When opening a tool's test panel from within a specific device's configuration panel, the device UUID (generated at onboarding time) is now pre-filled as `device_id` in the test parameters JSON.

This resolves the error "当前存在多台同类型设备，调用前必须显式传入
`device_id`" that appeared whenever multiple instances of the same device type were registered, because the registry's `_resolve_device_target` could not auto-select a target without an explicit `device_id`.

Changes:
- ToolDetailModal: add optional `deviceId` prop; inject it as the first key in the template produced by `buildParamsTemplate`, skipping any duplicate `device_id` param entry from the tool's parameter list only when the prop is already provided (avoids regression for tools whose YAML explicitly declares a required `device_id` parameter)
- ToolDetailModal: show a contextual hint below the params label when `deviceId` is pre-filled, so the user knows where the value came from
- DeviceConfigPanel: pass `device?.id` as `deviceId` when opening ToolDetailModal from the per-device tools tab
- buildParamsTemplate: fix number/boolean default values to emit actual `0` / `false` instead of the string literals `"0"` / `"false"`