### PR TITLE
Support structured ACP command arguments

### DIFF
--- a/flocks/acp/agent.py
+++ b/flocks/acp/agent.py
@@ -1189,6 +1189,16 @@ class ACPAgent:
         self._session_manager.set_mode(session_id, mode_id)
         
         return {"_meta": {}}
+
+    @staticmethod
+    def _parse_command_arguments(raw_args: str) -> Any:
+        stripped = (raw_args or "").strip()
+        if not stripped or stripped[0] not in "{[":
+            return None
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            return None
     
     async def prompt(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -1313,6 +1323,7 @@ class ACPAgent:
             session_id=session_id,
             command=cmd["name"],
             arguments=cmd["args"],
+            arguments_json=self._parse_command_arguments(cmd["args"]),
             model=f"{model['providerID']}/{model['modelID']}",
             agent=agent,
             directory=directory,

--- a/flocks/command/direct.py
+++ b/flocks/command/direct.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from flocks.agent.agent import AvailableAgent
 from flocks.agent.registry import Agent
@@ -132,6 +132,7 @@ async def run_direct_command(
     name: str,
     *,
     args: str = "",
+    args_json: Optional[Any] = None,
     surface: Optional[CommandSurface] = None,
 ) -> DirectCommandResult:
     """Execute a direct command and return its result."""
@@ -141,6 +142,7 @@ async def run_direct_command(
 
     name = resolved.name
     args = (args or "").strip()
+    _ = args_json
 
     if name == "help":
         return DirectCommandResult(handled=True, text=format_help(surface=surface))

--- a/flocks/command/handler.py
+++ b/flocks/command/handler.py
@@ -6,6 +6,7 @@ from typing import Awaitable, Callable, Optional
 
 from flocks.command.command import Command, CommandSurface
 from flocks.command.direct import run_direct_command
+from flocks.input.events import ParsedCommand
 
 
 SendText = Callable[[str], Awaitable[None]]
@@ -17,6 +18,7 @@ ClearHistory = Callable[[], Awaitable[None]]
 async def handle_slash_command(
     content: str,
     *,
+    parsed_command: Optional[ParsedCommand] = None,
     send_text: SendText,
     send_prompt: SendPrompt,
     clear_screen: Optional[ClearScreen] = None,
@@ -28,21 +30,33 @@ async def handle_slash_command(
 
     Returns True if handled.
     """
-    stripped = content.strip()
-    if not stripped.startswith("/"):
-        return False
+    parsed = parsed_command
+    if parsed is None:
+        stripped = content.strip()
+        if not stripped.startswith("/"):
+            return False
 
-    cmd_parts = stripped[1:].split(None, 1)
-    if not cmd_parts:
-        return False
+        cmd_parts = stripped[1:].split(None, 1)
+        if not cmd_parts:
+            return False
+        parsed = ParsedCommand(
+            raw_text=stripped,
+            command_name=cmd_parts[0].lower(),
+            canonical_name=cmd_parts[0].lower(),
+            args=cmd_parts[1].strip() if len(cmd_parts) > 1 else "",
+        )
 
-    resolved = Command.resolve(cmd_parts[0].lower())
+    resolved = Command.resolve(parsed.command_name)
     if not resolved or resolved.execution_kind != "direct":
         return False
 
     name = resolved.name
-    args = cmd_parts[1].strip() if len(cmd_parts) > 1 else ""
-    result = await run_direct_command(name, args=args, surface=surface)
+    result = await run_direct_command(
+        name,
+        args=parsed.args,
+        args_json=parsed.args_json,
+        surface=surface,
+    )
     if not result.handled:
         return False
 

--- a/flocks/input/dispatcher.py
+++ b/flocks/input/dispatcher.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from flocks.command.command import Command
 from flocks.command.handler import handle_slash_command
@@ -20,7 +20,10 @@ class DispatchResult:
     handled: bool = True
 
 
-def parse_slash_command(text: str) -> Optional[ParsedCommand]:
+def parse_slash_command(
+    text: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[ParsedCommand]:
     """Parse slash text into a command and registry metadata."""
     stripped = (text or "").strip()
     if not stripped.startswith("/"):
@@ -38,6 +41,7 @@ def parse_slash_command(text: str) -> Optional[ParsedCommand]:
         command_name=command_name.lower(),
         canonical_name=canonical_name,
         args=raw_args.strip(),
+        args_json=metadata.get("commandArgumentsJson") if isinstance(metadata, dict) else None,
         command_def=command_def,
     )
 
@@ -48,7 +52,7 @@ def _has_non_text_parts(event: UserInputEvent) -> bool:
 
 async def dispatch_user_input(event: UserInputEvent, sink: OutputSink) -> DispatchResult:
     """Route a normalized user input through direct / llm / session-control paths."""
-    parsed = parse_slash_command(event.text)
+    parsed = parse_slash_command(event.text, event.metadata)
     if parsed is None:
         await sink.run_llm(event, event.text, event.display_text)
         return DispatchResult(action="llm", handled=False)
@@ -112,6 +116,7 @@ async def dispatch_user_input(event: UserInputEvent, sink: OutputSink) -> Dispat
         clear_history_cb = getattr(sink, "_clear_history", None)
         handled = await handle_slash_command(
             parsed.raw_text,
+            parsed_command=parsed,
             send_text=_collect_text,
             send_prompt=_collect_prompt,
             clear_screen=clear_cb,

--- a/flocks/input/events.py
+++ b/flocks/input/events.py
@@ -50,4 +50,5 @@ class ParsedCommand(BaseModel):
     command_name: str
     canonical_name: str
     args: str = ""
+    args_json: Optional[Any] = None
     command_def: Optional[CommandInfo] = None

--- a/flocks/server/client.py
+++ b/flocks/server/client.py
@@ -13,7 +13,7 @@ from flocks.session.message import Message
 from flocks.agent.registry import Agent
 from flocks.project.project import Project
 from flocks.config.config import Config
-from flocks.mcp.server import get_manager
+from flocks.mcp import get_manager
 from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 
@@ -85,11 +85,13 @@ class SessionClient:
         model: str,
         agent: str,
         directory: str,
+        arguments_json: Optional[Any] = None,
     ) -> None:
         """Execute a command in the session"""
         log.info("session.command", {
             "session_id": session_id,
             "command": command,
+            "arguments_json": arguments_json is not None,
         })
     
     async def summarize(

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -2803,13 +2803,21 @@ def _extract_text_from_parts(parts: List[Dict[str, Any]]) -> str:
     return "".join(part.get("text", "") for part in parts if part.get("type") == "text")
 
 
-def _replace_text_parts(parts: Optional[List[Dict[str, Any]]], text: str) -> List[Dict[str, Any]]:
+def _replace_text_parts(
+    parts: Optional[List[Dict[str, Any]]],
+    text: str,
+    text_metadata: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
     updated_parts: List[Dict[str, Any]] = []
     replaced = False
     for part in parts or []:
         if part.get("type") == "text" and not replaced:
             next_part = dict(part)
             next_part["text"] = text
+            if text_metadata:
+                merged_metadata = dict(next_part.get("metadata") or {})
+                merged_metadata.update(text_metadata)
+                next_part["metadata"] = merged_metadata
             updated_parts.append(next_part)
             replaced = True
             continue
@@ -2818,7 +2826,10 @@ def _replace_text_parts(parts: Optional[List[Dict[str, Any]]], text: str) -> Lis
         updated_parts.append(dict(part))
 
     if not replaced:
-        updated_parts.insert(0, {"type": "text", "text": text})
+        next_part: Dict[str, Any] = {"type": "text", "text": text}
+        if text_metadata:
+            next_part["metadata"] = dict(text_metadata)
+        updated_parts.insert(0, next_part)
     return updated_parts
 
 
@@ -3059,7 +3070,7 @@ def _build_prompt_request_from_event(event, prompt_text: str, display_text: Opti
     import types
 
     return types.SimpleNamespace(
-        parts=_replace_text_parts(event.parts, prompt_text),
+        parts=_replace_text_parts(event.parts, prompt_text, event.metadata or None),
         display_text=display_text,
         agent=event.agent,
         model=_coerce_model_for_prompt_request(event.model),
@@ -3441,6 +3452,7 @@ class CommandRequest(BaseModel):
     
     command: str = Field(..., description="Command name")
     arguments: str = Field("", description="Command arguments")
+    arguments_json: Optional[Any] = Field(None, alias="argumentsJson", description="Structured command arguments")
     messageID: Optional[str] = Field(None, description="Message ID")
     agent: Optional[str] = Field(None, description="Agent name")
     model: Optional[str] = Field(None, description="Model string (provider/model)")
@@ -3487,11 +3499,17 @@ async def send_session_command(sessionID: str, request: CommandRequest, http_req
         _require_session_write_access(session, current_user)
 
     working_directory = session.directory or os.getcwd()
+    raw_arguments = request.arguments
+    if not raw_arguments and request.arguments_json is not None:
+        raw_arguments = json.dumps(request.arguments_json, ensure_ascii=False)
+    command_metadata: Dict[str, Any] = {}
+    if request.arguments_json is not None:
+        command_metadata["commandArgumentsJson"] = request.arguments_json
 
     # The text the user typed, shown verbatim in the chat bubble
     slash_text = f"/{request.command}"
-    if request.arguments:
-        slash_text += f" {request.arguments}"
+    if raw_arguments:
+        slash_text += f" {raw_arguments}"
 
     # ── Background task ──────────────────────────────────────────────────────
     async def _handle_command() -> None:
@@ -3503,6 +3521,7 @@ async def send_session_command(sessionID: str, request: CommandRequest, http_req
             agent=request.agent,
             model=request.model,
             variant=request.variant,
+            metadata=command_metadata,
             display_text=slash_text,
             messageID=request.messageID,
             working_directory=working_directory,

--- a/tests/acp/test_agent_command_arguments.py
+++ b/tests/acp/test_agent_command_arguments.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flocks.acp.agent import ACPAgent
+from flocks.acp.types import ACPConfig
+
+
+class _DummySessionManager:
+    def __init__(self, state):
+        self._state = state
+
+    def get(self, session_id: str):
+        assert session_id == self._state.id
+        return self._state
+
+    def set_model(self, session_id: str, model):
+        assert session_id == self._state.id
+        self._state.model = model
+
+
+@pytest.mark.asyncio
+async def test_prompt_command_parses_json_arguments_for_acp():
+    session_state = SimpleNamespace(
+        id="ses_acp_json",
+        cwd="/tmp/project",
+        model=None,
+        mode_id="rex",
+    )
+    sdk = SimpleNamespace(
+        session=SimpleNamespace(
+            prompt=AsyncMock(),
+            command=AsyncMock(),
+        )
+    )
+    agent = ACPAgent(SimpleNamespace(), ACPConfig(sdk=sdk))
+    agent._session_manager = _DummySessionManager(session_state)
+    agent._get_default_model = AsyncMock(
+        return_value={"providerID": "anthropic", "modelID": "claude-test"}
+    )
+
+    with patch(
+        "flocks.agent.registry.Agent.default_agent",
+        new=AsyncMock(return_value="rex"),
+    ):
+        result = await agent.prompt(
+            {
+                "sessionId": "ses_acp_json",
+                "prompt": [{"type": "text", "text": '/bug {"scope":"acp","retry":1}'}],
+            }
+        )
+
+    assert result == {"stopReason": "end_turn", "_meta": {}}
+    sdk.session.prompt.assert_not_called()
+    sdk.session.command.assert_awaited_once_with(
+        session_id="ses_acp_json",
+        command="bug",
+        arguments='{"scope":"acp","retry":1}',
+        arguments_json={"scope": "acp", "retry": 1},
+        model="anthropic/claude-test",
+        agent="rex",
+        directory="/tmp/project",
+    )
+
+
+@pytest.mark.asyncio
+async def test_prompt_command_keeps_legacy_string_arguments_when_not_json():
+    session_state = SimpleNamespace(
+        id="ses_acp_string",
+        cwd="/tmp/project",
+        model={"providerID": "anthropic", "modelID": "claude-test"},
+        mode_id="rex",
+    )
+    sdk = SimpleNamespace(
+        session=SimpleNamespace(
+            prompt=AsyncMock(),
+            command=AsyncMock(),
+        )
+    )
+    agent = ACPAgent(SimpleNamespace(), ACPConfig(sdk=sdk))
+    agent._session_manager = _DummySessionManager(session_state)
+
+    with patch(
+        "flocks.agent.registry.Agent.default_agent",
+        new=AsyncMock(return_value="rex"),
+    ):
+        result = await agent.prompt(
+            {
+                "sessionId": "ses_acp_string",
+                "prompt": [{"type": "text", "text": "/bug investigate routing"}],
+            }
+        )
+
+    assert result == {"stopReason": "end_turn", "_meta": {}}
+    sdk.session.prompt.assert_not_called()
+    sdk.session.command.assert_awaited_once_with(
+        session_id="ses_acp_string",
+        command="bug",
+        arguments="investigate routing",
+        model="anthropic/claude-test",
+        agent="rex",
+        directory="/tmp/project",
+        arguments_json=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_prompt_command_falls_back_when_json_parse_fails():
+    session_state = SimpleNamespace(
+        id="ses_acp_invalid_json",
+        cwd="/tmp/project",
+        model={"providerID": "anthropic", "modelID": "claude-test"},
+        mode_id="rex",
+    )
+    sdk = SimpleNamespace(
+        session=SimpleNamespace(
+            prompt=AsyncMock(),
+            command=AsyncMock(),
+        )
+    )
+    agent = ACPAgent(SimpleNamespace(), ACPConfig(sdk=sdk))
+    agent._session_manager = _DummySessionManager(session_state)
+
+    with patch(
+        "flocks.agent.registry.Agent.default_agent",
+        new=AsyncMock(return_value="rex"),
+    ):
+        result = await agent.prompt(
+            {
+                "sessionId": "ses_acp_invalid_json",
+                "prompt": [{"type": "text", "text": '/bug {"scope":'}],
+            }
+        )
+
+    assert result == {"stopReason": "end_turn", "_meta": {}}
+    sdk.session.prompt.assert_not_called()
+    sdk.session.command.assert_awaited_once_with(
+        session_id="ses_acp_invalid_json",
+        command="bug",
+        arguments='{"scope":',
+        model="anthropic/claude-test",
+        agent="rex",
+        directory="/tmp/project",
+        arguments_json=None,
+    )

--- a/tests/command/test_handler_json_args.py
+++ b/tests/command/test_handler_json_args.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flocks.command.handler import handle_slash_command
+from flocks.input.events import ParsedCommand
+
+
+@pytest.mark.asyncio
+async def test_handle_slash_command_forwards_structured_arguments():
+    send_text = AsyncMock()
+    send_prompt = AsyncMock()
+
+    with patch("flocks.command.handler.run_direct_command", new=AsyncMock()) as run_mock:
+        run_mock.return_value.handled = True
+        run_mock.return_value.prompt = None
+        run_mock.return_value.clear_screen = False
+        run_mock.return_value.clear_history = False
+        run_mock.return_value.text = "ok"
+
+        handled = await handle_slash_command(
+            '/agents {"team":"blue"}',
+            parsed_command=ParsedCommand(
+                raw_text='/agents {"team":"blue"}',
+                command_name="agents",
+                canonical_name="agents",
+                args='{"team":"blue"}',
+                args_json={"team": "blue"},
+            ),
+            send_text=send_text,
+            send_prompt=send_prompt,
+        )
+
+    assert handled is True
+    run_mock.assert_awaited_once_with(
+        "agents",
+        args='{"team":"blue"}',
+        args_json={"team": "blue"},
+        surface=None,
+    )
+    send_text.assert_awaited_once_with("ok")
+    send_prompt.assert_not_called()

--- a/tests/server/test_input_dispatcher.py
+++ b/tests/server/test_input_dispatcher.py
@@ -19,6 +19,15 @@ class TestParseSlashCommand:
         assert parsed.command_name == "reset"
         assert parsed.canonical_name == "new"
 
+    def test_reads_structured_arguments_from_metadata(self):
+        parsed = parse_slash_command(
+            '/bug {"scope":"acp"}',
+            {"commandArgumentsJson": {"scope": "acp"}},
+        )
+        assert parsed is not None
+        assert parsed.args == '{"scope":"acp"}'
+        assert parsed.args_json == {"scope": "acp"}
+
     def test_removed_restart_command_no_longer_resolves(self):
         parsed = parse_slash_command("/restart")
         assert parsed is not None

--- a/tests/server/test_internal_sdk_client.py
+++ b/tests/server/test_internal_sdk_client.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def test_internal_sdk_client_module_imports():
+    import flocks.server.client as client
+
+    assert client.FlocksClient
+    assert client.SessionClient

--- a/tests/server/test_session_command_arguments.py
+++ b/tests/server/test_session_command_arguments.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class TestSessionCommandArguments:
+    @pytest.mark.asyncio
+    async def test_command_route_preserves_arguments_json_metadata(self, monkeypatch):
+        from flocks.server.routes import session as session_routes
+
+        dispatch_mock = AsyncMock()
+        session_id = "ses_json_args"
+
+        async def fake_provide(*, directory, init, fn):
+            await fn()
+
+        monkeypatch.setattr(session_routes, "_dispatch_sse_input", dispatch_mock)
+        monkeypatch.setattr("flocks.project.instance.Instance.provide", fake_provide)
+        monkeypatch.setattr(
+            "flocks.session.session.Session.get_by_id",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    id=session_id,
+                    directory="/tmp/project",
+                )
+            ),
+        )
+
+        payload = {"scope": "acp", "retry": 2}
+        request = session_routes.CommandRequest(command="bug", argumentsJson=payload)
+
+        resp = await session_routes.send_session_command(session_id, request)
+        assert resp["status"] == "accepted"
+        await asyncio.sleep(0)
+
+        dispatch_mock.assert_awaited_once()
+        event = dispatch_mock.await_args.args[2]
+        assert event.text == f"/bug {json.dumps(payload, ensure_ascii=False)}"
+        assert event.display_text == f"/bug {json.dumps(payload, ensure_ascii=False)}"
+        assert event.metadata == {"commandArgumentsJson": payload}
+
+    @pytest.mark.asyncio
+    async def test_command_route_keeps_legacy_string_arguments_unchanged(self, monkeypatch):
+        from flocks.server.routes import session as session_routes
+
+        dispatch_mock = AsyncMock()
+        session_id = "ses_string_args"
+
+        async def fake_provide(*, directory, init, fn):
+            await fn()
+
+        monkeypatch.setattr(session_routes, "_dispatch_sse_input", dispatch_mock)
+        monkeypatch.setattr("flocks.project.instance.Instance.provide", fake_provide)
+        monkeypatch.setattr(
+            "flocks.session.session.Session.get_by_id",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    id=session_id,
+                    directory="/tmp/project",
+                )
+            ),
+        )
+
+        request = session_routes.CommandRequest(command="bug", arguments="investigate routing")
+
+        resp = await session_routes.send_session_command(session_id, request)
+        assert resp["status"] == "accepted"
+        await asyncio.sleep(0)
+
+        dispatch_mock.assert_awaited_once()
+        event = dispatch_mock.await_args.args[2]
+        assert event.text == "/bug investigate routing"
+        assert event.display_text == "/bug investigate routing"
+        assert event.metadata == {}
+
+    @pytest.mark.asyncio
+    async def test_command_route_prefers_explicit_string_for_display_when_json_also_present(self, monkeypatch):
+        from flocks.server.routes import session as session_routes
+
+        dispatch_mock = AsyncMock()
+        session_id = "ses_both_args"
+
+        async def fake_provide(*, directory, init, fn):
+            await fn()
+
+        monkeypatch.setattr(session_routes, "_dispatch_sse_input", dispatch_mock)
+        monkeypatch.setattr("flocks.project.instance.Instance.provide", fake_provide)
+        monkeypatch.setattr(
+            "flocks.session.session.Session.get_by_id",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    id=session_id,
+                    directory="/tmp/project",
+                )
+            ),
+        )
+
+        payload = {"scope": "acp"}
+        request = session_routes.CommandRequest(
+            command="bug",
+            arguments="use this exact text",
+            argumentsJson=payload,
+        )
+
+        resp = await session_routes.send_session_command(session_id, request)
+        assert resp["status"] == "accepted"
+        await asyncio.sleep(0)
+
+        dispatch_mock.assert_awaited_once()
+        event = dispatch_mock.await_args.args[2]
+        assert event.text == "/bug use this exact text"
+        assert event.display_text == "/bug use this exact text"
+        assert event.metadata == {"commandArgumentsJson": payload}
+
+    def test_build_prompt_request_from_event_attaches_metadata_to_text_part(self):
+        from flocks.server.routes import session as session_routes
+        from flocks.input.events import UserInputEvent
+
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_meta_parts",
+            text='/bug {"scope":"acp"}',
+            parts=[
+                {"type": "text", "text": '/bug {"scope":"acp"}', "metadata": {"existing": True}},
+                {"type": "file", "url": "file:///tmp/evidence.txt", "filename": "evidence.txt"},
+            ],
+            metadata={"commandArgumentsJson": {"scope": "acp"}},
+            display_text='/bug {"scope":"acp"}',
+        )
+
+        request = session_routes._build_prompt_request_from_event(event, "/bug {\"scope\":\"acp\"}")
+
+        assert request.parts[0]["type"] == "text"
+        assert request.parts[0]["text"] == "/bug {\"scope\":\"acp\"}"
+        assert request.parts[0]["metadata"] == {
+            "existing": True,
+            "commandArgumentsJson": {"scope": "acp"},
+        }
+        assert request.parts[1] == {
+            "type": "file",
+            "url": "file:///tmp/evidence.txt",
+            "filename": "evidence.txt",
+        }
+
+    @pytest.mark.asyncio
+    async def test_llm_command_path_passes_arguments_json_into_prompt_parts(self, monkeypatch):
+        from flocks.server.routes import session as session_routes
+        from flocks.input.events import UserInputEvent
+
+        session_id = "ses_llm_metadata"
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID=session_id,
+            text='/bug {"scope":"acp"}',
+            parts=[{"type": "text", "text": '/bug {"scope":"acp"}'}],
+            metadata={"commandArgumentsJson": {"scope": "acp"}},
+            display_text='/bug {"scope":"acp"}',
+        )
+        session = SimpleNamespace(id=session_id, directory="/tmp/project")
+
+        process_mock = AsyncMock()
+        monkeypatch.setattr(session_routes, "_process_session_message", process_mock)
+
+        await session_routes._dispatch_sse_input(session_id, session, event, "/tmp/project")
+
+        process_mock.assert_awaited_once()
+        request = process_mock.await_args.args[2]
+        assert request.parts[0]["type"] == "text"
+        assert request.parts[0]["text"] == '/bug {"scope":"acp"}'
+        assert request.parts[0]["metadata"] == {
+            "commandArgumentsJson": {"scope": "acp"},
+        }


### PR DESCRIPTION
支持 ACP 命令的结构化 JSON 参数透传，同时保持原有字符串参数行为不变。
本次改动在 ACP 命令解析、session command 路由和 slash command 分发链路中新增了 argumentsJson / args_json 兼容能力：当参数是合法 JSON 时会解析并透传，解析失败则自动回退为原始字符串。
另外补充了 ACP、command handler、session route 和 internal SDK client 的定向回归测试，确保旧逻辑不受影响。

