### PR TITLE
fix(provider): thinking params

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -1055,6 +1055,54 @@
           "output": 16.0,
           "currency": "CNY"
         }
+      },
+      "deepseek-v4-flash": {
+        "name": "DeepSeek V4 Flash",
+        "family": "deepseek-v4",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "interleaved": {
+            "field": "reasoning_content",
+            "echo": "tool_calls",
+            "placeholder": " ",
+            "cross_provider_policy": "placeholder"
+          },
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 1000000,
+          "max_output_tokens": 384000
+        },
+        "pricing": {
+          "input": 1.0,
+          "output": 2.0,
+          "currency": "CNY"
+        }
+      },
+      "deepseek-v4-pro": {
+        "name": "DeepSeek V4 Pro",
+        "family": "deepseek-v4",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_reasoning": true,
+          "interleaved": {
+            "field": "reasoning_content",
+            "echo": "tool_calls",
+            "placeholder": " ",
+            "cross_provider_policy": "placeholder"
+          },
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 1000000,
+          "max_output_tokens": 384000
+        },
+        "pricing": {
+          "input": 3.0,
+          "output": 9.0,
+          "currency": "CNY"
+        }
       }
     }
   },

--- a/flocks/provider/interleaved.py
+++ b/flocks/provider/interleaved.py
@@ -34,11 +34,13 @@ _ANTHROPIC_THINKING = {
 }
 
 _STRICT_REASONING_CONTENT_TOKENS = (
-    "deepseek-reasoner",
-    "deepseek-r1",
+    "deepseek",
+    "deepseek-v3",
     "deepseek-v4",
     "deepseek-v4-pro",
     "deepseek-v4-flash",
+    "deepseek-reasoner",
+    "deepseek-r1",
     "reasoner",
     "r1-0528",
     "kimi-k2.5",

--- a/flocks/provider/interleaved.py
+++ b/flocks/provider/interleaved.py
@@ -34,7 +34,6 @@ _ANTHROPIC_THINKING = {
 }
 
 _STRICT_REASONING_CONTENT_TOKENS = (
-    "deepseek",
     "deepseek-v3",
     "deepseek-v4",
     "deepseek-v4-pro",

--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -49,34 +49,18 @@ def _openai_base_thinking_shape(
     """Standard OpenAI-compat-with-thinking shape: ``extra_body.enable_thinking``.
 
     Used by Alibaba DashScope, ThreatBook (cn + io), Moonshot/Kimi, Zhipu/GLM,
-    MiniMax, and Stepfun — every OpenAI-compatible endpoint that exposes
-    thinking as a single boolean in extra_body.  When the user disables
+    MiniMax, Stepfun, and DeepSeek — every OpenAI-compatible endpoint that
+    exposes thinking as a single boolean in extra_body.  When the user disables
     reasoning (``reasoning_enabled=False``) the value mirrors that toggle so
     users can override per-model via flocks.json.
+
+    This shape is unconditional on the model name: the gate is the catalog's
+    ``interleaved`` capability, not the model id.  If ``deepseek-chat`` (V3)
+    is non-thinking, the catalog should not declare it as interleaved — and
+    indeed it does not (only ``deepseek-reasoner`` does).  Re-introducing a
+    model-name branch here would re-create the exact fragility the
+    catalog-driven dispatch was meant to eliminate.
     """
-    return {"enable_thinking": True if reasoning_enabled is not False else False}
-
-
-def _deepseek_thinking_shape(
-    model_id: str, reasoning_enabled: Optional[bool]
-) -> Dict[str, Any]:
-    """DeepSeek shape.
-
-    The V3 family (``deepseek-chat``, ``deepseek-v3-*``) is non-thinking — the
-    API doesn't accept or return ``reasoning_content``, so we leave the wire
-    format untouched.  V4+ and the legacy ``deepseek-reasoner`` (R1) are
-    thinking-capable and accept ``enable_thinking: true`` on Flocks' current
-    DashScope-style transport.  This matches the existing
-    test_kimi_*_enable_thinking_by_default assertions, which exercise the
-    same code path.  If DeepSeek V4 ever diverges to the Anthropic-style
-    ``thinking: {type: "enabled"}`` shape, only this function needs to
-    change.
-    """
-    m = (model_id or "").strip().lower()
-    if m == "deepseek-chat":
-        return {}
-    if m.startswith("deepseek-v3"):
-        return {}
     return {"enable_thinking": True if reasoning_enabled is not False else False}
 
 
@@ -90,7 +74,7 @@ _THINKING_REQUEST_SHAPES: Dict[
     "minimax": _openai_base_thinking_shape,
     "stepfun": _openai_base_thinking_shape,
     "moonshot": _openai_base_thinking_shape,
-    "deepseek": _deepseek_thinking_shape,
+    "deepseek": _openai_base_thinking_shape,
     # Generic openai-compatible user-configured endpoint.  When the model in
     # the catalog declares ``interleaved``, this emits the same enable_thinking
     # flag (DashScope / Moonshot style).  Endpoints that don't accept it will

--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -28,6 +28,11 @@ log = Log.create(service="provider.options")
 DEFAULT_THINKING_BUDGET = 16000
 DEFAULT_OUTPUT_BUFFER = 8192
 
+_GENERIC_CHAT_REASONING_EXTRA_BODY_KEYS = {
+    "reasoning_content": "enable_thinking",
+    "reasoning_details": "reasoning_split",
+}
+
 
 def _coerce_optional_bool(value: Any) -> Optional[bool]:
     """Coerce config values to bool while preserving None."""
@@ -170,6 +175,65 @@ def _resolve_reasoning_transport(provider_id: str, model_id: str) -> str:
     return transport
 
 
+def _build_generic_chat_extra_body(
+    provider_id: str,
+    model_id: str,
+    interleaved_capability: Optional[Dict[str, Any]],
+    reasoning_enabled: Optional[bool],
+) -> Optional[Dict[str, Any]]:
+    """Build OpenAI-compatible reasoning params for the active replay field."""
+    provider_lower = provider_id.lower()
+    model_lower = model_id.lower()
+    enabled = reasoning_enabled is not False
+
+    if "deepseek" in model_lower or provider_lower == "deepseek":
+        return {
+            "thinking": (
+                {"type": "enabled"}
+                if enabled
+                else {"type": "disabled"}
+            )
+        }
+
+    if "glm" in model_lower or provider_lower == "zhipu":
+        return {
+            "thinking": (
+                {"type": "enabled", "clear_thinking": False}
+                if enabled
+                else {"type": "disabled"}
+            )
+        }
+
+    if "mimo" in model_lower:
+        return {
+            "thinking": (
+                {"type": "enabled"}
+                if enabled
+                else {"type": "disabled"}
+            )
+        }
+
+    if "kimi" in model_lower:
+        return {
+            "thinking": (
+                {"type": "enabled"}
+                if enabled
+                else {"type": "disabled"}
+            )
+        }
+
+    if isinstance(interleaved_capability, dict):
+        field = interleaved_capability.get("field")
+        key = _GENERIC_CHAT_REASONING_EXTRA_BODY_KEYS.get(field)
+        if key:
+            return {key: enabled}
+
+    if reasoning_enabled is True:
+        return {"enable_thinking": True}
+
+    return None
+
+
 def build_provider_options(
     provider_id: str,
     model_id: str,
@@ -254,33 +318,27 @@ def build_provider_options(
 
     # -- Generic-chat (OpenAI-compat) interleaved thinking --------------------
     # The Anthropic branch above handles ``anthropic_messages`` transport.
-    # Everything else that exposes thinking as a single boolean in extra_body
-    # (Alibaba DashScope, ThreatBook, Moonshot, Zhipu/GLM, MiniMax, Stepfun,
-    # DeepSeek, generic openai-compatible user-configured endpoints) sits on
-    # the ``generic_chat`` transport, and the wire format is identical —
-    # ``extra_body.enable_thinking``.  No per-provider dispatch needed.
-    #
-    # The gate is the resolved ``interleaved_capability``: catalog explicit
-    # declaration wins, with the series-token inference in
-    # ``interleaved.infer_interleaved_capability`` as fallback.  This means a
-    # new model from a known family (qwen*, glm-*, kimi-k2*, deepseek-v4*,
-    # step-3.5*, minimax-m*, …) Just Works without anyone editing the
-    # dispatch — the prior hard-coded token whitelist that silently dropped
-    # GLM-5 / minimax / deepseek / stepfun is gone, and so is the
-    # provider-keyed shape registry that replaced it (every entry produced
-    # the same dict).
+    # Generic-chat endpoints expose provider-specific extra_body toggles:
+    # most reasoning_content models use enable_thinking, while MiniMax's
+    # OpenAI-compatible interleaved format uses reasoning_split so the model
+    # returns reasoning_details that can be replayed in later tool turns.
     elif (
-        interleaved_enabled
+        (interleaved_enabled or reasoning_enabled is True)
         and reasoning_transport == REASONING_TRANSPORT_GENERIC_CHAT
     ):
-        options["extra_body"] = {
-            "enable_thinking": True if reasoning_enabled is not False else False,
-        }
-        log.debug("options.thinking_params.resolved", {
-            "provider_id": provider_id,
-            "model_id": model_id,
-            "extra_body_keys": list(options["extra_body"].keys()),
-        })
+        extra_body = _build_generic_chat_extra_body(
+            provider_id,
+            model_id,
+            interleaved_capability,
+            reasoning_enabled,
+        )
+        if extra_body:
+            options["extra_body"] = extra_body
+            log.debug("options.thinking_params.resolved", {
+                "provider_id": provider_id,
+                "model_id": model_id,
+                "extra_body_keys": list(options["extra_body"].keys()),
+            })
 
     # -- max_tokens fallback from model config ------------------------------
     if resolve_max_tokens and "max_tokens" not in options:

--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -9,7 +9,7 @@ Both ``SessionRunner`` (session/runner.py) and ``AgentExecutor``
 so that provider rules are maintained in exactly one place.
 """
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from flocks.provider.interleaved import (
     REASONING_TRANSPORT_ANTHROPIC_MESSAGES,
@@ -27,14 +27,77 @@ log = Log.create(service="provider.options")
 DEFAULT_THINKING_BUDGET = 16000
 DEFAULT_OUTPUT_BUFFER = 8192
 
-_ENABLE_THINKING_EXTRA_BODY_TOKENS = (
-    "qwen3",
-    "qwq",
-    "qwen-max",
-    "kimi",
-    "k2-thinking",
-    "mimo",
-)
+# ---------------------------------------------------------------------------
+# Per-provider thinking-params request shapes
+# ---------------------------------------------------------------------------
+# Each entry is a callable ``(model_id, reasoning_enabled) -> extra_body_dict``
+# that emits the wire-format fields the upstream API expects to enable
+# interleaved thinking.  The dispatch gate is the catalog's ``interleaved``
+# capability — a model must declare it for any shape to fire.  This makes the
+# catalog the single source of truth for "this model wants thinking-aware
+# streaming", and removes the fragile model-name-substring whitelist that
+# used to live below.
+#
+# To add a new provider: drop a Callable into ``_THINKING_REQUEST_SHAPES``
+# below.  No token list, no inner if/elif.
+# ---------------------------------------------------------------------------
+
+
+def _openai_base_thinking_shape(
+    model_id: str, reasoning_enabled: Optional[bool]
+) -> Dict[str, Any]:
+    """Standard OpenAI-compat-with-thinking shape: ``extra_body.enable_thinking``.
+
+    Used by Alibaba DashScope, ThreatBook (cn + io), Moonshot/Kimi, Zhipu/GLM,
+    MiniMax, and Stepfun — every OpenAI-compatible endpoint that exposes
+    thinking as a single boolean in extra_body.  When the user disables
+    reasoning (``reasoning_enabled=False``) the value mirrors that toggle so
+    users can override per-model via flocks.json.
+    """
+    return {"enable_thinking": True if reasoning_enabled is not False else False}
+
+
+def _deepseek_thinking_shape(
+    model_id: str, reasoning_enabled: Optional[bool]
+) -> Dict[str, Any]:
+    """DeepSeek shape.
+
+    The V3 family (``deepseek-chat``, ``deepseek-v3-*``) is non-thinking — the
+    API doesn't accept or return ``reasoning_content``, so we leave the wire
+    format untouched.  V4+ and the legacy ``deepseek-reasoner`` (R1) are
+    thinking-capable and accept ``enable_thinking: true`` on Flocks' current
+    DashScope-style transport.  This matches the existing
+    test_kimi_*_enable_thinking_by_default assertions, which exercise the
+    same code path.  If DeepSeek V4 ever diverges to the Anthropic-style
+    ``thinking: {type: "enabled"}`` shape, only this function needs to
+    change.
+    """
+    m = (model_id or "").strip().lower()
+    if m == "deepseek-chat":
+        return {}
+    if m.startswith("deepseek-v3"):
+        return {}
+    return {"enable_thinking": True if reasoning_enabled is not False else False}
+
+
+_THINKING_REQUEST_SHAPES: Dict[
+    str, Callable[[str, Optional[bool]], Dict[str, Any]]
+] = {
+    "alibaba": _openai_base_thinking_shape,
+    "threatbook-cn-llm": _openai_base_thinking_shape,
+    "threatbook-io-llm": _openai_base_thinking_shape,
+    "zhipu": _openai_base_thinking_shape,
+    "minimax": _openai_base_thinking_shape,
+    "stepfun": _openai_base_thinking_shape,
+    "moonshot": _openai_base_thinking_shape,
+    "deepseek": _deepseek_thinking_shape,
+    # Generic openai-compatible user-configured endpoint.  When the model in
+    # the catalog declares ``interleaved``, this emits the same enable_thinking
+    # flag (DashScope / Moonshot style).  Endpoints that don't accept it will
+    # see a 4xx and the user can disable per-model via
+    # ``default_parameters.enable_thinking: false``.
+    "openai-compatible": _openai_base_thinking_shape,
+}
 
 
 def _coerce_optional_bool(value: Any) -> Optional[bool]:
@@ -178,11 +241,6 @@ def _resolve_reasoning_transport(provider_id: str, model_id: str) -> str:
     return transport
 
 
-def _needs_enable_thinking_extra_body(model_id: str) -> bool:
-    lowered = model_id.lower()
-    return any(token in lowered for token in _ENABLE_THINKING_EXTRA_BODY_TOKENS)
-
-
 def build_provider_options(
     provider_id: str,
     model_id: str,
@@ -265,23 +323,28 @@ def build_provider_options(
         if reasoning_enabled is not False:
             options["thinkingLevel"] = "high"
 
-    # -- Qwen reasoning (ThreatBook-hosted or Alibaba DashScope) -------------
-    elif (
-        provider_id in ("threatbook-cn-llm", "threatbook-io-llm", "alibaba", "moonshot")
-        or (
-            interleaved_enabled
-            and _needs_enable_thinking_extra_body(model_id)
-            and provider_id not in {"openai", "anthropic", "google"}
-        )
-    ):
-        if "qwen" in model_lower or "qwq" in model_lower:
-            options["extra_body"] = {
-                "enable_thinking": True if reasoning_enabled is None else reasoning_enabled
-            }
-        elif any(token in model_lower for token in ("kimi", "k2-thinking", "mimo")):
-            options["extra_body"] = {
-                "enable_thinking": True if reasoning_enabled is None else reasoning_enabled
-            }
+    # -- Per-provider thinking-params shapes (catalog-driven) ----------------
+    # If the catalog declares the model has interleaved reasoning capability,
+    # look up the provider's request shape and emit the right extra_body
+    # fields.  Replaces the old token-substring dispatch that silently
+    # dropped GLM-5 / minimax / deepseek / stepfun because their model names
+    # didn't match any of the magic substrings.
+    #
+    # The shape fires whenever the catalog says interleaved, even when the
+    # caller passed ``reasoning_enabled=False`` — that produces
+    # ``enable_thinking: false`` so the upstream API gets an explicit opt-out
+    # (the prior token-matching branch did the same).
+    elif interleaved_enabled:
+        shape_fn = _THINKING_REQUEST_SHAPES.get(provider_id)
+        if shape_fn is not None:
+            extra_body = shape_fn(model_id, reasoning_enabled)
+            if extra_body:
+                options["extra_body"] = extra_body
+                log.debug("options.thinking_params.resolved", {
+                    "provider_id": provider_id,
+                    "model_id": model_id,
+                    "extra_body_keys": list(extra_body.keys()),
+                })
 
     # -- max_tokens fallback from model config ------------------------------
     if resolve_max_tokens and "max_tokens" not in options:

--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -9,10 +9,11 @@ Both ``SessionRunner`` (session/runner.py) and ``AgentExecutor``
 so that provider rules are maintained in exactly one place.
 """
 
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from flocks.provider.interleaved import (
     REASONING_TRANSPORT_ANTHROPIC_MESSAGES,
+    REASONING_TRANSPORT_GENERIC_CHAT,
     resolve_interleaved_capability,
     resolve_reasoning_transport,
 )
@@ -26,62 +27,6 @@ log = Log.create(service="provider.options")
 # ---------------------------------------------------------------------------
 DEFAULT_THINKING_BUDGET = 16000
 DEFAULT_OUTPUT_BUFFER = 8192
-
-# ---------------------------------------------------------------------------
-# Per-provider thinking-params request shapes
-# ---------------------------------------------------------------------------
-# Each entry is a callable ``(model_id, reasoning_enabled) -> extra_body_dict``
-# that emits the wire-format fields the upstream API expects to enable
-# interleaved thinking.  The dispatch gate is the catalog's ``interleaved``
-# capability — a model must declare it for any shape to fire.  This makes the
-# catalog the single source of truth for "this model wants thinking-aware
-# streaming", and removes the fragile model-name-substring whitelist that
-# used to live below.
-#
-# To add a new provider: drop a Callable into ``_THINKING_REQUEST_SHAPES``
-# below.  No token list, no inner if/elif.
-# ---------------------------------------------------------------------------
-
-
-def _openai_base_thinking_shape(
-    model_id: str, reasoning_enabled: Optional[bool]
-) -> Dict[str, Any]:
-    """Standard OpenAI-compat-with-thinking shape: ``extra_body.enable_thinking``.
-
-    Used by Alibaba DashScope, ThreatBook (cn + io), Moonshot/Kimi, Zhipu/GLM,
-    MiniMax, Stepfun, and DeepSeek — every OpenAI-compatible endpoint that
-    exposes thinking as a single boolean in extra_body.  When the user disables
-    reasoning (``reasoning_enabled=False``) the value mirrors that toggle so
-    users can override per-model via flocks.json.
-
-    This shape is unconditional on the model name: the gate is the catalog's
-    ``interleaved`` capability, not the model id.  If ``deepseek-chat`` (V3)
-    is non-thinking, the catalog should not declare it as interleaved — and
-    indeed it does not (only ``deepseek-reasoner`` does).  Re-introducing a
-    model-name branch here would re-create the exact fragility the
-    catalog-driven dispatch was meant to eliminate.
-    """
-    return {"enable_thinking": True if reasoning_enabled is not False else False}
-
-
-_THINKING_REQUEST_SHAPES: Dict[
-    str, Callable[[str, Optional[bool]], Dict[str, Any]]
-] = {
-    "alibaba": _openai_base_thinking_shape,
-    "threatbook-cn-llm": _openai_base_thinking_shape,
-    "threatbook-io-llm": _openai_base_thinking_shape,
-    "zhipu": _openai_base_thinking_shape,
-    "minimax": _openai_base_thinking_shape,
-    "stepfun": _openai_base_thinking_shape,
-    "moonshot": _openai_base_thinking_shape,
-    "deepseek": _openai_base_thinking_shape,
-    # Generic openai-compatible user-configured endpoint.  When the model in
-    # the catalog declares ``interleaved``, this emits the same enable_thinking
-    # flag (DashScope / Moonshot style).  Endpoints that don't accept it will
-    # see a 4xx and the user can disable per-model via
-    # ``default_parameters.enable_thinking: false``.
-    "openai-compatible": _openai_base_thinking_shape,
-}
 
 
 def _coerce_optional_bool(value: Any) -> Optional[bool]:
@@ -307,28 +252,35 @@ def build_provider_options(
         if reasoning_enabled is not False:
             options["thinkingLevel"] = "high"
 
-    # -- Per-provider thinking-params shapes (catalog-driven) ----------------
-    # If the catalog declares the model has interleaved reasoning capability,
-    # look up the provider's request shape and emit the right extra_body
-    # fields.  Replaces the old token-substring dispatch that silently
-    # dropped GLM-5 / minimax / deepseek / stepfun because their model names
-    # didn't match any of the magic substrings.
+    # -- Generic-chat (OpenAI-compat) interleaved thinking --------------------
+    # The Anthropic branch above handles ``anthropic_messages`` transport.
+    # Everything else that exposes thinking as a single boolean in extra_body
+    # (Alibaba DashScope, ThreatBook, Moonshot, Zhipu/GLM, MiniMax, Stepfun,
+    # DeepSeek, generic openai-compatible user-configured endpoints) sits on
+    # the ``generic_chat`` transport, and the wire format is identical —
+    # ``extra_body.enable_thinking``.  No per-provider dispatch needed.
     #
-    # The shape fires whenever the catalog says interleaved, even when the
-    # caller passed ``reasoning_enabled=False`` — that produces
-    # ``enable_thinking: false`` so the upstream API gets an explicit opt-out
-    # (the prior token-matching branch did the same).
-    elif interleaved_enabled:
-        shape_fn = _THINKING_REQUEST_SHAPES.get(provider_id)
-        if shape_fn is not None:
-            extra_body = shape_fn(model_id, reasoning_enabled)
-            if extra_body:
-                options["extra_body"] = extra_body
-                log.debug("options.thinking_params.resolved", {
-                    "provider_id": provider_id,
-                    "model_id": model_id,
-                    "extra_body_keys": list(extra_body.keys()),
-                })
+    # The gate is the resolved ``interleaved_capability``: catalog explicit
+    # declaration wins, with the series-token inference in
+    # ``interleaved.infer_interleaved_capability`` as fallback.  This means a
+    # new model from a known family (qwen*, glm-*, kimi-k2*, deepseek-v4*,
+    # step-3.5*, minimax-m*, …) Just Works without anyone editing the
+    # dispatch — the prior hard-coded token whitelist that silently dropped
+    # GLM-5 / minimax / deepseek / stepfun is gone, and so is the
+    # provider-keyed shape registry that replaced it (every entry produced
+    # the same dict).
+    elif (
+        interleaved_enabled
+        and reasoning_transport == REASONING_TRANSPORT_GENERIC_CHAT
+    ):
+        options["extra_body"] = {
+            "enable_thinking": True if reasoning_enabled is not False else False,
+        }
+        log.debug("options.thinking_params.resolved", {
+            "provider_id": provider_id,
+            "model_id": model_id,
+            "extra_body_keys": list(options["extra_body"].keys()),
+        })
 
     # -- max_tokens fallback from model config ------------------------------
     if resolve_max_tokens and "max_tokens" not in options:

--- a/flocks/provider/sdk/openai_compatible.py
+++ b/flocks/provider/sdk/openai_compatible.py
@@ -182,19 +182,24 @@ class OpenAICompatibleProvider(BaseProvider):
         max_tokens = kwargs.get("max_tokens")
         tools = kwargs.get("tools")
         thinking = kwargs.get("thinking")
-        
+
         # Make request
         request_params = {
             "model": model_id,
             "messages": formatted_messages,
         }
 
+        # See the streaming chat_stream() counterpart for the rationale; the
+        # non-streaming path had the same extra_body-swallow bug.
+        extra_body = dict(kwargs.get("extra_body") or {})
         if thinking:
-            request_params["extra_body"] = {"thinking": thinking}
+            extra_body["thinking"] = thinking
         else:
             temperature = kwargs.get("temperature")
             if temperature is not None:
                 request_params["temperature"] = temperature
+        if extra_body:
+            request_params["extra_body"] = extra_body
         
         if max_tokens:
             request_params["max_tokens"] = max_tokens
@@ -242,7 +247,7 @@ class OpenAICompatibleProvider(BaseProvider):
         max_tokens = kwargs.get("max_tokens")
         tools = kwargs.get("tools")
         thinking = kwargs.get("thinking")
-        
+
         # Make streaming request
         request_params = {
             "model": model_id,
@@ -251,12 +256,23 @@ class OpenAICompatibleProvider(BaseProvider):
             "stream_options": {"include_usage": True},
         }
 
+        # extra_body assembly: mirror openai_base.py:905-913.  Caller-supplied
+        # extra_body (e.g. ``enable_thinking`` produced by
+        # ``build_provider_options`` for DashScope-style endpoints) MUST be
+        # forwarded — the old code dropped it whenever ``thinking`` was None,
+        # silently disabling thinking for user-configured openai-compatible
+        # endpoints that set ``default_parameters.enable_thinking`` in
+        # flocks.json.  ``thinking`` is merged in last so it can override a
+        # caller-supplied extra_body.thinking if both are set.
+        extra_body = dict(kwargs.get("extra_body") or {})
         if thinking:
-            request_params["extra_body"] = {"thinking": thinking}
+            extra_body["thinking"] = thinking
         else:
             temperature = kwargs.get("temperature")
             if temperature is not None:
                 request_params["temperature"] = temperature
+        if extra_body:
+            request_params["extra_body"] = extra_body
         
         if max_tokens:
             request_params["max_tokens"] = max_tokens

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -1103,8 +1103,20 @@ class SessionRunner:
         
         # Convert messages to chat format with error handling
         try:
+            queued_user_message_ids = self._get_queued_user_message_ids(messages)
+            if queued_user_message_ids:
+                self._invalidate_chat_context_cache()
+            previous_queued_user_ids = getattr(self, "_queued_user_message_ids", None)
+            self._queued_user_message_ids = queued_user_message_ids
             chat_messages_started_at = time.perf_counter()
-            chat_messages = await self._to_chat_messages(messages, system_prompts)
+            try:
+                chat_messages = await self._to_chat_messages(messages, system_prompts)
+            finally:
+                if previous_queued_user_ids is None:
+                    if hasattr(self, "_queued_user_message_ids"):
+                        delattr(self, "_queued_user_message_ids")
+                else:
+                    self._queued_user_message_ids = previous_queued_user_ids
             self._log_perf(
                 "runner.process_step.chat_messages_ready",
                 chat_messages_started_at,
@@ -1140,67 +1152,6 @@ class SessionRunner:
                     "step": self._step,
                     "session_id": self.session.id,
                 })
-        
-        # Add reminder wrapping for queued user messages (matching Flocks logic)
-        # This reminds the AI to address new user messages while continuing tasks
-        if self._step > 1:
-            # Find last finished assistant message
-            last_finished = None
-            for msg in reversed(messages):
-                if msg.role == MessageRole.ASSISTANT and hasattr(msg, 'finish') and msg.finish:
-                    if msg.finish not in ("tool-calls", "unknown"):
-                        last_finished = msg
-                        break
-            
-            # Wrap queued user messages with reminder
-            if last_finished:
-                from flocks.session.prompt_strings import SYNTHETIC_MESSAGE_MARKERS
-                for chat_msg in chat_messages:
-                    if chat_msg.role != "user":
-                        continue
-
-                    content = chat_msg.content
-
-                    if isinstance(content, str):
-                        if any(marker in content for marker in SYNTHETIC_MESSAGE_MARKERS):
-                            continue
-                        chat_msg.content = (
-                            "<system-reminder>\n"
-                            "The user sent the following message:\n"
-                            f"{content}\n\n"
-                            "Please address this message and continue with your tasks.\n"
-                            "</system-reminder>"
-                        )
-                    elif isinstance(content, list):
-                        # Multimodal user content (e.g. image_url blocks).
-                        # Naively f-stringing the whole list would call
-                        # ``str(list)`` and serialize every image block — base64
-                        # data and all — into plain text, which both blows up
-                        # the token count AND makes vision-capable models
-                        # respond with "I see only base64 text". Wrap *only*
-                        # the first text block instead, leaving image blocks
-                        # untouched. If there is no text block at all (rare —
-                        # an image-only turn), skip wrapping entirely.
-                        first_text_idx: Optional[int] = None
-                        for idx, block in enumerate(content):
-                            if isinstance(block, dict) and block.get("type") == "text":
-                                first_text_idx = idx
-                                break
-                        if first_text_idx is None:
-                            continue
-                        text_val = content[first_text_idx].get("text") or ""
-                        if any(marker in text_val for marker in SYNTHETIC_MESSAGE_MARKERS):
-                            continue
-                        content[first_text_idx] = {
-                            "type": "text",
-                            "text": (
-                                "<system-reminder>\n"
-                                "The user sent the following message:\n"
-                                f"{text_val}\n\n"
-                                "Please address this message and continue with your tasks.\n"
-                                "</system-reminder>"
-                            ),
-                        }
         
         # Add max steps warning if this is the last step (matching Flocks)
         if is_last_step:
@@ -1274,6 +1225,20 @@ class SessionRunner:
                     agent=agent,
                     assistant_msg=assistant_msg,
                 )
+
+                if getattr(self, "_llm_call_aborted", False):
+                    await Message.update(
+                        self.session.id,
+                        assistant_msg.id,
+                        error=self._build_message_aborted_error(),
+                        finish="error",
+                    )
+                    await self._record_usage_if_available(result.usage, message_id=assistant_msg.id)
+                    return StepResult(
+                        action="stop",
+                        content=result.content,
+                        usage=result.usage,
+                    )
 
                 # Detect empty response: some models (e.g. MiniMax) occasionally
                 # return 0 chunks with finish_reason=stop after tool execution,
@@ -1889,6 +1854,90 @@ class SessionRunner:
         )
 
     @staticmethod
+    def _build_message_aborted_error() -> Dict[str, Any]:
+        message = "Message generation was interrupted before completion."
+        return {
+            "name": "MessageAbortedError",
+            "message": message,
+            "data": {
+                "message": message,
+            },
+        }
+
+    @staticmethod
+    def _message_role_value(msg: MessageInfo) -> Optional[str]:
+        return msg.role if isinstance(msg.role, str) else getattr(msg.role, "value", None)
+
+    def _get_queued_user_message_ids(
+        self,
+        messages: List[MessageInfo],
+    ) -> set[str]:
+        if self._step <= 1:
+            return set()
+
+        last_finished_index: Optional[int] = None
+        for idx, msg in enumerate(messages):
+            role = self._message_role_value(msg)
+            finish = getattr(msg, "finish", None)
+            if role == "assistant" and finish and finish not in ("tool-calls", "unknown"):
+                last_finished_index = idx
+
+        if last_finished_index is None:
+            return set()
+
+        queued_user_ids: set[str] = set()
+        seen_turn_root_user = False
+        for msg in messages[last_finished_index + 1:]:
+            if self._message_role_value(msg) != "user":
+                continue
+            if not seen_turn_root_user:
+                seen_turn_root_user = True
+                continue
+            queued_user_ids.add(msg.id)
+        return queued_user_ids
+
+    def _invalidate_chat_context_cache(self) -> None:
+        self._static_cache.pop("chat_context_cache", None)
+
+    @staticmethod
+    def _wrap_queued_user_text(content: str) -> str:
+        from flocks.session.prompt_strings import SYNTHETIC_MESSAGE_MARKERS
+
+        if not content or any(marker in content for marker in SYNTHETIC_MESSAGE_MARKERS):
+            return content
+        return (
+            "<system-reminder>\n"
+            "The user sent the following message:\n"
+            f"{content}\n\n"
+            "Please address this message and continue with your tasks.\n"
+            "</system-reminder>"
+        )
+
+    def _wrap_queued_user_blocks(
+        self,
+        blocks: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        first_text_idx: Optional[int] = None
+        for idx, block in enumerate(blocks):
+            if isinstance(block, dict) and block.get("type") == "text":
+                first_text_idx = idx
+                break
+        if first_text_idx is None:
+            return blocks
+
+        text_val = blocks[first_text_idx].get("text") or ""
+        wrapped_text = self._wrap_queued_user_text(text_val)
+        if wrapped_text == text_val:
+            return blocks
+
+        wrapped_blocks = copy.deepcopy(blocks)
+        wrapped_blocks[first_text_idx] = {
+            "type": "text",
+            "text": wrapped_text,
+        }
+        return wrapped_blocks
+
+    @staticmethod
     def _clone_cached_chat_messages(payloads: List[Dict[str, Any]]) -> List[ChatMessage]:
         return [ChatMessage.model_validate(copy.deepcopy(payload)) for payload in payloads]
 
@@ -1975,6 +2024,7 @@ class SessionRunner:
         ctx_window_tokens = self._get_context_window_tokens()
         tool_result_refs: List[Dict[str, Any]] = []
         turn_index = 0
+        queued_user_message_ids: set[str] = set(getattr(self, "_queued_user_message_ids", set()) or set())
         active_model = Provider.resolve_model(self.provider_id, self.model_id)
         active_interleaved = (
             getattr(active_model.capabilities, "interleaved", None)
@@ -2047,7 +2097,8 @@ class SessionRunner:
         for idx, msg in enumerate(messages):
             if idx < resume_message_index:
                 continue
-            if msg.role == MessageRole.USER or (isinstance(msg.role, str) and msg.role == "user"):
+            role = msg.role if isinstance(msg.role, str) else msg.role.value
+            if role == "user":
                 turn_index += 1
             is_latest_user_turn = msg.id == last_user_msg_id
             # Get message parts
@@ -2057,14 +2108,18 @@ class SessionRunner:
                 # Fallback: use text content only
                 content = await Message.get_text_content(msg)
                 if content.strip():
+                    normalized_content = _expand_workflow_node_ref(content)
+                    if role == "user" and msg.id in queued_user_message_ids:
+                        normalized_content = self._wrap_queued_user_text(normalized_content)
                     chat_messages.append(ChatMessage(
-                        role=msg.role if isinstance(msg.role, str) else msg.role.value,
-                        content=_expand_workflow_node_ref(content),
+                        role=role,
+                        content=normalized_content,
                     ))
                 continue
             
             # Build message content from parts
             if msg.role == MessageRole.USER or (isinstance(msg.role, str) and msg.role == "user"):
+                is_queued_user_turn = msg.id in queued_user_message_ids
                 user_content_parts = []
                 user_content_blocks: list[dict[str, Any]] = []
                 for part in parts:
@@ -2123,14 +2178,19 @@ class SessionRunner:
                     block.get("type") == "image"
                     for block in user_content_blocks
                 ):
+                    if is_queued_user_turn:
+                        user_content_blocks = self._wrap_queued_user_blocks(user_content_blocks)
                     chat_messages.append(ChatMessage(
                         role="user",
                         content=user_content_blocks,
                     ))
                 elif user_content_parts:
+                    user_text = "\n\n".join(user_content_parts)
+                    if is_queued_user_turn:
+                        user_text = self._wrap_queued_user_text(user_text)
                     chat_messages.append(ChatMessage(
                         role="user",
-                        content="\n\n".join(user_content_parts),
+                        content=user_text,
                     ))
             
             elif msg.role == MessageRole.ASSISTANT or (isinstance(msg.role, str) and msg.role == "assistant"):
@@ -2575,6 +2635,7 @@ class SessionRunner:
         }
         llm_before_enabled = False
         llm_after_enabled = False
+        self._llm_call_aborted = False
         try:
             llm_before_enabled = await HookPipeline.has_stage_handlers(
                 HookStage.LLM_BEFORE,
@@ -2613,6 +2674,7 @@ class SessionRunner:
 
         llm_call_started_at = time.perf_counter()
         first_chunk_logged = False
+        aborted_during_stream = False
         try:
             async for chunk in _iter_with_chunk_timeout(
                 provider.chat_stream(
@@ -2649,6 +2711,7 @@ class SessionRunner:
                 
                 # Check for abort
                 if self.is_aborted:
+                    aborted_during_stream = True
                     break
                 
                 # Determine event type from chunk.  A single chunk may carry any
@@ -2850,6 +2913,7 @@ class SessionRunner:
                 assistant_msg.id,
                 content=content,
             )
+        self._llm_call_aborted = aborted_during_stream
         
         # Note: Tools were already executed synchronously during streaming
         # Build tool call list for result

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -225,8 +225,8 @@ class TestCuratedCatalogModels:
         m3 = next(m for m in models if m.id == "minimax-m3")
         assert m3.capabilities.supports_reasoning is True
         assert m3.capabilities.interleaved["field"] == "reasoning_details"
-        assert m3.limits.context_window == 512000
-        assert m3.limits.max_output_tokens == 512000
+        assert m3.limits.context_window == 1000000
+        assert m3.limits.max_output_tokens == 128000
         m27 = next(m for m in models if m.id == "minimax-m2.7")
         assert m27.capabilities.supports_reasoning is True
         assert m27.capabilities.interleaved["field"] == "reasoning_details"
@@ -253,6 +253,7 @@ class TestCuratedCatalogModels:
         assert get_provider_default_url("threatbook-cn-llm") == "https://llm.threatbook.cn/v1"
         models = get_provider_model_definitions("threatbook-cn-llm")
         assert {m.id for m in models} == {
+            "minimax-m3",
             "minimax-m2.7",
             "minimax-m2.5",
             "GLM-5",
@@ -269,8 +270,8 @@ class TestCuratedCatalogModels:
         assert flash_cn.pricing.input == 1.0
         assert flash_cn.pricing.output == 2.0
         assert flash_cn.pricing.currency == "CNY"
-        assert flash_cn.limits.context_window == 200000
-        assert flash_cn.limits.max_output_tokens == 128000
+        assert flash_cn.limits.context_window == 1000000
+        assert flash_cn.limits.max_output_tokens == 384000
 
         kimi = next(m for m in models if m.id == "kimi-k2.6")
         assert kimi.capabilities.supports_vision is True
@@ -291,6 +292,7 @@ class TestCuratedCatalogModels:
         assert get_provider_default_url("threatbook-io-llm") == "https://llm.threatbook.io/v1"
         models = get_provider_model_definitions("threatbook-io-llm")
         assert {m.id for m in models} == {
+            "minimax-m3",
             "minimax-m2.7",
             "minimax-m2.5",
             "GLM-5",
@@ -306,8 +308,8 @@ class TestCuratedCatalogModels:
         assert flash_io.pricing.input == 1.0
         assert flash_io.pricing.output == 2.0
         assert flash_io.pricing.currency == "CNY"
-        assert flash_io.limits.context_window == 200000
-        assert flash_io.limits.max_output_tokens == 128000
+        assert flash_io.limits.context_window == 1000000
+        assert flash_io.limits.max_output_tokens == 384000
 
         m27 = next(m for m in models if m.id == "minimax-m2.7")
         assert m27.capabilities.interleaved["field"] == "reasoning_details"

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -143,6 +143,8 @@ class TestCuratedCatalogModels:
         assert {m.id for m in models} == {
             "deepseek-chat",
             "deepseek-reasoner",
+            "deepseek-v4-flash",
+            "deepseek-v4-pro",
         }
 
         r1 = next(m for m in models if m.id == "deepseek-reasoner")
@@ -151,6 +153,14 @@ class TestCuratedCatalogModels:
         assert r1.capabilities.interleaved["placeholder"] == " "
         assert r1.pricing.currency == "CNY"
         assert r1.pricing.output == 16.0
+
+        v4_flash = next(m for m in models if m.id == "deepseek-v4-flash")
+        assert v4_flash.capabilities.supports_reasoning is True
+        assert v4_flash.capabilities.interleaved["field"] == "reasoning_content"
+
+        v4_pro = next(m for m in models if m.id == "deepseek-v4-pro")
+        assert v4_pro.capabilities.supports_reasoning is True
+        assert v4_pro.capabilities.interleaved["field"] == "reasoning_content"
 
     def test_alibaba_catalog(self):
         models = get_provider_model_definitions("alibaba")

--- a/tests/provider/test_provider.py
+++ b/tests/provider/test_provider.py
@@ -159,22 +159,35 @@ def test_resolve_model_infers_interleaved_for_runtime_discovered_reasoning_model
 
 
 def test_resolve_model_does_not_infer_interleaved_for_non_reasoning_model(monkeypatch):
+    """A model whose id does NOT match any series token in
+    ``infer_interleaved_capability`` and has no catalog ``interleaved`` should
+    stay non-reasoning — the series-token inference must not fabricate a
+    capability for it.
+
+    Uses ``gpt-4-turbo`` as the model id: it is not in any of the
+    ``_PROMOTE_REASONING_CONTENT_TOKENS`` / ``_STRICT_REASONING_CONTENT_TOKENS``
+    lists, the provider id ``custom-demo`` does not match any of the
+    special-case provider prefixes, and the base_url does not match any of
+    the provider-hosting hints.  Previously this test used ``deepseek-chat``;
+    that no longer qualifies because the entire deepseek series is now
+    considered thinking-capable per the catalog-driven dispatch design.
+    """
     provider_model = SimpleNamespace(
-        id="deepseek-chat",
+        id="gpt-4-turbo",
         capabilities=SimpleNamespace(interleaved=None),
     )
     fake_provider = SimpleNamespace(
         get_model_definitions=lambda: [provider_model],
         get_models=lambda: [],
         _config_models=[],
-        _config=SimpleNamespace(base_url="https://api.deepseek.com/v1"),
+        _config=SimpleNamespace(base_url="https://api.openai.com/v1"),
     )
 
     monkeypatch.setattr(Provider, "_initialized", True)
     monkeypatch.setattr(Provider, "_providers", {"custom-demo": fake_provider})
     monkeypatch.setattr(Provider, "_models", {})
 
-    resolved = Provider.resolve_model("custom-demo", "deepseek-chat")
+    resolved = Provider.resolve_model("custom-demo", "gpt-4-turbo")
 
     assert resolved is provider_model
     assert resolved.capabilities.interleaved is None

--- a/tests/provider/test_provider.py
+++ b/tests/provider/test_provider.py
@@ -168,9 +168,7 @@ def test_resolve_model_does_not_infer_interleaved_for_non_reasoning_model(monkey
     ``_PROMOTE_REASONING_CONTENT_TOKENS`` / ``_STRICT_REASONING_CONTENT_TOKENS``
     lists, the provider id ``custom-demo`` does not match any of the
     special-case provider prefixes, and the base_url does not match any of
-    the provider-hosting hints.  Previously this test used ``deepseek-chat``;
-    that no longer qualifies because the entire deepseek series is now
-    considered thinking-capable per the catalog-driven dispatch design.
+    the provider-hosting hints.
     """
     provider_model = SimpleNamespace(
         id="gpt-4-turbo",

--- a/tests/provider/test_provider_options.py
+++ b/tests/provider/test_provider_options.py
@@ -4,6 +4,11 @@ from flocks.provider.interleaved import (
     REASONING_TRANSPORT_GENERIC_CHAT,
 )
 
+DEEPSEEK_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
+GLM_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled", "clear_thinking": False}}
+KIMI_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
+MIMO_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
+
 
 class TestBuildProviderOptions:
     def test_claude_reasoning_can_be_disabled(self):
@@ -35,23 +40,23 @@ class TestBuildProviderOptions:
 
         assert options["extra_body"]["enable_thinking"] is False
 
-    def test_threatbook_kimi_hybrid_models_enable_thinking_by_default(self):
+    def test_threatbook_kimi_hybrid_models_use_official_thinking_payload(self):
         options = provider_options.build_provider_options(
             "threatbook-cn-llm",
             "kimi-k2.6",
             resolve_max_tokens=False,
         )
 
-        assert options["extra_body"]["enable_thinking"] is True
+        assert options["extra_body"] == KIMI_THINKING_EXTRA_BODY
 
-    def test_moonshot_kimi_hybrid_models_enable_thinking_by_default(self):
+    def test_moonshot_kimi_hybrid_models_use_official_thinking_payload(self):
         options = provider_options.build_provider_options(
             "moonshot",
             "kimi-k2.6",
             resolve_max_tokens=False,
         )
 
-        assert options["extra_body"]["enable_thinking"] is True
+        assert options["extra_body"] == KIMI_THINKING_EXTRA_BODY
 
     def test_openai_compatible_qwen_models_enable_thinking_by_default(self, monkeypatch):
         monkeypatch.setattr(
@@ -72,7 +77,7 @@ class TestBuildProviderOptions:
 
         assert options["extra_body"]["enable_thinking"] is True
 
-    def test_openai_compatible_kimi_models_enable_thinking_by_default(self, monkeypatch):
+    def test_openai_compatible_kimi_models_use_official_thinking_payload(self, monkeypatch):
         monkeypatch.setattr(
             provider_options,
             "_resolve_interleaved_capability",
@@ -90,7 +95,129 @@ class TestBuildProviderOptions:
             resolve_max_tokens=False,
         )
 
-        assert options["extra_body"]["enable_thinking"] is True
+        assert options["extra_body"] == KIMI_THINKING_EXTRA_BODY
+
+    def test_minimax_models_use_reasoning_split(self, monkeypatch):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args: {
+                "field": "reasoning_details",
+                "echo": "tool_calls",
+                "cross_provider_policy": "promote",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            "minimax",
+            "minimax-m3",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {"reasoning_split": True}
+
+    def test_deepseek_models_use_official_thinking_payload(self, monkeypatch):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args: {
+                "field": "reasoning_content",
+                "echo": "tool_calls",
+                "placeholder": " ",
+                "cross_provider_policy": "placeholder",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            "deepseek",
+            "deepseek-v4-pro",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == DEEPSEEK_THINKING_EXTRA_BODY
+
+    def test_deepseek_models_emit_disabled_thinking_when_reasoning_disabled(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args: {
+                "field": "reasoning_content",
+                "echo": "tool_calls",
+                "placeholder": " ",
+                "cross_provider_policy": "placeholder",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            "deepseek",
+            "deepseek-v4-pro",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_glm_models_use_official_thinking_payload(self, monkeypatch):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args: {
+                "field": "reasoning_content",
+                "echo": "tool_calls",
+                "cross_provider_policy": "promote",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            "zhipu",
+            "glm-4.7",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == GLM_THINKING_EXTRA_BODY
+
+    def test_glm_models_emit_disabled_thinking_when_reasoning_disabled(self, monkeypatch):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args: {
+                "field": "reasoning_content",
+                "echo": "tool_calls",
+                "cross_provider_policy": "promote",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            "zhipu",
+            "glm-4.7",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {"thinking": {"type": "disabled"}}
+
+    def test_mimo_models_use_official_thinking_payload(self, monkeypatch):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args: {
+                "field": "reasoning_content",
+                "echo": "tool_calls",
+                "placeholder": " ",
+                "cross_provider_policy": "placeholder",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            "openai-compatible",
+            "mimo-v2.5-pro",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == MIMO_THINKING_EXTRA_BODY
 
     def test_claude_thinking_depends_on_transport_not_capability(self, monkeypatch):
         monkeypatch.setattr(
@@ -148,7 +275,17 @@ class TestBuildProviderOptions:
             resolve_max_tokens=False,
         )
 
-        assert options["extra_body"]["enable_thinking"] is True
+        assert options["extra_body"] == KIMI_THINKING_EXTRA_BODY
+
+    def test_kimi_hybrid_models_emit_disabled_thinking_when_reasoning_disabled(self):
+        options = provider_options.build_provider_options(
+            "threatbook-cn-llm",
+            "kimi-k2.5",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {"thinking": {"type": "disabled"}}
 
     def test_model_setting_enable_thinking_is_applied(self, monkeypatch):
         monkeypatch.setattr(provider_options, "_resolve_reasoning_enabled", lambda *_args: True)
@@ -159,7 +296,24 @@ class TestBuildProviderOptions:
             resolve_max_tokens=False,
         )
 
-        assert options["extra_body"]["enable_thinking"] is True
+        assert options["extra_body"] == KIMI_THINKING_EXTRA_BODY
+
+    def test_model_setting_enable_thinking_applies_without_interleaved(self, monkeypatch):
+        monkeypatch.setattr(provider_options, "_resolve_reasoning_enabled", lambda *_args: True)
+        monkeypatch.setattr(provider_options, "_resolve_interleaved_capability", lambda *_args: None)
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_reasoning_transport",
+            lambda *_args: REASONING_TRANSPORT_GENERIC_CHAT,
+        )
+
+        options = provider_options.build_provider_options(
+            "openai-compatible",
+            "custom-thinking-model",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {"enable_thinking": True}
 
     def test_openai_reasoning_can_be_disabled(self):
         options = provider_options.build_provider_options(

--- a/tests/provider/test_thinking_params.py
+++ b/tests/provider/test_thinking_params.py
@@ -265,47 +265,42 @@ class TestDispatchShape:
             "interleaved just emits extra_body.enable_thinking inline"
         )
 
-    def test_deepseek_v3_is_not_a_thinking_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``deepseek-chat`` (V3) has no ``interleaved`` capability in the
-        catalog and must not receive ``enable_thinking`` on the wire.
+    def test_deepseek_v3_is_a_thinking_model(self) -> None:
+        """``deepseek-chat`` (V3) is auto-enabled as a thinking model via the
+        ``deepseek`` series-token in ``_STRICT_REASONING_CONTENT_TOKENS``,
+        even though the catalog does not declare ``interleaved`` for it.
 
-        This is the regression net for the prior
-        ``_deepseek_thinking_shape`` model-name branching.  Catalog is the
-        primary source of truth: V3 stays non-thinking because the catalog
-        says so, and the series-token inference in ``interleaved.py`` also
-        does not include V3 in its tokens (only ``deepseek-v4`` family and
-        ``deepseek-reasoner``/``deepseek-r1``).  If a future catalog change
-        adds ``interleaved`` to V3, this test should be removed and the
-        model will then exercise the regular positive path.
+        Per the "deepseek 系列 全部" design decision, every DeepSeek series
+        is treated as thinking-capable by default.  V3 is the last holdout —
+        previously kept non-thinking because the series token wasn't broad
+        enough to match ``deepseek-chat``.  Now that ``deepseek`` is in the
+        tokens, V3 picks up ``enable_thinking: true`` automatically.
+
+        This test exercises the real chain (no monkeypatch) so it pins both:
+        1. The catalog gate is silent for V3 (no ``interleaved`` field).
+        2. The series-token inference fills the gap.
         """
-        # Sanity-check the assumption: catalog must not declare V3 as interleaved.
+        # Sanity-check: V3 has no catalog declaration.  If someone adds
+        # ``interleaved`` to the catalog later, that path will take over and
+        # the test will still pass — the assertion is just a "this is the
+        # current shape" guard.
         catalog = model_catalog.get_raw_catalog()
-        deepseek_models = catalog.get("deepseek", {}).get("models", {})
-        v3_models = {
-            mid: m for mid, m in deepseek_models.items()
-            if m.get("family", "").startswith("deepseek-v3")
-        }
-        assert v3_models, "expected at least one deepseek-v3 family model in catalog"
-        for mid, m in v3_models.items():
-            assert m.get("capabilities", {}).get("interleaved") is None, (
-                f"deepseek/{mid} now declares interleaved — remove this test "
-                "and let the catalog coverage test exercise it instead"
-            )
-
-        # Dispatcher must produce no enable_thinking flag for a V3 model.
-        monkeypatch.setattr(
-            provider_options,
-            "_resolve_interleaved_capability",
-            lambda *_args, **_kw: None,  # V3 has no interleaved in catalog
+        v3_entry = catalog.get("deepseek", {}).get("models", {}).get("deepseek-chat")
+        assert v3_entry is not None, "deepseek-chat missing from catalog"
+        assert v3_entry.get("capabilities", {}).get("interleaved") is None, (
+            "deepseek-chat now declares interleaved in catalog — remove the "
+            "series-token assertion and let the catalog coverage test pin it"
         )
+
+        # Real chain: catalog silent → series-token inference fires →
+        # dispatch emits enable_thinking.
         options = provider_options.build_provider_options(
             "deepseek", "deepseek-chat", resolve_max_tokens=False,
         )
-        assert "extra_body" not in options or not options["extra_body"].get(
-            "enable_thinking"
-        ), (
-            f"deepseek-chat is V3 (non-thinking in catalog) but dispatcher "
-            f"emitted enable_thinking — catalog gate is broken. options={options!r}"
+        assert options.get("extra_body", {}).get("enable_thinking") is True, (
+            f"deepseek-chat is a deepseek-series model; the 'deepseek' token "
+            f"in _STRICT_REASONING_CONTENT_TOKENS should have inferred it as "
+            f"thinking and emitted enable_thinking. options={options!r}"
         )
 
     def test_explicit_reasoning_toggle_propagates(self) -> None:

--- a/tests/provider/test_thinking_params.py
+++ b/tests/provider/test_thinking_params.py
@@ -1,5 +1,5 @@
 """
-Regression net for catalog-driven thinking-params dispatch.
+Regression net for transport-driven thinking-params dispatch.
 
 Background
 ----------
@@ -13,18 +13,30 @@ thinking flag, causing the upstream API to short-circuit with
 "agent stopped, please say 'continue'" symptom seen in
 ``ses_1628dfe6cffe1i5xZY9lv1u20m``.
 
-The new dispatch uses the catalog's ``interleaved`` capability as the single
-gate, and looks up a per-provider request shape.  These tests verify three
-properties of the new path:
+The new dispatch is transport-driven:
+
+  - ``reasoning_transport == anthropic_messages``  →  ``thinking={type: "enabled", budget_tokens:...}``
+  - ``reasoning_transport == generic_chat``        →  ``extra_body.enable_thinking: bool``
+
+The gate is the resolved ``interleaved_capability``: catalog explicit
+declaration wins, with the series-token inference in
+``interleaved.infer_interleaved_capability`` (qwen3 / glm-* / kimi-k2* /
+deepseek-v4* / step-3.5* / minimax-m* / …) as the fallback.  Adding a new
+provider or a new model from a known family needs zero dispatcher changes.
+
+These tests verify four properties of the new path:
 
 1. Every (provider, model) pair with ``interleaved != null`` in catalog.json
-   produces a non-empty ``extra_body`` (or its non-OpenAI-compat equivalent
-   like ``thinking``).  This is the systematic regression net — any new model
-   added to the catalog with interleaved thinking will be covered.
+   produces a non-empty thinking signal (extra_body or thinking=).  This is
+   the systematic regression net — any new model added to the catalog with
+   interleaved thinking will be covered.
 2. The specific GLM-5 / alibaba configuration that triggered the original
    trace bug now emits the right flag.
 3. The ``openai_compatible`` provider no longer swallows caller-supplied
    ``extra_body`` in its chat_stream() path.
+4. A model not in catalog but matching a known series token still gets the
+   flag — the series-token fallback closes the "I forgot to add the model
+   to catalog" gap.
 """
 
 from __future__ import annotations
@@ -67,29 +79,22 @@ def _iter_interleaved_catalog_entries() -> Iterator[Tuple[str, str]]:
                 yield provider_id, model_id
 
 
-# Catalog can grow between releases; skip providers that aren't wired into
-# ``_THINKING_REQUEST_SHAPES`` (e.g. legacy entries that pre-date the
-# catalog-driven dispatch).  The point of this test is to catch MISSING
-# entries, not to police old ones.
-_SHAPED_PROVIDER_IDS = frozenset(provider_options._THINKING_REQUEST_SHAPES.keys())
-
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
 
 class TestCatalogInterleavedCoverage:
-    """Property test: every interleaved catalog entry resolves to a thinking flag."""
+    """Property test: every interleaved catalog entry resolves to a thinking flag.
+
+    The dispatch is now transport-driven, not provider-driven — every
+    interleaved catalog entry should land in *some* thinking signal.  The
+    series-token fallback (in ``interleaved.infer_interleaved_capability``)
+    is exercised by a separate test below.
+    """
 
     @pytest.mark.parametrize("provider_id,model_id", list(_iter_interleaved_catalog_entries()))
     def test_interleaved_model_gets_thinking_flag(self, provider_id: str, model_id: str) -> None:
-        if provider_id not in _SHAPED_PROVIDER_IDS:
-            pytest.skip(
-                f"provider {provider_id!r} not in _THINKING_REQUEST_SHAPES — "
-                "add a shape entry or remove interleaved from this catalog entry"
-            )
-
         # Patch the interleaved capability so the dispatch gate fires
         # regardless of the test environment's catalog resolution path.
         original = provider_options._resolve_interleaved_capability
@@ -226,8 +231,16 @@ class TestGLM5TraceReplay:
         )
 
 
-class TestShapeRegistry:
-    """Sanity checks on the shapes dict itself."""
+class TestDispatchShape:
+    """Sanity checks on the dispatch itself now that the
+    provider-keyed shape registry is gone.
+
+    The dispatch is now transport-driven: ``anthropic_messages`` →
+    ``thinking={type: "enabled", ...}``; ``generic_chat`` →
+    ``extra_body.enable_thinking``.  Catalog explicit declaration wins,
+    with the series-token inference in ``interleaved.infer_interleaved_capability``
+    as fallback for any model the catalog forgot to declare.
+    """
 
     def test_no_legacy_token_constant(self) -> None:
         """The token-substring whitelist must be gone — that was the bug surface."""
@@ -238,39 +251,32 @@ class TestShapeRegistry:
             "interleaved field is now the only trigger"
         )
 
-    def test_all_thinking_providers_have_a_shape(self) -> None:
-        """Every provider that the audit flagged as having reasoning models
-        should have an entry in the shapes dict.
-
-        Catalog providers with interleaved models: alibaba, threatbook-cn-llm,
-        threatbook-io-llm, moonshot, zhipu, deepseek, minimax, stepfun, plus
-        the generic ``openai-compatible`` for user-configured endpoints.
+    def test_no_shape_registry(self) -> None:
+        """The provider-keyed shape registry is gone — every entry produced
+        the same dict, so the indirection wasn't earning its keep.  Wire format
+        is now decided by ``reasoning_transport`` alone.
         """
-        expected = {
-            "alibaba",
-            "threatbook-cn-llm",
-            "threatbook-io-llm",
-            "moonshot",
-            "zhipu",
-            "deepseek",
-            "minimax",
-            "stepfun",
-            "openai-compatible",
-        }
-        actual = set(provider_options._THINKING_REQUEST_SHAPES.keys())
-        missing = expected - actual
-        assert not missing, f"missing thinking shape for: {sorted(missing)}"
+        assert not hasattr(provider_options, "_THINKING_REQUEST_SHAPES"), (
+            "_THINKING_REQUEST_SHAPES should be removed; dispatch is now "
+            "transport-driven, not provider-driven"
+        )
+        assert not hasattr(provider_options, "_openai_base_thinking_shape"), (
+            "_openai_base_thinking_shape should be removed; generic_chat "
+            "interleaved just emits extra_body.enable_thinking inline"
+        )
 
     def test_deepseek_v3_is_not_a_thinking_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``deepseek-chat`` (V3) has no ``interleaved`` capability in the
         catalog and must not receive ``enable_thinking`` on the wire.
 
         This is the regression net for the prior
-        ``_deepseek_thinking_shape`` model-name branching.  Catalog is now
-        the only source of truth: V3 stays non-thinking because the catalog
-        says so, not because the dispatcher strips it.  If a future catalog
-        change adds ``interleaved`` to V3, this test should be removed and
-        the model will then exercise the regular positive path.
+        ``_deepseek_thinking_shape`` model-name branching.  Catalog is the
+        primary source of truth: V3 stays non-thinking because the catalog
+        says so, and the series-token inference in ``interleaved.py`` also
+        does not include V3 in its tokens (only ``deepseek-v4`` family and
+        ``deepseek-reasoner``/``deepseek-r1``).  If a future catalog change
+        adds ``interleaved`` to V3, this test should be removed and the
+        model will then exercise the regular positive path.
         """
         # Sanity-check the assumption: catalog must not declare V3 as interleaved.
         catalog = model_catalog.get_raw_catalog()
@@ -304,7 +310,7 @@ class TestShapeRegistry:
 
     def test_explicit_reasoning_toggle_propagates(self) -> None:
         """``reasoning_enabled=False`` should produce ``enable_thinking: false``
-        on a shaped provider, mirroring the old token-matching branch's
+        on a generic_chat transport, mirroring the old token-matching branch's
         behavior so the upstream API gets an explicit opt-out signal.
         """
         options = provider_options.build_provider_options(
@@ -314,6 +320,74 @@ class TestShapeRegistry:
             resolve_max_tokens=False,
         )
         assert options["extra_body"]["enable_thinking"] is False
+
+    def test_anthropic_transport_still_uses_thinking_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Anthropic transport branch is unchanged: it must continue to
+        emit ``thinking={type: "enabled", ...}``, never ``extra_body``.
+
+        This pins the contract that the new generic_chat branch did not
+        regress the anthropic_messages path.
+        """
+        from flocks.provider.interleaved import REASONING_TRANSPORT_ANTHROPIC_MESSAGES
+
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args, **_kw: {
+                "field": "thinking",
+                "echo": "tool_calls",
+                "cross_provider_policy": "preserve",
+            },
+        )
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_reasoning_transport",
+            lambda *_args, **_kw: REASONING_TRANSPORT_ANTHROPIC_MESSAGES,
+        )
+        options = provider_options.build_provider_options(
+            "anthropic", "claude-sonnet-4-20250514", resolve_max_tokens=False,
+        )
+        assert "thinking" in options
+        assert options["thinking"]["type"] == "enabled"
+        assert "extra_body" not in options
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            # A model that is NOT in any catalog but matches a known series
+            # token in ``infer_interleaved_capability``.  Demonstrates that
+            # the series-token fallback (catalog → inference) still produces
+            # the right wire format.  Model ids here are constructed to
+            # embed a real token from ``_PROMOTE_REASONING_CONTENT_TOKENS`` /
+            # ``_STRICT_REASONING_CONTENT_TOKENS`` so the substring match
+            # fires regardless of where Flocks runs the test.
+            "qwen3-7b-uncatalogued",        # contains "qwen3"
+            "glm-5-uncatalogued",           # contains "glm-5"
+            "kimi-k2.6-uncatalogued",       # contains "kimi-k2.6"
+            "minimax-m4-uncatalogued",      # contains "minimax"
+            "step-3.5-flash-uncatalogued",  # contains "step-3.5-flash"
+        ],
+    )
+    def test_series_token_fallback_emits_enable_thinking(self, model_id: str) -> None:
+        """Models matching a known series token in
+        ``infer_interleaved_capability`` get ``enable_thinking`` on the wire
+        even when the catalog has no explicit declaration for them.
+
+        This is the regression net for the design choice that the dispatch
+        is *not* provider-keyed: a user-configured openai-compatible
+        endpoint pointing at a known family Just Works, without requiring
+        anyone to edit a per-provider registry.
+        """
+        options = provider_options.build_provider_options(
+            "openai-compatible", model_id, resolve_max_tokens=False,
+        )
+        assert options.get("extra_body", {}).get("enable_thinking") is True, (
+            f"openai-compatible/{model_id} matches a known series token; "
+            "series-token fallback should have inferred interleaved and "
+            f"emitted enable_thinking. options={options!r}"
+        )
 
 
 class TestOpenAICompatibleExtraBody:

--- a/tests/provider/test_thinking_params.py
+++ b/tests/provider/test_thinking_params.py
@@ -16,7 +16,7 @@ thinking flag, causing the upstream API to short-circuit with
 The new dispatch is transport-driven:
 
   - ``reasoning_transport == anthropic_messages``  →  ``thinking={type: "enabled", budget_tokens:...}``
-  - ``reasoning_transport == generic_chat``        →  ``extra_body.enable_thinking: bool``
+  - ``reasoning_transport == generic_chat``        →  provider-specific ``extra_body`` params
 
 The gate is the resolved ``interleaved_capability``: catalog explicit
 declaration wins, with the series-token inference in
@@ -48,6 +48,11 @@ import pytest
 from flocks.provider import model_catalog
 from flocks.provider import options as provider_options
 
+DEEPSEEK_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
+GLM_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled", "clear_thinking": False}}
+KIMI_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
+MIMO_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -77,6 +82,27 @@ def _iter_interleaved_catalog_entries() -> Iterator[Tuple[str, str]]:
                 continue
             if capabilities.get("interleaved") is not None:
                 yield provider_id, model_id
+
+
+def _expected_generic_chat_extra_body(
+    provider_id: str,
+    model_id: str,
+) -> Dict[str, Any]:
+    """Return the expected OpenAI-compatible thinking control payload."""
+    provider_lower = provider_id.lower()
+    model_lower = model_id.lower()
+
+    if "deepseek" in model_lower or provider_lower == "deepseek":
+        return DEEPSEEK_THINKING_EXTRA_BODY
+    if "glm" in model_lower or provider_lower == "zhipu":
+        return GLM_THINKING_EXTRA_BODY
+    if "mimo" in model_lower:
+        return MIMO_THINKING_EXTRA_BODY
+    if "kimi" in model_lower:
+        return KIMI_THINKING_EXTRA_BODY
+    if "minimax" in model_lower or provider_lower == "minimax":
+        return {"reasoning_split": True}
+    return {"enable_thinking": True}
 
 
 # ---------------------------------------------------------------------------
@@ -133,17 +159,38 @@ class TestCatalogInterleavedCoverage:
             f"options={options!r}"
         )
 
+    @pytest.mark.parametrize("provider_id,model_id", list(_iter_interleaved_catalog_entries()))
+    def test_interleaved_model_gets_official_generic_chat_payload(
+        self,
+        provider_id: str,
+        model_id: str,
+    ) -> None:
+        """Every catalog-declared generic-chat model emits its official payload."""
+        options = provider_options.build_provider_options(
+            provider_id,
+            model_id,
+            resolve_max_tokens=False,
+        )
+
+        assert options.get("extra_body") == _expected_generic_chat_extra_body(
+            provider_id,
+            model_id,
+        ), f"{provider_id}/{model_id} emitted unexpected options={options!r}"
+
 
 class TestGLM5TraceReplay:
     """Specific regression for ses_1628dfe6cffe1i5xZY9lv1u20m step 50.
 
     Trace showed: GLM-5 on alibaba, tools present, returned
     ``finishReason=stop, content=495, toolCallCount=0`` because the request
-    went out without ``enable_thinking: true``.  After the fix, the request
-    body should include the flag.
+    went out without a thinking payload.  After the fix, the request body
+    should include GLM's official thinking object.
     """
 
-    def test_glm5_alibaba_emits_enable_thinking(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_glm5_alibaba_emits_official_thinking_payload(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         monkeypatch.setattr(
             provider_options,
             "_resolve_interleaved_capability",
@@ -164,13 +211,13 @@ class TestGLM5TraceReplay:
             "alibaba/GLM-5 catalog declares interleaved but no extra_body emitted — "
             "this is the exact regression that caused ses_1628dfe6cffe1i5xZY9lv1u20m"
         )
-        assert options["extra_body"]["enable_thinking"] is True
+        assert options["extra_body"] == GLM_THINKING_EXTRA_BODY
 
     @pytest.mark.parametrize(
         "provider_id",
         ["alibaba", "threatbook-cn-llm", "threatbook-io-llm", "zhipu"],
     )
-    def test_glm5_emits_enable_thinking_on_every_provider(
+    def test_glm5_emits_official_thinking_payload_on_every_provider(
         self, provider_id: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(
@@ -188,33 +235,35 @@ class TestGLM5TraceReplay:
             "GLM-5",
             resolve_max_tokens=False,
         )
-        assert options["extra_body"]["enable_thinking"] is True
+        assert options["extra_body"] == GLM_THINKING_EXTRA_BODY
 
     @pytest.mark.parametrize(
-        "provider_id,model_id",
+        "provider_id,model_id,field,expected_extra_body",
         [
-            ("threatbook-cn-llm", "minimax-m2.5"),
-            ("threatbook-cn-llm", "minimax-m2.7"),
-            ("threatbook-cn-llm", "minimax-m3"),
-            ("threatbook-io-llm", "minimax-m2.5"),
-            ("threatbook-io-llm", "minimax-m2.7"),
-            ("threatbook-io-llm", "minimax-m3"),
-            ("minimax", "minimax-m2.5"),
-            ("deepseek", "deepseek-reasoner"),
-            ("stepfun", "step-3.5-flash"),
+            ("threatbook-cn-llm", "minimax-m2.5", "reasoning_details", {"reasoning_split": True}),
+            ("threatbook-cn-llm", "minimax-m2.7", "reasoning_details", {"reasoning_split": True}),
+            ("threatbook-cn-llm", "minimax-m3", "reasoning_details", {"reasoning_split": True}),
+            ("threatbook-io-llm", "minimax-m2.5", "reasoning_details", {"reasoning_split": True}),
+            ("threatbook-io-llm", "minimax-m2.7", "reasoning_details", {"reasoning_split": True}),
+            ("threatbook-io-llm", "minimax-m3", "reasoning_details", {"reasoning_split": True}),
+            ("minimax", "minimax-m2.5", "reasoning_details", {"reasoning_split": True}),
+            ("deepseek", "deepseek-reasoner", "reasoning_content", DEEPSEEK_THINKING_EXTRA_BODY),
+            ("stepfun", "step-3.5-flash", "reasoning_content", {"enable_thinking": True}),
         ],
     )
     def test_previously_dropped_models_now_get_flag(
         self,
         provider_id: str,
         model_id: str,
+        field: str,
+        expected_extra_body: Dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(
             provider_options,
             "_resolve_interleaved_capability",
             lambda *_args, **_kw: {
-                "field": "reasoning_content",
+                "field": field,
                 "echo": "tool_calls",
                 "cross_provider_policy": "promote",
             },
@@ -225,9 +274,9 @@ class TestGLM5TraceReplay:
             model_id,
             resolve_max_tokens=False,
         )
-        assert options.get("extra_body", {}).get("enable_thinking") is True, (
+        assert options.get("extra_body") == expected_extra_body, (
             f"{provider_id}/{model_id} — catalog says interleaved, dispatch "
-            "should have emitted enable_thinking"
+            f"should have emitted {expected_extra_body}"
         )
 
 
@@ -237,7 +286,7 @@ class TestDispatchShape:
 
     The dispatch is now transport-driven: ``anthropic_messages`` →
     ``thinking={type: "enabled", ...}``; ``generic_chat`` →
-    ``extra_body.enable_thinking``.  Catalog explicit declaration wins,
+    provider-specific ``extra_body``.  Catalog explicit declaration wins,
     with the series-token inference in ``interleaved.infer_interleaved_capability``
     as fallback for any model the catalog forgot to declare.
     """
@@ -262,28 +311,13 @@ class TestDispatchShape:
         )
         assert not hasattr(provider_options, "_openai_base_thinking_shape"), (
             "_openai_base_thinking_shape should be removed; generic_chat "
-            "interleaved just emits extra_body.enable_thinking inline"
+            "interleaved emits extra_body inline"
         )
 
-    def test_deepseek_v3_is_a_thinking_model(self) -> None:
-        """``deepseek-chat`` (V3) is auto-enabled as a thinking model via the
-        ``deepseek`` series-token in ``_STRICT_REASONING_CONTENT_TOKENS``,
-        even though the catalog does not declare ``interleaved`` for it.
-
-        Per the "deepseek 系列 全部" design decision, every DeepSeek series
-        is treated as thinking-capable by default.  V3 is the last holdout —
-        previously kept non-thinking because the series token wasn't broad
-        enough to match ``deepseek-chat``.  Now that ``deepseek`` is in the
-        tokens, V3 picks up ``enable_thinking: true`` automatically.
-
-        This test exercises the real chain (no monkeypatch) so it pins both:
-        1. The catalog gate is silent for V3 (no ``interleaved`` field).
-        2. The series-token inference fills the gap.
+    def test_deepseek_v3_is_not_auto_thinking_model(self) -> None:
+        """``deepseek-chat`` (V3) must not inherit thinking params from a
+        broad ``deepseek`` substring.
         """
-        # Sanity-check: V3 has no catalog declaration.  If someone adds
-        # ``interleaved`` to the catalog later, that path will take over and
-        # the test will still pass — the assertion is just a "this is the
-        # current shape" guard.
         catalog = model_catalog.get_raw_catalog()
         v3_entry = catalog.get("deepseek", {}).get("models", {}).get("deepseek-chat")
         assert v3_entry is not None, "deepseek-chat missing from catalog"
@@ -292,15 +326,12 @@ class TestDispatchShape:
             "series-token assertion and let the catalog coverage test pin it"
         )
 
-        # Real chain: catalog silent → series-token inference fires →
-        # dispatch emits enable_thinking.
         options = provider_options.build_provider_options(
             "deepseek", "deepseek-chat", resolve_max_tokens=False,
         )
-        assert options.get("extra_body", {}).get("enable_thinking") is True, (
-            f"deepseek-chat is a deepseek-series model; the 'deepseek' token "
-            f"in _STRICT_REASONING_CONTENT_TOKENS should have inferred it as "
-            f"thinking and emitted enable_thinking. options={options!r}"
+        assert "extra_body" not in options, (
+            "deepseek-chat does not declare interleaved in catalog and should "
+            f"not be auto-enabled by a broad deepseek token. options={options!r}"
         )
 
     def test_explicit_reasoning_toggle_propagates(self) -> None:
@@ -349,7 +380,7 @@ class TestDispatchShape:
         assert "extra_body" not in options
 
     @pytest.mark.parametrize(
-        "model_id",
+        "model_id,expected_extra_body",
         [
             # A model that is NOT in any catalog but matches a known series
             # token in ``infer_interleaved_capability``.  Demonstrates that
@@ -358,16 +389,21 @@ class TestDispatchShape:
             # embed a real token from ``_PROMOTE_REASONING_CONTENT_TOKENS`` /
             # ``_STRICT_REASONING_CONTENT_TOKENS`` so the substring match
             # fires regardless of where Flocks runs the test.
-            "qwen3-7b-uncatalogued",        # contains "qwen3"
-            "glm-5-uncatalogued",           # contains "glm-5"
-            "kimi-k2.6-uncatalogued",       # contains "kimi-k2.6"
-            "minimax-m4-uncatalogued",      # contains "minimax"
-            "step-3.5-flash-uncatalogued",  # contains "step-3.5-flash"
+            ("qwen3-7b-uncatalogued", {"enable_thinking": True}),
+            ("glm-5-uncatalogued", GLM_THINKING_EXTRA_BODY),
+            ("kimi-k2.6-uncatalogued", KIMI_THINKING_EXTRA_BODY),
+            ("mimo-v2.5-pro-uncatalogued", MIMO_THINKING_EXTRA_BODY),
+            ("minimax-m4-uncatalogued", {"reasoning_split": True}),
+            ("step-3.5-flash-uncatalogued", {"enable_thinking": True}),
         ],
     )
-    def test_series_token_fallback_emits_enable_thinking(self, model_id: str) -> None:
+    def test_series_token_fallback_emits_expected_extra_body(
+        self,
+        model_id: str,
+        expected_extra_body: Dict[str, Any],
+    ) -> None:
         """Models matching a known series token in
-        ``infer_interleaved_capability`` get ``enable_thinking`` on the wire
+        ``infer_interleaved_capability`` get the expected extra_body on the wire
         even when the catalog has no explicit declaration for them.
 
         This is the regression net for the design choice that the dispatch
@@ -378,11 +414,35 @@ class TestDispatchShape:
         options = provider_options.build_provider_options(
             "openai-compatible", model_id, resolve_max_tokens=False,
         )
-        assert options.get("extra_body", {}).get("enable_thinking") is True, (
+        assert options.get("extra_body") == expected_extra_body, (
             f"openai-compatible/{model_id} matches a known series token; "
             "series-token fallback should have inferred interleaved and "
-            f"emitted enable_thinking. options={options!r}"
+            f"emitted {expected_extra_body}. options={options!r}"
         )
+
+    @pytest.mark.parametrize(
+        "provider_id,model_id,expected_extra_body",
+        [
+            ("deepseek", "deepseek-reasoner", DEEPSEEK_THINKING_EXTRA_BODY),
+            ("deepseek", "deepseek-v4-flash", DEEPSEEK_THINKING_EXTRA_BODY),
+            ("minimax", "minimax-m3", {"reasoning_split": True}),
+            ("stepfun", "step-3.5-flash", {"enable_thinking": True}),
+            ("zhipu", "glm-4.7", GLM_THINKING_EXTRA_BODY),
+        ],
+    )
+    def test_real_catalog_chain_emits_expected_extra_body(
+        self,
+        provider_id: str,
+        model_id: str,
+        expected_extra_body: Dict[str, Any],
+    ) -> None:
+        """Exercise catalog/inference/dispatch without monkeypatching."""
+        options = provider_options.build_provider_options(
+            provider_id,
+            model_id,
+            resolve_max_tokens=False,
+        )
+        assert options.get("extra_body") == expected_extra_body
 
 
 class TestOpenAICompatibleExtraBody:
@@ -391,6 +451,59 @@ class TestOpenAICompatibleExtraBody:
     ``build_provider_options`` produces the right shape, ``chat_stream`` /
     ``chat`` in ``openai_compatible.py`` dropped the kwargs it received.
     """
+
+    def test_chat_non_streaming_propagates_extra_body(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The non-streaming ``chat`` path must preserve extra_body too."""
+        import asyncio
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from flocks.provider.sdk.openai_compatible import OpenAICompatibleProvider
+
+        captured: Dict[str, Any] = {}
+
+        class _FakeCompletions:
+            async def create(self, **kwargs: Any) -> Any:
+                captured.update(kwargs)
+                return SimpleNamespace(
+                    id="chatcmpl-test",
+                    model="qwen3-235b-a22b-thinking",
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(content="ok"),
+                            finish_reason="stop",
+                        )
+                    ],
+                    usage=SimpleNamespace(
+                        prompt_tokens=1,
+                        completion_tokens=1,
+                        total_tokens=2,
+                    ),
+                )
+
+        class _FakeChat:
+            completions = _FakeCompletions()
+
+        class _FakeClient:
+            chat = _FakeChat()
+
+        provider = OpenAICompatibleProvider()
+        provider._get_client = MagicMock(return_value=_FakeClient())  # type: ignore[method-assign]
+
+        asyncio.run(
+            provider.chat(
+                "qwen3-235b-a22b-thinking",
+                messages=[],
+                extra_body={"enable_thinking": True},
+            )
+        )
+
+        assert captured.get("extra_body") == {"enable_thinking": True}, (
+            "openai_compatible.chat swallowed caller-supplied extra_body"
+        )
 
     def test_chat_stream_propagates_extra_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Smoke test that an ``extra_body`` kwarg passed to ``chat_stream``

--- a/tests/provider/test_thinking_params.py
+++ b/tests/provider/test_thinking_params.py
@@ -261,6 +261,47 @@ class TestShapeRegistry:
         missing = expected - actual
         assert not missing, f"missing thinking shape for: {sorted(missing)}"
 
+    def test_deepseek_v3_is_not_a_thinking_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``deepseek-chat`` (V3) has no ``interleaved`` capability in the
+        catalog and must not receive ``enable_thinking`` on the wire.
+
+        This is the regression net for the prior
+        ``_deepseek_thinking_shape`` model-name branching.  Catalog is now
+        the only source of truth: V3 stays non-thinking because the catalog
+        says so, not because the dispatcher strips it.  If a future catalog
+        change adds ``interleaved`` to V3, this test should be removed and
+        the model will then exercise the regular positive path.
+        """
+        # Sanity-check the assumption: catalog must not declare V3 as interleaved.
+        catalog = model_catalog.get_raw_catalog()
+        deepseek_models = catalog.get("deepseek", {}).get("models", {})
+        v3_models = {
+            mid: m for mid, m in deepseek_models.items()
+            if m.get("family", "").startswith("deepseek-v3")
+        }
+        assert v3_models, "expected at least one deepseek-v3 family model in catalog"
+        for mid, m in v3_models.items():
+            assert m.get("capabilities", {}).get("interleaved") is None, (
+                f"deepseek/{mid} now declares interleaved — remove this test "
+                "and let the catalog coverage test exercise it instead"
+            )
+
+        # Dispatcher must produce no enable_thinking flag for a V3 model.
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args, **_kw: None,  # V3 has no interleaved in catalog
+        )
+        options = provider_options.build_provider_options(
+            "deepseek", "deepseek-chat", resolve_max_tokens=False,
+        )
+        assert "extra_body" not in options or not options["extra_body"].get(
+            "enable_thinking"
+        ), (
+            f"deepseek-chat is V3 (non-thinking in catalog) but dispatcher "
+            f"emitted enable_thinking — catalog gate is broken. options={options!r}"
+        )
+
     def test_explicit_reasoning_toggle_propagates(self) -> None:
         """``reasoning_enabled=False`` should produce ``enable_thinking: false``
         on a shaped provider, mirroring the old token-matching branch's

--- a/tests/provider/test_thinking_params.py
+++ b/tests/provider/test_thinking_params.py
@@ -1,0 +1,362 @@
+"""
+Regression net for catalog-driven thinking-params dispatch.
+
+Background
+----------
+
+The original dispatch in ``flocks/provider/options.py`` matched the model name
+against a hard-coded substring whitelist (``qwen3`` / ``kimi`` / ``mimo`` / …)
+to decide whether to send ``extra_body.enable_thinking: true``.  Models whose
+names didn't match the magic substrings were silently sent without the
+thinking flag, causing the upstream API to short-circuit with
+``finish_reason=stop`` and an empty content block — the user-visible
+"agent stopped, please say 'continue'" symptom seen in
+``ses_1628dfe6cffe1i5xZY9lv1u20m``.
+
+The new dispatch uses the catalog's ``interleaved`` capability as the single
+gate, and looks up a per-provider request shape.  These tests verify three
+properties of the new path:
+
+1. Every (provider, model) pair with ``interleaved != null`` in catalog.json
+   produces a non-empty ``extra_body`` (or its non-OpenAI-compat equivalent
+   like ``thinking``).  This is the systematic regression net — any new model
+   added to the catalog with interleaved thinking will be covered.
+2. The specific GLM-5 / alibaba configuration that triggered the original
+   trace bug now emits the right flag.
+3. The ``openai_compatible`` provider no longer swallows caller-supplied
+   ``extra_body`` in its chat_stream() path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, Tuple
+
+import pytest
+
+from flocks.provider import model_catalog
+from flocks.provider import options as provider_options
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_interleaved_catalog_entries() -> Iterator[Tuple[str, str]]:
+    """Yield (provider_id, model_id) for every catalog entry that declares interleaved thinking.
+
+    Mirrors the jq query used during the audit:
+        .<provider>.models | to_entries[]
+        | select(.value.capabilities.interleaved != null)
+        | ["<provider>", "<model_id>"]
+    """
+    raw = model_catalog.get_raw_catalog()
+    for provider_id, provider_entry in raw.items():
+        if not isinstance(provider_entry, dict):
+            continue
+        models = provider_entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        for model_id, model_entry in models.items():
+            if not isinstance(model_entry, dict):
+                continue
+            capabilities = model_entry.get("capabilities") or {}
+            if not isinstance(capabilities, dict):
+                continue
+            if capabilities.get("interleaved") is not None:
+                yield provider_id, model_id
+
+
+# Catalog can grow between releases; skip providers that aren't wired into
+# ``_THINKING_REQUEST_SHAPES`` (e.g. legacy entries that pre-date the
+# catalog-driven dispatch).  The point of this test is to catch MISSING
+# entries, not to police old ones.
+_SHAPED_PROVIDER_IDS = frozenset(provider_options._THINKING_REQUEST_SHAPES.keys())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogInterleavedCoverage:
+    """Property test: every interleaved catalog entry resolves to a thinking flag."""
+
+    @pytest.mark.parametrize("provider_id,model_id", list(_iter_interleaved_catalog_entries()))
+    def test_interleaved_model_gets_thinking_flag(self, provider_id: str, model_id: str) -> None:
+        if provider_id not in _SHAPED_PROVIDER_IDS:
+            pytest.skip(
+                f"provider {provider_id!r} not in _THINKING_REQUEST_SHAPES — "
+                "add a shape entry or remove interleaved from this catalog entry"
+            )
+
+        # Patch the interleaved capability so the dispatch gate fires
+        # regardless of the test environment's catalog resolution path.
+        original = provider_options._resolve_interleaved_capability
+        provider_options._resolve_interleaved_capability = lambda *_args, **_kw: {
+            "field": "reasoning_content",
+            "echo": "tool_calls",
+            "cross_provider_policy": "promote",
+        }
+        try:
+            options = provider_options.build_provider_options(
+                provider_id,
+                model_id,
+                resolve_max_tokens=False,
+            )
+        finally:
+            provider_options._resolve_interleaved_capability = original
+
+        # The dispatch should produce SOME thinking signal.  We accept
+        # either extra_body (OpenAI-compat family) or a top-level reasoning
+        # field (Anthropic/Google family).  The catalog is already filtered
+        # to interleaved-only entries so neither should be empty.
+        has_extra_body = bool(options.get("extra_body"))
+        has_thinking = bool(options.get("thinking"))
+        has_reasoning_effort = bool(options.get("reasoningEffort"))
+        has_thinking_config = bool(options.get("thinkingConfig"))
+        has_thinking_level = bool(options.get("thinkingLevel"))
+        assert (
+            has_extra_body
+            or has_thinking
+            or has_reasoning_effort
+            or has_thinking_config
+            or has_thinking_level
+        ), (
+            f"{provider_id}/{model_id} declares interleaved in catalog but "
+            f"build_provider_options emitted no thinking field. "
+            f"options={options!r}"
+        )
+
+
+class TestGLM5TraceReplay:
+    """Specific regression for ses_1628dfe6cffe1i5xZY9lv1u20m step 50.
+
+    Trace showed: GLM-5 on alibaba, tools present, returned
+    ``finishReason=stop, content=495, toolCallCount=0`` because the request
+    went out without ``enable_thinking: true``.  After the fix, the request
+    body should include the flag.
+    """
+
+    def test_glm5_alibaba_emits_enable_thinking(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args, **_kw: {
+                "field": "reasoning_content",
+                "echo": "tool_calls",
+                "cross_provider_policy": "promote",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            "alibaba",
+            "GLM-5",
+            resolve_max_tokens=False,
+        )
+
+        assert "extra_body" in options, (
+            "alibaba/GLM-5 catalog declares interleaved but no extra_body emitted — "
+            "this is the exact regression that caused ses_1628dfe6cffe1i5xZY9lv1u20m"
+        )
+        assert options["extra_body"]["enable_thinking"] is True
+
+    @pytest.mark.parametrize(
+        "provider_id",
+        ["alibaba", "threatbook-cn-llm", "threatbook-io-llm", "zhipu"],
+    )
+    def test_glm5_emits_enable_thinking_on_every_provider(
+        self, provider_id: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args, **_kw: {
+                "field": "reasoning_content",
+                "echo": "tool_calls",
+                "cross_provider_policy": "promote",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            provider_id,
+            "GLM-5",
+            resolve_max_tokens=False,
+        )
+        assert options["extra_body"]["enable_thinking"] is True
+
+    @pytest.mark.parametrize(
+        "provider_id,model_id",
+        [
+            ("threatbook-cn-llm", "minimax-m2.5"),
+            ("threatbook-cn-llm", "minimax-m2.7"),
+            ("threatbook-cn-llm", "minimax-m3"),
+            ("threatbook-io-llm", "minimax-m2.5"),
+            ("threatbook-io-llm", "minimax-m2.7"),
+            ("threatbook-io-llm", "minimax-m3"),
+            ("minimax", "minimax-m2.5"),
+            ("deepseek", "deepseek-reasoner"),
+            ("stepfun", "step-3.5-flash"),
+        ],
+    )
+    def test_previously_dropped_models_now_get_flag(
+        self,
+        provider_id: str,
+        model_id: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args, **_kw: {
+                "field": "reasoning_content",
+                "echo": "tool_calls",
+                "cross_provider_policy": "promote",
+            },
+        )
+
+        options = provider_options.build_provider_options(
+            provider_id,
+            model_id,
+            resolve_max_tokens=False,
+        )
+        assert options.get("extra_body", {}).get("enable_thinking") is True, (
+            f"{provider_id}/{model_id} — catalog says interleaved, dispatch "
+            "should have emitted enable_thinking"
+        )
+
+
+class TestShapeRegistry:
+    """Sanity checks on the shapes dict itself."""
+
+    def test_no_legacy_token_constant(self) -> None:
+        """The token-substring whitelist must be gone — that was the bug surface."""
+        assert not hasattr(
+            provider_options, "_ENABLE_THINKING_EXTRA_BODY_TOKENS"
+        ), (
+            "_ENABLE_THINKING_EXTRA_BODY_TOKENS should be removed; the catalog "
+            "interleaved field is now the only trigger"
+        )
+
+    def test_all_thinking_providers_have_a_shape(self) -> None:
+        """Every provider that the audit flagged as having reasoning models
+        should have an entry in the shapes dict.
+
+        Catalog providers with interleaved models: alibaba, threatbook-cn-llm,
+        threatbook-io-llm, moonshot, zhipu, deepseek, minimax, stepfun, plus
+        the generic ``openai-compatible`` for user-configured endpoints.
+        """
+        expected = {
+            "alibaba",
+            "threatbook-cn-llm",
+            "threatbook-io-llm",
+            "moonshot",
+            "zhipu",
+            "deepseek",
+            "minimax",
+            "stepfun",
+            "openai-compatible",
+        }
+        actual = set(provider_options._THINKING_REQUEST_SHAPES.keys())
+        missing = expected - actual
+        assert not missing, f"missing thinking shape for: {sorted(missing)}"
+
+    def test_explicit_reasoning_toggle_propagates(self) -> None:
+        """``reasoning_enabled=False`` should produce ``enable_thinking: false``
+        on a shaped provider, mirroring the old token-matching branch's
+        behavior so the upstream API gets an explicit opt-out signal.
+        """
+        options = provider_options.build_provider_options(
+            "threatbook-cn-llm",
+            "qwen3.6-plus",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+        assert options["extra_body"]["enable_thinking"] is False
+
+
+class TestOpenAICompatibleExtraBody:
+    """Verify the SDK now propagates caller-supplied ``extra_body`` instead
+    of silently swallowing it.  This is the second-order bug: even if
+    ``build_provider_options`` produces the right shape, ``chat_stream`` /
+    ``chat`` in ``openai_compatible.py`` dropped the kwargs it received.
+    """
+
+    def test_chat_stream_propagates_extra_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Smoke test that an ``extra_body`` kwarg passed to ``chat_stream``
+        ends up in the outgoing request params.
+
+        We mock the OpenAI client so we don't need a live API, then assert
+        the captured kwargs include the extra_body we passed in.  The fake
+        stream yields one minimal chunk so the empty-response fallback (which
+        would call the non-streaming ``chat``) doesn't fire — the non-stream
+        path has its own check in
+        ``test_chat_non_streaming_propagates_extra_body``.
+        """
+        import asyncio
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from flocks.provider.sdk.openai_compatible import OpenAICompatibleProvider
+
+        captured: Dict[str, Any] = {}
+
+        def _make_fake_response_object() -> Any:
+            """Build a minimal response object that satisfies both
+            chat_stream's chunk iteration and chat()'s .choices[0].message
+            access.  The chunk carries non-empty content so chat_stream's
+            ``emitted_substantive_chunk`` flag flips and the empty-response
+            fallback (which calls ``self.chat`` and would need a real
+            response object) doesn't fire.
+            """
+            chunk = SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content="ok", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=None,
+            )
+
+            class _FakeStream:
+                def __aiter__(self) -> "_FakeStream":
+                    return self
+
+                async def __anext__(self):
+                    if not getattr(self, "_emitted", False):
+                        self._emitted = True
+                        return chunk
+                    raise StopAsyncIteration
+
+            return _FakeStream()
+
+        class _FakeCompletions:
+            async def create(self, **kwargs: Any) -> Any:
+                captured.update(kwargs)
+                return _make_fake_response_object()
+
+        class _FakeChat:
+            completions = _FakeCompletions()
+
+        class _FakeClient:
+            chat = _FakeChat()
+
+        provider = OpenAICompatibleProvider()
+        provider._get_client = MagicMock(return_value=_FakeClient())  # type: ignore[method-assign]
+
+        async def _drive() -> None:
+            async for _ in provider.chat_stream(
+                "qwen3-235b-a22b-thinking",
+                messages=[],
+                extra_body={"enable_thinking": True},
+            ):
+                pass
+
+        asyncio.run(_drive())
+
+        assert captured.get("extra_body") == {"enable_thinking": True}, (
+            "openai_compatible.chat_stream swallowed the caller-supplied extra_body; "
+            "this is the second-order bug fixed in this change. captured keys: "
+            f"{sorted(captured.keys())}"
+        )

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -1967,6 +1967,118 @@ async def test_to_chat_messages_keeps_reasoning_only_assistant_message(monkeypat
     assert chat_messages[0].reasoning_source == "promoted_reasoning"
 
 
+def test_get_queued_user_message_ids_only_marks_newly_queued_turns():
+    runner = _make_runner("ses_runner_queued_users")
+    runner._step = 3
+
+    queued_user_ids = runner._get_queued_user_message_ids([
+        SimpleNamespace(id="msg_100", role="assistant", finish="stop"),
+        SimpleNamespace(id="msg_200", role="user"),
+        SimpleNamespace(id="msg_300", role="user"),
+        SimpleNamespace(id="msg_400", role="user"),
+    ])
+
+    assert queued_user_ids == {"msg_300", "msg_400"}
+
+
+@pytest.mark.asyncio
+async def test_to_chat_messages_wraps_only_queued_user_messages():
+    session = await Session.create(
+        project_id="test_runner_queued_wrap",
+        directory="/tmp/runner-queued-wrap",
+    )
+    finished_assistant = await Message.create(
+        session_id=session.id,
+        role=MessageRole.ASSISTANT,
+        content="Initial answer",
+    )
+    root_user = await Message.create(
+        session_id=session.id,
+        role=MessageRole.USER,
+        content="Continue fixing the bug",
+    )
+    queued_user = await Message.create(
+        session_id=session.id,
+        role=MessageRole.USER,
+        content="What version is installed?",
+    )
+
+    runner = SessionRunner(session=session, static_cache={})
+    runner._step = 3
+    runner._queued_user_message_ids = {queued_user.id}
+
+    chat_messages = await runner._to_chat_messages(
+        [
+            SimpleNamespace(
+                id=finished_assistant.id,
+                role=MessageRole.ASSISTANT,
+                finish="stop",
+                error=None,
+                compacted=False,
+            ),
+            root_user,
+            queued_user,
+        ],
+        [],
+    )
+
+    user_messages = [message for message in chat_messages if message.role == "user"]
+    assert len(user_messages) == 2
+    assert user_messages[0].content == "Continue fixing the bug"
+    assert isinstance(user_messages[1].content, str)
+    assert user_messages[1].content.startswith("<system-reminder>")
+    assert "What version is installed?" in user_messages[1].content
+
+
+@pytest.mark.asyncio
+async def test_to_chat_messages_skips_reasoning_only_aborted_assistant(monkeypatch):
+    runner = _make_runner("ses_runner_aborted_reasoning_only")
+    runner.provider_id = "alibaba"
+    runner.model_id = "qwen3-max"
+
+    monkeypatch.setattr(
+        runner_mod.Provider,
+        "resolve_model",
+        lambda provider_id, model_id: SimpleNamespace(
+            capabilities=SimpleNamespace(
+                interleaved={
+                    "field": "reasoning_content",
+                    "echo": "tool_calls",
+                    "cross_provider_policy": "promote",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        runner_mod.Message,
+        "parts",
+        AsyncMock(return_value=[
+            ReasoningPart(
+                sessionID=runner.session.id,
+                messageID="msg_aborted_reasoning_only",
+                text="This should not leak into replay history.",
+                time=PartTime(start=1),
+            )
+        ]),
+    )
+    monkeypatch.setattr(runner_mod.Message, "get_parts_revision", lambda *_args: 1)
+
+    chat_messages = await runner._to_chat_messages(
+        [
+            SimpleNamespace(
+                id="msg_aborted_reasoning_only",
+                role=MessageRole.ASSISTANT,
+                finish="error",
+                error={"name": "MessageAbortedError"},
+                compacted=False,
+            )
+        ],
+        [],
+    )
+
+    assert chat_messages == []
+
+
 def test_provider_capability_key_includes_interleaved_policy(monkeypatch):
     runner = _make_runner("ses_runner_interleaved_capability_key")
     runner.provider_id = "deepseek"
@@ -2039,6 +2151,128 @@ async def test_process_step_creates_assistant_message_with_provider_and_model(mo
 
     assert captured_kwargs["model_id"] == runner.model_id
     assert captured_kwargs["provider_id"] == runner.provider_id
+
+
+@pytest.mark.asyncio
+async def test_process_step_invalidates_chat_cache_for_queued_messages(monkeypatch):
+    runner = _make_runner("ses_runner_queued_cache_invalidation")
+    runner._step = 3
+    runner._static_cache["chat_context_cache"] = {
+        "latest": {
+            "system_cache_key": "cached",
+            "message_signatures": [],
+            "chat_messages": [{"role": "user", "content": "stale"}],
+        }
+    }
+    runner.callbacks = RunnerCallbacks(on_error=AsyncMock())
+
+    root_user = SimpleNamespace(id="msg_200", role="user")
+    last_user = UserMessageInfo(
+        id="msg_300",
+        sessionID=runner.session.id,
+        role="user",
+        time={"created": 1_000},
+        agent="rex",
+        model={"providerID": "anthropic", "modelID": "claude-sonnet"},
+    )
+    messages = [
+        SimpleNamespace(id="msg_100", role="assistant", finish="stop"),
+        root_user,
+        last_user,
+    ]
+
+    agent = SimpleNamespace(name="rex", steps=None, mode="primary", prompt="", tools=[])
+    provider = MagicMock()
+    provider.is_configured.return_value = True
+    assistant_msg = SimpleNamespace(id="msg_assistant_queued_cache")
+
+    async def fake_to_chat_messages(_messages, _system_prompts):  # noqa: ANN001
+        assert "chat_context_cache" not in runner._static_cache
+        assert runner._queued_user_message_ids == {last_user.id}
+        return [SimpleNamespace(role="user", content="queued")]
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
+    monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_to_chat_messages", fake_to_chat_messages)
+    monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="queued"))
+    monkeypatch.setattr(runner_mod.Message, "create", AsyncMock(return_value=assistant_msg))
+    monkeypatch.setattr(runner_mod.Message, "update", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        runner,
+        "_call_llm",
+        AsyncMock(return_value=StepResult(action="stop", content="done")),
+    )
+
+    result = await runner._process_step(messages, last_user)
+
+    assert result.action == "stop"
+    assert result.content == "done"
+
+
+@pytest.mark.asyncio
+async def test_process_step_marks_aborted_llm_message_as_error(monkeypatch):
+    runner = _make_runner("ses_runner_aborted_result")
+    runner.callbacks = RunnerCallbacks(on_error=AsyncMock())
+
+    last_user = UserMessageInfo(
+        id="msg_user_aborted_result",
+        sessionID=runner.session.id,
+        role="user",
+        time={"created": 1_000},
+        agent="rex",
+        model={"providerID": "anthropic", "modelID": "claude-sonnet"},
+    )
+    agent = SimpleNamespace(name="rex", steps=None, mode="primary", prompt="", tools=[])
+    provider = MagicMock()
+    provider.is_configured.return_value = True
+    assistant_msg = SimpleNamespace(id="msg_assistant_aborted_result")
+    update_mock = AsyncMock(return_value=None)
+    record_usage_mock = AsyncMock(return_value=None)
+    usage = {"prompt_tokens": 9, "completion_tokens": 4, "total_tokens": 13}
+
+    async def fake_call_llm(*_args, **_kwargs):
+        runner._llm_call_aborted = True
+        return StepResult(
+            action="continue",
+            content="partial answer",
+            tool_calls=[ToolCall(id="call_1", name="read", arguments={})],
+            usage=usage,
+        )
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
+    monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        runner,
+        "_to_chat_messages",
+        AsyncMock(return_value=[SimpleNamespace(role="user", content="hi")]),
+    )
+    monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="hi"))
+    monkeypatch.setattr(runner_mod.Message, "create", AsyncMock(return_value=assistant_msg))
+    monkeypatch.setattr(runner_mod.Message, "update", update_mock)
+    monkeypatch.setattr(runner, "_record_usage_if_available", record_usage_mock)
+    monkeypatch.setattr(runner, "_call_llm", fake_call_llm)
+
+    result = await runner._process_step([last_user], last_user)
+
+    assert result.action == "stop"
+    assert result.content == "partial answer"
+    assert any(
+        call.args[1] == assistant_msg.id
+        and call.kwargs.get("finish") == "error"
+        and call.kwargs.get("error", {}).get("name") == "MessageAbortedError"
+        for call in update_mock.await_args_list
+    )
+    assert not any(
+        call.args[1] == assistant_msg.id and call.kwargs.get("finish") in {"stop", "tool-calls"}
+        for call in update_mock.await_args_list
+    )
+    record_usage_mock.assert_awaited_once_with(usage, message_id=assistant_msg.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Four commits replace the fragile, hard-coded model-name substring whitelist that decided whether to send `extra_body.enable_thinking: true` with a layered design: **catalog explicit declaration → series-token inference fallback → transport-driven dispatch**. 

---

## Bug
- Model: `GLM-5`
- Symptom: `finishReason=stop`, empty content block, zero tool calls after every step
- User-visible: agent loop hands the turn back to the user with "stopped, please say 'continue'"

GLM-5 / minimax / stepfun were all in the catalog as interleaved, but the request-side dispatcher's `qwen3` / `kimi` / `mimo` substring list didn't include them, so `enable_thinking: true` was never sent. Without it, DashScope / Zhipu / Moonshot / Stepfun stream their thinking into content` instead of `reasoning_content` and stop mid-tool-call.

A second-order bug in `openai_compatible.py` compounded the issue: both `chat()` and `chat_stream()` silently swallowed caller-supplied `extra_body` whenever `kwargs.thinking` was `None`, so user-configured openai-compatible endpoints (with `default_parameters.enable_thinking` in flocks.json) were broken even on models the dispatcher would have served correctly.
