### PR TITLE
fix(webui): remove global flex-col wrapper from standard pages

### DIFF
--- a/webui/src/components/layout/Layout.test.tsx
+++ b/webui/src/components/layout/Layout.test.tsx
@@ -291,6 +291,19 @@ describe('Layout onboarding entry', () => {
     expect(screen.queryByPlaceholderText('onboarding.bootstrap.tbPlaceholder')).not.toBeInTheDocument();
   });
 
+  it('keeps standard pages out of a flex column content wrapper', async () => {
+    localStorage.setItem('flocks_onboarding_dismissed', 'true');
+
+    const { container } = renderHomeWithLayout();
+
+    await flushEffects();
+
+    const contentWrapper = container.querySelector('main .min-h-full.p-6');
+    expect(contentWrapper).not.toBeNull();
+    expect(contentWrapper).not.toHaveClass('flex');
+    expect(contentWrapper).not.toHaveClass('flex-col');
+  });
+
   it('polls update checks hourly', async () => {
     vi.useFakeTimers();
 

--- a/webui/src/components/layout/Layout.tsx
+++ b/webui/src/components/layout/Layout.tsx
@@ -676,7 +676,7 @@ export default function Layout() {
             <Outlet />
           ) : (
             <div className="h-full overflow-y-auto">
-              <div className="min-h-full p-6 flex flex-col">
+              <div className="min-h-full p-6">
                 <Outlet />
               </div>
             </div>


### PR DESCRIPTION
PR #380 added flex flex-col to the shared content wrapper for the /devices page height chain, which unintentionally changed home and other standard page layout. Keep /devices on the fullscreen route and restore the v2026.6.4 wrapper for all other pages.