### PR TITLE
Default model reasoning to enabled

### DIFF
--- a/flocks/provider/model_catalog.py
+++ b/flocks/provider/model_catalog.py
@@ -132,14 +132,14 @@ def _parse_model_definitions(
             features.append(ModelFeature.TOOL_CALL)
         if caps_raw.get("supports_vision"):
             features.append(ModelFeature.VISION)
-        if caps_raw.get("supports_reasoning"):
+        if caps_raw.get("supports_reasoning", True):
             features.append(ModelFeature.REASONING)
 
         capabilities = ModelCapabilitiesV2(
             features=features,
             supports_tools=caps_raw.get("supports_tools", False),
             supports_vision=caps_raw.get("supports_vision", False),
-            supports_reasoning=caps_raw.get("supports_reasoning", False),
+            supports_reasoning=caps_raw.get("supports_reasoning", True),
             interleaved=caps_raw.get("interleaved"),
             supports_streaming=caps_raw.get("supports_streaming", True),
         )

--- a/flocks/provider/provider.py
+++ b/flocks/provider/provider.py
@@ -111,7 +111,7 @@ class ModelCapabilities(BaseModel):
     supports_streaming: bool = True
     supports_tools: bool = True
     supports_vision: bool = False
-    supports_reasoning: bool = False
+    supports_reasoning: bool = True
     interleaved: Optional[Dict[str, Any]] = None
     max_tokens: Optional[int] = None
     context_window: Optional[int] = None
@@ -848,7 +848,7 @@ class Provider:
                                     supports_streaming=model_dict.get("supports_streaming", True),
                                     supports_tools=model_dict.get("supports_tools", True),
                                     supports_vision=model_dict.get("supports_vision", False),
-                                    supports_reasoning=model_dict.get("supports_reasoning", False),
+                                    supports_reasoning=model_dict.get("supports_reasoning", True),
                                     interleaved=model_dict.get("interleaved"),
                                     max_tokens=model_dict.get("max_output_tokens") or model_dict.get("max_tokens"),
                                     context_window=model_dict.get("context_window"),
@@ -1216,7 +1216,7 @@ class BaseProvider:
                 supports_streaming=model.capabilities.supports_streaming,
                 supports_tools=model.capabilities.supports_tools,
                 supports_vision=model.capabilities.supports_vision,
-                supports_reasoning=getattr(model.capabilities, "supports_reasoning", False),
+                supports_reasoning=getattr(model.capabilities, "supports_reasoning", True),
                 interleaved=getattr(model.capabilities, "interleaved", None),
             ),
             limits=ModelLimits(
@@ -1250,7 +1250,7 @@ class BaseProvider:
         never touched keep their richer catalog values.  This avoids e.g. a catalog
         ``supports_reasoning=True`` being silently reset to ``False`` by a default.
         """
-        from flocks.provider.types import PriceConfig
+        from flocks.provider.types import ModelFeature, PriceConfig
 
         overridden = catalog_def.model_copy(deep=True)
         keys = getattr(model, "_explicit_keys", set())
@@ -1267,9 +1267,19 @@ class BaseProvider:
         if "supports_vision" in keys:
             overridden.capabilities.supports_vision = model.capabilities.supports_vision
         if "supports_reasoning" in keys:
-            overridden.capabilities.supports_reasoning = getattr(
-                model.capabilities, "supports_reasoning", False
+            supports_reasoning = getattr(
+                model.capabilities, "supports_reasoning", True
             )
+            overridden.capabilities.supports_reasoning = supports_reasoning
+            if supports_reasoning:
+                if ModelFeature.REASONING not in overridden.capabilities.features:
+                    overridden.capabilities.features.append(ModelFeature.REASONING)
+            else:
+                overridden.capabilities.features = [
+                    feature
+                    for feature in overridden.capabilities.features
+                    if feature != ModelFeature.REASONING and feature != ModelFeature.REASONING.value
+                ]
         if "interleaved" in keys:
             overridden.capabilities.interleaved = getattr(
                 model.capabilities, "interleaved", None

--- a/flocks/provider/types.py
+++ b/flocks/provider/types.py
@@ -244,7 +244,7 @@ class ModelCapabilitiesV2(BaseModel):
     supports_streaming: bool = True
     supports_tools: bool = True
     supports_vision: bool = False
-    supports_reasoning: bool = False
+    supports_reasoning: bool = True
     interleaved: Optional[Dict[str, Any]] = None
     supports_temperature: bool = True
     supports_json_mode: bool = False

--- a/flocks/server/routes/custom_provider.py
+++ b/flocks/server/routes/custom_provider.py
@@ -72,7 +72,7 @@ class CreateModelReq(BaseModel):
     supports_vision: bool = False
     supports_tools: bool = True
     supports_streaming: bool = True
-    supports_reasoning: bool = False
+    supports_reasoning: bool = True
     input_price: float = Field(0.0, ge=0)
     output_price: float = Field(0.0, ge=0)
     currency: str = "USD"
@@ -403,7 +403,7 @@ async def load_custom_providers_on_startup():
                     supports_streaming=mcfg.get("supports_streaming", True),
                     supports_tools=mcfg.get("supports_tools", True),
                     supports_vision=mcfg.get("supports_vision", False),
-                    supports_reasoning=mcfg.get("supports_reasoning", False),
+                    supports_reasoning=mcfg.get("supports_reasoning", True),
                     max_tokens=mcfg.get("max_output_tokens", 4096),
                     context_window=mcfg.get("context_window", 128000),
                 ),

--- a/flocks/tool/system/model_config.py
+++ b/flocks/tool/system/model_config.py
@@ -353,7 +353,7 @@ async def add_model_tool(
             "supports_vision": supports_vision,
             "supports_tools": supports_tools,
             "supports_streaming": True,
-            "supports_reasoning": False,
+            "supports_reasoning": True,
             "input_price": 0.0,
             "output_price": 0.0,
             "currency": "USD",

--- a/tests/provider/test_model_management.py
+++ b/tests/provider/test_model_management.py
@@ -252,6 +252,33 @@ class TestBaseProviderExtensions:
         assert defs[0].limits.context_window == 100000
         assert defs[0].limits.max_output_tokens == 8000
 
+    def test_config_override_false_removes_reasoning_feature(self):
+        from flocks.provider.provider import BaseProvider, ModelInfo, ModelCapabilities
+
+        catalog_def = ModelDefinition(
+            id="dummy-model",
+            name="Dummy Model",
+            provider_id="dummy",
+            fetch_from=FetchFrom.PREDEFINED,
+            capabilities=ModelCapabilitiesV2(
+                features=[ModelFeature.REASONING],
+                supports_reasoning=True,
+            ),
+        )
+        model = ModelInfo(
+            id="dummy-model",
+            name="Dummy Model",
+            provider_id="dummy",
+            capabilities=ModelCapabilities(supports_reasoning=False),
+        )
+        model._explicit_keys = {"supports_reasoning"}
+
+        p = BaseProvider("dummy", "Dummy")
+        overridden = p._apply_config_overrides(catalog_def, model)
+
+        assert overridden.capabilities.supports_reasoning is False
+        assert ModelFeature.REASONING not in overridden.capabilities.features
+
     def test_configure_from_credential(self):
         from flocks.provider.provider import BaseProvider
 

--- a/tests/provider/test_model_management_p2p3.py
+++ b/tests/provider/test_model_management_p2p3.py
@@ -166,6 +166,24 @@ class TestModelCatalog:
         assert ModelFeature.VISION in sonnet4.capabilities.features
         assert ModelFeature.REASONING in sonnet4.capabilities.features
 
+    def test_model_catalog_defaults_reasoning_on_when_omitted(self):
+        from flocks.provider.model_catalog import _parse_model_definitions
+
+        models = _parse_model_definitions(
+            "custom-defaults",
+            {
+                "custom-model": {
+                    "name": "Custom Model",
+                    "capabilities": {
+                        "supports_tools": True,
+                    },
+                }
+            },
+        )
+
+        assert models[0].capabilities.supports_reasoning is True
+        assert ModelFeature.REASONING in models[0].capabilities.features
+
     def test_google_gemini_multimodal(self):
         from flocks.provider.model_catalog import get_provider_model_definitions
         models = get_provider_model_definitions("google")

--- a/tests/server/routes/test_custom_provider_routes.py
+++ b/tests/server/routes/test_custom_provider_routes.py
@@ -37,7 +37,8 @@ def temp_custom_provider_project(tmp_path, monkeypatch):
 @pytest.fixture
 async def client():
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+    headers = {"Authorization": "Bearer abc123", "User-Agent": "curl/8.0"}
+    async with AsyncClient(transport=transport, base_url="http://test", headers=headers) as ac:
         yield ac
 
 
@@ -79,3 +80,29 @@ async def test_create_custom_model_accepts_string_currency(
     assert raw is not None
     assert raw["models"]["minimax:MiniMax-M2.7"]["currency"] == "USD"
     assert Provider._models["minimax:MiniMax-M2.7"].pricing["currency"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_model_defaults_reasoning_on(
+    client: AsyncClient,
+    temp_custom_provider_project,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from flocks.config.config_writer import ConfigWriter
+    from flocks.provider.provider import Provider
+
+    monkeypatch.setattr(Provider, "_models", Provider._models.copy())
+
+    response = await client.post(
+        "/api/custom/models/custom-tb-inner",
+        json={
+            "model_id": "custom-reasoning-default",
+            "name": "Custom Reasoning Default",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    raw = ConfigWriter.get_provider_raw("custom-tb-inner")
+    assert raw is not None
+    assert raw["models"]["custom-reasoning-default"]["supports_reasoning"] is True
+    assert Provider._models["custom-reasoning-default"].capabilities.supports_reasoning is True

--- a/tui/flocks/cli/cmd/tui/context/local.tsx
+++ b/tui/flocks/cli/cmd/tui/context/local.tsx
@@ -214,7 +214,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             return {
               provider: "Connect a provider",
               model: "No provider selected",
-              reasoning: false,
+              reasoning: true,
             }
           }
           const provider = sync.data.provider.find((x) => x.id === value.providerID)
@@ -222,7 +222,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return {
             provider: provider?.name ?? value.providerID,
             model: info?.name ?? value.modelID,
-            reasoning: info?.capabilities?.reasoning ?? false,
+            reasoning: info?.capabilities?.reasoning ?? true,
           }
         }),
         cycle(direction: 1 | -1) {

--- a/tui/flocks/provider/provider.ts
+++ b/tui/flocks/provider/provider.ts
@@ -762,7 +762,7 @@ export namespace Provider {
           providerID,
           capabilities: {
             temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
-            reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
+            reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? true,
             attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
             toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
             input: {

--- a/webui/src/pages/Model/index.tsx
+++ b/webui/src/pages/Model/index.tsx
@@ -1833,7 +1833,7 @@ function useModelForm() {
   const [supportsVision, setSupportsVision] = useState(false);
   const [supportsTools, setSupportsTools] = useState(true);
   const [supportsStreaming, setSupportsStreaming] = useState(true);
-  const [supportsReasoning, setSupportsReasoning] = useState(false);
+  const [supportsReasoning, setSupportsReasoning] = useState(true);
   const [inputPrice, setInputPrice] = useState('0');
   const [outputPrice, setOutputPrice] = useState('0');
   const [currency, setCurrency] = useState('USD');
@@ -1842,7 +1842,7 @@ function useModelForm() {
     setModelId(''); setName('');
     setContextWindow('128000'); setMaxOutput('128000');
     setSupportsVision(false); setSupportsTools(true);
-    setSupportsStreaming(true); setSupportsReasoning(false);
+    setSupportsStreaming(true); setSupportsReasoning(true);
     setInputPrice('0'); setOutputPrice('0'); setCurrency('USD');
   }, []);
 
@@ -2160,10 +2160,9 @@ function getDefaultReasoningToggleValue(providerId: string, modelId: string): bo
 
   if (['threatbook-cn-llm', 'threatbook-io-llm', 'alibaba', 'moonshot'].includes(providerId)) {
     if (lowered.includes('qwen3-max') || lowered.includes('qwen3.6-plus')) return true;
-    if (lowered.includes('kimi-k2.5') || lowered.includes('kimi-k2.6')) return false;
   }
 
-  return false;
+  return true;
 }
 
 function allowsBuiltInVisionToggle(modelId: string): boolean {


### PR DESCRIPTION
## Summary
- default model reasoning support to enabled when provider/model metadata omits it
- default the model management reasoning toggle to on for new models and detail fallback values
- add regression tests for custom model creation and catalog parsing defaults

## Tests
- uv run pytest tests/server/routes/test_custom_provider_routes.py tests/server/routes/test_custom_provider_runtime.py tests/provider/test_model_management_p2p3.py -q
- uv run ruff check flocks/server/routes/custom_provider.py flocks/provider/types.py flocks/provider/provider.py flocks/provider/model_catalog.py flocks/tool/system/model_config.py tests/server/routes/test_custom_provider_routes.py tests/provider/test_model_management_p2p3.py
- npm run build