### PR TITLE
fix/device tool test fixture drops device

### DIFF
--- a/flocks/tool/credential_context.py
+++ b/flocks/tool/credential_context.py
@@ -33,9 +33,18 @@ _config_override: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
     "device_config_override", default=None
 )
 
-# The service_id this config override belongs to (scoping guard)
+# The service_id this config override belongs to (scoping guard).
+# Matched by get_config_override() for the bare service_id alias.
 _config_override_service: ContextVar[Optional[str]] = ContextVar(
     "device_config_override_service", default=None
+)
+
+# The storage_key for the same override (versioned name, e.g. "sangfor_af_v8_0_48").
+# Many handlers set SERVICE_ID to the full storage_key, not the bare service_id,
+# so we keep both to avoid a key mismatch causing credential lookup to silently
+# fall back to the global default config (wrong IP, wrong credentials).
+_config_override_storage_key: ContextVar[Optional[str]] = ContextVar(
+    "device_config_override_storage_key", default=None
 )
 
 # The currently active device_id (for logging / introspection)
@@ -61,11 +70,22 @@ def get_secret_override(secret_id: str) -> Optional[str]:
 
 
 def get_config_override(service_id: str) -> Optional[Dict[str, Any]]:
-    """Return device-specific config dict if an override is active for *service_id*."""
-    expected = _config_override_service.get()
-    if expected is None or expected != service_id:
+    """Return device-specific config dict if an override is active for *service_id*.
+
+    Matches against both the bare service_id (e.g. ``"sangfor_af"``) stored by
+    :func:`activate_device_credentials` and the raw storage_key
+    (e.g. ``"sangfor_af_v8_0_48"``) so that handlers whose ``SERVICE_ID``
+    includes the version suffix still resolve the correct per-device config
+    rather than silently falling back to the global default.
+    """
+    override = _config_override.get()
+    if override is None:
         return None
-    return _config_override.get()
+    expected_service = _config_override_service.get()
+    expected_storage = _config_override_storage_key.get()
+    if service_id in (expected_service, expected_storage):
+        return override
+    return None
 
 
 def get_active_device_id() -> Optional[str]:
@@ -90,7 +110,7 @@ async def activate_device_credentials(device_id: str) -> AsyncIterator[bool]:
     Yields ``True`` if activation succeeded, ``False`` if the device was not
     found / disabled (caller may still continue with default credentials).
     """
-    secret_ovr, config_ovr, service_id = await _build_overrides(device_id)
+    secret_ovr, config_ovr, service_id, storage_key = await _build_overrides(device_id)
     if secret_ovr is None and config_ovr is None or service_id is None:
         yield False
         return
@@ -105,6 +125,10 @@ async def activate_device_credentials(device_id: str) -> AsyncIterator[bool]:
     # the previous coroutine's value visible).
     verify_ssl = bool((config_ovr or {}).get("verify_ssl", False))
     t5 = _verify_ssl_override.set(verify_ssl)
+    # Also store the raw storage_key so handlers whose SERVICE_ID includes the
+    # version suffix (e.g. "sangfor_af_v8_0_48") can still match the override
+    # via get_config_override() without re-querying the DB.
+    t6 = _config_override_storage_key.set(storage_key or None)
     try:
         yield True
     finally:
@@ -113,24 +137,29 @@ async def activate_device_credentials(device_id: str) -> AsyncIterator[bool]:
         _config_override_service.reset(t3)
         _active_device_id.reset(t4)
         _verify_ssl_override.reset(t5)
+        _config_override_storage_key.reset(t6)
 
 
 async def _build_overrides(
     device_id: str,
-) -> tuple[Optional[Dict[str, str]], Optional[Dict[str, Any]], Optional[str]]:
+) -> tuple[Optional[Dict[str, str]], Optional[Dict[str, Any]], Optional[str], Optional[str]]:
     """Build secret and config override dicts for *device_id*.
 
