### PR TITLE
Fix device refresh sync flow

### DIFF
--- a/flocks/server/routes/device.py
+++ b/flocks/server/routes/device.py
@@ -5,6 +5,7 @@ return responses. No business logic or SQL lives here.
 """
 from __future__ import annotations
 
+import json
 from typing import Any, List, Optional
 
 import aiosqlite
@@ -40,6 +41,7 @@ from flocks.tool.device.plugin_index import (
     create_custom_device_template,
     list_device_templates,
 )
+from flocks.tool.device.secrets import resolve_for_runtime
 from flocks.tool.device.store import (
     create_group,
     delete_device_tool_setting,
@@ -181,6 +183,13 @@ async def route_list_devices(group_id: Optional[str] = None, refresh: bool = Fal
 @router.get("/templates", response_model=List[DeviceTemplate])
 async def route_list_device_templates(refresh: bool = False):
     return list_device_templates(refresh=refresh)
+
+
+@router.post("/sync")
+async def route_sync_devices(refresh: bool = True):
+    """Synchronize device instances from installed user-level templates."""
+    created = await ensure_user_device_instances(refresh_templates=refresh)
+    return {"created": created}
 
 
 @router.post(

--- a/tests/server/routes/test_device_routes.py
+++ b/tests/server/routes/test_device_routes.py
@@ -19,6 +19,7 @@ import pytest
 from httpx import AsyncClient
 
 from flocks.server.routes import device as device_routes
+from flocks.tool.device import intake as device_intake
 from flocks.tool.device.models import DeviceTestResult
 
 
@@ -43,8 +44,7 @@ def _install_route_stubs(
     probe_result: DeviceTestResult,
     captured: dict,
 ) -> None:
-    """Stub out fetch_device, _probe and record_test_result on the
-    routes module so the test stays isolated from DB / network."""
+    """Stub out intake dependencies so the test stays isolated from DB / network."""
 
     async def fake_fetch_device(device_id: str):
         captured["device_id"] = device_id
@@ -60,13 +60,13 @@ def _install_route_stubs(
             {"device_id": device_id, "success": success, "message": message}
         )
 
-    monkeypatch.setattr(device_routes, "fetch_device", fake_fetch_device)
-    monkeypatch.setattr(device_routes, "_probe", fake_probe)
-    monkeypatch.setattr(device_routes, "record_test_result", fake_record)
+    monkeypatch.setattr(device_intake, "fetch_device", fake_fetch_device)
+    monkeypatch.setattr(device_intake, "_probe", fake_probe)
+    monkeypatch.setattr(device_intake, "record_test_result", fake_record)
     # secrets resolution: return the persisted dict untouched so tests can
     # drive the field values directly.
     monkeypatch.setattr(
-        device_routes,
+        device_intake,
         "resolve_for_runtime",
         lambda db_fields: dict(db_fields),
     )
@@ -192,7 +192,7 @@ class TestDeviceTestEndpoint:
         async def fake_fetch_device(device_id: str):
             return None
 
-        monkeypatch.setattr(device_routes, "fetch_device", fake_fetch_device)
+        monkeypatch.setattr(device_intake, "fetch_device", fake_fetch_device)
 
         resp = await client.post("/api/devices/missing-id/test", json={})
 
@@ -258,3 +258,49 @@ class TestDeviceCredentialEndpoint:
         resp = await client.post("/api/devices/missing-id/credentials", json={})
 
         assert resp.status_code == 404
+
+
+class TestDeviceSyncEndpoint:
+    @pytest.mark.asyncio
+    async def test_sync_invokes_auto_instance_creation_with_refresh_flag(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        captured: dict = {}
+
+        async def fake_ensure_user_device_instances(*, refresh_templates: bool):
+            captured["refresh_templates"] = refresh_templates
+            return 3
+
+        monkeypatch.setattr(
+            device_routes,
+            "ensure_user_device_instances",
+            fake_ensure_user_device_instances,
+        )
+
+        resp = await client.post("/api/devices/sync?refresh=true")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"created": 3}
+        assert captured["refresh_templates"] is True
+
+    @pytest.mark.asyncio
+    async def test_sync_allows_non_refresh_sync(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        captured: dict = {}
+
+        async def fake_ensure_user_device_instances(*, refresh_templates: bool):
+            captured["refresh_templates"] = refresh_templates
+            return 0
+
+        monkeypatch.setattr(
+            device_routes,
+            "ensure_user_device_instances",
+            fake_ensure_user_device_instances,
+        )
+
+        resp = await client.post("/api/devices/sync?refresh=false")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"created": 0}
+        assert captured["refresh_templates"] is False

--- a/webui/src/api/device.ts
+++ b/webui/src/api/device.ts
@@ -173,6 +173,9 @@ export const deviceAPI = {
   listTemplates: (params?: { refresh?: boolean }) =>
     client.get<DeviceTemplate[]>('/api/devices/templates', { params }),
 
+  sync: (params?: { refresh?: boolean }) =>
+    client.post<{ created: number }>('/api/devices/sync', null, { params }),
+
   createCustomTemplate: (data: CustomDeviceTemplateCreate) =>
     client.post<DeviceTemplate>('/api/devices/templates/custom', data),
 

--- a/webui/src/pages/DeviceIntegration/index.test.tsx
+++ b/webui/src/pages/DeviceIntegration/index.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   sessionId: null as string | null,
   resetSession: vi.fn(),
   listDevices: vi.fn(),
+  syncDevices: vi.fn(),
   getDevice: vi.fn(),
   listGroups: vi.fn(),
   createGroup: vi.fn(),
@@ -160,6 +161,7 @@ vi.mock('@/hooks/useSessionChat', () => ({
 vi.mock('@/api/device', () => ({
   deviceAPI: {
     list: (...args: unknown[]) => mocks.listDevices(...args),
+    sync: (...args: unknown[]) => mocks.syncDevices(...args),
     get: (...args: unknown[]) => mocks.getDevice(...args),
     revealCredentials: (...args: unknown[]) => mocks.revealDeviceCredentials(...args),
     listGroups: (...args: unknown[]) => mocks.listGroups(...args),
@@ -211,6 +213,7 @@ describe('DeviceIntegrationPage', () => {
     vi.clearAllMocks();
     mocks.sessionId = null;
     mocks.listDevices.mockResolvedValue({ data: [] });
+    mocks.syncDevices.mockResolvedValue({ data: { created: 0 } });
     mocks.getDevice.mockResolvedValue({
       data: {
         id: 'device-1',
@@ -238,6 +241,29 @@ describe('DeviceIntegrationPage', () => {
     mocks.listDeviceTools.mockResolvedValue({ data: [] });
     mocks.updateDeviceTool.mockResolvedValue({ data: {} });
     mocks.refreshTools.mockResolvedValue({ data: { ok: true } });
+  });
+
+  it('refreshes devices and templates when the window regains focus', async () => {
+    render(<DeviceIntegrationPage />);
+
+    await screen.findByText('设备接入');
+    await waitFor(() => {
+      expect(mocks.listDevices).toHaveBeenCalledTimes(1);
+    });
+    mocks.listDevices.mockClear();
+    mocks.listTemplates.mockClear();
+    mocks.listGroups.mockClear();
+
+    window.dispatchEvent(new Event('focus'));
+
+    await waitFor(() => {
+      expect(mocks.syncDevices).toHaveBeenCalledWith({ refresh: true });
+    });
+    await waitFor(() => {
+      expect(mocks.listDevices).toHaveBeenCalledWith();
+      expect(mocks.listTemplates).toHaveBeenCalledWith({ refresh: true });
+      expect(mocks.listGroups).toHaveBeenCalled();
+    });
   });
 
   it('shows custom device option and access modes', async () => {

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -1302,6 +1302,7 @@ export default function DeviceIntegrationPage() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [panel, setPanel] = useState<PanelMode>(null);
+  const lastRefreshRef = useRef(0);
   // null = "全部机房" aggregate view; string = specific group id
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   // Group ids whose section is collapsed in the "全部机房" view. Default
@@ -1332,8 +1333,11 @@ export default function DeviceIntegrationPage() {
     if (!silent) setLoading(true);
     else setRefreshing(true);
     try {
+      if (refreshTemplates) {
+        await deviceAPI.sync({ refresh: true });
+      }
       const [devRes, tplRes, grpRes] = await Promise.all([
-        deviceAPI.list(refreshTemplates ? { refresh: true } : undefined),
+        deviceAPI.list(),
         deviceAPI.listTemplates(refreshTemplates ? { refresh: true } : undefined),
         deviceAPI.listGroups(),
       ]);
@@ -1352,6 +1356,31 @@ export default function DeviceIntegrationPage() {
   }, []);
 
   useEffect(() => { void fetchData(); }, [fetchData]);
+
+  const refreshOnResume = useCallback(() => {
+    const now = Date.now();
+    if (now - lastRefreshRef.current < 1000) return;
+    lastRefreshRef.current = now;
+    void fetchData(true, true);
+  }, [fetchData]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refreshOnResume();
+      }
+    };
+    const handleWindowFocus = () => {
+      refreshOnResume();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', handleWindowFocus);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleWindowFocus);
+    };
+  }, [refreshOnResume]);
 
   // Count instances per storage_key (for wizard display)
   const instanceCounts = useMemo(() => {


### PR DESCRIPTION
## Summary
- Add an explicit device sync endpoint for installed user-level device templates.
- Refresh device templates on focus/visibility resume without duplicating device auto-sync work.
- Cover the sync endpoint and device page refresh behavior with tests.

## Verification
- uv run pytest tests/server/routes/test_device_routes.py
- npm run test:run -- DeviceIntegration
- uv run ruff check flocks/server/routes/device.py tests/server/routes/test_device_routes.py
- npx eslint src/pages/DeviceIntegration/index.tsx src/pages/DeviceIntegration/index.test.tsx src/api/device.ts