### PR TITLE
fix(session): stabilize streaming status

### DIFF
--- a/flocks/session/session_loop.py
+++ b/flocks/session/session_loop.py
@@ -189,6 +189,27 @@ class SessionLoop:
             })
 
     @classmethod
+    async def _publish_session_status(
+        cls,
+        callbacks: "LoopCallbacks",
+        session_id: str,
+        status: str,
+    ) -> None:
+        if not callbacks.event_publish_callback:
+            return
+        try:
+            await callbacks.event_publish_callback("session.status", {
+                "sessionID": session_id,
+                "status": {"type": status},
+            })
+        except Exception as exc:
+            log.debug("loop.session_status.publish_failed", {
+                "session_id": session_id,
+                "status": status,
+                "error": str(exc),
+            })
+
+    @classmethod
     async def _publish_session_notice(
         cls,
         callbacks: "LoopCallbacks",
@@ -341,6 +362,7 @@ class SessionLoop:
         
         # Set status to busy
         SessionStatus.set(session_id, SessionStatusBusy())
+        await cls._publish_session_status(callbacks or LoopCallbacks(), session_id, "busy")
         
         # Mark orphaned running tool parts as error (e.g. from server restart).
         # Wrapped in try/except so cleanup failures never block the session loop.
@@ -384,6 +406,7 @@ class SessionLoop:
             
             # Set status to idle
             SessionStatus.set(session_id, SessionStatusIdle())
+            await cls._publish_session_status(callbacks or LoopCallbacks(), session_id, "idle")
             
             # Touch session (update timestamp)
             await Session.touch(session.project_id, session_id)

--- a/tests/session/test_session_abort_inject.py
+++ b/tests/session/test_session_abort_inject.py
@@ -117,6 +117,50 @@ class TestAbortPropagation:
         runner.abort()
         assert runner.is_aborted is True
 
+    @pytest.mark.asyncio
+    async def test_session_loop_run_publishes_busy_and_idle_status_events(self):
+        session_info = _make_session_info("status_event_session")
+        event_callback = AsyncMock()
+        callbacks = LoopCallbacks(event_publish_callback=event_callback)
+
+        with patch(
+            "flocks.session.session_loop.Session.get_by_id",
+            AsyncMock(return_value=session_info),
+        ), patch(
+            "flocks.session.session_loop.Message.list",
+            AsyncMock(return_value=[]),
+        ), patch(
+            "flocks.session.orphan_tools.abort_orphan_running_parts",
+            AsyncMock(return_value=0),
+        ), patch(
+            "flocks.session.session_loop.SessionLoop._run_loop",
+            AsyncMock(return_value=LoopResult(action="stop")),
+        ), patch(
+            "flocks.session.session_loop.Session.touch",
+            AsyncMock(),
+        ), patch(
+            "flocks.bus.bus.Bus.publish",
+            AsyncMock(),
+        ):
+            result = await SessionLoop.run(
+                session_id=session_info.id,
+                provider_id="test-provider",
+                model_id="test-model",
+                agent_name="rex",
+                callbacks=callbacks,
+            )
+
+        assert result.action == "stop"
+        status_events = [
+            call.args
+            for call in event_callback.await_args_list
+            if call.args and call.args[0] == "session.status"
+        ]
+        assert status_events == [
+            ("session.status", {"sessionID": session_info.id, "status": {"type": "busy"}}),
+            ("session.status", {"sessionID": session_info.id, "status": {"type": "idle"}}),
+        ]
+
 
 # ---------------------------------------------------------------------------
 # SessionLoop abort tests
@@ -575,5 +619,3 @@ class TestLoopContext:
             agent_name="test",
         )
         assert ctx.step == 0
-
-

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -20,6 +20,7 @@ import {
   getUserAvatarContainerClassName,
   getUserAvatarSpacerClassName,
   listUploadedDocumentPaths,
+  shouldRenderMessage,
   shouldRefetchFinishedMessage,
   truncateToolDisplayText,
 } from './SessionChat';