-    Returns (None, None, None) when the device is not found or disabled.
-    Third element is the service_id used to scope the config override.
+    Returns ``(secret_ovr, config_ovr, service_id, storage_key)``.
+    All four are ``None`` when the device is not found or disabled.
+    ``service_id`` is the bare alias (e.g. ``"sangfor_af"``);
+    ``storage_key`` is the full versioned key (e.g. ``"sangfor_af_v8_0_48"``)
+    — both are stored in ContextVars so handlers that use either form as
+    their ``SERVICE_ID`` will still resolve the correct per-device config.
     """
     try:
         from flocks.tool.device.store import get_device_credentials
         creds = await get_device_credentials(device_id)
     except Exception:
-        return None, None, None
+        return None, None, None, None
 
     if creds is None:
-        return None, None, None
+        return None, None, None, None
 
     storage_key: str = creds.get("storage_key", "")
     service_id: str = creds.get("service_id", "")
@@ -182,7 +211,7 @@ async def _build_overrides(
     config_ovr["verify_ssl"] = verify_ssl
     config_ovr["ssl_verify"] = verify_ssl
 
-    return secret_ovr or None, config_ovr or None, service_id or None
+    return secret_ovr or None, config_ovr or None, service_id or None, storage_key or None
 
 
 def _load_credential_fields(storage_key: str) -> list[Dict[str, Any]]:

--- a/flocks/tool/credential_context.py
+++ b/flocks/tool/credential_context.py
@@ -111,7 +111,7 @@ async def activate_device_credentials(device_id: str) -> AsyncIterator[bool]:
     found / disabled (caller may still continue with default credentials).
     """
     secret_ovr, config_ovr, service_id, storage_key = await _build_overrides(device_id)
-    if secret_ovr is None and config_ovr is None or service_id is None:
+    if (secret_ovr is None and config_ovr is None) or service_id is None:
         yield False
         return
 

--- a/flocks/tool/credential_context.py
+++ b/flocks/tool/credential_context.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
-from typing import Any, AsyncIterator, Dict, Optional
+from typing import Any, AsyncIterator, Dict, NamedTuple, Optional
 
 # ContextVars – per-coroutine, so concurrent calls don't interfere.
 
