### PR TITLE
[codex] Fix fallback port conflict detection

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -798,11 +798,10 @@ def _port_owner_lookup_available() -> bool:
 
 
 def _bind_port_available(port: int) -> bool:
-    """Return True when the TCP port can be bound locally."""
+    """Return True when the TCP port can be bound on any local IPv4 interface."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            sock.bind(("127.0.0.1", port))
+            sock.bind(("0.0.0.0", port))
         except OSError:
             return False
     return True

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -361,6 +361,30 @@ def test_port_is_in_use_falls_back_to_bind_when_pid_lookup_unavailable(monkeypat
         assert service_manager.port_is_in_use(5173) is True
 
 
+def test_bind_port_available_checks_all_ipv4_interfaces(monkeypatch) -> None:
+    binds: list[tuple[str, int]] = []
+    sockopts: list[tuple[object, ...]] = []
+
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def setsockopt(self, *args) -> None:
+            sockopts.append(args)
+
+        def bind(self, address: tuple[str, int]) -> None:
+            binds.append(address)
+
+    monkeypatch.setattr(service_manager.socket, "socket", lambda *_args, **_kwargs: FakeSocket())
+
+    assert service_manager._bind_port_available(8000) is True
+    assert binds == [("0.0.0.0", 8000)]
+    assert sockopts == []
+
+
 def test_wait_for_http_rejects_unreachable_responses(monkeypatch) -> None:
     responses = iter([
         httpx.Response(503, json={"detail": "not found"}),


### PR DESCRIPTION
## Summary

- Fix fallback backend port conflict detection when PID lookup tools are unavailable.
- Check port availability with a plain wildcard IPv4 bind instead of loopback-only `SO_REUSEADDR` bind.
- Add regression coverage for the fallback bind behavior.

## Root Cause

When `lsof`/`fuser` were unavailable, `flocks start` fell back to probing only `127.0.0.1:<port>` with `SO_REUSEADDR`. That could miss an existing backend listening on another local address with the same port, allowing a second backend on `127.0.0.1:8000`.

## Validation

- `uv run pytest tests/cli/test_service_manager.py`
- `uv run pytest tests/server/test_server_port_config.py`
