### PR TITLE
feat: Improve chat model picker controls

### DIFF
--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -108,6 +108,8 @@ export interface SessionChatProps {
   onInitialMessageConsumed?: () => void;
   /** Agent name to include in prompt_async requests */
   agentName?: string;
+  /** Model override to include in prompt_async requests */
+  model?: { providerID: string; modelID: string } | null;
   /** Agents available for one-turn @mention routing. */
   mentionAgents?: Agent[];
   /** Display configuration (compact, showActions, showTimestamp) */
@@ -120,8 +122,10 @@ export interface SessionChatProps {
   onSSEEvent?: (event: SSEChatEvent) => void;
   /** Called on session errors from SSE */
   onError?: (message: string) => void;
-  /** Extra content injected into the composer toolbar (left of send button, after divider) */
+  /** Extra content injected into the left side of the composer toolbar */
   toolbarSlot?: React.ReactNode;
+  /** Extra content injected between left toolbar controls and right actions */
+  centerToolbarSlot?: React.ReactNode;
   /**
    * Called when the user sends a message but sessionId is not yet available.
    * The parent should create a session and dispatch the prompt (with the
@@ -135,7 +139,12 @@ export interface SessionChatProps {
    * session id) directly without an empty ``async (..) => { await ... }``
    * shim.
    */
-  onCreateAndSend?: (text: string, imageParts?: ImagePartData[], agentOverride?: string) => Promise<unknown> | unknown;
+  onCreateAndSend?: (
+    text: string,
+    imageParts?: ImagePartData[],
+    agentOverride?: string,
+    modelOverride?: { providerID: string; modelID: string } | null,
+  ) => Promise<unknown> | unknown;
   /** Called when the user sends "/new" to create a new session */
   onCreateNewSession?: () => Promise<void> | void;
   /**
@@ -693,6 +702,7 @@ export default function SessionChat({
   onStreamingDone,
   initialMessage,
   agentName,
+  model,
   display,
   welcomeContent,
   onSseStatusChange,
@@ -703,6 +713,7 @@ export default function SessionChat({
   onInitialMessageConsumed,
   supportsVision,
   toolbarSlot,
+  centerToolbarSlot,
   mentionAgents = [],
 }: SessionChatProps) {
   const { t, i18n } = useTranslation('session');
@@ -1522,6 +1533,7 @@ export default function SessionChat({
         parts: buildPromptParts(text, imageParts),
       };
       if (effectiveAgent) payload.agent = effectiveAgent;
+      if (model) payload.model = model;
 
       await client.post(`/api/session/${sessionId}/prompt_async`, payload);
     } catch (err: unknown) {
@@ -1549,6 +1561,7 @@ export default function SessionChat({
       await sessionApi.enqueuePrompt(sessionId, {
         parts: buildPromptParts(text, imageParts),
         ...(effectiveAgent ? { agent: effectiveAgent } : {}),
+        ...(model ? { model } : {}),
       });
       await fetchPromptQueue();
       setQueueExpanded(true);
@@ -1625,7 +1638,7 @@ export default function SessionChat({
         setSending(true);
         try {
           setPendingAgentName(mentionedAgent || 'rex');
-          await onCreateAndSend(text, imageParts, mentionedAgent || undefined);
+          await onCreateAndSend(text, imageParts, mentionedAgent || undefined, model);
           setAttachments([]);
         } catch {
           // Restore both the text and the attachment list so the user can
@@ -2458,6 +2471,16 @@ export default function SessionChat({
 
                 {/* Bottom toolbar inside the composer card */}
                 <div className="flex items-center gap-1 px-2 pb-2">
+                  {toolbarSlot}
+
+                  {centerToolbarSlot && (
+                    <div className="ml-1">
+                      {centerToolbarSlot}
+                    </div>
+                  )}
+
+                  <div className="flex-1" />
+
                   <button
                     type="button"
                     onClick={() => fileInputRef.current?.click()}
@@ -2467,16 +2490,6 @@ export default function SessionChat({
                   >
                     <Paperclip className="w-4 h-4" />
                   </button>
-
-                  {/* divider + injected slot (e.g. agent selector) */}
-                  {toolbarSlot && (
-                    <>
-                      <div className="w-px h-4 bg-zinc-200 mx-1 flex-shrink-0" />
-                      {toolbarSlot}
-                    </>
-                  )}
-
-                  <div className="flex-1" />
 
                   {isStreaming ? (
                     <>

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -53,6 +53,13 @@
       "custom": "Custom"
     }
   },
+  "modelPicker": {
+    "title": "Choose Model",
+    "hint": "Overrides the model used when sending this chat message",
+    "empty": "No available models",
+    "count": "{{count}}",
+    "vision": "Vision"
+  },
   "welcome": {
     "title": "Start a new conversation",
     "description": "AI-native security operations assistant — threat analysis, incident response, and security orchestration",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -53,6 +53,13 @@
       "custom": "自定义"
     }
   },
+  "modelPicker": {
+    "title": "选择模型",
+    "hint": "作为本次对话发送时的模型覆盖",
+    "empty": "暂无可用模型",
+    "count": "{{count}} 个",
+    "vision": "视觉"
+  },
   "welcome": {
     "title": "开始新的对话",
     "description": "AI 原生的安全运营助手，帮您进行威胁分析、应急响应、安全编排等任务",

--- a/webui/src/pages/Agent/AgentSheet.tsx
+++ b/webui/src/pages/Agent/AgentSheet.tsx
@@ -16,12 +16,14 @@ import { sessionApi } from '@/api/session';
 import client from '@/api/client';
 import EntitySheet, { useEntitySheet } from '@/components/common/EntitySheet';
 import PillGroup from '@/components/common/PillGroup';
-import { providerAPI, defaultModelAPI } from '@/api/provider';
+import { providerAPI, defaultModelAPI, modelV2API } from '@/api/provider';
 import { toolAPI, Tool } from '@/api/tool';
 import { skillAPI, Skill } from '@/api/skill';
+import type { ModelDefinitionV2 } from '@/types';
 
 interface AvailableModel {
   providerID: string;
+  providerName: string;
   modelID: string;
   label: string;
 }
@@ -68,6 +70,7 @@ export default function AgentSheet({ agent, onClose, onSaved }: AgentSheetProps)
   });
   const [loading, setLoading] = useState(false);
   const [availableModels, setAvailableModels] = useState<AvailableModel[]>([]);
+  const [modelsLoaded, setModelsLoaded] = useState(false);
   const [defaultModel, setDefaultModel] = useState<{ providerID: string; modelID: string } | null>(null);
   const [allTools, setAllTools] = useState<Tool[]>([]);
   const [allSkills, setAllSkills] = useState<Skill[]>([]);
@@ -78,17 +81,30 @@ export default function AgentSheet({ agent, onClose, onSaved }: AgentSheetProps)
   const isPrimary = formData.mode === 'primary';
 
   useEffect(() => {
-    providerAPI.list().then((r) => {
-      const connectedSet = new Set<string>(r.data.connected ?? []);
-      const list: AvailableModel[] = [];
-      for (const provider of r.data.all) {
-        if (!connectedSet.has(provider.id)) continue;
-        for (const [modelId, modelInfo] of Object.entries(provider.models ?? {})) {
-          list.push({ providerID: provider.id, modelID: modelId, label: (modelInfo as any).name || modelId });
-        }
-      }
+    Promise.all([
+      providerAPI.list(),
+      modelV2API.listDefinitions({ enabled_only: true }),
+    ]).then(([providersRes, modelsRes]) => {
+      const connectedSet = new Set<string>(providersRes.data.connected ?? []);
+      const providerById = new Map(
+        providersRes.data.all
+          .filter((provider) => connectedSet.has(provider.id))
+          .map((provider) => [provider.id, provider]),
+      );
+      const enabledModels = (modelsRes.data.models ?? []) as ModelDefinitionV2[];
+      const list: AvailableModel[] = enabledModels.flatMap((model) => {
+        const provider = providerById.get(model.provider_id);
+        if (!provider) return [];
+        return [{
+          providerID: provider.id,
+          providerName: provider.name || provider.id,
+          modelID: model.id,
+          label: model.name || model.id,
+        }];
+      });
       setAvailableModels(list);
-    }).catch(() => {});
+    }).catch(() => setAvailableModels([]))
+      .finally(() => setModelsLoaded(true));
 
     defaultModelAPI.getResolved().then((r) => {
       const d = r.data;
@@ -112,6 +128,16 @@ export default function AgentSheet({ agent, onClose, onSaved }: AgentSheetProps)
       }
     }).catch(() => {}).finally(() => setSkillsLoading(false));
   }, []);