@@ -60,6 +60,18 @@ _verify_ssl_override: ContextVar[Optional[bool]] = ContextVar(
 
 
 # ---------------------------------------------------------------------------
+# Internal result type for _build_overrides
+# ---------------------------------------------------------------------------
+
+class _DeviceOverrides(NamedTuple):
+    """Resolved credential and config data for a single device call."""
+    secret_ovr: Optional[Dict[str, str]]
+    config_ovr: Optional[Dict[str, Any]]
+    service_id: Optional[str]   # bare alias  e.g. "sangfor_af"
+    storage_key: Optional[str]  # versioned   e.g. "sangfor_af_v8_0_48"
+
+
+# ---------------------------------------------------------------------------
 # Read helpers (called from SecretManager / ConfigWriter)
 # ---------------------------------------------------------------------------
 
@@ -72,18 +84,28 @@ def get_secret_override(secret_id: str) -> Optional[str]:
 def get_config_override(service_id: str) -> Optional[Dict[str, Any]]:
     """Return device-specific config dict if an override is active for *service_id*.
 
-    Matches against both the bare service_id (e.g. ``"sangfor_af"``) stored by
-    :func:`activate_device_credentials` and the raw storage_key
-    (e.g. ``"sangfor_af_v8_0_48"``) so that handlers whose ``SERVICE_ID``
-    includes the version suffix still resolve the correct per-device config
-    rather than silently falling back to the global default.
+    Device handlers reference their provider config under two different naming
+    conventions:
+
+    * **Bare service_id** (e.g. ``"sangfor_af"``) — produced by
+      ``storage_key_to_service_id()`` and stored in ``_config_override_service``.
+    * **Versioned storage_key** (e.g. ``"sangfor_af_v8_0_48"``) — the full key
+      stored in the DB and in ``_config_override_storage_key``.
+
+    Both are checked so that a handler whose ``SERVICE_ID`` uses either form
+    still resolves the correct per-device config rather than silently falling
+    back to the global default (wrong IP / wrong credentials).
     """
     override = _config_override.get()
     if override is None:
         return None
     expected_service = _config_override_service.get()
     expected_storage = _config_override_storage_key.get()
-    if service_id in (expected_service, expected_storage):
+    # Match on bare service_id alias OR full versioned storage_key — whichever
+    # the calling handler's SERVICE_ID constant happens to use.
+    matches_service = expected_service is not None and service_id == expected_service
+    matches_storage = expected_storage is not None and service_id == expected_storage
+    if matches_service or matches_storage:
         return override
     return None
 
@@ -110,7 +132,8 @@ async def activate_device_credentials(device_id: str) -> AsyncIterator[bool]:
     Yields ``True`` if activation succeeded, ``False`` if the device was not
     found / disabled (caller may still continue with default credentials).
     """
-    secret_ovr, config_ovr, service_id, storage_key = await _build_overrides(device_id)
+    ovr = await _build_overrides(device_id)
+    secret_ovr, config_ovr, service_id, storage_key = ovr
     if (secret_ovr is None and config_ovr is None) or service_id is None:
         yield False
         return
@@ -140,26 +163,29 @@ async def activate_device_credentials(device_id: str) -> AsyncIterator[bool]:
         _config_override_storage_key.reset(t6)
 
 
-async def _build_overrides(
-    device_id: str,
-) -> tuple[Optional[Dict[str, str]], Optional[Dict[str, Any]], Optional[str], Optional[str]]:
+async def _build_overrides(device_id: str) -> _DeviceOverrides:
     """Build secret and config override dicts for *device_id*.
 
-    Returns ``(secret_ovr, config_ovr, service_id, storage_key)``.
-    All four are ``None`` when the device is not found or disabled.
-    ``service_id`` is the bare alias (e.g. ``"sangfor_af"``);
-    ``storage_key`` is the full versioned key (e.g. ``"sangfor_af_v8_0_48"``)
-    — both are stored in ContextVars so handlers that use either form as
-    their ``SERVICE_ID`` will still resolve the correct per-device config.
+    Returns a :class:`_DeviceOverrides` named-tuple.  All fields are ``None``
+    when the device is not found or disabled.
+
+    * ``service_id``  — bare alias derived by ``storage_key_to_service_id``
+                        (e.g. ``"sangfor_af"``).
+    * ``storage_key`` — full versioned key as stored in the DB
+                        (e.g. ``"sangfor_af_v8_0_48"``).
+
+    Both keys are propagated to ContextVars so :func:`get_config_override`
+    can match whichever form a handler's ``SERVICE_ID`` uses.
     """
+    _null = _DeviceOverrides(None, None, None, None)
     try:
         from flocks.tool.device.store import get_device_credentials
         creds = await get_device_credentials(device_id)
     except Exception:
-        return None, None, None, None
+        return _null
 
     if creds is None:
-        return None, None, None, None
+        return _null
 
     storage_key: str = creds.get("storage_key", "")
     service_id: str = creds.get("service_id", "")
@@ -211,7 +237,12 @@ async def _build_overrides(
     config_ovr["verify_ssl"] = verify_ssl
     config_ovr["ssl_verify"] = verify_ssl
 
-    return secret_ovr or None, config_ovr or None, service_id or None, storage_key or None
+    return _DeviceOverrides(
+        secret_ovr=secret_ovr or None,
+        config_ovr=config_ovr or None,
+        service_id=service_id or None,
+        storage_key=storage_key or None,
+    )
 
 
 def _load_credential_fields(storage_key: str) -> list[Dict[str, Any]]:

--- a/tests/tool/test_credential_context_config_override.py
+++ b/tests/tool/test_credential_context_config_override.py
@@ -1,0 +1,120 @@
+"""Unit tests for get_config_override dual-key matching.
+
+Regression suite for the bug where handlers whose ``SERVICE_ID`` constant uses
+the full versioned storage_key (e.g. ``"sangfor_af_v8_0_48"``) instead of the
+bare service_id (e.g. ``"sangfor_af"``) would always receive ``None`` from
+``get_config_override``, causing a silent fallback to the global default config
+(wrong IP / wrong credentials).
+
+The tests set ContextVars directly — no DB, no ToolRegistry, no network.
+"""
+from __future__ import annotations
+
+import pytest
+
+from flocks.tool.credential_context import (
+    _config_override,
+    _config_override_service,
+    _config_override_storage_key,
+    get_config_override,
+)
+
+_SAMPLE_CONFIG = {"base_url": "https://10.201.255.17", "enabled": True}
+
+
+def _set_context(
+    *,
+    config: dict,
+    service_id: str | None,
+    storage_key: str | None,
+):
+    """Set the three ContextVars that activate_device_credentials populates."""
+    _config_override.set(config)
+    _config_override_service.set(service_id)
+    _config_override_storage_key.set(storage_key)
+
+
+# ---------------------------------------------------------------------------
+# Core matching scenarios
+# ---------------------------------------------------------------------------
+
+def test_matches_bare_service_id():
+    """Handler uses bare service_id — original behaviour must still work."""
+    _set_context(
+        config=_SAMPLE_CONFIG,
+        service_id="sangfor_af",
+        storage_key="sangfor_af_v8_0_48",
+    )
+    result = get_config_override("sangfor_af")
+    assert result is _SAMPLE_CONFIG
+
+
+def test_matches_versioned_storage_key():
+    """Handler uses versioned SERVICE_ID — the new behaviour introduced by this fix."""
+    _set_context(
+        config=_SAMPLE_CONFIG,
+        service_id="sangfor_af",
+        storage_key="sangfor_af_v8_0_48",
+    )
+    result = get_config_override("sangfor_af_v8_0_48")
+    assert result is _SAMPLE_CONFIG
+
+
+def test_no_match_returns_none():
+    """A completely unrelated service_id must never receive another device's config."""
+    _set_context(
+        config=_SAMPLE_CONFIG,
+        service_id="sangfor_af",
+        storage_key="sangfor_af_v8_0_48",
+    )
+    assert get_config_override("tdp_api") is None
+    assert get_config_override("sangfor_af_v8_0_85") is None  # different version
+
+
+def test_no_override_active_returns_none():
+    """When no device credential context is active, always return None."""
+    _config_override.set(None)
+    _config_override_service.set(None)
+    _config_override_storage_key.set(None)
+
+    assert get_config_override("sangfor_af") is None
+    assert get_config_override("sangfor_af_v8_0_48") is None
+
+
+# ---------------------------------------------------------------------------
+# Guard: storage_key=None should not accidentally match an empty string lookup
+# ---------------------------------------------------------------------------
+
+def test_none_storage_key_does_not_match_empty_string():
+    """storage_key=None must not match service_id='' (falsy equality trap)."""
+    _set_context(
+        config=_SAMPLE_CONFIG,
+        service_id="sangfor_af",
+        storage_key=None,
+    )
+    assert get_config_override("") is None
+
+
+def test_none_service_id_does_not_match_empty_string():
+    """service_id=None must not match service_id='' (falsy equality trap)."""
+    _set_context(
+        config=_SAMPLE_CONFIG,
+        service_id=None,
+        storage_key="sangfor_af_v8_0_48",
+    )
+    assert get_config_override("") is None
+
+
+# ---------------------------------------------------------------------------
+# Identical service_id and storage_key (edge case)
+# ---------------------------------------------------------------------------
+
+def test_identical_service_and_storage_key():
+    """When both keys are the same (no version suffix), matching still works."""
+    _set_context(
+        config=_SAMPLE_CONFIG,
+        service_id="tdp_api",
+        storage_key="tdp_api",
+    )
+    assert get_config_override("tdp_api") is _SAMPLE_CONFIG
+    assert get_config_override("other") is None

--- a/tests/tool/test_credential_context_config_override.py
+++ b/tests/tool/test_credential_context_config_override.py
@@ -22,6 +22,24 @@ from flocks.tool.credential_context import (
 _SAMPLE_CONFIG = {"base_url": "https://10.201.255.17", "enabled": True}
 
 
+@pytest.fixture(autouse=True)
+def _reset_context_vars():
+    """Reset all three ContextVars before AND after every test.
+
+    ContextVars persist for the lifetime of an execution context (the test
+    thread), so without explicit cleanup a test that sets a var can leak state
+    into the next test — even if the next test calls _set_context(), it might
+    leave the var in an unexpected state if it only sets some of the vars.
+    """
+    _config_override.set(None)
+    _config_override_service.set(None)
+    _config_override_storage_key.set(None)
+    yield
+    _config_override.set(None)
+    _config_override_service.set(None)
+    _config_override_storage_key.set(None)
+
+
 def _set_context(
     *,
     config: dict,

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -776,7 +776,7 @@ function DeviceConfigPanel({
                               </td>
                               <td className="px-4 py-3 text-right">
                                 <button
-                                  onClick={() => setToolModal(tool)}
+                                  onClick={() => setToolModal({ ...tool, enabled: isOn })}
                                   className="text-xs text-blue-600 hover:text-blue-800 font-medium"
                                 >
                                   {t('tools.detail')}

--- a/webui/src/pages/Tool/components/ToolDetailModal.tsx
+++ b/webui/src/pages/Tool/components/ToolDetailModal.tsx
@@ -218,7 +218,10 @@ export default function ToolDetailModal({ tool, initialSection, deviceId, onClos
                             key={idx}
                             type="button"
                             onClick={() => {
-                              setTestParams(JSON.stringify(fx.params, null, 2));
+                              const merged = deviceId
+                                ? { device_id: deviceId, ...fx.params }
+                                : fx.params;
+                              setTestParams(JSON.stringify(merged, null, 2));
                               setFixturesOpen(false);
                             }}
                             className="w-full flex items-start gap-3 px-4 py-2.5 hover:bg-blue-100 transition-colors text-left"

--- a/webui/src/pages/Tool/components/ToolDetailModal.tsx
+++ b/webui/src/pages/Tool/components/ToolDetailModal.tsx
@@ -219,7 +219,7 @@ export default function ToolDetailModal({ tool, initialSection, deviceId, onClos
                             type="button"
                             onClick={() => {
                               const merged = deviceId
-                                ? { device_id: deviceId, ...fx.params }
+                                ? { ...fx.params, device_id: deviceId }
                                 : fx.params;
                               setTestParams(JSON.stringify(merged, null, 2));
                               setFixturesOpen(false);


### PR DESCRIPTION
_config_override_service was set to the bare service_id (e.g. \"sangfor_af\")
derived by storage_key_to_service_id(), but several device handlers declare
SERVICE_ID as the full versioned storage key (e.g. \"sangfor_af_v8_0_48\").
get_config_override() performed an exact match, so these handlers always
got None and silently fell back to the global default config — using the
plugin's hardcoded DEFAULT_BASE_URL (192.168.1.1) instead of the device's
configured IP (e.g. 10.201.255.17).

Fix:
- _build_overrides() now returns a 4-tuple including storage_key
- activate_device_credentials() stores storage_key in a new ContextVar
  _config_override_storage_key alongside the existing service_id var
- get_config_override() accepts a match on either bare service_id OR
  full storage_key, so all handler SERVICE_ID conventions work correctly

Affected handlers (non-exhaustive):
  sangfor_af_v8_0_48, sangfor_af_v8_0_85, sangfor_af_v8_0_106"