### PR TITLE
feat(device): Improve device integration auto-sync

### DIFF
--- a/flocks/server/routes/device.py
+++ b/flocks/server/routes/device.py
@@ -32,6 +32,7 @@ from flocks.tool.device.intake import (
     DeviceNotFoundError,
     create_device,
     delete_device,
+    ensure_user_device_instances,
     test_device,
     update_device,
 )
@@ -172,13 +173,14 @@ async def route_delete_group(group_id: str):
 # ===========================================================================
 
 @router.get("", response_model=List[DeviceIntegration])
-async def route_list_devices(group_id: Optional[str] = None):
+async def route_list_devices(group_id: Optional[str] = None, refresh: bool = False):
+    await ensure_user_device_instances(refresh_templates=refresh)
     return await list_devices(group_id)
 
 
 @router.get("/templates", response_model=List[DeviceTemplate])
-async def route_list_device_templates():
-    return list_device_templates()
+async def route_list_device_templates(refresh: bool = False):
+    return list_device_templates(refresh=refresh)
 
 
 @router.post(

--- a/flocks/tool/device/intake.py
+++ b/flocks/tool/device/intake.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 import httpx
 
+from flocks.storage.storage import Storage
 from flocks.tool.device.models import (
     DEFAULT_GROUP_ID,
     MULTI_GROUP_ENABLED,
@@ -24,15 +25,19 @@ from flocks.tool.device.models import (
 from flocks.tool.device.secrets import delete_secrets, persist_fields, resolve_for_runtime
 from flocks.tool.device.store import (
     delete_device_row,
+    ensure_default_group,
     fetch_device,
     group_exists,
     insert_device,
+    list_devices,
     record_test_result,
     row_to_device,
     storage_key_to_service_id,
     update_device_row,
 )
 from flocks.tool.device.sync import sync_service_tool_state
+
+_AUTO_INSTANCE_IGNORED_KEY = "device.auto_instance_ignored_storage_keys"
 
 
 class DeviceIntakeError(Exception):
@@ -41,6 +46,99 @@ class DeviceIntakeError(Exception):
 
 class DeviceNotFoundError(DeviceIntakeError):
     status_code = 404
+
+
+async def _load_auto_instance_ignored_storage_keys() -> set[str]:
+    raw = await Storage.get(_AUTO_INSTANCE_IGNORED_KEY)
+    if isinstance(raw, list):
+        return {str(item) for item in raw if item}
+    if isinstance(raw, dict):
+        values = raw.get("storage_keys")
+        if isinstance(values, list):
+            return {str(item) for item in values if item}
+    return set()
+
+
+async def _save_auto_instance_ignored_storage_keys(storage_keys: set[str]) -> None:
+    await Storage.set(_AUTO_INSTANCE_IGNORED_KEY, sorted(storage_keys))
+
+
+async def _remember_auto_instance_ignore(storage_key: str) -> None:
+    if not storage_key:
+        return
+    ignored = await _load_auto_instance_ignored_storage_keys()
+    if storage_key in ignored:
+        return
+    ignored.add(storage_key)
+    await _save_auto_instance_ignored_storage_keys(ignored)
+
+
+async def _forget_auto_instance_ignore(storage_key: str) -> None:
+    if not storage_key:
+        return
+    ignored = await _load_auto_instance_ignored_storage_keys()
+    if storage_key not in ignored:
+        return
+    ignored.remove(storage_key)
+    await _save_auto_instance_ignored_storage_keys(ignored)
+
+
+def _user_device_template_storage_keys(*, refresh_templates: bool = False) -> set[str]:
+    from flocks.tool.device.plugin_index import list_device_templates
+
+    return {
+        template.storage_key
+        for template in list_device_templates(refresh=refresh_templates)
+        if template.source == "global" and template.installed
+    }
+
+
+async def ensure_user_device_instances(*, refresh_templates: bool = False) -> int:
+    """Create default device rows for user-level device plugin templates.
+
+    Device templates discovered under ``~/.flocks/plugins/tools/device`` are
+    installable product definitions. The device access page's left pane shows
+    concrete ``device_integrations`` rows, so a user-created local template
+    would otherwise appear only in the right-side picker until the user manually
+    added an instance. Auto-provision one editable instance per user-level
+    template when no instance for the same storage_key exists yet.
+    """
+    await ensure_default_group()
+    existing_storage_keys = {device.storage_key for device in await list_devices()}
+    ignored_storage_keys = await _load_auto_instance_ignored_storage_keys()
+    user_template_storage_keys = _user_device_template_storage_keys(
+        refresh_templates=refresh_templates,
+    )
+    created = 0
+
+    from flocks.tool.device.plugin_index import list_device_templates
+
+    for template in list_device_templates(refresh=False):
+        if template.source != "global" or not template.installed:
+            continue
+        if template.storage_key in existing_storage_keys:
+            continue
+        if template.storage_key in ignored_storage_keys:
+            continue
+        if template.storage_key not in user_template_storage_keys:
+            continue
+
+        device_id = str(uuid.uuid4())
+        await insert_device(
+            device_id=device_id,
+            group_id=DEFAULT_GROUP_ID,
+            name=template.name,
+            storage_key=template.storage_key,
+            service_id=template.service_id,
+            enabled=True,
+            verify_ssl=False,
+            db_fields={},
+        )
+        existing_storage_keys.add(template.storage_key)
+        created += 1
+        await sync_service_tool_state(template.service_id)
+
+    return created
 
 
 async def create_device(body: DeviceIntegrationCreate) -> DeviceIntegration:
@@ -69,6 +167,7 @@ async def create_device(body: DeviceIntegrationCreate) -> DeviceIntegration:
         verify_ssl=body.verify_ssl,
         db_fields=db_fields,
     )
+    await _forget_auto_instance_ignore(storage_key)
     await sync_service_tool_state(service_id)
 
     row = await fetch_device(device_id)
@@ -127,6 +226,8 @@ async def delete_device(device_id: str) -> None:
     service_id: str = storage_key_to_service_id(storage_key)
     db_fields: dict = json.loads(row["fields"] or "{}")
 
+    if storage_key in _user_device_template_storage_keys(refresh_templates=True):
+        await _remember_auto_instance_ignore(storage_key)
     delete_secrets(device_id, db_fields)
     await delete_device_row(device_id)
     await sync_service_tool_state(service_id, deleted_storage_keys=[storage_key])

--- a/flocks/tool/device/intake.py
+++ b/flocks/tool/device/intake.py
@@ -5,6 +5,7 @@ state sync, and connectivity probing for device integrations.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 import uuid
@@ -38,6 +39,7 @@ from flocks.tool.device.store import (
 from flocks.tool.device.sync import sync_service_tool_state
 
 _AUTO_INSTANCE_IGNORED_KEY = "device.auto_instance_ignored_storage_keys"
+_AUTO_INSTANCE_LOCKS: dict[int, asyncio.Lock] = {}
 
 
 class DeviceIntakeError(Exception):
@@ -93,6 +95,16 @@ def _user_device_template_storage_keys(*, refresh_templates: bool = False) -> se
     }
 
 
+def _auto_instance_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    loop_id = id(loop)
+    lock = _AUTO_INSTANCE_LOCKS.get(loop_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _AUTO_INSTANCE_LOCKS[loop_id] = lock
+    return lock
+
+
 async def ensure_user_device_instances(*, refresh_templates: bool = False) -> int:
     """Create default device rows for user-level device plugin templates.
 
@@ -103,6 +115,13 @@ async def ensure_user_device_instances(*, refresh_templates: bool = False) -> in
     added an instance. Auto-provision one editable instance per user-level
     template when no instance for the same storage_key exists yet.
     """
+    async with _auto_instance_lock():
+        return await _ensure_user_device_instances_unlocked(
+            refresh_templates=refresh_templates,
+        )
+
+
+async def _ensure_user_device_instances_unlocked(*, refresh_templates: bool = False) -> int:
     await ensure_default_group()
     existing_storage_keys = {device.storage_key for device in await list_devices()}
     ignored_storage_keys = await _load_auto_instance_ignored_storage_keys()

--- a/flocks/tool/device/plugin_index.py
+++ b/flocks/tool/device/plugin_index.py
@@ -34,7 +34,7 @@ _SAFE_SERVICE_ID = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 def list_device_templates(*, refresh: bool = False) -> list[DeviceTemplate]:
     """Return device templates from Hub catalog plus local descriptor discovery."""
     if refresh:
-        discover_api_service_descriptors(refresh=True)
+        _refresh_device_plugin_runtime()
 
     by_key: dict[str, DeviceTemplate] = {}
     for entry in hub_catalog.list_catalog(plugin_type="device"):
@@ -73,7 +73,7 @@ def list_device_templates(*, refresh: bool = False) -> list[DeviceTemplate]:
     # Defensive pass for project/user device plugins that may not have Hub
     # records yet. This also explicitly exercises the descriptor API so version
     # and storage_key stay aligned with the runtime credential namespace.
-    for descriptor in discover_api_service_descriptors(refresh=refresh):
+    for descriptor in discover_api_service_descriptors(refresh=False):
         root = descriptor.provider_yaml.parent
         provider = _read_provider_yaml(root)
         if _integration_type(provider) != "device":
@@ -135,13 +135,21 @@ def create_custom_device_template(body: CustomDeviceTemplateCreate) -> DeviceTem
     )
     hub_local.save_installed_record(record)
 
-    discover_api_service_descriptors(refresh=True)
-    ToolRegistry.refresh_plugin_tools()
+    _refresh_device_plugin_runtime()
 
-    for template in list_device_templates(refresh=True):
+    for template in list_device_templates(refresh=False):
         if template.plugin_id == plugin_id:
             return template
     raise RuntimeError(f"created device plugin '{plugin_id}' was not indexed")
+
+
+def _refresh_device_plugin_runtime() -> None:
+    """Refresh both device descriptors and runtime tool registrations."""
+    discover_api_service_descriptors(refresh=True)
+    try:
+        ToolRegistry.refresh_plugin_tools()
+    except Exception as exc:  # pragma: no cover - defensive runtime isolation
+        log.warn("device.templates.tool_refresh_failed", {"error": str(exc)})
 
 
 def _template_from_plugin_root(

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -1766,7 +1766,7 @@ def _tool_event_should_reload(event: object) -> bool:
 class ToolFileWatcher:
     """Watch plugin tool directories and auto-reload plugin tools on change.
 
-    Monitors the ``api/`` and ``python/`` subdirectories under:
+    Monitors the ``api/``, ``device/``, and ``python/`` subdirectories under:
     - ``~/.flocks/plugins/tools/``       (user-level)
     - ``<cwd>/.flocks/plugins/tools/``   (project-level)
 
@@ -1776,7 +1776,7 @@ class ToolFileWatcher:
     """
 
     _DEBOUNCE_SECONDS = 1.0
-    _WATCH_SUBDIRS = ("api", "python")
+    _WATCH_SUBDIRS = ("api", "device", "python")
 
     def __init__(self) -> None:
         self._observer: Optional[object] = None

--- a/tests/tool/test_device_plugin_index.py
+++ b/tests/tool/test_device_plugin_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -176,6 +177,23 @@ def test_device_plugin_index_normalizes_plugin_id_name(monkeypatch, tmp_path):
     assert templates[0].name == "onesig"
     assert templates[0].storage_key == "onesig_v2_5_3_D20250710_api_v2_5_3_D20250710"
     assert templates[0].version == "2.5.3 D20250710"
+
+
+def test_device_template_refresh_reloads_plugin_tools(monkeypatch, tmp_path):
+    from flocks.tool.device import plugin_index
+
+    _reset_env(monkeypatch, tmp_path)
+    calls: list[str] = []
+
+    monkeypatch.setattr(plugin_index.hub_catalog, "list_catalog", lambda plugin_type=None: [])
+    monkeypatch.setattr(
+        plugin_index.ToolRegistry,
+        "refresh_plugin_tools",
+        classmethod(lambda cls: calls.append("refresh") or []),
+    )
+
+    assert plugin_index.list_device_templates(refresh=True) == []
+    assert calls == ["refresh"]
 
 
 def test_create_custom_device_template_writes_user_plugin(monkeypatch, tmp_path):
@@ -356,3 +374,58 @@ async def test_device_list_auto_creates_user_device_plugin_instance(monkeypatch,
     assert manual_create.status_code == 201
     assert len(after_manual_create.json()) == 1
     assert after_manual_create.json()[0]["name"] == "Custom Demo Manual"
+
+
+@pytest.mark.asyncio
+async def test_auto_creating_user_device_instances_is_serialized(monkeypatch, tmp_path):
+    from flocks.storage.storage import Storage
+    from flocks.tool.device import intake, plugin_index
+    from flocks.tool.device.store import list_devices
+
+    home, _data, _project = _reset_env(monkeypatch, tmp_path)
+    await Storage.init()
+
+    root = home / ".flocks" / "plugins" / "tools" / "device" / "custom_demo"
+    _write_provider(
+        root,
+        {
+            "name": "Custom Demo",
+            "service_id": "custom_demo_api",
+            "version": "0.1.0",
+            "integration_type": "device",
+            "vendor": "custom_vendor",
+            "credential_fields": [],
+        },
+    )
+    _write_tool(root, "custom_demo_ping")
+
+    async def fake_sync_service_tool_state(service_id: str) -> None:
+        return None
+
+    original_insert_device = intake.insert_device
+    insert_attempts = 0
+
+    async def slow_insert_device(**kwargs):
+        nonlocal insert_attempts
+        insert_attempts += 1
+        await asyncio.sleep(0)
+        await original_insert_device(**kwargs)
+
+    monkeypatch.setattr(plugin_index.hub_catalog, "list_catalog", lambda plugin_type=None: [])
+    monkeypatch.setattr(plugin_index.hub_catalog, "system_plugin_root", lambda plugin_type, plugin_id: None)
+    monkeypatch.setattr(plugin_index.ToolRegistry, "refresh_plugin_tools", classmethod(lambda cls: []))
+    monkeypatch.setattr(plugin_index.ToolRegistry, "init", classmethod(lambda cls: None))
+    monkeypatch.setattr(plugin_index.ToolRegistry, "list_tools", classmethod(lambda cls: []))
+    monkeypatch.setattr(intake, "insert_device", slow_insert_device)
+    monkeypatch.setattr(intake, "sync_service_tool_state", fake_sync_service_tool_state)
+
+    created_counts = await asyncio.gather(
+        intake.ensure_user_device_instances(refresh_templates=True),
+        intake.ensure_user_device_instances(refresh_templates=True),
+    )
+    devices = await list_devices()
+
+    assert sorted(created_counts) == [0, 1]
+    assert insert_attempts == 1
+    assert len(devices) == 1
+    assert devices[0].storage_key == "custom_demo_api_v0_1_0"

--- a/tests/tool/test_device_plugin_index.py
+++ b/tests/tool/test_device_plugin_index.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import yaml
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -37,6 +38,7 @@ def _write_tool(root: Path, name: str = "device_ping") -> None:
 def _reset_env(monkeypatch, tmp_path):
     from flocks.config.config import Config
     from flocks.config import api_versioning
+    from flocks.storage.storage import Storage
 
     home = tmp_path / "home"
     data = tmp_path / "data"
@@ -49,6 +51,8 @@ def _reset_env(monkeypatch, tmp_path):
     monkeypatch.chdir(project)
     Config._global_config = None
     Config._cached_config = None
+    Storage._db_path = None
+    Storage._initialized = False
     api_versioning._reset_descriptor_cache()
     return home, data, project
 
@@ -224,7 +228,7 @@ def test_device_template_route_is_not_shadowed_by_device_id(monkeypatch):
     monkeypatch.setattr(
         device_routes,
         "list_device_templates",
-        lambda: [
+        lambda refresh=False: [
             {
                 "plugin_id": "demo",
                 "storage_key": "demo_api_v1",
@@ -248,3 +252,107 @@ def test_device_template_route_is_not_shadowed_by_device_id(monkeypatch):
 
     assert response.status_code == 200
     assert response.json()[0]["plugin_id"] == "demo"
+
+
+def test_device_template_route_forwards_refresh(monkeypatch):
+    from flocks.server.routes import device as device_routes
+
+    calls: list[bool] = []
+
+    def fake_list_device_templates(*, refresh: bool = False):
+        calls.append(refresh)
+        return [
+            {
+                "plugin_id": "demo",
+                "storage_key": "demo_api_v1",
+                "service_id": "demo_api",
+                "name": "Demo",
+                "version": "1",
+                "credential_schema": [],
+                "tool_count": 0,
+                "installed": True,
+                "state": "installed",
+                "source": "project",
+            }
+        ]
+
+    monkeypatch.setattr(device_routes, "list_device_templates", fake_list_device_templates)
+
+    app = FastAPI()
+    app.include_router(device_routes.router, prefix="/api/devices")
+    client = TestClient(app)
+
+    response = client.get("/api/devices/templates?refresh=true")
+
+    assert response.status_code == 200
+    assert calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_device_list_auto_creates_user_device_plugin_instance(monkeypatch, tmp_path):
+    from flocks.server.routes import device as device_routes
+    from flocks.storage.storage import Storage
+    from flocks.tool.device.store import list_devices
+    from flocks.tool.device import plugin_index
+
+    home, _data, _project = _reset_env(monkeypatch, tmp_path)
+    await Storage.init()
+
+    root = home / ".flocks" / "plugins" / "tools" / "device" / "custom_demo"
+    _write_provider(
+        root,
+        {
+            "name": "Custom Demo",
+            "service_id": "custom_demo_api",
+            "version": "0.1.0",
+            "integration_type": "device",
+            "vendor": "custom_vendor",
+            "credential_fields": [],
+        },
+    )
+    _write_tool(root, "custom_demo_ping")
+
+    monkeypatch.setattr(plugin_index.hub_catalog, "list_catalog", lambda plugin_type=None: [])
+    monkeypatch.setattr(plugin_index.hub_catalog, "system_plugin_root", lambda plugin_type, plugin_id: None)
+    monkeypatch.setattr(plugin_index.ToolRegistry, "init", classmethod(lambda cls: None))
+    monkeypatch.setattr(plugin_index.ToolRegistry, "list_tools", classmethod(lambda cls: []))
+
+    app = FastAPI()
+    app.include_router(device_routes.router, prefix="/api/devices")
+    client = TestClient(app)
+
+    response = client.get("/api/devices?refresh=true")
+    repeated = client.get("/api/devices?refresh=true")
+    devices = await list_devices()
+
+    assert response.status_code == 200
+    assert repeated.status_code == 200
+    assert len(devices) == 1
+    assert devices[0].name == "Custom Demo"
+    assert devices[0].storage_key == "custom_demo_api_v0_1_0"
+    assert devices[0].service_id == "custom_demo_api"
+    assert devices[0].enabled is True
+
+    delete_response = client.delete(f"/api/devices/{devices[0].id}")
+    after_delete = client.get("/api/devices?refresh=true")
+    devices_after_delete = await list_devices()
+
+    assert delete_response.status_code == 204
+    assert after_delete.status_code == 200
+    assert after_delete.json() == []
+    assert devices_after_delete == []
+
+    manual_create = client.post(
+        "/api/devices",
+        json={
+            "name": "Custom Demo Manual",
+            "storage_key": "custom_demo_api_v0_1_0",
+            "service_id": "custom_demo_api",
+            "fields": {},
+        },
+    )
+    after_manual_create = client.get("/api/devices?refresh=true")
+
+    assert manual_create.status_code == 201
+    assert len(after_manual_create.json()) == 1
+    assert after_manual_create.json()[0]["name"] == "Custom Demo Manual"

--- a/tests/tool/test_watcher_atomic_save.py
+++ b/tests/tool/test_watcher_atomic_save.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from flocks.tool.registry import _tool_event_should_reload
+from flocks.tool.registry import ToolFileWatcher, _tool_event_should_reload
 from flocks.agent.registry import _agent_event_should_reload
 from flocks.skill.skill import _skill_event_should_reload
 
@@ -58,6 +58,10 @@ def test_tool_watcher_rejects_irrelevant_paths() -> None:
 def test_tool_watcher_accepts_direct_modify_on_yaml() -> None:
     evt = _modify_event("/repo/.flocks/plugins/tools/api/foo/tool.yaml")
     assert _tool_event_should_reload(evt) is True
+
+
+def test_tool_watcher_includes_device_plugin_directory() -> None:
+    assert "device" in ToolFileWatcher._WATCH_SUBDIRS
 
 
 # ---------------------------------------------------------------------------

--- a/tui/flocks/acp/agent.ts
+++ b/tui/flocks/acp/agent.ts
@@ -32,15 +32,15 @@ import { LoadAPIKeyError } from "ai"
 import type { Event, FlocksClient, SessionMessageResponse } from "@flocks-ai/sdk/v2"
 import { applyPatch } from "diff"
 
-const LegacyTodoWriteOutput = z.array(Todo.Info)
+const LegacyTodoEntriesOutput = z.array(Todo.Info)
 
-function parseTodoWriteEntries(rawOutput: string, rawMetadata: unknown): Todo.Info[] | undefined {
+function parseTodoEntries(rawOutput: string, rawMetadata: unknown): Todo.Info[] | undefined {
   try {
     const parsed = JSON.parse(rawOutput)
     const structured = Todo.WriteOutput.safeParse(parsed)
     if (structured.success) return structured.data.newTodos
 
-    const legacy = LegacyTodoWriteOutput.safeParse(parsed)
+    const legacy = LegacyTodoEntriesOutput.safeParse(parsed)
     if (legacy.success) return legacy.data
   } catch {
     // Fall through to metadata-based parsing below.
@@ -52,10 +52,10 @@ function parseTodoWriteEntries(rawOutput: string, rawMetadata: unknown): Todo.In
   const structuredMetadata = Todo.WriteOutput.safeParse(metadata)
   if (structuredMetadata.success) return structuredMetadata.data.newTodos
 
-  const explicitNewTodos = LegacyTodoWriteOutput.safeParse(metadata["newTodos"])
+  const explicitNewTodos = LegacyTodoEntriesOutput.safeParse(metadata["newTodos"])
   if (explicitNewTodos.success) return explicitNewTodos.data
 
-  const legacyMetadata = LegacyTodoWriteOutput.safeParse(metadata["todos"])
+  const legacyMetadata = LegacyTodoEntriesOutput.safeParse(metadata["todos"])
   if (legacyMetadata.success) return legacyMetadata.data
 
   return undefined
@@ -301,7 +301,7 @@ export namespace ACP {
                 }
 
                 if (part.tool === "todo") {
-                  const parsedTodos = parseTodoWriteEntries(part.state.output, part.state.metadata)
+                  const parsedTodos = parseTodoEntries(part.state.output, part.state.metadata)
                   if (parsedTodos) {
                     await this.connection
                       .sessionUpdate({
@@ -638,7 +638,7 @@ export namespace ACP {
               }
 
               if (part.tool === "todo") {
-                const parsedTodos = parseTodoWriteEntries(part.state.output, part.state.metadata)
+                const parsedTodos = parseTodoEntries(part.state.output, part.state.metadata)
                 if (parsedTodos) {
                   await this.connection
                     .sessionUpdate({

--- a/tui/flocks/cli/cmd/tui/routes/session/index.tsx
+++ b/tui/flocks/cli/cmd/tui/routes/session/index.tsx
@@ -1518,7 +1518,7 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
           <ApplyPatch {...toolprops} />
         </Match>
         <Match when={props.part.tool === "todo"}>
-          <TodoWrite {...toolprops} />
+          <TodoToolView {...toolprops} />
         </Match>
         <Match when={props.part.tool === "question"}>
           <Question {...toolprops} />
@@ -2167,7 +2167,7 @@ function ApplyPatch(props: ToolProps<typeof ApplyPatchTool>) {
   )
 }
 
-function TodoWrite(props: ToolProps<typeof TodoTool>) {
+function TodoToolView(props: ToolProps<typeof TodoTool>) {
   const todos = () => props.metadata.newTodos ?? props.metadata.todos ?? props.input.todos ?? []
   return (
     <Switch>

--- a/webui/src/api/device.ts
+++ b/webui/src/api/device.ts
@@ -167,11 +167,11 @@ export const deviceAPI = {
     client.delete(`/api/devices/groups/${id}`),
 
   // devices
-  list: (params?: { group_id?: string }) =>
+  list: (params?: { group_id?: string; refresh?: boolean }) =>
     client.get<DeviceIntegration[]>('/api/devices', { params }),
 
-  listTemplates: () =>
-    client.get<DeviceTemplate[]>('/api/devices/templates'),
+  listTemplates: (params?: { refresh?: boolean }) =>
+    client.get<DeviceTemplate[]>('/api/devices/templates', { params }),
 
   createCustomTemplate: (data: CustomDeviceTemplateCreate) =>
     client.post<DeviceTemplate>('/api/devices/templates/custom', data),

--- a/webui/src/pages/DeviceIntegration/customDevice.test.ts
+++ b/webui/src/pages/DeviceIntegration/customDevice.test.ts
@@ -1,70 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import type { CustomDeviceApiDraft, CustomDeviceWebCliDraft } from '@/types';
 import type { DeviceTemplate } from '@/api/device';
 import {
-  buildCustomDevicePrompt,
   buildCustomDeviceServiceId,
   buildCustomDeviceVendorKey,
   findTemplateForCustomDevice,
 } from './customDevice';
 
 describe('customDevice helpers', () => {
-  it('builds api prompt with device plugin constraints', () => {
-    const draft: CustomDeviceApiDraft = {
-      accessMode: 'api',
-      deviceName: 'Acme Guard',
-      vendorName: 'Acme Security',
-      version: 'v3.2.1',
-      baseUrl: 'https://device.example.com/api',
-      docsUrl: 'https://device.example.com/openapi',
-      capabilities: '全部 API',
-    };
-
-    const prompt = buildCustomDevicePrompt(draft);
-
-    expect(prompt).toContain('设备产品名：Acme Guard');
-    expect(prompt).toContain('API 文档链接：https://device.example.com/openapi');
-    expect(prompt).toContain('integration_type: device');
-    expect(prompt).toContain('~/.flocks/plugins/tools/device/<plugin_id>/');
-    expect(prompt).toContain('`name` 必须精确使用产品名：`Acme Guard`');
-    expect(prompt).toContain('`service_id` 建议使用：`acme_guard_device`');
-    expect(prompt).toContain('`description` / `description_cn` 会直接展示在设备接入页、概览页和 Hub 列表');
-    expect(prompt).toContain('更长的兼容性、版本差异、使用限制和调试说明优先写进 `notes`');
-    expect(prompt).toContain('tool-builder skill');
-    expect(prompt).toContain('返回设备页查看是否已经出现对应 device 插件');
-  });
-
-  it('builds webcli prompt with device plugin constraints', () => {
-    const draft: CustomDeviceWebCliDraft = {
-      accessMode: 'webcli',
-      deviceName: 'Acme Portal',
-      vendorName: 'Acme Security',
-      version: '',
-      productUrl: 'https://portal.example.com',
-      targetInterfaces: '告警列表和资产详情',
-      authHint: 'Cookie + CSRF Token',
-    };
-
-    const prompt = buildCustomDevicePrompt(draft);
-
-    expect(prompt).toContain('接入方式：WebCLI');
-    expect(prompt).toContain('产品 URL：https://portal.example.com');
-    expect(prompt).toContain('需要获取的接口/页面行为：告警列表和资产详情');
-    expect(prompt).toContain('browser-use / web2cli');
-    expect(prompt).toContain('web2cli skill');
-    expect(prompt).toContain('integration_type: device');
-    expect(prompt).toContain('~/.flocks/plugins/tools/device/<plugin_id>/');
-    expect(prompt).toContain('`service_id` 建议使用：`acme_portal_device`');
-    expect(prompt).toContain('`auth_state_path`');
-    expect(prompt).toContain('`cookie/auth-state`');
-    expect(prompt).toContain('`username` / `password`');
-    expect(prompt).toContain('`flocks browser`');
-    expect(prompt).toContain('`flocks browser state save <auth_state_path>`');
-    expect(prompt).toContain('`api`、`webcli_api`、`process`、`composed`');
-    expect(prompt).toContain('不要生成 `auth_state_json`');
-    expect(prompt).toContain('返回设备页查看是否已经出现对应 WebCLI device 插件');
-  });
-
   it('sanitizes vendor key and service id', () => {
     expect(buildCustomDeviceVendorKey('Acme Security CN')).toBe('acme_security_cn');
     expect(buildCustomDeviceServiceId('Acme Guard')).toBe('acme_guard_device');

--- a/webui/src/pages/DeviceIntegration/customDevice.ts
+++ b/webui/src/pages/DeviceIntegration/customDevice.ts
@@ -1,8 +1,4 @@
-import type {
-  CustomDeviceAccessMode,
-  CustomDeviceApiDraft,
-  CustomDeviceWebCliDraft,
-} from '@/types';
+import type { CustomDeviceAccessMode } from '@/types';
 import type { DeviceTemplate } from '@/api/device';
 
 function sanitizeSlug(value: string, fallback: string): string {
@@ -23,70 +19,15 @@ export function buildCustomDeviceServiceId(deviceName: string): string {
   return base.endsWith('_device') ? base : `${base}_device`;
 }
 
-function buildBaseDevicePluginRequirements(deviceName: string, vendorName: string): string[] {
-  const vendorKey = buildCustomDeviceVendorKey(vendorName);
-  const serviceId = buildCustomDeviceServiceId(deviceName);
-  return [
-    '最终产物必须落到 `~/.flocks/plugins/tools/device/<plugin_id>/` 目录。',
-    '必须生成 `_provider.yaml`，并满足以下要求：',
-    `- \`name\` 必须精确使用产品名：\`${deviceName}\``,
-    `- \`vendor\` 建议使用：\`${vendorKey}\``,
-    `- \`service_id\` 建议使用：\`${serviceId}\``,
-    '- 必须包含 `integration_type: device`',
-    '- 必须声明 `version`、`credential_fields`、`description`、`description_cn`',
-    '- `description` / `description_cn` 会直接展示在设备接入页、概览页和 Hub 列表，不能留空，也不能写成“自定义设备插件”这类泛化占位文案',
-    '- `description` 用英文、`description_cn` 用中文；都要明确说明：这是哪个产品/版本、提供什么能力、主要认证方式，以及用户需要填写哪些关键连接信息',
-    '- 首段先写 1 到 3 句高密度摘要；更长的兼容性、版本差异、使用限制和调试说明优先写进 `notes`',
-    '- 如果这是某个产品的特殊版本或兼容变体，必须在描述中写清楚差异点，避免与同系列标准插件混淆',
-    '- `credential_fields` 只定义运行时需要用户填写的字段，不能把真实凭据写进插件文件',
-    '- 至少生成一个可被设备页识别的 device YAML/script 工具，必要时补充 `.handler.py`',
-    '- 新建工具默认启用，并确保工具刷新后能出现在设备接入页',
-  ];
-}
-
 function buildBaseDeviceSessionContext(): string[] {
   return [
     '你是 Flocks 的自定义设备接入助手。',
-    '你必须先阅读并参考项目中现有 device 插件结构，例如 `.flocks/plugins/tools/device/*/_provider.yaml` 与对应 YAML/script handler。',
-    '请重点参考现有 `_provider.yaml` 中 `description`、`description_cn`、`notes` 的写法，因为这些内容会直接影响设备页展示效果。',
-    '不要把用户在表单里填写的账号、密码、Token、Cookie 直接写入插件；这些都应该通过 `credential_fields` 暴露为设备实例配置项。',
     '在正式开始构建设备插件之前，必须先做需求澄清：盘点已知信息、列出缺失/不确定信息，并向用户提出必要问题。',
     '当需要用户补充关键信息或澄清不确定项时，使用 `question` 工具明确。',
-    '除非用户已经提供了足够的信息，否则不要直接写文件或生成插件；优先通过简短问题确认产品名、厂商、版本、认证方式、目标能力、API/页面文档、测试环境和高风险写操作范围。',
-    '澄清问题应聚焦关键阻塞项，一次提出 3 到 6 个最重要的问题；可以给用户一个可直接复制填写的资料清单。',
+    '除非用户已经提供了足够的信息，否则不要直接写文件或生成插件；优先通过简短问题确认产品名、厂商、版本、认证方式、目标能力、API/页面文档。',
+    '澄清问题应聚焦关键阻塞项，一次提出 3 到 6 个最重要的问题（支持多选）。',
+    '不要把用户在表单里填写的账号、密码、Token、Cookie 直接写入插件；这些都应该通过 `credential_fields` 暴露为设备实例配置项。',
   ];
-}
-
-function buildApiDeviceRequirements(deviceName: string, vendorName: string): string {
-  return [
-    '请严格遵循当前项目的 device 插件契约，不要生成普通 api 工具后就停止。',
-    ...buildBaseDevicePluginRequirements(deviceName, vendorName),
-    '完成后请提醒用户返回设备页查看是否已经出现对应 device 插件，并继续后续配置。',
-  ].join('\n');
-}
-
-function buildWebCliDeviceRequirements(deviceName: string, vendorName: string): string {
-  return [
-    '请严格遵循当前项目的 web2cli skill 流程，不要只停留在临时抓包或一次性脚本。',
-    'WebCLI 接入必须先按 `references/cli-in-skill.md` 沉淀到 skill 中；这是必选步骤，用于承载 CLI 使用说明、浏览器恢复和认证失效处理。',
-    '如果目标是安全设备接入，还必须在 skill 集成完成后，再额外生成可在设备页识别、配置和调用的标准 device 插件。',
-    '请优先遵循 `web2cli` skill 中的捕获、导出、生成 CLI 的完整流程，再把沉淀出的能力包装为长期资产。',
-    ...buildBaseDevicePluginRequirements(deviceName, vendorName),
-    '- 自定义 CLI / WebCLI 默认认证方式为 `cookie/auth-state`；默认保存位置为 `~/.flocks/browser/<name>/auth-state.json`，优先使用 `auth_state_path`',
-    '- 模板应允许可选填写 `username` / `password`：前者用 config text，后者用 secret password；它们仅用于 cookie 失效后的浏览器认证恢复，不替代 `auth_state_path`',
-    '- 不要生成 `auth_state_json` 或 `Legacy Auth State JSON` 这类内联 JSON 兜底字段',
-    '- `cookie`、`csrf_token`、`access_token` 或特定认证头仅作为补充字段，不要和 `auth_state_path` 并列设计成多个默认认证入口',
-    '- skill 集成始终必选；CLI 主脚本默认放在 skill 的 `scripts/` 中，如设备运行时确有需要，可额外在 device 插件目录下保留适配层',
-    '- MVP 阶段优先生成单文件 handler；CLI 可以作为调试入口保留，但不应作为设备运行时主路径',
-    '运行时能力设计要求：',
-    '- 对外暴露统一业务 action，例如 `list_alerts`、`get_asset_detail`，不要把内部实现暴露成“API 版 / WebCLI 版”动作名',
-    '- handler 内部允许按 `api`、`webcli_api`、`process`、`composed` 四类来源编排，但对外返回统一结构',
-    '- 如果正式 API 稳定可用，优先正式 API；正式 API 缺能力时，再使用 WebCLI 抓到的隐藏接口',
-    '- 只有必须页面交互、验证码或强动态状态时，才记录为 browser fallback，不要作为默认设备运行时主路径',
-    '- cookie 失效时，返回明确认证失败话术，让 Rex 使用 `flocks browser` 和对应 skill 的认证失败处理刷新登录态；如已配置 `username` / `password`，Rex 可读取后辅助登录，再执行 `flocks browser state save <auth_state_path>`',
-    '- 高风险写操作必须设置 `requires_confirmation: true`',
-    '完成后请提醒用户返回设备页查看是否已经出现对应 WebCLI device 插件，并继续后续配置。',
-  ].join('\n');
 }
 
 export function buildCustomDeviceSessionContext(mode: CustomDeviceAccessMode): string {
@@ -98,7 +39,7 @@ export function buildCustomDeviceSessionContext(mode: CustomDeviceAccessMode): s
       '你必须先读取并使用 tool-builder skill，再开始生成插件。',
       '用户会提供 API 文档链接或后续上传文档文件，请根据文档盘点接口后生成 device 插件。',
       '优先选择 YAML-HTTP；如存在签名、登录换 token、复杂预处理，则使用 YAML-Script + handler。',
-      '虽然参考 tool-builder skill，但最终输出目录和插件结构必须符合 device 插件规范。',
+      '最终输出目录和插件结构必须符合 device 插件规范。',
     ].join('\n');
   }
   if (mode === 'webcli') {
@@ -106,9 +47,9 @@ export function buildCustomDeviceSessionContext(mode: CustomDeviceAccessMode): s
       ...buildBaseDeviceSessionContext(),
       '本次接入方式是 WebCLI 接入。',
       '你必须先读取并使用 web2cli skill，再开始捕获与转换流程。',
-      '用户会提供产品 URL 和需要获取的接口/页面行为。你可以使用 web2cli 思路抓取接口，但必须先完成 skill 集成；如果目标是安全设备接入，再额外生成 device 插件。',
+      '用户会提供产品 URL 和需要获取的接口/页面行为。目标是安全设备接入，需要生成 device 插件。',
       '自定义 CLI 默认复用 `cookie/auth-state`；可选暴露 `username` / `password` 仅用于 cookie 失效后的浏览器认证恢复。只有在站点确实需要补充 header、cookie 或 token 时，才额外暴露对应字段。',
-      'MVP 阶段优先生成单文件 script handler；可复用 CLI 只作为调试/回归入口，不作为设备运行时主路径。',
+      '最终输出目录和插件结构必须符合 device 插件规范。',
     ].join('\n');
   }
   return [
@@ -145,45 +86,6 @@ export function buildCustomDeviceWelcomeMessage(mode: CustomDeviceAccessMode): s
     ].join('\n');
   }
   return 'Workflow 接入不在这里创建插件，请前往工作流发布页面，根据需要配置 Syslog、Kafka 或 Webhook。';
-}
-
-export function buildCustomDevicePrompt(
-  draft: CustomDeviceApiDraft | CustomDeviceWebCliDraft,
-): string {
-  const header = [
-    `设备产品名：${draft.deviceName}`,
-    `厂商名称：${draft.vendorName}`,
-    draft.version ? `产品版本：${draft.version}` : '',
-    '',
-  ].filter(Boolean);
-
-  if (draft.accessMode === 'api') {
-    return [
-      ...header,
-      buildApiDeviceRequirements(draft.deviceName, draft.vendorName),
-      '',
-      '接入方式：API',
-      `Base URL：${draft.baseUrl}`,
-      `期望能力范围：${draft.capabilities.trim() || '全部 API'}`,
-      draft.docsUrl.trim() ? `API 文档链接：${draft.docsUrl.trim()}` : '',
-      '',
-      '必须先读取并使用 tool-builder skill，再根据 API 文档盘点接口并生成 device 插件。',
-      '请根据 API 文档盘点接口并生成 device 插件。若当前没有完整文档，请在后续 Rex 对话中继续索取或等待用户上传文档文件，不要假设接口细节。',
-    ].filter(Boolean).join('\n');
-  }
-
-  return [
-    ...header,
-    buildWebCliDeviceRequirements(draft.deviceName, draft.vendorName),
-    '',
-    '接入方式：WebCLI',
-    `产品 URL：${draft.productUrl}`,
-    `需要获取的接口/页面行为：${draft.targetInterfaces}`,
-    draft.authHint.trim() ? `认证/权限提示：${draft.authHint.trim()}` : '',
-    '',
-    '必须先读取并使用 web2cli skill，再执行捕获、导出与转换流程。',
-    '请使用 browser-use / web2cli 思路分析页面请求，并先完成 skill 集成；如果当前目标是安全设备接入，再把结果整理成 device 插件，不要只保留临时脚本。',
-  ].filter(Boolean).join('\n');
 }
 
 export function findTemplateForCustomDevice(

--- a/webui/src/pages/DeviceIntegration/index.test.tsx
+++ b/webui/src/pages/DeviceIntegration/index.test.tsx
@@ -48,6 +48,10 @@ vi.mock('react-i18next', () => ({
         'toolbar.addDevice': '立即添加设备',
         'empty.addNow': '立即添加设备',
         'config.closeAriaLabel': '关闭设备配置面板',
+        'config.nameLabel': '设备名称',
+        'config.roomLabel': '所属机房',
+        'config.saveBtn': '保存配置',
+        'config.addBtn': '添加设备',
         'config.showSecretAction': '显示',
         'config.hideSecretAction': '隐藏',
         'wizard.selectVendorTitle': `选择 ${String(params?.vendor ?? '')} 设备`,
@@ -483,6 +487,60 @@ describe('DeviceIntegrationPage', () => {
 
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: '关闭设备配置面板' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('allows editing an existing device room from a selected room view', async () => {
+    const user = userEvent.setup();
+    const initialDevice = {
+      id: 'device-1',
+      group_id: 'group-1',
+      name: 'TDP-test-02',
+      storage_key: 'tdp_api_v3_3_10',
+      service_id: 'tdp',
+      enabled: true,
+      verify_ssl: false,
+      fields: { base_url: 'https://tdp.example.com' },
+      fields_set: { api_key: true, secret: true, base_url: true },
+      status: 'connected',
+      created_at: 0,
+      updated_at: 0,
+    };
+    mocks.listDevices.mockResolvedValue({ data: [initialDevice] });
+    mocks.listTemplates.mockResolvedValue({
+      data: [
+        buildTemplate({
+          plugin_id: 'tdp_v3_3_10',
+          storage_key: 'tdp_api_v3_3_10',
+          service_id: 'tdp_api',
+          name: 'TDP',
+          tool_count: 21,
+          vendor: 'threatbook',
+        }),
+      ],
+    });
+    mocks.listGroups.mockResolvedValue({
+      data: [
+        { id: 'group-1', name: '默认机房', sort_order: 0, created_at: 0, updated_at: 0 },
+        { id: 'group-2', name: '测试', sort_order: 1, created_at: 0, updated_at: 0 },
+      ],
+    });
+    mocks.getDevice.mockResolvedValue({
+      data: { ...initialDevice, group_id: 'group-2' },
+    });
+
+    render(<DeviceIntegrationPage />);
+
+    await user.click(await screen.findByText('TDP-test-02'));
+    const roomSelect = await screen.findByRole('combobox');
+    await user.selectOptions(roomSelect, 'group-2');
+    await user.click(screen.getByRole('button', { name: /保存配置/ }));
+
+    await waitFor(() => {
+      expect(mocks.updateDevice).toHaveBeenCalledWith(
+        'device-1',
+        expect.objectContaining({ group_id: 'group-2' }),
+      );
     });
   });
 

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -1328,13 +1328,13 @@ export default function DeviceIntegrationPage() {
     [devices, selectedGroupId],
   );
 
-  const fetchData = useCallback(async (silent = false): Promise<DeviceTemplate[]> => {
+  const fetchData = useCallback(async (silent = false, refreshTemplates = false): Promise<DeviceTemplate[]> => {
     if (!silent) setLoading(true);
     else setRefreshing(true);
     try {
       const [devRes, tplRes, grpRes] = await Promise.all([
-        deviceAPI.list(),
-        deviceAPI.listTemplates(),
+        deviceAPI.list(refreshTemplates ? { refresh: true } : undefined),
+        deviceAPI.listTemplates(refreshTemplates ? { refresh: true } : undefined),
         deviceAPI.listGroups(),
       ]);
       const nextTemplates = tplRes.data || [];
@@ -1454,6 +1454,9 @@ export default function DeviceIntegrationPage() {
     await fetchData(true);
     if (panel?.kind === 'edit') {
       const updated = await deviceAPI.get(panel.device.id);
+      if (selectedGroupId && updated.data.group_id !== selectedGroupId) {
+        setSelectedGroupId(updated.data.group_id);
+      }
       setPanel({ kind: 'edit', device: updated.data });
     }
   };
@@ -1531,7 +1534,7 @@ export default function DeviceIntegrationPage() {
         action={
           <div className="flex items-center gap-2">
             <button
-              onClick={() => void fetchData(true)}
+              onClick={() => void fetchData(true, true)}
               disabled={refreshing}
               title={t('toolbar.refresh')}
               className="p-1.5 rounded-lg border border-zinc-200 text-zinc-500 hover:bg-zinc-50 hover:text-zinc-700 disabled:opacity-50 transition-colors"
@@ -1810,7 +1813,7 @@ export default function DeviceIntegrationPage() {
             vendorKey={panelVendorKey}
             initialGroupId={panelInitGroupId}
             groups={groups}
-            groupLocked={panel.kind === 'edit' ? true : groupLocked}
+            groupLocked={panel.kind === 'add' ? groupLocked : false}
             onSave={handleSave}
             onDelete={panel.kind === 'edit' ? handleDelete : undefined}
             onClose={() => setPanel(null)}

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -269,27 +269,6 @@ export interface APIServiceMetadata {
 
 export type CustomDeviceAccessMode = 'api' | 'webcli' | 'workflow';
 
-export interface CustomDeviceBaseDraft {
-  accessMode: CustomDeviceAccessMode;
-  deviceName: string;
-  vendorName: string;
-  version: string;
-}
-
-export interface CustomDeviceApiDraft extends CustomDeviceBaseDraft {
-  accessMode: 'api';
-  baseUrl: string;
-  docsUrl: string;
-  capabilities: string;
-}
-
-export interface CustomDeviceWebCliDraft extends CustomDeviceBaseDraft {
-  accessMode: 'webcli';
-  productUrl: string;
-  targetInterfaces: string;
-  authHint: string;
-}
-
 export interface MCPServerConfig {
   type: 'stdio' | 'sse';
   url?: string;


### PR DESCRIPTION
## Summary
- auto-register user-level device plugins from ~/.flocks/plugins/tools/device into the device integration list
- support refresh=true for device template and device list reloads, including tools/device watcher support
- preserve delete semantics with an auto-instance ignore list and allow manual re-add
- allow existing devices to move between rooms from the edit panel
- simplify custom device onboarding flow and tidy TUI todo naming

## Tests
- uv run python -m pytest tests/tool/test_device_plugin_index.py tests/tool/test_watcher_atomic_save.py
- npm run test:run -- src/pages/DeviceIntegration/index.test.tsx
- uv run ruff check flocks/tool/device/intake.py flocks/server/routes/device.py tests/tool/test_device_plugin_index.py tests/tool/test_watcher_atomic_save.py
- npm run lint -- src/pages/DeviceIntegration/index.tsx src/pages/DeviceIntegration/index.test.tsx