### PR TITLE
Fix browser doctor guidance and session streaming status

### DIFF
--- a/.flocks/plugins/skills/browser-use/SKILL.md
+++ b/.flocks/plugins/skills/browser-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-use
-description: 统一处理浏览器使用任务，支持 CDP 直连/无头模式 使用用户本机 Chromium 系浏览器。Use when the user asks to browse websites, interact with pages, fill forms, capture screenshots, reuse an existing Chrome/Chromium/Edge login session, access internal/login-only pages, handle access-restricted content, when websearch/webfetch are unavailable, or automate browser actions.
+description: 统一处理浏览器使用任务，支持可见浏览器 CDP 直连、专用 headless CDP、agent-browser。Use when the user asks to browse websites, interact with pages, fill forms, capture screenshots, reuse an existing Chrome/Chromium/Edge login session, work with an already-open browser/sidebar browser, access login-only/internal/dynamic pages, or automate browser actions.
 ---
 
 # Browser Use
@@ -22,9 +22,8 @@ description: 统一处理浏览器使用任务，支持 CDP 直连/无头模式 
 | `cdp-direct` | 复用本机 Chromium 系浏览器的 CDP 直连模式 | 用户明确说用 CDP 模式|
 | `cdp-headless` | 通过 `BU_CDP_WS` / `BU_CDP_URL` 连接独立 headless Chromium 实例 | 只有用户明确要求 headless，或任务本身是后台任务/定时任务，或系统不支持可视化 |
 
- - 用户明确指出模式后，直接阅读执行规则部分
- - 当用户没有明确指出使用模式时，进入下一步自动判定
- - 不要默认切到 `cdp-headless`；能用用户正常浏览器完成的任务，优先保持可见浏览器流程
+- 用户明确指出模式后，直接阅读执行规则部分
+- 当用户没有明确指出使用模式时，进入下一步自动判定
 
 ## 自动判定与失败处理
 
@@ -55,17 +54,18 @@ description: 统一处理浏览器使用任务，支持 CDP 直连/无头模式 
 flocks browser --doctor
 ```
 
-该命令会检查 `flocks browser` 的 daemon 是否可用、Chrome/Chromium/Edge 是否运行,以及当前是否有可用的浏览器连接。
+该命令会检查 `flocks browser` 的 daemon 是否可用、Chrome/Chromium/Edge 是否运行,以及当前是否有可用的浏览器连接。不要只看命令退出码；必须优先读取 `next action` 行，再结合 `browser running` / `daemon alive` / `active browser connections` 三行判断。
 
-### Step 3: 根据检测结果决定模式（if-then 三段式）
+### Step 3: 根据 doctor 输出决定模式
 
 | 结果 | 触发条件 | 一线修复 | 仍失败兜底 |
 |---|---|---|---|
-| **A** | `flocks browser --doctor` 通过 | 立即确定 `CDP 直连`,阅读 `references/cdp-direct.md`,之后不再切到 `agent-browser` | — |
-| **B** | 浏览器已运行,但 daemon 或 active connection 不可用 | 提示用户 `browser: not connected — 请确保 Chrome/Chromium/Edge 已打开,访问 `chrome://inspect/#remote-debugging` 勾选 Allow`,等用户确认 | 用户确认后 `flocks browser --setup`（不包短超时）→ `--doctor` 确认 → 仍失败则 `flocks browser --reload` 清旧 daemon → 重试 `--setup`。Windows PowerShell 中 `flocks browser -c` 用单行 `;` 分隔,避开多行单引号转义 |
-| **C** | `--doctor` 失败,或当前机器没 Chrome/Chromium/Edge | 明确告知缺哪项,提示安装路径 | **不**擅自降级到 curl/webfetch;坚持告知 skill 边界 |
+| **A** | `next action` 以 `ready` 开头 | 立即确定 `CDP 直连`,阅读 `references/cdp-direct.md`,之后不再切到 `agent-browser` | — |
+| **B** | `next action` 以 `attach` 开头 | 不要先反复 `--setup`；按输出执行 `flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'` 触发一次实际连接/观察 | 如果 `-c` 失败或仍无连接，执行 `flocks browser --reload` 清理旧 daemon，再执行 `flocks browser --setup`；setup 可能需要多次，直到用户完成浏览器 Allow/inspect 授权或错误信息稳定 |
+| **C** | `next action` 以 `setup` 开头 | 先执行 `flocks browser --setup`（不包短超时），再运行 `--doctor` 确认 | 如提示 remote debugging 未启用、`DevToolsActivePort` 缺失、403 handshake 或 not live yet，再提示用户打开对应 inspect 页面并 Allow；用户确认后可多次 `--setup` |
+| **D** | `next action` 提示启动浏览器或提供 endpoint | 明确告知需要先启动 Chrome/Chromium/Edge 或提供 CDP endpoint | **不**擅自降级到 curl/webfetch；坚持告知 skill 边界 |
 
