### PR TITLE
chore(gitignore): ignore .codex/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ changelog.md
 # Integration tests with real host credentials (not for commit)
 tests/integration_ssh_*.py
 .cursor
+.codex/


### PR DESCRIPTION
Local Codex CLI cache / config directory; not meant to be tracked.