### PR TITLE
Fix skill install from GitHub blob URLs

### DIFF
--- a/flocks/skill/installer.py
+++ b/flocks/skill/installer.py
@@ -77,6 +77,20 @@ def _resolve_install_root(scope: str) -> Path:
     return _user_skills_root()
 
 
+def _normalize_github_repo_path(repo_path: str) -> str:
+    """Normalize GitHub web paths to owner/repo[/skill-dir]."""
+    parts = repo_path.strip("/").split("/")
+    if len(parts) < 4 or parts[2] not in {"blob", "tree"}:
+        return repo_path.strip("/")
+
+    owner, repo, view_kind, _branch, *subpath_parts = parts
+    if view_kind == "blob" and subpath_parts[-1:] == ["SKILL.md"]:
+        subpath_parts = subpath_parts[:-1]
+
+    subpath = "/".join(subpath_parts)
+    return f"{owner}/{repo}/{subpath}".rstrip("/")
+
+
 def _resolve_source(source: str) -> dict:
     """
     Parse source string into a typed dict with keys: kind, value.
@@ -105,7 +119,10 @@ def _resolve_source(source: str) -> dict:
         return {"kind": "clawhub", "value": source[len("clawhub:"):]}
 
     if source.startswith("github:"):
-        return {"kind": "github", "value": source[len("github:"):]}
+        return {
+            "kind": "github",
+            "value": _normalize_github_repo_path(source[len("github:"):]),
+        }
 
     if source.startswith(("http://", "https://")):
         skills_sh_match = re.match(
@@ -123,7 +140,8 @@ def _resolve_source(source: str) -> dict:
         if gh_match:
             repo = gh_match.group(1).rstrip("/")
             subpath = (gh_match.group(2) or "").strip("/")
-            return {"kind": "github", "value": f"{repo}/{subpath}" if subpath else repo}
+            repo_path = f"{repo}/{subpath}" if subpath else repo
+            return {"kind": "github", "value": _normalize_github_repo_path(repo_path)}
         return {"kind": "url", "value": source}
 
     if source.startswith(("/", "./", "../", "~/")):

--- a/tests/skill/test_installer.py
+++ b/tests/skill/test_installer.py
@@ -93,6 +93,27 @@ class TestResolveSource:
         assert r["kind"] == "github"
         assert "owner/repo" in r["value"]
 
+    def test_github_blob_url_with_skill_directory_subpath(self):
+        r = _resolve_source(
+            "https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose"
+        )
+        assert r["kind"] == "github"
+        assert r["value"] == "mattpocock/skills/skills/engineering/diagnose"
+
+    def test_github_blob_url_to_skill_md_uses_parent_directory(self):
+        r = _resolve_source(
+            "https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md"
+        )
+        assert r["kind"] == "github"
+        assert r["value"] == "mattpocock/skills/skills/engineering/diagnose"
+
+    def test_github_scheme_blob_path_with_subpath(self):
+        r = _resolve_source(
+            "github:mattpocock/skills/blob/main/skills/engineering/diagnose"
+        )
+        assert r["kind"] == "github"
+        assert r["value"] == "mattpocock/skills/skills/engineering/diagnose"
+
     def test_https_url(self):
         r = _resolve_source("https://example.com/SKILL.md")
         assert r["kind"] == "url"


### PR DESCRIPTION
## Summary
- Normalize GitHub web paths with blob/tree segments before resolving skill install sources
- Treat GitHub blob URLs that point directly to SKILL.md as the parent skill directory
- Add regression coverage for GitHub blob URL inputs and github: blob-style paths

## Tests
- uv run pytest tests/skill/test_installer.py
- uv run ruff check flocks/skill/installer.py tests/skill/test_installer.py