-### Step 4: 跨模式通用失败（if-then 三段式）
+### Step 4: 跨模式通用失败
 
 | 触发条件 | 一线修复 | 仍失败兜底 |
 |---|---|---|
@@ -80,6 +80,7 @@ flocks browser --doctor
 3. 在 `cdp-headless` 中，如果当前任务自己启动了专用浏览器实例，必须记录 PID / 日志 / 专用 profile，并只在任务结束或明确放弃后清理自己启动的实例；不要关闭用户提供的远程浏览器。
 4. 不要同时加载 `references/cdp-direct.md` 和 `references/agent-browser.md`。
 5. `flocks browser` 的 daemon 文件固定放在 `~/.flocks/browser/`,例如 `bu.sock`、`bu.log`、`bu.pid`、`bu.port`。
+6. 基础操作能力（打开、观察、点击、输入、滚动、截图、提取、等待、关闭）优先按 `references/cdp-direct.md` 的“基础操作速查”执行
 
 ## 产品经验Skill
 

--- a/.flocks/plugins/skills/browser-use/references/cdp-direct.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-direct.md
@@ -32,6 +32,179 @@ flocks browser --doctor
 
 通过`flocks browser -c '...'` 操作浏览器
 
+## 基础操作速查
+
+这些操作对应本地 `browser-use` skill 的常用能力。这里仅提供命令模板；执行顺序和选择原则见“主流程”。
+
+### 打开页面或复用目标 tab
+
+```bash
+flocks browser -c '
+tid = open_or_attach_tab("https://example.com", activate=True)
+wait_for_load()
+print({"targetId": tid, "page": page_info()})
+'
+```
+
+如果用户说页面已经在浏览器或侧边栏打开，先列出非内部页并选择目标 tab；不要直接新开 headless：
+
+```bash
+flocks browser -c '
+for tab in list_tabs(include_chrome=False):
+    print(tab)
+'
+```
+
+确认目标后：
+
+```bash
+flocks browser -c '
+attach_tab("<TARGET_ID>")
+print(page_info())
+'
+```
+
+### 观察页面状态
+
+```bash
+flocks browser -c '
+print(page_info())
+print(js("document.body.innerText.slice(0, 4000)"))
+'
+```
+
+查找可点击元素：
+
+```bash
+flocks browser -c '
+items = js("""
+Array.from(document.querySelectorAll("a,button,input,textarea,select,[role=button],[onclick]"))
+  .slice(0, 80)
+  .map((el, i) => ({
+    i,
+    tag: el.tagName,
+    text: (el.innerText || el.value || el.getAttribute("aria-label") || el.title || "").trim().slice(0, 120),
+    selector: el.id ? "#" + el.id : el.name ? el.tagName.toLowerCase() + "[name=" + JSON.stringify(el.name) + "]" : null,
+    disabled: !!el.disabled,
+    rect: (() => { const r = el.getBoundingClientRect(); return {x:r.x,y:r.y,w:r.width,h:r.height}; })()
+  }))
+""")
+print(items)
+'
+```
+
+### 点击、输入与按键
+
+优先用稳定 DOM 操作：
+
+```bash
+flocks browser -c '
+js("document.querySelector(\"button[type=submit]\")?.click()")
+wait(0.5)
+print(page_info())
+'
+```
+
+输入字段必须触发 `input` / `change` 事件：
+
+```bash
+flocks browser -c '
+js("""
+const el = document.querySelector("input[name=q], textarea[name=q]");
+el.value = "search text";
+el.dispatchEvent(new Event("input", {bubbles: true}));
+el.dispatchEvent(new Event("change", {bubbles: true}));
+""")
+press_key("Enter")
+wait(0.5)
+print(page_info())
+'
+```
+
+只有 DOM 难以稳定定位时，才退到坐标：
+
+```bash
+flocks browser -c '
+click_at_xy(420, 315)
+type_text("text")
+press_key("Enter")
+wait(0.5)
+print(page_info())
+'
+```
+
+### 滚动、等待与截图
+
+```bash
+flocks browser -c '
+scroll(500, 500, dy=-800)
+wait(0.5)
+print(page_info())
+'
+```
+
+等待指定文本或选择器时，用短轮询，避免盲等：
+
+```bash
+flocks browser -c '
+import time
+deadline = time.time() + 10
+while time.time() < deadline:
+    if js("document.body.innerText.includes(\"Success\")"):
+        print("found")
+        break
+    wait(0.5)
+else:
+    print("not found")
+'
+```
+
+截图只在需要视觉证据或调试时保存：
+
+```bash
+flocks browser -c '
+print(capture_screenshot("/tmp/browser-use-shot.png", full=False, max_dim=1800))
+'
+```
+
+### 提取数据
+
+提取文本、HTML、链接或结构化数据时，优先在页面内组装 JSON：
+
+```bash
+flocks browser -c '
+print(js("document.title"))
+print(js("location.href"))
+print(js("document.body.innerText.slice(0, 8000)"))
+'
+```
+
+```bash
+flocks browser -c '
+rows = js("""
+Array.from(document.querySelectorAll("a[href]")).map(a => ({
+  text: a.innerText.trim(),
+  href: a.href
+})).filter(x => x.text || x.href).slice(0, 200)
+""")
+print(rows)
+'
+```
+
+静态资源或接口可直接访问时，优先 `http_get(url)`，不要浪费浏览器上下文。
+
+### 关闭当前任务资源
+
+只关闭自己创建或确认属于本任务的 tab：
+
+```bash
+flocks browser -c '
+close_tab("<TARGET_ID>", activate_next=False)
+'
+```
+
+不确定是否是用户原有 tab 时，保留 tab 并说明原因。
+
 ## 语法说明
 
 - `flocks browser -c '...'` 执行的是一段 Python 代码，不是交互式 REPL；如果希望看到结果，必须显式 `print(...)`。
