### PR TITLE
Fix session model persistence

### DIFF
--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -95,8 +95,7 @@ class SessionResponse(BaseModel):
     """
     Session response - Flocks compatible
     
-    Matches Flocks Session.Info format exactly.
-    No agent/model/provider at top level - these come from messages.
+    Matches Flocks Session.Info format.
     """
     model_config = ConfigDict(populate_by_name=True, by_alias=True)
     
@@ -112,6 +111,9 @@ class SessionResponse(BaseModel):
     permission: Optional[List[Dict[str, Any]]] = Field(None, description="Permission rules")
     revert: Optional[Dict[str, Any]] = Field(None, description="Revert state")
     category: str = Field("user", description="Session category: user or task")
+    provider: Optional[str] = Field(None, description="Pinned provider ID")
+    model: Optional[str] = Field(None, description="Pinned model ID")
+    model_pinned: bool = Field(False, description="Whether provider/model are pinned for this session")
     ownerUserID: Optional[str] = Field(None, description="Session owner user id")
     ownerUsername: Optional[str] = Field(None, description="Session owner username")
     canWrite: bool = Field(False, description="Whether current user can continue this session")
@@ -122,9 +124,6 @@ class SessionResponse(BaseModel):
 def _session_to_response(session: SessionModel) -> SessionResponse:
     """
     Convert SessionModel to SessionResponse
-    
-    Note: agent/model/provider are NOT included at session level.
-    They are retrieved from the latest user message in the session.
     """
     current_user = get_current_auth_user()
     can_write = SessionPolicy.can_write(session, current_user)
@@ -149,6 +148,9 @@ def _session_to_response(session: SessionModel) -> SessionResponse:
         revert=session.revert.model_dump(by_alias=True) if session.revert else None,
         permission=[p.model_dump() for p in session.permission] if session.permission else None,
         category=session.category,
+        provider=session.provider,
+        model=session.model,
+        model_pinned=session.model_pinned,
         ownerUserID=session.owner_user_id,
         ownerUsername=session.owner_username,
         canWrite=can_write,
@@ -561,6 +563,9 @@ class SessionUpdateRequest(BaseModel):
     
     title: Optional[str] = Field(None, description="New title")
     time: Optional[Dict[str, Any]] = Field(None, description="Time updates (archived)")