@@ -371,6 +372,26 @@ describe('SessionChat standalone thinking indicator', () => {
       expect(container.querySelectorAll('.animate-bounce').length).toBeGreaterThanOrEqual(3);
       expect(container.textContent).not.toContain('思考中...');
     });
+  });
+});
+
+describe('shouldRenderMessage', () => {
+  it('keeps active empty assistant messages eligible for the thinking indicator', () => {
+    expect(shouldRenderMessage(makeMessage({
+      id: 'assistant-active',
+      role: 'assistant',
+      parts: [],
+      finish: null,
+    }))).toBe(true);
+  });
+
+  it('hides stopped empty assistant messages after abort before first content', () => {
+    expect(shouldRenderMessage(makeMessage({
+      id: 'assistant-stopped',
+      role: 'assistant',
+      parts: [],
+      finish: 'stop',
+    }))).toBe(false);
   });
 });
 

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -436,6 +436,17 @@ export function getRenderableFileUrl(url: string): string {
   }
 }
 
+export function shouldRenderMessage(message: Pick<Message, 'role' | 'parts' | 'finish'>): boolean {
+  if (
+    message.role === 'assistant' &&
+    (message.parts?.length ?? 0) === 0 &&
+    !!message.finish
+  ) {
+    return false;
+  }
+  return true;
+}
+
 export function getUserAvatarContainerClassName(compact: boolean): string {
   return `pointer-events-none absolute left-full top-0 ml-2.5 translate-y-1/2 flex items-center justify-end ${
     compact ? 'h-7' : 'h-8'
@@ -820,6 +831,7 @@ export default function SessionChat({
   // Tracks "sessionId::message" key to prevent double-send in React StrictMode
   const initialMessageSentRef = useRef('');
   const abortingRef = useRef(false);
+  const sessionBusyRef = useRef(false);
   // ID of the assistant message that was aborted; used to ignore its finish event
   const abortedMessageIdRef = useRef<string | null>(null);
   const statusCheckedRef = useRef<string | null>(null);
@@ -938,16 +950,44 @@ export default function SessionChat({
 
       if (type === 'session.cleared' && properties.sessionID === sessionId) {
         abortingRef.current = false;
+        sessionBusyRef.current = false;
         abortedMessageIdRef.current = null;
         setIsStreaming(false);
         refetch();
-      } else if (type === 'session.updated' && properties.id === sessionId && properties.status === 'idle') {
-        setIsStreaming(false);
-        const lastAsstMsg = [...messagesRef.current].reverse().find(
-          (message) => message.role === 'assistant' && !message.finish,
-        );
-        if (lastAsstMsg?.parts?.length) {
-          markMessageStopped(lastAsstMsg.id);
+      } else if (
+        (type === 'session.status' && properties.sessionID === sessionId)
+        || (type === 'session.updated' && properties.id === sessionId && properties.status === 'idle')
+      ) {
+        const statusType = type === 'session.status' ? properties.status?.type : properties.status;
+        if (statusType === 'busy') {
+          sessionBusyRef.current = true;
+          if (!abortingRef.current) setIsStreaming(true);
+          setIsCompacting(false);
+          isCompactingRef.current = false;
+        } else if (statusType === 'compacting') {
+          sessionBusyRef.current = true;
+          if (!abortingRef.current) setIsStreaming(true);
+          setIsCompacting(true);
+          isCompactingRef.current = true;
+          setCompactingMessage(properties.status?.message || t('chat.compacting'));
+          // Reset progress state on each new compaction cycle so a stale
+          // run's stages do not leak into a fresh "Compacting..." panel.
+          setCompactionStages([]);
+        } else if (statusType === 'idle') {
+          const wasCompacting = isCompactingRef.current;
+          sessionBusyRef.current = false;
+          setIsStreaming(false);
+          setIsCompacting(false);
+          isCompactingRef.current = false;
+          setCompactingMessage('');
+          setCompactionStages([]);
+          if (wasCompacting) refetch();
+          const lastAsstMsg = [...messagesRef.current].reverse().find(
+            (message) => message.role === 'assistant' && !message.finish,
+          );
+          if (lastAsstMsg?.parts?.length) {
+            markMessageStopped(lastAsstMsg.id);
+          }
         }
       } else if (type === 'message.updated' && properties.info?.sessionID === sessionId) {
         updateMessage(properties.info);
@@ -961,7 +1001,9 @@ export default function SessionChat({
           // would replace the visible partial response with an empty message.
           if (shouldRefetch) {
             refetch();
-            setIsStreaming(false);
+            if (!sessionBusyRef.current) {
+              setIsStreaming(false);
+            }
           }
           abortingRef.current = false;
           abortedMessageIdRef.current = null;
@@ -989,22 +1031,6 @@ export default function SessionChat({
         const requestId: string | undefined = properties.requestID;
         if (requestId) {
           removeByRequestId(requestId);
-        }
-      } else if (type === 'session.status' && properties.sessionID === sessionId) {
-        if (properties.status?.type === 'compacting') {
-          setIsCompacting(true);
-          isCompactingRef.current = true;
-          setCompactingMessage(properties.status.message || t('chat.compacting'));
-          // Reset progress state on each new compaction cycle so a stale
-          // run's stages do not leak into a fresh "Compacting..." panel.
-          setCompactionStages([]);
-        } else {
-          const wasCompacting = isCompactingRef.current;
-          setIsCompacting(false);
-          isCompactingRef.current = false;
-          setCompactingMessage('');
-          setCompactionStages([]);
-          if (wasCompacting) refetch();
         }
       } else if (type === 'session.compaction_progress' && properties.sessionID === sessionId) {
         const stage = properties.stage as CompactionStage | undefined;
@@ -1035,6 +1061,7 @@ export default function SessionChat({
         setIsCompacting(false);
         setCompactionStages([]);
         abortingRef.current = false;
+        sessionBusyRef.current = false;
         onError?.(properties.error?.message || t('chat.placeholder'));
       }
     },
@@ -1132,6 +1159,7 @@ export default function SessionChat({
     setPendingAgentName(agentName || 'rex');
     abortingRef.current = false;
     abortedMessageIdRef.current = null;
+    sessionBusyRef.current = false;
     statusCheckedRef.current = null;
     isAtBottomRef.current = true;
     clearPendingQuestions();
@@ -1164,12 +1192,16 @@ export default function SessionChat({
         const res = await client.get('/api/session/status');
         const status = res.data[sessionId];
         if (status?.type === 'busy') {
+          sessionBusyRef.current = true;
           setIsStreaming(true);
         } else if (status?.type === 'compacting') {
+          sessionBusyRef.current = true;
           setIsStreaming(true);
           setIsCompacting(true);
           isCompactingRef.current = true;
           setCompactingMessage(status.message || t('chat.compacting'));
+        } else {
+          sessionBusyRef.current = false;
         }
       } catch {
         if (messages.length > 0) {
@@ -2031,6 +2063,10 @@ export default function SessionChat({
 
     for (let idx = 0; idx < merged.length; idx++) {
       const msg = merged[idx];
+      if (!shouldRenderMessage(msg)) {
+        skipIndices.add(idx);
+        continue;
+      }
       if (msg.parts.length > 0 && msg.parts.every(p => p.synthetic)) {
         skipIndices.add(idx);
         continue;

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -25,14 +25,17 @@ function makeMsg(overrides: Partial<Message> & { id: string }): Message {
 
 describe('applyMessagePartUpdate', () => {
   describe('message not found', () => {
-    it('appends part to the last in-progress assistant message when messageID does not match', () => {
+    it('creates a placeholder for the part message instead of reusing a previous assistant', () => {
       const partInfo = { id: 'p1', messageID: 'msg-unknown', sessionID: 'sess-1', type: 'text', text: 'hello' };
       const prev: Message[] = [
-        makeMsg({ id: 'msg-1', role: 'assistant', parts: [] }),
+        makeMsg({ id: 'msg-1', role: 'assistant', parts: [], finish: null } as any),
       ];
       const result = applyMessagePartUpdate(prev, partInfo);
-      expect(result[0].parts).toHaveLength(1);
-      expect((result[0].parts as any[])[0].id).toBe('p1');
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('msg-1');
+      expect(result[0].parts).toHaveLength(0);
+      expect(result[1].id).toBe('msg-unknown');
+      expect((result[1].parts as any[])[0].id).toBe('p1');
     });
 
     it('skips finished assistant messages when looking for in-progress message', () => {
@@ -250,6 +253,47 @@ describe('updateMessagePart scheduling', () => {
     expect(msg).toBeDefined();
     expect((msg!.parts as any[])[0].text).toBe('before-1');
     expect((msg!.parts as any[])[1].text).toBe('after');
+  });
+
+  it('inserts late user metadata before an already streamed assistant child', async () => {
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.addMessage(makeMsg({
+        id: 'old-assistant',
+        role: 'assistant',
+        parts: [{ id: 'old-text', type: 'text', text: 'old reply' } as any],
+        finish: 'stop',
+      } as any));
+      result.current.updateMessagePart({
+        id: 'new-text',
+        messageID: 'new-assistant',
+        sessionID: 'sess-1',
+        type: 'text',
+        text: 'new reply',
+      });
+      result.current.updateMessage({
+        id: 'new-assistant',
+        sessionID: 'sess-1',
+        role: 'assistant',
+        parentID: 'new-user',
+        time: { created: 200 },
+      });
+      result.current.updateMessage({
+        id: 'new-user',
+        sessionID: 'sess-1',
+        role: 'user',
+        time: { created: 100 },
+      });
+    });
+
+    expect(result.current.messages.map((msg) => msg.id)).toEqual([
+      'old-assistant',
+      'new-user',
+      'new-assistant',
+    ]);
+    expect((result.current.messages[2].parts as any[])[0].text).toBe('new reply');
   });
 
   it('truncateAfterMessage keeps the target by default', async () => {

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -66,26 +66,9 @@ export function applyMessagePartUpdate(
   const messageIndex = prev.findIndex(m => m.id === partInfo.messageID);
 
   if (messageIndex < 0) {
-    // Message not found — reuse the last in-progress assistant message if available
-    let lastAssistantIndex = -1;
-    for (let i = prev.length - 1; i >= 0; i--) {
-      if (prev[i].role === 'assistant' && !prev[i].finish) {
-        lastAssistantIndex = i;
-        break;
-      }
-    }
-
-    if (lastAssistantIndex >= 0) {
-      const updated = [...prev];
-      const message = { ...updated[lastAssistantIndex] };
-      const parts = [...(message.parts || [])];
-      parts.push(partInfo);
-      message.parts = parts;
-      updated[lastAssistantIndex] = message;
-      return updated;
-    }
-
-    // No in-progress assistant message — create a placeholder
+    // Message metadata can arrive after part updates over SSE. Keep the part
+    // attached to its own messageID instead of borrowing a nearby assistant,
+    // otherwise chunks from a new turn can render inside the previous reply.
     return [...prev, {
       id: partInfo.messageID,
       sessionID: partInfo.sessionID,
@@ -319,7 +302,7 @@ export function useSessionMessages(sessionId?: string) {
         }
 
         // Add new message
-        return [...prev, {
+        const nextMessage = {
           id: messageInfo.id,
           sessionID: messageInfo.sessionID,
           role: messageInfo.role,
@@ -328,6 +311,21 @@ export function useSessionMessages(sessionId?: string) {
           agent: messageInfo.agent,
           model: messageInfo.model,
           timestamp: messageInfo.time?.created || Date.now(),
+        };
+
+        if (messageInfo.role === 'user') {
+          const childIndex = prev.findIndex(
+            (m) => m.role === 'assistant' && m.parentID === messageInfo.id,
+          );
+          if (childIndex >= 0) {
+            const updated = [...prev];
+            updated.splice(childIndex, 0, nextMessage);
+            return updated;
+          }
+        }
+
+        return [...prev, {
+          ...nextMessage,
         }];
       });
     },


### PR DESCRIPTION
## Summary
- publish explicit session.status busy/idle events from the session loop
- make the chat UI follow session status instead of assistant finish events for stop/streaming state
- keep out-of-order SSE parts attached to their own messages and hide empty stopped assistant placeholders