@@ -58,59 +231,20 @@ print(page_info())
 flocks browser -c (Get-Content -Raw "$env:TEMP\flocks-browser-cmd.py")
 ```
 
-## 核心操作循环
-> 打开页面 -> 观察当前状态 -> 执行动作 -> 再观察验证
+## 主流程
 
-1. 新建或打开已打开 tab
-2. 用 `page_info()` / `js(...)` 观察当前页面、URL、文本、结构和阻塞状态
-3. 选择当前最稳妥的动作方式
-4. 动作后重新观察，确认页面是否真的变化
-5. 如果未达成目标，先解释当前卡点，再换一种方式继续
+按同一个循环执行：准备目标 tab -> 观察页面 -> 选择动作 -> 执行 -> 再观察验证。不要凭旧状态继续操作。
 
+1. 如果是具体网站/产品任务，先搜索已存在的 skill，看 `<产品>-use` skill 下是否存在浏览器相关操作；如果没有，再自己探索。
+2. 创建自己的 tab，或在用户明确要求继续当前页面时先列出并 attach 目标 tab。保存 `targetId`，等待加载，并读取页面基础状态。后续步骤继续使用同一个 tab 时，优先 `attach_tab(target_id)`，不要反复 `switch_tab(...)` 抢用户焦点。
 
-## 标准工作流
+3. 先用 `page_info()` 看 URL、标题、滚动位置、页面尺寸和对话框阻塞状态，再用 `js(...)` 读取文本、DOM 结构、元素状态或业务字段。
+4. 能稳定定位 DOM 时，优先直接在页面内执行 JS 或 raw CDP；只有 DOM 难以稳定定位，或需要操作 compositor 级控件时，才退到坐标点击。iframe / 特殊 target 场景，再考虑 `iframe_target(...)` 配合 `js(..., target_id=...)`。
 
-1. 如果是具体网站/产品任务，先搜索已存在的skill，看 `<产品>-use` skill 下是否存在浏览器相关操作；如果没有，再自己探索。
-2. 创建自己的 tab，保存 `targetId`，等待加载，并先读取页面基础状态：
-
-```bash
-flocks browser -c '
-tid = new_tab("https://example.com", activate=True)
-wait_for_load()
-print(page_info())
-'
-```
-
-如需进一步观察页面结构、文本或候选交互元素，再按当前站点实际情况用 `js(...)` 做针对性提取；
-
-后续步骤继续使用同一个 tab 时，先恢复它：
-
-```bash
-flocks browser -c '
-attach_tab("<TARGET_ID>")
-print(page_info())
-'
-```
-
-3. 执行动作并验证。能稳定定位 DOM 时，优先用 `js(...)`；必须操作可见但 DOM 难以稳定定位的控件时，再使用 `click_at_xy(...)`、`type_text(...)`、`press_key(...)`：
-
-```bash
-flocks browser -c '
-js("document.querySelector(\"button[type=submit]\")?.click()")
-wait(0.5)
-print(page_info())
-'
-```
-
-4. 需要提取数据时用 `js(...)` 或 `http_get(...)`。静态页面/接口批量抓取优先 `http_get`，不要浪费浏览器。
-5. 结束时只关闭自己创建的 tab。若不确定 tab 是否属于自己，保留它并说明；如果当前任务还临时拉起了专用 headless 浏览器实例，tab 清理完后再按 `references/cdp-headless.md` 的约定决定是否关闭整个浏览器进程。
-
-注意：
-
-- 每次点击、输入、提交、弹窗处理、导航、滚动或重渲染后，都重新调用 `page_info()` 或 `js(...)`。
-- 页面变化后，之前读取到的元素状态、坐标和文本都可能过期，必须重新观察。
-- 提取大量结构化数据时，优先在页面内用 `js(...)` 组装 JSON 后返回。
-- 判断内容是否已在 DOM 中，不要只依赖当前可见区域；懒加载或虚拟列表再配合 `scroll(...)` 分段读取。
+5. 坐标点击前用 DOM 布局信息确认目标位置，例如 `getBoundingClientRect()`。坐标点击不稳定、目标不可见或需要隐藏 input 时，改用 DOM、iframe target 或 raw CDP。
+6. 需要提取数据时用 `js(...)` 或 `http_get(...)`。提取大量结构化数据时，优先在页面内用 `js(...)` 组装 JSON 后返回；静态页面/接口批量抓取优先 `http_get`，不要浪费浏览器。
+7. 判断内容是否已在 DOM 中，不要只依赖当前可见区域；懒加载或虚拟列表再配合 `scroll(...)` 分段读取。
+8. 结束时只关闭自己创建的 tab。若不确定 tab 是否属于自己，保留它并说明；如果当前任务还临时拉起了专用 headless 浏览器实例，tab 清理完后再按 `references/cdp-headless.md` 的约定决定是否关闭整个浏览器进程。
 
 
 ## Tab 与可见性
@@ -125,47 +259,6 @@ print(page_info())
 - `list_tabs()` 默认会包含 `chrome://`、`about:` 等内部页面；要面向用户页面时用 `list_tabs(include_chrome=False)`。
 - 忽略 `chrome://omnibox-popup.top-chrome/` 这类假 page target。页面 `w=0 h=0` 时通常是 attach 到了错误 target。
 - 当当前 session stale、内部页或不可见，并且确实要恢复到某个用户页面时，先 `ensure_real_tab()`；它会先 attach 到非内部页而不是主动激活浏览器 UI。
