### PR TITLE
fix(channel): preserve plugin instances across load_all

### DIFF
--- a/flocks/channel/registry.py
+++ b/flocks/channel/registry.py
@@ -32,7 +32,21 @@ class ChannelRegistry:
 
     def register(self, plugin: ChannelPlugin) -> None:
         meta = plugin.meta()
-        self._channels[meta.id.lower()] = plugin
+        key = meta.id.lower()
+        existing = self._channels.get(key)
+        if existing is not None:
+            log.debug(
+                "channel.register.skip_existing",
+                {
+                    "id": meta.id,
+                    "aliases": meta.aliases,
+                    "existing_instance": f"{id(existing):x}",
+                    "candidate_instance": f"{id(plugin):x}",
+                },
+            )
+            return
+
+        self._channels[key] = plugin
         for alias in meta.aliases:
             self._channels[alias.lower()] = plugin
         log.info("channel.registered", {"id": meta.id, "aliases": meta.aliases})
@@ -105,6 +119,7 @@ class ChannelRegistry:
             dedup_key=lambda ch: ch.meta().id,
             recursive=True,
             max_depth=2,
+            load_once=True,
         ))
 
     def _load_plugin_channels(self) -> None:

--- a/flocks/plugin/loader.py
+++ b/flocks/plugin/loader.py
@@ -173,7 +173,16 @@ class ExtensionPoint:
     E.g. ``frozenset({"mcp", "generated"})`` — these are managed by
     dedicated subsystems rather than the generic PluginLoader."""
 
+    load_once: bool = False
+    """When True, skip later ``load_all`` passes after this extension has loaded.
+
+    Stateful extension points, such as channels, own runtime connections and
+    callbacks on their plugin instances. Re-importing those modules can create
+    replacement instances that have not been started.
+    """
+
     _seen_keys: Set[str] = field(default_factory=set, repr=False)
+    _loaded: bool = field(default=False, repr=False)
 
 
 class PluginLoader:
@@ -225,6 +234,15 @@ class PluginLoader:
         project_plugin_root = project_dir / ".flocks" / "plugins"
 
         for ext in cls._extension_points.values():
+            if ext.load_once and ext._loaded:
+                log.debug(
+                    "plugin.load_all.skip_load_once",
+                    {
+                        "attr": ext.attr_name,
+                    },
+                )
+                continue
+
             ext._seen_keys = set()
 
             # 1. User-level plugin subdirectory (~/.flocks/plugins/{subdir}/)
@@ -269,6 +287,9 @@ class PluginLoader:
             if extra_sources:
                 cls._load_sources_for_ext(ext, extra_sources, project_dir)
 
+            if ext.load_once:
+                ext._loaded = True
+
         # 4. Installed package entry-points
         cls._load_entry_points()
 
@@ -299,6 +320,8 @@ class PluginLoader:
         ext._seen_keys = set()
         try:
             cls._load_sources_for_ext(ext, sources, base_dir)
+            if ext.load_once and sources:
+                ext._loaded = True
         finally:
             ext.consumer = original_consumer
         return collected

--- a/tests/channel/test_channel.py
+++ b/tests/channel/test_channel.py
@@ -1248,6 +1248,17 @@ class TestChannelRegistry:
         reg.register(plugin)
         assert reg.get("test_ch") is plugin
 
+    def test_register_keeps_existing_channel_instance(self):
+        from flocks.channel.registry import ChannelRegistry
+        reg = ChannelRegistry()
+        first = _StubChannel("test_ch", "First")
+        replacement = _StubChannel("test_ch", "Replacement")
+
+        reg.register(first)
+        reg.register(replacement)
+
+        assert reg.get("test_ch") is first
+
     def test_get_by_alias(self):
         from flocks.channel.registry import ChannelRegistry
         reg = ChannelRegistry()

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -151,6 +151,41 @@ class TestPluginLoader:
         assert len(collected) == 1
         assert collected[0]["name"] == "lookup"
 
+    def test_load_once_extension_skips_later_load_all_passes(self, tmp_path: Path):
+        """Stateful extension points should not be re-imported by load_all."""
+        channels_dir = tmp_path / "channels"
+        counter_file = tmp_path / "counter.txt"
+        _write_plugin(channels_dir, "my_channel.py", f"""\
+            from pathlib import Path
+
+            counter = Path({str(counter_file)!r})
+            count = int(counter.read_text() or "0") if counter.exists() else 0
+            counter.write_text(str(count + 1))
+
+            CHANNELS = [
+                {{"id": "test-channel", "import_count": count + 1}},
+            ]
+        """)
+
+        collected = []
+
+        PluginLoader._plugin_root = tmp_path
+        PluginLoader.register_extension_point(ExtensionPoint(
+            attr_name="CHANNELS",
+            subdir="channels",
+            consumer=lambda items, src: collected.extend(items),
+            item_type=dict,
+            dedup_key=lambda d: d["id"],
+            load_once=True,
+        ))
+
+        PluginLoader.load_all(project_dir=tmp_path)
+        PluginLoader.load_all(project_dir=tmp_path)
+
+        assert counter_file.read_text() == "1"
+        assert len(collected) == 1
+        assert collected[0]["import_count"] == 1
+
     def test_multiple_extension_points(self, tmp_path: Path):
         """Both AGENTS and TOOLS extension points loaded in one load_all."""
         agents_dir = tmp_path / "agents"


### PR DESCRIPTION
## Summary
- Fixes #377 by preserving stateful channel plugin instances after the first load, so webhook routes keep resolving to the started channel object.

## Key Changes
- Added `ExtensionPoint.load_once` to let stateful extension points opt out of repeated `PluginLoader.load_all()` imports.
- Marked `CHANNELS` as `load_once=True`.
- Made `ChannelRegistry.register()` keep the first registered channel instance for a channel id instead of silently replacing it.
- Added regression coverage for `load_once` behavior and duplicate channel registration.

## Impact Scope
- User-visible behavior: custom passive/webhook channel plugins keep their configured dispatcher after repeated plugin loads, so inbound webhooks can reach the running channel instance.
- Compatibility / migration: no public API break; channel plugin source changes still require a process restart, which matches the safe behavior for stateful runtime connections.
- Configuration / environment: no configuration changes.
- Dependencies: no dependency changes.
- Performance / resources: avoids repeated imports for load-once extension points.
- Security / permissions: no authentication or permission changes.

## Business Logic to Review
- `PluginLoader.load_all()` now skips an extension point after the first pass when `load_once=True`.
- `PluginLoader.load_for_extension()` marks load-once extensions as loaded after explicit source loading, covering the channel registry's initial default/project plugin load path.
- `ChannelRegistry.register()` keeps the first instance for each primary channel id, preserving any runtime state set by `ChannelGateway.start()`.

## Why This Approach
- The fix makes the stateful nature of channel plugins explicit at the extension-point layer while also retaining a channel-local guard against accidental instance replacement.

## Test Plan
- [x] `uv run pytest tests/plugin/test_plugin.py tests/channel/test_channel.py -q`

## Compatibility, Migration & Rollback
- No migration required.
- Rollback by reverting this PR if channel plugin reload behavior needs to be redesigned separately.
