### PR TITLE
Fix updater cancellation and session statistics

### DIFF
--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -3740,11 +3740,16 @@ async def get_session_statistics(sessionID: str):
     - Model usage
     """
     try:
-        # Get session
-        session = await Session.load(sessionID)
-        
-        # Get messages
-        messages = await session.get_messages()
+        session = await _get_session_by_id_unfiltered(sessionID)
+        if not session:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Session {sessionID} not found",
+            )
+
+        from flocks.session.message import Message
+
+        messages = await Message.list_with_parts(sessionID, include_archived=True)
         
         # Calculate statistics
         message_count = len(messages)
@@ -3752,26 +3757,27 @@ async def get_session_statistics(sessionID: str):
         tool_call_count = 0
         model_usage = {}
         
-        for msg in messages:
+        for message_with_parts in messages:
+            msg = message_with_parts.info
+
             # Count tokens (approximate from parts)
-            for part in msg.parts:
-                if hasattr(part, 'text') and part.text:
+            for part in message_with_parts.parts:
+                if hasattr(part, "text") and part.text:
                     token_count += len(part.text.split())  # Rough approximation
                 
                 # Count tool calls
-                if hasattr(part, 'toolCall') and part.toolCall:
+                if getattr(part, "type", None) == "tool":
                     tool_call_count += 1
             
             # Track model usage
-            if msg.model:
-                model_usage[msg.model] = model_usage.get(msg.model, 0) + 1
-        
-        # Get session info
-        info = await session.get_info()
+            model = getattr(msg, "model", None)
+            if model:
+                model_key = model if isinstance(model, str) else json.dumps(model, sort_keys=True, default=str)
+                model_usage[model_key] = model_usage.get(model_key, 0) + 1
         
         # Calculate duration
-        created_ms = info.time.created
-        updated_ms = info.time.updated
+        created_ms = session.time.created
+        updated_ms = session.time.updated
         duration_ms = updated_ms - created_ms
         duration_seconds = duration_ms / 1000
         
@@ -3788,6 +3794,8 @@ async def get_session_statistics(sessionID: str):
         
         log.info("session.statistics", {"sessionID": sessionID, "messages": message_count})
         return stats
+    except HTTPException:
+        raise
     except Exception as e:
         log.error("session.statistics.error", {"sessionID": sessionID, "error": str(e)})
         raise HTTPException(status_code=500, detail=f"Failed to get session statistics: {str(e)}")

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -55,6 +55,7 @@ _FRONTEND_DEPENDENCY_INSTALL_TIMEOUT_SECONDS = 300
 _FRONTEND_BUILD_TIMEOUT_SECONDS = 300
 _DEPENDENCY_SYNC_TIMEOUT_SECONDS = 180
 _WINDOWS_DEPENDENCY_SYNC_TIMEOUT_SECONDS = 300
+_CANCELLATION_RETRY_DELAY_SECONDS = 0.1
 
 _PRESERVE_NAMES: set[str] = {
     ".venv",
@@ -561,6 +562,7 @@ async def _await_ignoring_cancellation(awaitable):
             return await asyncio.shield(task)
         except asyncio.CancelledError:
             log.warning("updater.restart.critical_step_cancelled_ignored")
+            await asyncio.sleep(_CANCELLATION_RETRY_DELAY_SECONDS)
 
 
 def _dependency_sync_timeout_seconds() -> int:

--- a/tests/server/routes/test_session_routes.py
+++ b/tests/server/routes/test_session_routes.py
@@ -1046,6 +1046,26 @@ class TestSessionUtilities:
         assert resp.status_code == status.HTTP_200_OK
 
     @pytest.mark.asyncio
+    async def test_session_statistics(self, client: AsyncClient, session_id: str):
+        """GET /api/session/{id}/statistics reports stored session messages."""
+        payload = {
+            "parts": [{"type": "text", "text": "Hello from statistics"}],
+            "noReply": True,
+        }
+        message_resp = await client.post(f"/api/session/{session_id}/message", json=payload)
+        assert message_resp.status_code == status.HTTP_200_OK
+
+        resp = await client.get(f"/api/session/{session_id}/statistics")
+        assert resp.status_code == status.HTTP_200_OK
+
+        data = resp.json()
+        assert data["sessionID"] == session_id
+        assert data["messageCount"] == 1
+        assert data["tokenCount"] >= 3
+        assert data["toolCallCount"] == 0
+        assert data["durationSeconds"] >= 0
+
+    @pytest.mark.asyncio
     async def test_session_status(self, client: AsyncClient):
         """GET /api/session/status returns aggregate status."""
         resp = await client.get("/api/session/status")

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -54,6 +54,39 @@ def test_run_replaces_invalid_windows_stderr_bytes(
     assert stderr == "failed�output"
 
 
+@pytest.mark.asyncio
+async def test_await_ignoring_cancellation_backs_off_on_repeated_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shield_calls = 0
+    sleep_delays: list[float] = []
+
+    async def fake_shield(task):
+        nonlocal shield_calls
+        shield_calls += 1
+        if shield_calls <= 2:
+            raise updater.asyncio.CancelledError
+        return await task
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    async def critical_step() -> str:
+        return "done"
+
+    monkeypatch.setattr(updater.asyncio, "shield", fake_shield)
+    monkeypatch.setattr(updater.asyncio, "sleep", fake_sleep)
+
+    result = await updater._await_ignoring_cancellation(critical_step())
+
+    assert result == "done"
+    assert shield_calls == 3
+    assert sleep_delays == [
+        updater._CANCELLATION_RETRY_DELAY_SECONDS,
+        updater._CANCELLATION_RETRY_DELAY_SECONDS,
+    ]
+
+
 def test_get_current_version_prefers_higher_marker_version(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- Add a short backoff when restart handover work is repeatedly cancelled so updater logging cannot spin in a tight loop.
- Replace the stale `Session.load()` statistics path with the current session lookup and message-part storage APIs.
- Add focused regression coverage for updater cancellation backoff and session statistics.

## Root Cause

The updater continued immediately after every `CancelledError` while shielding a post-handover critical step, which could flood logs when the outer request stayed cancelled. The session statistics route still used an old `Session.load()` API that no longer exists.

## Validation

- `uv run pytest tests/server/routes/test_session_routes.py::TestSessionUtilities tests/updater/test_updater.py::test_await_ignoring_cancellation_backs_off_on_repeated_cancellation`
- `uv run ruff check flocks/server/routes/session.py flocks/updater/updater.py tests/server/routes/test_session_routes.py tests/updater/test_updater.py`
