### PR TITLE
fix: bound SSH connection pool

### DIFF
--- a/flocks/tool/security/ssh_utils.py
+++ b/flocks/tool/security/ssh_utils.py
@@ -7,6 +7,10 @@ both ssh_host_cmd and ssh_run_script tools.
 """
 
 import asyncio
+import os
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -54,16 +58,76 @@ def audit_log(
 # Session-level SSH connection pool
 # ---------------------------------------------------------------------------
 
+
+DEFAULT_POOL_MAX_CONNECTIONS = 128
+DEFAULT_POOL_IDLE_TTL_S = 120.0
+
+
+def _env_int(name: str, default: int, minimum: int) -> int:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        log.warn("ssh_pool.invalid_int_env", {"name": name, "value": raw})
+        return default
+
+
+def _env_float(name: str, default: float, minimum: float) -> float:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except ValueError:
+        log.warn("ssh_pool.invalid_float_env", {"name": name, "value": raw})
+        return default
+
+
+@dataclass
+class _PoolEntry:
+    conn: asyncssh.SSHClientConnection
+    last_used: float
+    in_use: int = 0
+
+
 class SSHConnectionPool:
     """Per-session SSH connection cache.
 
     Keeps at most one connection per (session_id, host, port, username) tuple.
-    Connections are released when the pool is explicitly closed or when the
-    pool object is garbage-collected.
+    Idle connections are released by LRU/TTL pressure, explicit session close,
+    or process shutdown.
     """
 
-    def __init__(self) -> None:
-        self._connections: dict[tuple[str, str, int, str], asyncssh.SSHClientConnection] = {}
+    def __init__(
+        self,
+        *,
+        max_connections: Optional[int] = None,
+        idle_ttl_s: Optional[float] = None,
+    ) -> None:
+        self.max_connections = (
+            max_connections
+            if max_connections is not None
+            else _env_int(
+                "FLOCKS_SSH_POOL_MAX_CONNECTIONS",
+                DEFAULT_POOL_MAX_CONNECTIONS,
+                1,
+            )
+        )
+        self.idle_ttl_s = (
+            idle_ttl_s
+            if idle_ttl_s is not None
+            else _env_float(
+                "FLOCKS_SSH_POOL_IDLE_TTL_SECONDS",
+                DEFAULT_POOL_IDLE_TTL_S,
+                1.0,
+            )
+        )
+        self._connections: OrderedDict[
+            tuple[str, str, int, str],
+            _PoolEntry,
+        ] = OrderedDict()
         self._locks: dict[tuple[str, str, int, str], asyncio.Lock] = {}
         self._global_lock = asyncio.Lock()
 
@@ -79,7 +143,7 @@ class SSHConnectionPool:
         key_path: Optional[str],
         password: Optional[str],
     ) -> asyncssh.SSHClientConnection:
-        """Return an existing connection or create a new one.
+        """Return an existing connection or create a new one and mark it in use.
 
         Stale connections are not proactively detected here — the caller is
         responsible for catching connection errors and calling
@@ -89,13 +153,19 @@ class SSHConnectionPool:
         key = self._key(session_id, host, port, username)
 
         async with self._global_lock:
+            self._prune_idle_locked(time.monotonic())
             if key not in self._locks:
                 self._locks[key] = asyncio.Lock()
 
         async with self._locks[key]:
-            conn = self._connections.get(key)
-            if conn is not None:
-                return conn
+            now = time.monotonic()
+            async with self._global_lock:
+                entry = self._connections.get(key)
+                if entry is not None:
+                    entry.in_use += 1
+                    entry.last_used = now
+                    self._connections.move_to_end(key)
+                    return entry.conn
 
             connect_kwargs: dict = dict(
                 host=host,
@@ -111,35 +181,115 @@ class SSHConnectionPool:
                 connect_kwargs["password"] = password
 
             conn = await asyncssh.connect(**connect_kwargs)
-            self._connections[key] = conn
+            async with self._global_lock:
+                self._connections[key] = _PoolEntry(
+                    conn=conn,
+                    last_used=time.monotonic(),
+                    in_use=1,
+                )
+                self._connections.move_to_end(key)
+                self._enforce_limits_locked()
             return conn
 
-    def invalidate_connection(
+    async def release_connection(
         self, session_id: str, host: str, port: int, username: str
     ) -> None:
-        """Evict a stale connection from the pool so the next call reconnects."""
+        """Mark a pooled connection as no longer actively executing a command."""
         key = self._key(session_id, host, port, username)
-        self._connections.pop(key, None)
+        async with self._global_lock:
+            entry = self._connections.get(key)
+            if entry is None:
+                return
+            entry.in_use = max(0, entry.in_use - 1)
+            entry.last_used = time.monotonic()
+            self._connections.move_to_end(key)
+            self._prune_idle_locked(entry.last_used)
+            self._enforce_limits_locked()
+
+    async def invalidate_connection(
+        self, session_id: str, host: str, port: int, username: str
+    ) -> None:
+        """Close and evict a stale connection so the next call reconnects."""
+        key = self._key(session_id, host, port, username)
+        async with self._global_lock:
+            entry = self._connections.pop(key, None)
+            self._locks.pop(key, None)
+        if entry is not None:
+            self._close_connection(entry.conn)
 
     async def close_session(self, session_id: str) -> None:
         """Close all connections belonging to *session_id*."""
-        to_close: list[tuple] = [k for k in self._connections if k[0] == session_id]
-        for key in to_close:
-            conn = self._connections.pop(key, None)
-            if conn:
-                try:
-                    conn.close()
-                except Exception:
-                    pass
+        async with self._global_lock:
+            to_close: list[tuple] = [
+                k for k in self._connections if k[0] == session_id
+            ]
+            entries = [self._connections.pop(key) for key in to_close]
+            for key in to_close:
+                self._locks.pop(key, None)
+        for entry in entries:
+            self._close_connection(entry.conn)
 
     async def close_all(self) -> None:
         """Close every cached connection."""
-        for conn in self._connections.values():
-            try:
-                conn.close()
-            except Exception:
-                pass
-        self._connections.clear()
+        async with self._global_lock:
+            entries = list(self._connections.values())
+            self._connections.clear()
+            self._locks.clear()
+        for entry in entries:
+            self._close_connection(entry.conn)
+
+    def _prune_idle_locked(self, now: float) -> None:
+        """Close idle expired connections. Caller must hold ``_global_lock``."""
+        if self.idle_ttl_s <= 0:
+            return
+        expired = [
+            key
+            for key, entry in self._connections.items()
+            if entry.in_use <= 0 and now - entry.last_used >= self.idle_ttl_s
+        ]
+        for key in expired:
+            entry = self._connections.pop(key, None)
+            self._locks.pop(key, None)
+            if entry is not None:
+                self._close_connection(entry.conn)
+
+    def _enforce_limits_locked(self) -> None:
+        """Apply LRU cap to idle connections. Caller must hold ``_global_lock``."""
+        if self.max_connections <= 0:
+            return
+        while len(self._connections) > self.max_connections:
+            evicted_key = None
+            for key, entry in self._connections.items():
+                if entry.in_use <= 0:
+                    evicted_key = key
+                    break
+            if evicted_key is None:
+                # Every connection is active; allow temporary overflow rather
+                # than closing a command that is still running.
+                return
+            entry = self._connections.pop(evicted_key, None)
+            self._locks.pop(evicted_key, None)
+            if entry is not None:
+                self._close_connection(entry.conn)
+
+    def _close_connection(self, conn: asyncssh.SSHClientConnection) -> None:
+        """Best-effort close for asyncssh connections."""
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    def stats(self) -> dict[str, int | float]:
+        """Return lightweight pool stats for tests and diagnostics."""
+        return {
+            "connections": len(self._connections),
+            "locks": len(self._locks),
+            "active_connections": sum(
+                1 for entry in self._connections.values() if entry.in_use > 0
+            ),
+            "max_connections": self.max_connections,
+            "idle_ttl_s": self.idle_ttl_s,
+        }
 
 
 _pool = SSHConnectionPool()
@@ -209,6 +359,7 @@ async def execute_ssh_command(
         (exit_code, stdout, stderr)
     """
     if session_id:
+        invalidated = False
         conn = await _pool.get_connection(
             session_id=session_id,
             host=host, port=port, username=username,
@@ -226,21 +377,28 @@ async def execute_ssh_command(
             )
         except (asyncssh.ConnectionLost, asyncssh.DisconnectError, BrokenPipeError, OSError):
             # Stale connection — evict from pool and retry with a fresh one.
-            _pool.invalidate_connection(session_id, host, port, username)
+            invalidated = True
+            await _pool.invalidate_connection(session_id, host, port, username)
             conn = await _pool.get_connection(
                 session_id=session_id,
                 host=host, port=port, username=username,
                 key_path=key_path, password=password,
             )
-            result = await asyncio.wait_for(
-                conn.run(command, check=False),
-                timeout=timeout_s,
-            )
-            return (
-                result.exit_status or 0,
-                result.stdout or "",
-                result.stderr or "",
-            )
+            try:
+                result = await asyncio.wait_for(
+                    conn.run(command, check=False),
+                    timeout=timeout_s,
+                )
+                return (
+                    result.exit_status or 0,
+                    result.stdout or "",
+                    result.stderr or "",
+                )
+            finally:
+                await _pool.release_connection(session_id, host, port, username)
+        finally:
+            if not invalidated:
+                await _pool.release_connection(session_id, host, port, username)
 
     connect_kwargs: dict = dict(
         host=host,

--- a/tests/tool/test_ssh_utils_pool.py
+++ b/tests/tool/test_ssh_utils_pool.py
@@ -1,0 +1,108 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from flocks.tool.security import ssh_utils
+
+
+class DummyConnection:
+    def __init__(self, host: str) -> None:
+        self.host = host
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def run(self, command: str, check: bool = False) -> SimpleNamespace:
+        return SimpleNamespace(exit_status=0, stdout=f"{self.host}:{command}", stderr="")
+
+
+@pytest.mark.asyncio
+async def test_ssh_pool_evicts_least_recent_idle_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: list[DummyConnection] = []
+
+    async def fake_connect(**kwargs):
+        conn = DummyConnection(kwargs["host"])
+        created.append(conn)
+        return conn
+
+    monkeypatch.setattr(ssh_utils.asyncssh, "connect", fake_connect)
+    pool = ssh_utils.SSHConnectionPool(max_connections=2, idle_ttl_s=3600)
+
+    for host in ("host-1", "host-2", "host-3"):
+        await pool.get_connection("session", host, 22, "root", None, None)
+        await pool.release_connection("session", host, 22, "root")
+
+    assert pool.stats()["connections"] == 2
+    assert pool.stats()["locks"] == 2
+    assert created[0].closed is True
+    assert created[1].closed is False
+    assert created[2].closed is False
+
+
+@pytest.mark.asyncio
+async def test_ssh_pool_prunes_idle_connections_by_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: list[DummyConnection] = []
+
+    async def fake_connect(**kwargs):
+        conn = DummyConnection(kwargs["host"])
+        created.append(conn)
+        return conn
+
+    monkeypatch.setattr(ssh_utils.asyncssh, "connect", fake_connect)
+    pool = ssh_utils.SSHConnectionPool(max_connections=10, idle_ttl_s=0.01)
+
+    await pool.get_connection("session", "host-1", 22, "root", None, None)
+    await pool.release_connection("session", "host-1", 22, "root")
+    await asyncio.sleep(0.02)
+    await pool.get_connection("session", "host-2", 22, "root", None, None)
+
+    assert created[0].closed is True
+    assert pool.stats()["connections"] == 1
+    assert pool.stats()["locks"] == 1
+
+
+@pytest.mark.asyncio
+async def test_ssh_pool_invalidate_closes_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_connect(**kwargs):
+        return DummyConnection(kwargs["host"])
+
+    monkeypatch.setattr(ssh_utils.asyncssh, "connect", fake_connect)
+    pool = ssh_utils.SSHConnectionPool(max_connections=10, idle_ttl_s=3600)
+
+    conn = await pool.get_connection("session", "host-1", 22, "root", None, None)
+    await pool.invalidate_connection("session", "host-1", 22, "root")
+
+    assert conn.closed is True
+    assert pool.stats()["connections"] == 0
+    assert pool.stats()["locks"] == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_ssh_command_releases_connection_after_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_connect(**kwargs):
+        return DummyConnection(kwargs["host"])
+
+    pool = ssh_utils.SSHConnectionPool(max_connections=10, idle_ttl_s=3600)
+    monkeypatch.setattr(ssh_utils.asyncssh, "connect", fake_connect)
+    monkeypatch.setattr(ssh_utils, "_pool", pool)
+
+    exit_code, stdout, stderr = await ssh_utils.execute_ssh_command(
+        host="host-1",
+        command="uptime",
+        username="root",
+        port=22,
+        key_path=None,
+        password=None,
+        timeout_s=5,
+        session_id="session",
+    )
+
+    assert exit_code == 0
+    assert stdout == "host-1:uptime"
+    assert stderr == ""
+    assert pool.stats()["connections"] == 1
+    assert pool.stats()["active_connections"] == 0


### PR DESCRIPTION
## Summary
- add max connection and idle TTL limits to the shared SSH connection pool
- close evicted, expired, and invalidated SSH connections instead of only dropping references
- release pooled connections after each command and clean up per-key locks
- add regression tests for LRU eviction, idle TTL pruning, invalidation, and command release behavior

## Verification
- uv run pytest tests/tool/test_ssh_utils_pool.py tests/integration/test_ssh_host_cmd.py
- uv run ruff check flocks/tool/security/ssh_utils.py tests/tool/test_ssh_utils_pool.py