-
-## 读取、定位与执行
-
-本节的核心不是罗列所有操作方式，而是确定优先级：先读清楚，再选最稳的执行方式。
-
-默认先用 `page_info()` 与 `js(...)` 观察页面，不依赖截图：
-
-```python
-print(page_info())
-print(js("document.body.innerText.slice(0, 2000)"))
-```
-
-推荐顺序：
-
-1. 先用 `page_info()` 看 URL、标题、滚动位置、页面尺寸，以及是否被原生对话框阻塞
-2. 再用 `js(...)` 读取文本、DOM 结构、元素状态、业务字段
-3. 能稳定定位 DOM 时，优先直接在页面内执行 JS 或 raw CDP
-4. 只有 DOM 难以稳定定位，或需要操作 compositor 级控件时，才退到坐标点击
-5. iframe / 特殊 target 场景，再考虑 `iframe_target(...)` 配合 `js(..., target_id=...)`
-
-能稳定定位 DOM 时，优先通过页面内 JS 或 selector 相关能力操作；需要穿过 iframe、shadow DOM、cross-origin 或自定义控件时，再使用 compositor 级坐标点击：
-
-```python
-click_at_xy(x, y)
-```
-
-坐标点击前尽量用 DOM 布局信息确认目标位置，例如 `getBoundingClientRect()`。坐标点击不稳定、目标不可见或需要隐藏 input 时，改用 DOM、iframe target 或 raw CDP。
-
-截图仅作为可选调试产物：
-
-```python
-capture_screenshot("<workspace_dir>/tmp/shot.png", max_dim=1800)
-```
-
-如果启用点击调试：
-
-```bash
-flocks browser --debug-clicks -c '
-click_at_xy(420, 315)
-'
-```
 
 ## 表单填充与点击操作模式
 