+
+  useEffect(() => {
+    if (!modelsLoaded || !formData.modelKey) return;
+    const selectedStillAvailable = availableModels.some(
+      (model) => `${model.providerID}::${model.modelID}` === formData.modelKey,
+    );
+    if (!selectedStillAvailable) {
+      setFormData((prev) => ({ ...prev, modelKey: '' }));
+    }
+  }, [availableModels, formData.modelKey, modelsLoaded]);
 
   const isNative = !!agent?.native;
   const submitDisabled = false;
@@ -303,6 +329,10 @@ function AgentFormContent({
     acc[m.providerID].push(m);
     return acc;
   }, {});
+  const providerLabelById = availableModels.reduce<Record<string, string>>((acc, m) => {
+    acc[m.providerID] = m.providerName;
+    return acc;
+  }, {});
 
   const defaultModelLabel = defaultModel
     ? `${defaultModel.modelID} (${defaultModel.providerID})`
@@ -449,7 +479,7 @@ function AgentFormContent({
           >
             <option value="">— {defaultModelLabel} —</option>
             {Object.entries(modelsByProvider).map(([pID, pModels]) => (
-              <optgroup key={pID} label={pID}>
+              <optgroup key={pID} label={providerLabelById[pID] || pID}>
                 {pModels.map((m) => (
                   <option key={`${m.providerID}::${m.modelID}`} value={`${m.providerID}::${m.modelID}`}>
                     {m.label}

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -15,6 +15,9 @@ const {
   refetchSessions,
   useSessions,
   useAgents,
+  useProviders,
+  defaultModelAPI,
+  modelV2API,
   toast,
 } = vi.hoisted(() => ({
   client: {
@@ -33,6 +36,13 @@ const {
   refetchSessions: vi.fn(),
   useSessions: vi.fn(),
   useAgents: vi.fn(),
+  useProviders: vi.fn(),
+  defaultModelAPI: {
+    getResolved: vi.fn(),
+  },
+  modelV2API: {
+    listDefinitions: vi.fn(),
+  },
   toast: {
     error: vi.fn(),
     info: vi.fn(),
@@ -56,6 +66,15 @@ vi.mock('@/hooks/useSessions', () => ({
 
 vi.mock('@/hooks/useAgents', () => ({
   useAgents,
+}));
+
+vi.mock('@/hooks/useProviders', () => ({
+  useProviders,
+}));
+
+vi.mock('@/api/provider', () => ({
+  defaultModelAPI,
+  modelV2API,
 }));
 
 vi.mock('@/components/common/Toast', () => ({
@@ -157,6 +176,15 @@ describe('SessionPage session actions menu', () => {
       error: null,
       refetch: vi.fn(),
     });
+    useProviders.mockReturnValue({
+      providers: [],
+      connectedIds: [],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    defaultModelAPI.getResolved.mockResolvedValue({ data: { provider_id: '', model_id: '' } });
+    modelV2API.listDefinitions.mockResolvedValue({ data: { models: [] } });
 
     sessionApi.update.mockResolvedValue({ ...session, title: 'Renamed Session' });
     client.post.mockResolvedValue({ data: secondSession });

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -4,7 +4,7 @@ import {
   ChevronDown, Sparkles, Shield, Search, AlertTriangle,
   PanelLeftClose, PanelLeft, Bot, Loader2,
   Workflow as WorkflowIcon, Settings2, CheckSquare,
-  MoreHorizontal, PencilLine, Download, Share2,
+  MoreHorizontal, PencilLine, Download, Share2, Cpu,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import i18n from '@/i18n';
@@ -16,11 +16,14 @@ import { sessionApi } from '@/api/session';
 import type { Agent } from '@/api/agent';
 import { useSessions } from '@/hooks/useSessions';
 import { useAgents } from '@/hooks/useAgents';
+import { useProviders } from '@/hooks/useProviders';
 import client from '@/api/client';
+import { defaultModelAPI, modelV2API } from '@/api/provider';
 import { useDefaultModelVision } from '@/hooks/useDefaultModelVision';
 import { buildPromptParts, type ImagePartData } from '@/utils/imageUpload';
 import { getAgentDisplayDescription } from '@/utils/agentDisplay';
 import { formatSessionDate } from '@/utils/time';
+import type { ModelDefinitionV2 } from '@/types';
 
 function sanitizeSessionExportName(value: string) {
   const trimmed = value.trim();
@@ -33,6 +36,19 @@ function sanitizeSessionExportName(value: string) {
 
 const LAST_SELECTED_SESSION_STORAGE_KEY = 'flocks:last-selected-session';
 type AgentSourceFilter = 'all' | 'builtin' | 'custom';
+type ChatModelOption = {
+  key: string;
+  providerID: string;
+  providerName: string;
+  modelID: string;
+  label: string;
+  supportsVision: boolean | null;
+};
+type ChatModelProviderGroup = {
+  providerID: string;
+  providerName: string;
+  models: ChatModelOption[];
+};
 
 function formatAgentName(name: string): string {
   return name ? name.charAt(0).toUpperCase() + name.slice(1) : name;
@@ -73,6 +89,10 @@ export default function SessionPage() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState('rex');
   const [showAgentOptions, setShowAgentOptions] = useState(false);
+  const [selectedModelKey, setSelectedModelKey] = useState<string | null>(null);
+  const [showModelOptions, setShowModelOptions] = useState(false);
+  const [enabledModelDefinitions, setEnabledModelDefinitions] = useState<ModelDefinitionV2[]>([]);
+  const [loadingEnabledModels, setLoadingEnabledModels] = useState(true);
   const [sseStatus, setSseStatus] = useState<SSEConnectionStatus>('disconnected');
   const [creating, setCreating] = useState(false);
   const [pendingInitialMessage, setPendingInitialMessage] = useState<string | null>(null);
@@ -94,6 +114,7 @@ export default function SessionPage() {
 
   const { sessions, loading: loadingSessions, refetch: refetchSessions, updateSessionTitle, removeSession, removeSessions, addSession } = useSessions();
   const { agents, loading: loadingAgents } = useAgents();
+  const { providers, loading: loadingProviders } = useProviders();
   const primaryAgents = useMemo(() => agents.filter((a) => a.mode === 'primary'), [agents]);
   const subAgents = useMemo(
     () => agents.filter((a) => a.mode !== 'primary' && !(a.tags ?? []).includes('system')),
@@ -112,6 +133,61 @@ export default function SessionPage() {
     () => chatAgents.find((agent) => agent.name === selectedAgent),
     [chatAgents, selectedAgent],
   );
+  const chatModelOptions = useMemo<ChatModelOption[]>(() => {
+    const providerById = new Map(
+      providers
+        .filter((provider) => provider.configured)
+        .map((provider) => [provider.id, provider]),
+    );
+
+    return enabledModelDefinitions.flatMap((model) => {
+      const provider = providerById.get(model.provider_id);
+      if (!provider) return [];
+      return [{
+        key: `${provider.id}::${model.id}`,
+        providerID: provider.id,
+        providerName: provider.name || provider.id,
+        modelID: model.id,
+        label: model.name || model.id,
+        supportsVision: typeof model.capabilities?.supports_vision === 'boolean'
+          ? model.capabilities.supports_vision
+          : null,
+      }];
+    });
+  }, [enabledModelDefinitions, providers]);
+  const groupedChatModelOptions = useMemo<ChatModelProviderGroup[]>(() => {
+    const groups = new Map<string, ChatModelProviderGroup>();
+
+    providers.forEach((provider) => {
+      if (!provider.configured) return;
+      groups.set(provider.id, {
+        providerID: provider.id,
+        providerName: provider.name || provider.id,
+        models: [],
+      });
+    });
+
+    chatModelOptions.forEach((option) => {
+      const group = groups.get(option.providerID);
+      if (group) group.models.push(option);
+    });
+
+    return Array.from(groups.values())
+      .map((group) => ({
+        ...group,
+        models: [...group.models].sort((a, b) => a.label.localeCompare(b.label)),
+      }))
+      .filter((group) => group.models.length > 0)
+      .sort((a, b) => a.providerName.localeCompare(b.providerName));
+  }, [chatModelOptions, providers]);
+  const selectedModelOption = useMemo(
+    () => chatModelOptions.find((option) => option.key === selectedModelKey) ?? chatModelOptions[0] ?? null,
+    [chatModelOptions, selectedModelKey],
+  );
+  const selectedPromptModel = selectedModelOption
+    ? { providerID: selectedModelOption.providerID, modelID: selectedModelOption.modelID }
+    : null;
+  const effectiveSupportsVision = selectedModelOption?.supportsVision ?? supportsVision;
   const selectedSession = useMemo(
     () => sessions.find(s => s.id === selectedSessionId) ?? null,
     [sessions, selectedSessionId],
@@ -210,6 +286,24 @@ export default function SessionPage() {
     writeLastSelectedSessionId(selectedSessionId);
   }, [selectedSessionId]);
 
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingEnabledModels(true);
+    modelV2API.listDefinitions({ enabled_only: true })
+      .then((response) => {
+        if (!cancelled) setEnabledModelDefinitions(response.data.models ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setEnabledModelDefinitions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingEnabledModels(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Close agent dropdown on outside click
   useEffect(() => {
     if (!showAgentOptions) return;
@@ -220,6 +314,41 @@ export default function SessionPage() {
     document.addEventListener('mousedown', handle);
     return () => document.removeEventListener('mousedown', handle);
   }, [showAgentOptions]);
+
+  useEffect(() => {
+    if (!showModelOptions) return;
+    const handle = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('[data-model-selector]')) setShowModelOptions(false);
+    };
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [showModelOptions]);
+
+  useEffect(() => {
+    if (selectedModelKey || chatModelOptions.length === 0) return;
+    let cancelled = false;
+    defaultModelAPI.getResolved()
+      .then((response) => {
+        if (cancelled) return;
+        const { provider_id: providerID, model_id: modelID } = response.data;
+        const defaultKey = `${providerID}::${modelID}`;
+        const fallbackKey = chatModelOptions[0]?.key ?? null;
+        setSelectedModelKey(chatModelOptions.some((option) => option.key === defaultKey) ? defaultKey : fallbackKey);
+      })
+      .catch(() => {
+        if (!cancelled) setSelectedModelKey(chatModelOptions[0]?.key ?? null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chatModelOptions, selectedModelKey]);
+
+  useEffect(() => {
+    if (loadingEnabledModels || chatModelOptions.length === 0 || !selectedModelKey) return;
+    if (chatModelOptions.some((option) => option.key === selectedModelKey)) return;
+    setSelectedModelKey(chatModelOptions[0].key);
+  }, [chatModelOptions, loadingEnabledModels, selectedModelKey]);
 
   useEffect(() => {
     if (!openMenuSessionId) return;
@@ -294,6 +423,7 @@ export default function SessionPage() {
     text: string,
     imageParts?: ImagePartData[],
     agentOverride?: string,
+    modelOverride?: { providerID: string; modelID: string } | null,
   ) => {
     try {
       const response = await client.post('/api/session', { title: 'New Session' });
@@ -308,6 +438,7 @@ export default function SessionPage() {
       };
       const effectiveAgent = agentOverride || 'rex';
       if (effectiveAgent) payload.agent = effectiveAgent;
+      if (modelOverride) payload.model = modelOverride;
       client.post(`/api/session/${newSessionId}/prompt_async`, payload).catch((err: any) => {
         toast.error(t('chat.sendFailed', 'Send failed'), err.message);
       });
@@ -742,7 +873,8 @@ export default function SessionPage() {
           onCreateAndSend={handleCreateAndSend}
           onCreateNewSession={handleCreateSession}
           onStreamingDone={() => setPendingInitialMessage(null)}
-          supportsVision={supportsVision}
+          supportsVision={effectiveSupportsVision}
+          model={selectedPromptModel}
           welcomeContent={(setInput) => (
             <WelcomeScreen onSuggestion={setInput} />
           )}
@@ -827,6 +959,76 @@ export default function SessionPage() {
                       })
                     ) : (
                       <div className="p-4 text-center text-sm text-zinc-500">{t('noAgents')}</div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          }
+          centerToolbarSlot={
+            <div className="relative" data-model-selector>
+              <button
+                type="button"
+                onClick={() => setShowModelOptions(!showModelOptions)}
+                disabled={loadingProviders || loadingEnabledModels || chatModelOptions.length === 0}
+                className="flex h-8 max-w-[260px] items-center gap-1.5 rounded-lg px-2 text-sm text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-50"
+                title={selectedModelOption ? `${selectedModelOption.providerName} / ${selectedModelOption.modelID}` : t('modelPicker.empty')}
+              >
+                <Cpu className="h-4 w-4 shrink-0" />
+                <span className="truncate font-medium">
+                  {selectedModelOption?.label ?? (loadingProviders || loadingEnabledModels ? t('loading') : t('modelPicker.empty'))}
+                </span>
+                <ChevronDown className={`h-3.5 w-3.5 shrink-0 transition-transform ${showModelOptions ? 'rotate-180' : ''}`} />
+              </button>
+              {showModelOptions && (
+                <div className="absolute left-0 bottom-full z-50 mb-2 w-[32rem] max-w-[calc(100vw-2rem)] overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg">
+                  <div className="border-b border-zinc-100 px-3 py-2">
+                    <div className="text-xs font-semibold text-zinc-700">{t('modelPicker.title')}</div>
+                    <div className="text-[11px] text-zinc-400">{t('modelPicker.hint')}</div>
+                  </div>
+                  <div className="max-h-80 overflow-y-auto p-1.5">
+                    {loadingProviders || loadingEnabledModels ? (
+                      <div className="p-4 text-center text-sm text-zinc-500">{t('loading')}</div>
+                    ) : groupedChatModelOptions.length > 0 ? (
+                      groupedChatModelOptions.map((group) => (
+                        <div key={group.providerID} className="py-1 first:pt-0 last:pb-0">
+                          <div className="sticky top-0 z-10 flex items-center justify-between gap-2 bg-white/95 px-2 py-1.5 text-[11px] font-semibold text-zinc-500 backdrop-blur">
+                            <span className="truncate">{group.providerName}</span>
+                            <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-500">
+                              {t('modelPicker.count', { count: group.models.length })}
+                            </span>
+                          </div>
+                          <div className="space-y-0.5">
+                            {group.models.map((option) => (
+                              <button
+                                key={option.key}
+                                type="button"
+                                onClick={() => {
+                                  setSelectedModelKey(option.key);
+                                  setShowModelOptions(false);
+                                }}
+                                className={`w-full rounded-lg px-3 py-2 text-left transition-colors ${
+                                  selectedModelOption?.key === option.key
+                                    ? 'bg-zinc-100 text-zinc-900'
+                                    : 'text-zinc-700 hover:bg-zinc-50'
+                                }`}
+                              >
+                                <div className="flex min-w-0 items-center gap-2">
+                                  <Cpu className="h-4 w-4 shrink-0 text-zinc-500" />
+                                  <span className="min-w-0 flex-1 truncate text-sm font-semibold text-zinc-900">{option.label}</span>
+                                  {option.supportsVision === true && (
+                                    <span className="shrink-0 rounded bg-sky-50 px-1.5 py-0.5 text-[10px] font-medium text-sky-600">
+                                      {t('modelPicker.vision')}
+                                    </span>
+                                  )}
+                                </div>
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      ))
+                    ) : (
+                      <div className="p-4 text-center text-sm text-zinc-500">{t('modelPicker.empty')}</div>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Adjust session composer controls and add a model picker.
- Only show enabled models in session and agent model selectors.
- Group session model options by provider.

## Validation
- bunx tsc --noEmit
- Verified in local browser