+    provider: Optional[str] = Field(None, description="Pinned provider ID")
+    model: Optional[str] = Field(None, description="Pinned model ID")
+    model_pinned: Optional[bool] = Field(None, description="Whether provider/model are pinned for this session")
 
 
 @router.patch(
@@ -590,6 +595,12 @@ async def update_session(
         updates["title"] = request.title
     if request.time and request.time.get("archived") is not None:
         updates["archived"] = request.time["archived"]
+    if request.provider is not None:
+        updates["provider"] = request.provider
+    if request.model is not None:
+        updates["model"] = request.model
+    if request.model_pinned is not None:
+        updates["model_pinned"] = request.model_pinned
     
     session = await Session.update(
         project_id=existing.project_id,

--- a/webui/src/api/session.ts
+++ b/webui/src/api/session.ts
@@ -85,7 +85,7 @@ export const sessionApi = {
   /**
    * 更新会话
    */
-  update: async (sessionId: string, data: { title?: string }) => {
+  update: async (sessionId: string, data: { title?: string; provider?: string; model?: string; model_pinned?: boolean }) => {
     const response = await client.patch(`/api/session/${sessionId}`, data);
     return response.data;
   },

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -91,16 +91,25 @@ vi.mock('@/components/common/SessionChat', () => ({
     sessionId,
     mentionAgents,
     toolbarSlot,
+    centerToolbarSlot,
     onCreateAndSend,
+    model,
   }: {
     sessionId?: string | null;
     mentionAgents?: Array<{ name: string }>;
     toolbarSlot?: React.ReactNode;
+    centerToolbarSlot?: React.ReactNode;
+    model?: { providerID: string; modelID: string } | null;
     onCreateAndSend?: (text: string, imageParts?: unknown[], agentOverride?: string) => Promise<unknown> | unknown;
   }) => (
-    <div data-testid="session-chat" data-mention-agents={(mentionAgents ?? []).map((a) => a.name).join(',')}>
+    <div
+      data-testid="session-chat"
+      data-mention-agents={(mentionAgents ?? []).map((a) => a.name).join(',')}
+      data-model={model ? `${model.providerID}/${model.modelID}` : ''}
+    >
       {sessionId ?? 'no-session'}
       {toolbarSlot}
+      {centerToolbarSlot}
       <button type="button" onClick={() => void onCreateAndSend?.('hello from empty session')}>
         mock-create-and-send
       </button>
@@ -110,6 +119,7 @@ vi.mock('@/components/common/SessionChat', () => ({
 
 vi.mock('@/utils/agentDisplay', () => ({
   getAgentDisplayDescription: () => 'agent-description',
+  getAgentDisplayName: (agent: { name: string }) => agent.name.charAt(0).toUpperCase() + agent.name.slice(1),
 }));
 
 vi.mock('@/utils/time', () => ({
@@ -143,6 +153,34 @@ const secondSession = {
   slug: 'session-2',
   title: 'Second Session',
 };
+
+const modelProviders = [
+  { id: 'openai', name: 'OpenAI', configured: true },
+  { id: 'minimax', name: 'MiniMax', configured: true },
+];
+
+const modelDefinitions = [
+  {
+    provider_id: 'openai',
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    model_type: 'llm',
+    source: 'predefined',
+    capabilities: {},
+    pricing: null,
+    limits: {},
+  },
+  {
+    provider_id: 'minimax',
+    id: 'minimax-m3',
+    name: 'MiniMax M3',
+    model_type: 'llm',
+    source: 'predefined',
+    capabilities: {},
+    pricing: null,
+    limits: {},
+  },
+];
 
 function renderSessionPage(
   initialEntry: string | { pathname: string; state?: unknown } = '/sessions',
@@ -464,6 +502,131 @@ describe('SessionPage session actions menu', () => {
       expect(addSession).toHaveBeenCalledWith(secondSession);
     });
     expect(screen.getByRole('button', { name: /Rex/i })).toBeInTheDocument();
+  });
+
+  it('shows the pinned model for the selected session on load', async () => {
+    localStorage.setItem('flocks:last-selected-session', 'session-1');
+    useSessions.mockReturnValue({
+      sessions: [{
+        ...session,
+        provider: 'minimax',
+        model: 'minimax-m3',
+        model_pinned: true,
+      }],
+      loading: false,
+      error: null,
+      refetch: refetchSessions,
+      updateSessionTitle,
+      removeSession,
+      removeSessions,
+      addSession,
+    });
+    useProviders.mockReturnValue({
+      providers: modelProviders,
+      connectedIds: [],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    defaultModelAPI.getResolved.mockResolvedValue({ data: { provider_id: 'openai', model_id: 'gpt-4o' } });
+    modelV2API.listDefinitions.mockResolvedValue({ data: { models: modelDefinitions } });
+
+    renderSessionPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-chat')).toHaveAttribute('data-model', 'minimax/minimax-m3');
+    });
+    expect(defaultModelAPI.getResolved).not.toHaveBeenCalled();
+  });
+
+  it('persists model changes to the selected session', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('flocks:last-selected-session', 'session-1');
+    useSessions.mockReturnValue({
+      sessions: [session],
+      loading: false,
+      error: null,
+      refetch: refetchSessions,
+      updateSessionTitle,
+      removeSession,
+      removeSessions,
+      addSession,
+    });
+    useProviders.mockReturnValue({
+      providers: modelProviders,
+      connectedIds: [],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    defaultModelAPI.getResolved.mockResolvedValue({ data: { provider_id: 'openai', model_id: 'gpt-4o' } });
+    modelV2API.listDefinitions.mockResolvedValue({ data: { models: modelDefinitions } });
+    sessionApi.update.mockResolvedValue({
+      ...session,
+      provider: 'minimax',
+      model: 'minimax-m3',
+      model_pinned: true,
+    });
+
+    renderSessionPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-chat')).toHaveAttribute('data-model', 'openai/gpt-4o');
+    });
+
+    await user.click(screen.getByRole('button', { name: /GPT-4o/i }));
+    await user.click(screen.getByRole('button', { name: /MiniMax M3/i }));
+
+    await waitFor(() => {
+      expect(sessionApi.update).toHaveBeenCalledWith('session-1', {
+        provider: 'minimax',
+        model: 'minimax-m3',
+        model_pinned: true,
+      });
+    });
+    expect(refetchSessions).toHaveBeenCalled();
+  });
+
+  it('resets the selected model to the default when creating a new session', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('flocks:last-selected-session', 'session-1');
+    useSessions.mockReturnValue({
+      sessions: [{
+        ...session,
+        provider: 'minimax',
+        model: 'minimax-m3',
+        model_pinned: true,
+      }],
+      loading: false,
+      error: null,
+      refetch: refetchSessions,
+      updateSessionTitle,
+      removeSession,
+      removeSessions,
+      addSession,
+    });
+    useProviders.mockReturnValue({
+      providers: modelProviders,
+      connectedIds: [],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    defaultModelAPI.getResolved.mockResolvedValue({ data: { provider_id: 'openai', model_id: 'gpt-4o' } });
+    modelV2API.listDefinitions.mockResolvedValue({ data: { models: modelDefinitions } });
+
+    renderSessionPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-chat')).toHaveAttribute('data-model', 'minimax/minimax-m3');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'newSession' }));
+
+    await waitFor(() => {
+      expect(addSession).toHaveBeenCalledWith(secondSession);
+      expect(screen.getByTestId('session-chat')).toHaveAttribute('data-model', 'openai/gpt-4o');
+    });
   });
 
   it('uses Rex for the first message when an empty session is created by sending', async () => {

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -83,6 +83,10 @@ function writeLastSelectedSessionId(sessionId: string | null) {
   }
 }
 
+function makeModelKey(providerID: string, modelID: string): string {
+  return `${providerID}::${modelID}`;
+}
+
 export default function SessionPage() {
   const { t, i18n } = useTranslation('session');
   const navigate = useNavigate();
@@ -162,7 +166,7 @@ export default function SessionPage() {
       const provider = providerById.get(model.provider_id);
       if (!provider) return [];
       return [{
-        key: `${provider.id}::${model.id}`,
+        key: makeModelKey(provider.id, model.id),
         providerID: provider.id,
         providerName: provider.name || provider.id,
         modelID: model.id,
@@ -202,7 +206,7 @@ export default function SessionPage() {
       .sort((a, b) => a.providerName.localeCompare(b.providerName));
   }, [chatModelOptions, providers]);
   const selectedModelOption = useMemo(
-    () => chatModelOptions.find((option) => option.key === selectedModelKey) ?? chatModelOptions[0] ?? null,
+    () => chatModelOptions.find((option) => option.key === selectedModelKey) ?? (selectedModelKey ? null : chatModelOptions[0] ?? null),
     [chatModelOptions, selectedModelKey],
   );
   const selectedPromptModel = selectedModelOption
@@ -347,13 +351,26 @@ export default function SessionPage() {
   }, [showModelOptions]);
 
   useEffect(() => {
-    if (selectedModelKey || chatModelOptions.length === 0) return;
+    if (chatModelOptions.length === 0) {
+      setSelectedModelKey(null);
+      return;
+    }
+
+    const pinnedKey = selectedSession?.model_pinned && selectedSession.provider && selectedSession.model
+      ? makeModelKey(selectedSession.provider, selectedSession.model)
+      : null;
+    if (pinnedKey && chatModelOptions.some((option) => option.key === pinnedKey)) {
+      setSelectedModelKey(pinnedKey);
+      return;
+    }
+
     let cancelled = false;
+    setSelectedModelKey(null);
     defaultModelAPI.getResolved()
       .then((response) => {
         if (cancelled) return;
         const { provider_id: providerID, model_id: modelID } = response.data;
-        const defaultKey = `${providerID}::${modelID}`;
+        const defaultKey = makeModelKey(providerID, modelID);
         const fallbackKey = chatModelOptions[0]?.key ?? null;
         setSelectedModelKey(chatModelOptions.some((option) => option.key === defaultKey) ? defaultKey : fallbackKey);
       })
@@ -363,7 +380,13 @@ export default function SessionPage() {
     return () => {
       cancelled = true;
     };
-  }, [chatModelOptions, selectedModelKey]);
+  }, [
+    chatModelOptions,
+    selectedSession?.model,
+    selectedSession?.model_pinned,
+    selectedSession?.provider,
+    selectedSessionId,
+  ]);
 
   useEffect(() => {
     if (loadingEnabledModels || chatModelOptions.length === 0 || !selectedModelKey) return;
@@ -409,6 +432,7 @@ export default function SessionPage() {
       const response = await client.post('/api/session', { title: 'New Session' });
       addSession(response.data);
       setSelectedAgent('rex');
+      setSelectedModelKey(null);
       setSelectedSessionId(response.data.id);
     } catch (err: any) {
       toast.error(t('createFailed'), err.message);
@@ -416,6 +440,23 @@ export default function SessionPage() {
       setCreating(false);
     }
   }, [creating, addSession, toast, t]);
+
+  const handleSelectModel = useCallback(async (option: ChatModelOption) => {
+    setSelectedModelKey(option.key);
+    setShowModelOptions(false);
+    if (!selectedSessionId) return;
+
+    try {
+      await sessionApi.update(selectedSessionId, {
+        provider: option.providerID,
+        model: option.modelID,
+        model_pinned: true,
+      });
+      refetchSessions();
+    } catch (err: any) {
+      toast.error(t('chat.error', 'Error'), err.message);
+    }
+  }, [refetchSessions, selectedSessionId, toast, t]);
 
   useEffect(() => {
     if (loadingSessions) return;
@@ -457,6 +498,7 @@ export default function SessionPage() {
 
       addSession(response.data);
       setSelectedAgent('rex');
+      setSelectedModelKey(null);
       setSelectedSessionId(newSessionId);
 
       const payload: Record<string, unknown> = {
@@ -1063,10 +1105,7 @@ export default function SessionPage() {
                               <button
                                 key={option.key}
                                 type="button"
-                                onClick={() => {
-                                  setSelectedModelKey(option.key);
-                                  setShowModelOptions(false);
-                                }}
+                                onClick={() => void handleSelectModel(option)}
                                 className={`w-full rounded-md px-2 py-1.5 text-left transition-colors ${
                                   selectedModelOption?.key === option.key
                                     ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa]'

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -17,6 +17,9 @@ export interface Session {
   revert?: SessionRevert;
   /** Session category: 'user' | 'workflow' | 'task' | 'entity-config' | ... */
   category?: string;
+  provider?: string;
+  model?: string;
+  model_pinned?: boolean;
   ownerUserID?: string;
   ownerUsername?: string;
   canWrite?: boolean;


### PR DESCRIPTION
## Summary
- Expose session-level pinned provider/model fields through the session API and allow updating them.
- Persist model picker changes to the current session instead of keeping them only in component state.
- Reset new empty sessions to the resolved default model so the previous session's model does not leak into new sessions.
- Add Session page regression coverage for pinned model restore, model persistence, and new-session default reset.

## Tests
- npm run test:run -- src/pages/Session/index.test.tsx
- npm run build
- uv run ruff check flocks/server/routes/session.py

## Notes
- uv run pytest tests/integration/test_ui_integration.py -q still has one existing failure in test_create_session_via_routes because the test mock passes MagicMock as auth_user.id instead of a string; this is unrelated to this change.