@@ -255,19 +348,21 @@ print({"cookies": [c["name"] for c in cookies], "localStorage": js("Object.keys(
 
 如果 `flocks browser` 不可用或连接失败：
 
-1. 先运行 `flocks browser --doctor` 看版本、安装模式、daemon 和浏览器状态。
-2. 首次安装或冷启动优先运行 `flocks browser --setup`。
-3. Chrome / Chromium / Edge 未运行时只启动浏览器，再重试；不要直接让用户改设置。
-4. 只有在明确提示 remote debugging 未启用或 `DevToolsActivePort` 缺失时，才让用户打开对应浏览器的 inspect 页面（例如 `chrome://inspect/#remote-debugging` 或 `edge://inspect/#remote-debugging`）并勾选 Allow remote debugging。
-5. 用户刚开启 remote debugging 时，不要立刻再次运行 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 daemon attach，再用 `--doctor` 做只读确认。
-6. `connection refused`、`DevTools not live yet`、`/json/version` 404 通常是浏览器正在启动，轮询等待，不要重启。
-7. stale websocket / stale socket 时执行一次：
+1. 先运行 `flocks browser --doctor` 看版本、安装模式、daemon 和浏览器状态；不要只看退出码，优先读 `next action`，再看 `browser running`、`daemon alive`、`active browser connections`。
+2. `next action` 为 `attach`，或 `daemon alive` ok 但 `active browser connections` 为 0 时，不要先反复 `--setup`。先用一次实际命令触发连接/观察：`flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'`。
+3. 如果上一步失败或仍无连接，再执行 `flocks browser --reload` 清旧 daemon，然后执行 `flocks browser --setup`；setup 可能需要多次，因为用户可能需要完成浏览器 inspect/Allow 授权，或浏览器需要时间写入 remote debugging 状态。
+4. 首次安装、冷启动、daemon 不存在/不通，且浏览器已经运行或配置了 `BU_CDP_URL` / `BU_CDP_WS` 时，优先运行 `flocks browser --setup`。
+5. Chrome / Chromium / Edge 未运行且没有显式 CDP endpoint 时，只提示用户启动浏览器或提供 endpoint；不要直接让用户改设置。
+6. 只有在明确提示 remote debugging 未启用、`DevToolsActivePort` 缺失、403 handshake、remote-debugging page 或 not live yet 时，才让用户打开对应浏览器的 inspect 页面（例如 `chrome://inspect/#remote-debugging` 或 `edge://inspect/#remote-debugging`）并勾选 Allow remote debugging。
+7. 用户刚开启 remote debugging 时，不要立刻再次运行 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 daemon attach，再用 `--doctor` 做只读确认。
+8. `connection refused`、`DevTools not live yet`、`/json/version` 404 通常是浏览器正在启动，轮询等待，不要重启。
+9. stale websocket / stale socket 时执行一次：
 
 ```bash
 flocks browser -c 'restart_daemon()'
 ```
 
-8. 页面操作异常但连接本身正常时，优先回到上面的“页面操作排障”，不要把所有问题都归因为浏览器没连上。
+10. 页面操作异常但连接本身正常时，优先回到上面的“页面操作排障”，不要把所有问题都归因为浏览器没连上。
 
 ## The self-heal loop 自修复/扩展 循环
 

--- a/.flocks/plugins/skills/browser-use/references/cdp-setup.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-setup.md
@@ -1,8 +1,17 @@
 # Flocks browser setup
 
-浏览器已运行，但 daemon 或 active browser connection 不可用
+浏览器已运行，但 daemon 不存在/不通，或 active browser connection 不可用
 
-必须直接提示用户：
+先区分两种情况：
+
+1. `daemon alive` ok 但 `active browser connections` 为 0：
+   - 不要先反复执行 `flocks browser --setup`，因为 setup 在 daemon 已运行且协议正常时可能直接输出 nothing to do。
+   - 先执行 `flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'` 触发一次实际连接/观察。
+   - 如果仍失败，再执行 `flocks browser --reload` 清旧 daemon，然后执行 `flocks browser --setup`。
+2. daemon 不存在/不通，且浏览器已运行或配置了 `BU_CDP_URL` / `BU_CDP_WS`：
+   - 执行 `flocks browser --setup` 触发 attach，不要用短超时包装该命令。
+
+只有在错误明确指向 remote debugging 未启用、`DevToolsActivePort` 缺失、403 handshake 或 not live yet 时，才提示用户：
 
 ```text
 browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后访问对应浏览器的 inspect 页面（例如 chrome://inspect/#remote-debugging 或 edge://inspect/#remote-debugging）并勾选 Allow remote debugging
@@ -13,4 +22,4 @@ browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后
 当用户确认已开启remote-debugging后:
 1. 执行 `flocks browser --setup` 触发交互式 attach，不要用短超时包装该命令
 2. 再运行 `flocks browser --doctor` 做只读确认。
-3. 如果还失败，先执行 `flocks browser --reload` 清理旧 daemon，再重新执行 `flocks browser --setup`，避免因为残留 daemon 造成干扰。
+3. 如果还失败，先执行 `flocks browser --reload` 清理旧 daemon，再重新执行 `flocks browser --setup`，避免因为残留 daemon 造成干扰。setup 可能需要多次，直到用户完成浏览器 Allow/inspect 授权或错误信息稳定。

--- a/.flocks/plugins/skills/web2cli/SKILL.md
+++ b/.flocks/plugins/skills/web2cli/SKILL.md
@@ -61,6 +61,23 @@ mkdir -p "$CAPTURE_ROOT/captures"
 
 > 按照以下 1-11 的操作流程完成任务
 
+Copy this checklist and check off items as you complete them:
+
+```text
+Task Progress:
+- [ ] Step 1: Confirm target site/tab and prepare capture directory
+- [ ] Step 2: Check browser availability and open or attach target tab
+- [ ] Step 3: Wait for required manual login or authorization
+- [ ] Step 4: Inject Web2CLI capture hook and verify it is installed
+- [ ] Step 5: Perform the target page operation and confirm requests are captured
+- [ ] Step 6: Export captured API data and save browser auth state
+- [ ] Step 7: Analyze captured APIs and identify the CLI request chain
+- [ ] Step 8: Generate CLI, verify.json, and cli-reference.md
+- [ ] Step 9: Validate the generated CLI against live captured/authenticated data
+- [ ] Step 10: Integrate the WebCLI capability into a maintainable skill or device asset
+- [ ] Step 11: Summarize generated capability and close only the Web2CLI tab
+```
+
 ### 1. 打开浏览器或创建 Tab
 
 ```bash

--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -453,7 +453,7 @@ def run_setup() -> int:
 
 
 def run_doctor() -> int:
-    """Read-only diagnostics. Exit 0 iff everything looks healthy."""
+    """Read-only diagnostics. Exit 0 iff a browser target and daemon exist."""
     import platform
     import sys
 
@@ -470,6 +470,16 @@ def run_doctor() -> int:
     def row(label: str, ok: bool, detail: str = "") -> None:
         mark = "ok  " if ok else "FAIL"
         print(f"  [{mark}] {label}{(' — ' + detail) if detail else ''}")
+
+    target_available = browser_running or bool(endpoint_name)
+    if connections:
+        next_action = "ready; use `flocks browser -c 'print(page_info())'`"
+    elif target_available and daemon:
+        next_action = "attach; run `flocks browser -c 'print(page_info())'` before setup"
+    elif target_available:
+        next_action = "setup; run `flocks browser --setup`"
+    else:
+        next_action = "start Chrome/Chromium/Edge or provide BU_CDP_URL/BU_CDP_WS, then run `flocks browser --setup`"
 
     print(f"{BROWSER_LABEL} doctor")
     print(f"  platform          {platform.system()} {platform.release()}")
@@ -497,4 +507,5 @@ def run_doctor() -> int:
             print(f"        {conn['name']} — active page: {title} — {url}")
         else:
             print(f"        {conn['name']} — active page: (no real page)")
-    return 0 if ((browser_running or endpoint_name) and daemon) else 1
+    print(f"  next action       {next_action}")
+    return 0 if (target_available and daemon) else 1

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -187,6 +187,7 @@ def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypat
     assert "[ok  ] active browser connections — 2" in out
     assert "        default — active page: Example — https://example.test" in out
     assert "        cats — active page: Cat - Wikipedia — https://en.wikipedia.org/wiki/Cat" in out
+    assert "next action       ready; use `flocks browser -c 'print(page_info())'`" in out
     assert "profile-use installed" not in out
     assert "BROWSER_USE_API_KEY set" not in out
 
@@ -216,6 +217,36 @@ def test_doctor_page_output_truncates_long_text(monkeypatch, capsys) -> None:
     assert "https://example.t..." in out
     assert "profile-use installed" not in out
     assert "BROWSER_USE_API_KEY set" not in out
+
+
+def test_run_doctor_suggests_attach_when_daemon_alive_without_active_connections(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [])
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+
+    assert admin.run_doctor() == 0
+
+    out = capsys.readouterr().out
+    assert "[ok  ] active browser connections — 0" not in out
+    assert "[FAIL] active browser connections — 0" in out
+    assert "next action       attach; run `flocks browser -c 'print(page_info())'` before setup" in out
+
+
+def test_run_doctor_suggests_setup_when_target_exists_but_daemon_missing(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: False)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [])
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+
+    assert admin.run_doctor() == 1
+
+    out = capsys.readouterr().out
+    assert "next action       setup; run `flocks browser --setup`" in out
 
 
 def test_run_setup_uses_generic_missing_browser_wording(monkeypatch, capsys) -> None:
@@ -343,6 +374,7 @@ def test_run_doctor_uses_generic_browser_wording_when_missing(monkeypatch, capsy
     out = capsys.readouterr().out
     assert "[FAIL] browser running" in out
     assert "start Chrome, Chromium, or Edge and rerun `flocks browser --setup`" in out
+    assert "next action       start Chrome/Chromium/Edge or provide BU_CDP_URL/BU_CDP_WS" in out
 
 
 def test_run_doctor_accepts_explicit_remote_cdp_without_local_browser(monkeypatch, capsys) -> None:
@@ -359,6 +391,7 @@ def test_run_doctor_accepts_explicit_remote_cdp_without_local_browser(monkeypatc
     out = capsys.readouterr().out
     assert "[ok  ] browser target — configured via BU_CDP_URL" in out
     assert "[ok  ] daemon alive" in out
+    assert "next action       attach; run `flocks browser -c 'print(page_info())'` before setup" in out
 
 
 def test_chrome_running_on_windows_handles_non_utf8_tasklist_output(monkeypatch) -> None:

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -393,6 +393,16 @@ describe('shouldRenderMessage', () => {
       finish: 'stop',
     }))).toBe(false);
   });
