### PR TITLE
Fix channel image preview rendering

### DIFF
--- a/flocks/channel/builtin/dingtalk/inbound_media.py
+++ b/flocks/channel/builtin/dingtalk/inbound_media.py
@@ -161,6 +161,11 @@ def _guess_filename(
 ) -> str:
     """Resolve a filename from message raw body / header / URL fallback."""
     raw = msg.raw if isinstance(msg.raw, dict) else {}
+    content = _extract_content_dict(msg.raw)
+    for key in ("fileName", "filename", "name"):
+        candidate = str(content.get(key) or "").strip()
+        if candidate:
+            return _sanitize_filename(candidate)
     for key in ("fileName", "filename", "name"):
         candidate = str(raw.get(key) or "").strip()
         if candidate:
@@ -180,6 +185,35 @@ def _guess_filename(
         return _sanitize_filename(url_basename)
     msg_id = msg.message_id or "unknown"
     return _sanitize_filename(f"dingtalk_{msg_id[:12]}")
+
+
+def _extract_content_dict(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        content = raw.get("content")
+        return content if isinstance(content, dict) else {}
+
+    content = getattr(raw, "content", None)
+    if isinstance(content, dict):
+        return content
+
+    extensions = getattr(raw, "extensions", None)
+    if isinstance(extensions, dict):
+        content = extensions.get("content")
+        if isinstance(content, dict):
+            return content
+
+    file_content = getattr(raw, "file_content", None)
+    if isinstance(file_content, dict):
+        return file_content
+    if file_content is not None:
+        result: dict[str, Any] = {}
+        for key in ("fileName", "filename", "name"):
+            value = getattr(file_content, key, None)
+            if value:
+                result[key] = value
+        return result
+
+    return {}
 
 
 async def download_inbound_media(

--- a/flocks/channel/builtin/dingtalk/stream.py
+++ b/flocks/channel/builtin/dingtalk/stream.py
@@ -336,6 +336,17 @@ def _extract_media_url(message: Any) -> Optional[str]:
         if code:
             return str(code)
 
+    content = _extract_content_dict(message)
+    if content:
+        code = (
+            content.get("downloadCode")
+            or content.get("download_code")
+            or content.get("pictureDownloadCode")
+            or content.get("picture_download_code")
+        )
+        if code:
+            return str(code)
+
     rich_text = getattr(message, "rich_text_content", None) or getattr(
         message, "rich_text", None
     )
@@ -352,6 +363,42 @@ def _extract_media_url(message: Any) -> Optional[str]:
                     if code:
                         return str(code)
     return None
+
+
+def _extract_content_dict(message: Any) -> dict[str, Any]:
+    if isinstance(message, dict):
+        content = message.get("content")
+        return content if isinstance(content, dict) else {}
+
+    content = getattr(message, "content", None)
+    if isinstance(content, dict):
+        return content
+
+    extensions = getattr(message, "extensions", None)
+    if isinstance(extensions, dict):
+        content = extensions.get("content")
+        if isinstance(content, dict):
+            return content
+
+    file_content = getattr(message, "file_content", None)
+    if isinstance(file_content, dict):
+        return file_content
+    if file_content is not None:
+        result: dict[str, Any] = {}
+        for key in (
+            "downloadCode",
+            "download_code",
+            "fileName",
+            "filename",
+            "name",
+            "fileId",
+        ):
+            value = getattr(file_content, key, None)
+            if value:
+                result[key] = value
+        return result
+
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/flocks/server/routes/file.py
+++ b/flocks/server/routes/file.py
@@ -4,8 +4,11 @@ File operation routes
 Routes for file reading, searching, and listing
 """
 
+import mimetypes
+from pathlib import Path
 from typing import List, Optional, Dict
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from flocks.config.config import Config
@@ -56,6 +59,31 @@ async def read_file(path: str = Query(..., description="File path")):
         raise HTTPException(status_code=403, detail="Access denied")
     except Exception as e:
         log.error("file.read.error", {"error": str(e), "path": path})
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/download", summary="Download file")
+async def download_file(path: str = Query(..., description="File path")):
+    try:
+        cfg = await Config.get()
+        safe_path = await resolve_path_for_http_file_access(path, cfg)
+        target = Path(safe_path)
+        if not target.is_file():
+            raise HTTPException(status_code=400, detail=f"Not a file: {path}")
+        return FileResponse(
+            path=str(target),
+            filename=target.name,
+            media_type=mimetypes.guess_type(str(target))[0] or "application/octet-stream",
+        )
+    except HTTPException:
+        raise
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except PermissionError:
+        log.warning("http_file.download.denied", {"path": path})
+        raise HTTPException(status_code=403, detail="Access denied")
+    except Exception as e:
+        log.error("file.download.error", {"error": str(e), "path": path})
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/tests/channel/test_dingtalk.py
+++ b/tests/channel/test_dingtalk.py
@@ -13,6 +13,7 @@ import asyncio
 import contextlib
 import importlib.util
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -923,6 +924,36 @@ class TestStreamHelpers:
             message, channel_id="dingtalk", account_id="default",
         ) is None
 
+    def test_chatbot_message_to_inbound_extracts_file_download_code_from_content_extension(self):
+        from flocks.channel.builtin.dingtalk.stream import (
+            chatbot_message_to_inbound,
+        )
+        message = SimpleNamespace(
+            text=None,
+            extensions={
+                "content": {
+                    "fileName": "report.pdf",
+                    "downloadCode": "DL_FILE_1",
+                    "fileId": "file_1",
+                },
+            },
+            conversation_id="cid_file",
+            conversation_type="1",
+            sender_id="u1",
+            sender_staff_id="staff_001",
+            sender_nick="Alice",
+            message_id="msg_file_1",
+            message_type="file",
+        )
+
+        inbound = chatbot_message_to_inbound(
+            message, channel_id="dingtalk", account_id="default",
+        )
+
+        assert inbound is not None
+        assert inbound.media_url == "DL_FILE_1"
+        assert inbound.text == ""
+
 
 # ------------------------------------------------------------------
 # Resilience regressions: R1 (silent stall) + R3 (back-pressure)
@@ -1453,6 +1484,61 @@ class TestDingTalkInboundMedia:
         monkeypatch.setattr(mod, "_exchange_download_code", fake_exchange)
         monkeypatch.setattr(mod, "_download_remote_bytes_limited", fake_download)
         monkeypatch.setattr(mod, "_media_storage_dir", lambda _acc: tmp_path)
+
+        media = await mod.download_inbound_media(
+            InboundMessage(
+                channel_id="dingtalk",
+                account_id="acc1",
+                message_id="m1",
+                sender_id="u1",
+                media_url="download-code-1",
+            ),
+            config={},
+            max_bytes=20,
+        )
+
+        assert captured == {"code": "download-code-1", "account": "acc1"}
+        assert media is not None
+        assert media.filename == "report.png"
+        assert media.mime == "image/png"
+        assert Path(media.url.removeprefix("file://")).read_bytes() == b"hello-img"
+
+    @pytest.mark.asyncio
+    async def test_file_message_content_filename_is_preserved(self, monkeypatch, tmp_path):
+        from flocks.channel.builtin.dingtalk import inbound_media as mod
+
+        async def fake_exchange(*, config, account_id, download_code):
+            return "https://example.com/download", None
+
+        async def fake_download(_url, _max_bytes):
+            return b"%PDF", None
+
+        monkeypatch.setattr(mod, "_exchange_download_code", fake_exchange)
+        monkeypatch.setattr(mod, "_download_remote_bytes_limited", fake_download)
+        monkeypatch.setattr(mod, "_media_storage_dir", lambda _acc: tmp_path)
+
+        media = await mod.download_inbound_media(
+            InboundMessage(
+                channel_id="dingtalk",
+                account_id="acc1",
+                message_id="m_file",
+                sender_id="u1",
+                media_url="download-code-file",
+                raw=SimpleNamespace(
+                    extensions={
+                        "content": {
+                            "fileName": "安全报告.pdf",
+                            "downloadCode": "download-code-file",
+                        },
+                    },
+                ),
+            ),
+            config={},
+        )
+
+        assert media is not None
+        assert media.filename == "安全报告.pdf"
+        assert media.mime == "application/pdf"
 
     @pytest.mark.asyncio
     async def test_direct_url_skips_exchange(self, monkeypatch, tmp_path):

--- a/tests/server/routes/test_file_routes.py
+++ b/tests/server/routes/test_file_routes.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def file_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    data = tmp_path / "data"
+    workspace = tmp_path / "workspace"
+    data.mkdir()
+    workspace.mkdir()
+
+    monkeypatch.setenv("FLOCKS_DATA_DIR", str(data))
+    monkeypatch.setenv("FLOCKS_WORKSPACE_DIR", str(workspace))
+
+    from flocks.config.config import Config
+    from flocks.workspace.manager import WorkspaceManager
+
+    Config._global_config = None
+    WorkspaceManager._instance = None
+
+    from flocks.server.routes.file import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/file")
+
+    yield TestClient(app, raise_server_exceptions=True), data, workspace
+
+    Config._global_config = None
+    WorkspaceManager._instance = None
+
+
+def test_download_file_returns_binary_from_data_dir(file_client):
+    client, data, _workspace = file_client
+    image = data / "channel_media" / "wecom" / "image.png"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    response = client.get("/api/file/download", params={"path": str(image)})
+
+    assert response.status_code == 200
+    assert response.content == b"\x89PNG\r\n\x1a\n"
+    assert response.headers["content-type"].startswith("image/png")
+
+
+def test_download_file_rejects_unallowed_path(file_client, tmp_path: Path):
+    client, _data, _workspace = file_client
+    secret = tmp_path / "outside.png"
+    secret.write_bytes(b"nope")
+
+    response = client.get("/api/file/download", params={"path": str(secret)})
+
+    assert response.status_code == 403

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -14,6 +14,7 @@ import {
   getEditingActionBarClassName,
   getMessageBubbleClassName,
   getMessageGroupClassName,
+  getRenderableFileUrl,
   getRegenerateTruncateTarget,
   getStandaloneThinkingBubbleClassName,
   getUserAvatarContainerClassName,
@@ -293,6 +294,19 @@ describe('getStandaloneThinkingBubbleClassName', () => {
     expect(getStandaloneThinkingBubbleClassName(true)).toBe(
       getMessageBubbleClassName({ compact: true, isUser: false, isEditing: false }),
     );
+  });
+});
+
+describe('getRenderableFileUrl', () => {
+  it('converts local file URLs to the guarded file download endpoint', () => {
+    expect(getRenderableFileUrl('file:///tmp/channel%20image.png')).toBe(
+      '/api/file/download?path=%2Ftmp%2Fchannel%20image.png',
+    );
+  });
+
+  it('leaves browser-readable URLs unchanged', () => {
+    expect(getRenderableFileUrl('https://example.com/image.png')).toBe('https://example.com/image.png');
+    expect(getRenderableFileUrl('data:image/png;base64,abc')).toBe('data:image/png;base64,abc');
   });
 });
 

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -422,6 +422,20 @@ export function getStandaloneThinkingBubbleClassName(compact: boolean): string {
   return getMessageBubbleClassName({ compact, isUser: false, isEditing: false });
 }
 
+export function getRenderableFileUrl(url: string): string {
+  if (!url.startsWith('file://')) {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const path = decodeURIComponent(parsed.pathname);
+    return `${getApiBase()}/api/file/download?path=${encodeURIComponent(path)}`;
+  } catch {
+    return url;
+  }
+}
+
 export function getUserAvatarContainerClassName(compact: boolean): string {
   return `pointer-events-none absolute left-full top-0 ml-2.5 translate-y-1/2 flex items-center justify-end ${
     compact ? 'h-7' : 'h-8'
@@ -2774,13 +2788,14 @@ function ChatMessageBubbleInner({
                   {fileParts.map((part, i) => {
                     const isImage = (part.mime || '').startsWith('image/');
                     if (isImage && part.url) {
+                      const imageUrl = getRenderableFileUrl(part.url);
                       return (
                         <img
                           key={part.id || `file-${i}`}
-                          src={part.url}
+                          src={imageUrl}
                           alt={part.filename || ''}
                           className="h-24 w-24 flex-shrink-0 rounded-lg border border-gray-200 object-cover bg-gray-50 cursor-zoom-in transition-transform hover:scale-[1.02]"
-                          onClick={() => setPreviewImage({ url: part.url!, alt: part.filename })}
+                          onClick={() => setPreviewImage({ url: imageUrl, alt: part.filename })}
                         />
                       );
                     }


### PR DESCRIPTION
## Summary
- Add a guarded file download endpoint for browser-rendered local attachments
- Convert file:// image URLs to HTTP download URLs in SessionChat previews and lightbox
- Add backend and frontend regression tests for local channel image rendering

## Tests
- uv run pytest tests/channel/test_wecom.py tests/channel/test_channel.py tests/server/routes/test_file_routes.py -q
- npm run test:run -- src/components/common/SessionChat.test.ts
- npm run build