+
+  it('keeps empty assistant error messages visible', () => {
+    expect(shouldRenderMessage(makeMessage({
+      id: 'assistant-error',
+      role: 'assistant',
+      parts: [],
+      finish: 'error',
+      error: { code: 'SessionError', message: 'Provider failed' },
+    }))).toBe(true);
+  });
 });
 
 describe('SessionChat agent mentions', () => {
@@ -606,6 +616,8 @@ describe('ChatToolPart todo rendering', () => {
     expect(container.textContent).toContain('Todo 阶段');
     expect(container.textContent).toContain('定位 todo 摘要问题中');
     expect(container.textContent).toContain('completed');
+    expect(container.textContent).not.toContain('输入参数');
+    expect(container.textContent).not.toContain('输出结果');
     expect(container.textContent).not.toContain('[object Object]');
   });
 });

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -538,11 +538,12 @@ export function getRenderableFileUrl(url: string): string {
   }
 }
 
-export function shouldRenderMessage(message: Pick<Message, 'role' | 'parts' | 'finish'>): boolean {
+export function shouldRenderMessage(message: Pick<Message, 'role' | 'parts' | 'finish' | 'error'>): boolean {
   if (
     message.role === 'assistant' &&
     (message.parts?.length ?? 0) === 0 &&
-    !!message.finish
+    message.finish === 'stop' &&
+    !message.error
   ) {
     return false;
   }
@@ -1096,20 +1097,13 @@ export default function SessionChat({
           // run's stages do not leak into a fresh "Compacting..." panel.
           setCompactionStages([]);
         } else if (statusType === 'idle') {
-          const wasCompacting = isCompactingRef.current;
           sessionBusyRef.current = false;
           setIsStreaming(false);
           setIsCompacting(false);
           isCompactingRef.current = false;
           setCompactingMessage('');
           setCompactionStages([]);
-          if (wasCompacting) refetch();
-          const lastAsstMsg = [...messagesRef.current].reverse().find(
-            (message) => message.role === 'assistant' && !message.finish,
-          );
-          if (lastAsstMsg?.parts?.length) {
-            markMessageStopped(lastAsstMsg.id);
-          }
+          refetch();
         }
       } else if (type === 'message.updated' && properties.info?.sessionID === sessionId) {
         updateMessage(properties.info);
@@ -1191,7 +1185,6 @@ export default function SessionChat({
       sessionId,
       updateMessage,
       updateMessagePart,
-      markMessageStopped,
       refetch,
       handleQuestionAsked,
       removeByRequestId,
@@ -3490,6 +3483,7 @@ export function ChatToolPart({ part, pendingQuestion, onAnswer, onReject }: Chat
   const todoEntries = toolName === 'todo'
     ? pickTodoEntries(state.metadata?.newTodos, state.metadata?.todos, state.input?.todos)
     : [];
+  const showGenericToolPayload = toolName !== 'todo';
 
   // Reuse the shared helpers so the truncation rules stay in sync with the
   // delegate-task card and any other places that render tool input previews.
@@ -3579,7 +3573,7 @@ export function ChatToolPart({ part, pendingQuestion, onAnswer, onReject }: Chat
           </div>
         )}
 
-        {state.input && (
+        {showGenericToolPayload && state.input && (
           <details>
             <summary className="cursor-pointer text-[11px] text-zinc-500 font-medium hover:text-zinc-700 transition-colors mb-1">
               {t('chat.tool.inputParams')}
@@ -3590,7 +3584,7 @@ export function ChatToolPart({ part, pendingQuestion, onAnswer, onReject }: Chat
           </details>
         )}
 
-        {status === 'completed' && state.output !== undefined && (
+        {showGenericToolPayload && status === 'completed' && state.output !== undefined && (
           <details open>
             <summary className="cursor-pointer text-[11px] text-zinc-500 font-medium hover:text-zinc-700 transition-colors mb-1">
               {t('chat.tool.outputResult')}


### PR DESCRIPTION
## Summary
- add clearer browser doctor next-action guidance and tests for attach/setup cases
- expand browser-use and web2cli skill guidance for CDP attach workflows
- keep empty assistant error messages visible and avoid marking normal idle completions as aborted/stopped

## Root Cause
- browser doctor output did not clearly distinguish ready, attach, setup, and missing-browser states
- session.status idle can arrive before the final message.updated finish event, so the UI should refetch instead of mutating the last unfinished assistant locally
- empty finished assistant filtering was too broad and hid error messages with no parts

## Validation
- npm run test:run -- src/components/common/SessionChat.test.ts
- npm run test:run -- src/hooks/useSessions.test.ts
- uv run pytest tests/browser/test_admin.py