### PR TITLE
Fix skill install timeouts and session streaming state

### DIFF
--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -29,7 +29,7 @@ log = Log.create(service="provider.openai_base")
 # change covers all three providers. Granular values (instead of a flat
 # timeout) let small control-plane requests fail fast while multimodal
 # (image) uploads get the headroom they need on slow links.
-DEFAULT_HTTP_TIMEOUT = httpx.Timeout(connect=30.0, read=600.0, write=600.0, pool=60.0)
+DEFAULT_HTTP_TIMEOUT = httpx.Timeout(connect=30.0, read=180.0, write=1800.0, pool=60.0)
 
 
 # Canonical OpenAI-style content translation, shared by every provider that

--- a/flocks/session/lifecycle/retry.py
+++ b/flocks/session/lifecycle/retry.py
@@ -19,6 +19,20 @@ RETRY_INITIAL_DELAY = 2000  # 2 seconds in milliseconds
 RETRY_BACKOFF_FACTOR = 2
 RETRY_MAX_DELAY_NO_HEADERS = 30_000  # 30 seconds
 RETRY_MAX_DELAY = 2_147_483_647  # max 32-bit signed integer
+CONNECTION_ERROR_DISPLAY_MESSAGE = (
+    "Model is unavailable. Please check the provider connection and model configuration."
+)
+CONNECTION_ERROR_PATTERNS = [
+    "connection error",
+    "connection reset",
+    "connection refused",
+    "could not connect",
+    "failed to connect",
+    "api connection",
+    "model unavailable",
+    "model is unavailable",
+    "model not available",
+]
 
 
 class SessionRetry:
@@ -177,6 +191,7 @@ class SessionRetry:
             transient_patterns = [
                 "unavailable", "503", "502",
                 "timeout", "timed out",
+                *CONNECTION_ERROR_PATTERNS,
                 "null message", "returned choice with null",
                 "empty streaming response", "empty choices",
             ]
@@ -186,3 +201,13 @@ class SessionRetry:
                 return "Connection or Server Error"
         
         return None
+
+    @staticmethod
+    def is_connection_error(error: Dict[str, Any]) -> bool:
+        """Return True for provider/model connection failures."""
+        data = error.get("data", {})
+        message = data.get("message") or error.get("message", "")
+        if not isinstance(message, str):
+            return False
+        message_lower = message.lower()
+        return any(pattern in message_lower for pattern in CONNECTION_ERROR_PATTERNS)

--- a/flocks/session/lifecycle/retry.py
+++ b/flocks/session/lifecycle/retry.py
@@ -177,7 +177,6 @@ class SessionRetry:
             transient_patterns = [
                 "unavailable", "503", "502",
                 "timeout", "timed out",
-                "connection error", "connection reset", "connection refused",
                 "null message", "returned choice with null",
                 "empty streaming response", "empty choices",
             ]

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -1813,7 +1813,6 @@ class SessionRunner:
             "rate limit", "too many requests", "429",
             "overloaded", "unavailable", "503", "502",
             "timeout", "timed out", "server error",
-            "connection error", "connection reset", "connection refused",
         ]):
             error_dict["name"] = "APIError"
             error_dict["data"]["isRetryable"] = True

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -31,7 +31,7 @@ from flocks.session.core.defaults import (
     DOOM_LOOP_THRESHOLD,
     REPEATED_EXACT_TOOL_CALL_HALT_THRESHOLD,
 )
-from flocks.session.lifecycle.retry import SessionRetry
+from flocks.session.lifecycle.retry import CONNECTION_ERROR_DISPLAY_MESSAGE, SessionRetry
 from flocks.session.lifecycle.compaction import SessionCompaction, CompactionPolicy
 from flocks.session.streaming.stream_processor import StreamProcessor
 from flocks.session.streaming.stream_events import (
@@ -1207,7 +1207,7 @@ class SessionRunner:
         # The two counters are independent: empty-response retries (transient
         # model quirk) and exception retries (API errors) track separately so
         # that one kind of failure doesn't eat the other's budget.
-        MAX_ERROR_RETRIES = 7
+        MAX_ERROR_RETRIES = 3
         MAX_EMPTY_RETRIES = 3
         error_attempt = 0
         empty_attempt = 0
@@ -1366,6 +1366,7 @@ class SessionRunner:
                         "attempt": error_attempt,
                         "delay_ms": delay_ms,
                         "reason": retry_message,
+                        "max_retries": MAX_ERROR_RETRIES,
                     })
                     
                     # Set retry status
@@ -1394,8 +1395,13 @@ class SessionRunner:
                     else:
                         log.error("runner.step.not_retryable", {"error": str(e)})
 
+                    final_error_message = str(e)
+                    if SessionRetry.is_connection_error(error_dict):
+                        final_error_message = CONNECTION_ERROR_DISPLAY_MESSAGE
+                        error_dict["data"]["displayMessage"] = CONNECTION_ERROR_DISPLAY_MESSAGE
+
                     if self.callbacks.on_error:
-                        await self.callbacks.on_error(str(e))
+                        await self.callbacks.on_error(final_error_message)
                     
                     # Update assistant message with error (must be dict, not string)
                     await Message.update(
@@ -1405,7 +1411,7 @@ class SessionRunner:
                         finish="error",
                     )
                     
-                    return StepResult(action="stop", error=str(e))
+                    return StepResult(action="stop", error=final_error_message)
         
         # Aborted
         return StepResult(action="stop", error="Aborted")
@@ -1816,6 +1822,11 @@ class SessionRunner:
         ]):
             error_dict["name"] = "APIError"
             error_dict["data"]["isRetryable"] = True
+
+        if SessionRetry.is_connection_error(error_dict):
+            error_dict["name"] = "APIError"
+            error_dict["data"]["isRetryable"] = True
+            error_dict["data"]["displayMessage"] = CONNECTION_ERROR_DISPLAY_MESSAGE
         
         return error_dict
     

--- a/flocks/skill/installer.py
+++ b/flocks/skill/installer.py
@@ -829,6 +829,7 @@ class SkillInstaller:
 
             skill_root = _resolve_install_root(scope) / name
             skill_root.mkdir(parents=True, exist_ok=True)
+            skill_root_resolved = skill_root.resolve()
             prefix = f"{skill_dir}/"
             file_count = 0
             for member in zf.namelist():
@@ -838,7 +839,9 @@ class SkillInstaller:
                 if not rel_path:
                     continue
                 dest = (skill_root / rel_path).resolve()
-                if not str(dest).startswith(str(skill_root.resolve())):
+                try:
+                    dest.relative_to(skill_root_resolved)
+                except ValueError:
                     continue
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_bytes(zf.read(member))

--- a/flocks/skill/installer.py
+++ b/flocks/skill/installer.py
@@ -19,12 +19,14 @@ Source scheme routing:
 from __future__ import annotations
 
 import asyncio
+import io
 import os
 import platform
 import re
 import shutil
 import sys
 import tempfile
+import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List, Optional
@@ -34,6 +36,10 @@ from flocks.utils.log import Log
 
 
 log = Log.create(service="skill.installer")
+
+_NETWORK_TIMEOUT_SEC = 20
+_SKILLS_SH_CLI_TIMEOUT_SEC = 45
+_INSTALL_TIMEOUT_SEC = 90
 
 # ---------------------------------------------------------------------------
 # Result Types
@@ -161,6 +167,42 @@ def _resolve_source(source: str) -> dict:
 class SkillInstaller:
     """Install skills from external sources and manage skill dependencies."""
 
+    @staticmethod
+    async def _run_subprocess(
+        cmd: list[str],
+        *,
+        timeout_sec: float,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
+    ) -> tuple[int, str, str]:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=cwd,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=timeout_sec,
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                await asyncio.wait_for(proc.communicate(), timeout=5)
+            except Exception:
+                pass
+            raise TimeoutError(f"Command timed out after {timeout_sec:g}s: {' '.join(cmd)}")
+        return (
+            proc.returncode if proc.returncode is not None else 0,
+            stdout_b.decode(errors="replace"),
+            stderr_b.decode(errors="replace"),
+        )
+
     # ------------------------------------------------------------------
     # Install skill itself
     # ------------------------------------------------------------------
@@ -191,22 +233,30 @@ class SkillInstaller:
 
         log.info("skill.install.start", {"source": source, "kind": kind, "scope": scope, "yes": yes})
 
-        if kind == "skills_sh":
-            return await cls._install_from_skills_sh(value, scope, yes=yes)
-        elif kind == "safeskill":
-            return await cls._install_from_safeskill(value, scope)
-        elif kind == "clawhub":
-            return await cls._install_from_clawhub(value, scope)
-        elif kind == "github":
-            return await cls._install_from_github(value, scope)
-        elif kind == "url":
-            return await cls._install_from_url(value, scope)
-        elif kind == "local":
-            return await cls._install_from_local(value, scope)
-        else:
+        async def _install() -> SkillInstallResult:
+            if kind == "skills_sh":
+                return await cls._install_from_skills_sh(value, scope, yes=yes)
+            elif kind == "safeskill":
+                return await cls._install_from_safeskill(value, scope)
+            elif kind == "clawhub":
+                return await cls._install_from_clawhub(value, scope)
+            elif kind == "github":
+                return await cls._install_from_github(value, scope)
+            elif kind == "url":
+                return await cls._install_from_url(value, scope)
+            elif kind == "local":
+                return await cls._install_from_local(value, scope)
             return SkillInstallResult(
                 success=False,
                 error=f"Unsupported source kind: {kind}",
+            )
+
+        try:
+            return await asyncio.wait_for(_install(), timeout=_INSTALL_TIMEOUT_SEC)
+        except asyncio.TimeoutError:
+            return SkillInstallResult(
+                success=False,
+                error=f"Skill install timed out after {_INSTALL_TIMEOUT_SEC}s: {source}",
             )
 
     @classmethod
@@ -267,22 +317,25 @@ class SkillInstaller:
             cmd = [npx, "-y", "skills", "add", identifier]
             if yes:
                 cmd.append("-y")
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                cwd=str(staging),
-                env=env,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout_b, stderr_b = await proc.communicate()
-            output = (
-                stdout_b.decode(errors="replace")
-                + stderr_b.decode(errors="replace")
-            ).strip()
-            if proc.returncode != 0:
+            try:
+                returncode, stdout, stderr = await cls._run_subprocess(
+                    cmd,
+                    cwd=str(staging),
+                    env=env,
+                    timeout_sec=_SKILLS_SH_CLI_TIMEOUT_SEC,
+                )
+            except TimeoutError as exc:
+                return SkillInstallResult(success=False, error=str(exc))
+            except Exception as exc:
                 return SkillInstallResult(
                     success=False,
-                    error=output or f"skills.sh CLI failed with exit {proc.returncode}",
+                    error=f"Failed to run skills.sh CLI: {exc}",
+                )
+            output = (stdout + stderr).strip()
+            if returncode != 0:
+                return SkillInstallResult(
+                    success=False,
+                    error=output or f"skills.sh CLI failed with exit {returncode}",
                 )
 
             imported = cls._import_staged_skill_dirs(staging, scope)
@@ -337,21 +390,24 @@ class SkillInstaller:
                 "-a",
                 "universal",
             ]
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                cwd=str(staging),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout_b, stderr_b = await proc.communicate()
-            output = (
-                stdout_b.decode(errors="replace")
-                + stderr_b.decode(errors="replace")
-            ).strip()
-            if proc.returncode != 0:
+            try:
+                returncode, stdout, stderr = await cls._run_subprocess(
+                    cmd,
+                    cwd=str(staging),
+                    timeout_sec=_SKILLS_SH_CLI_TIMEOUT_SEC,
+                )
+            except TimeoutError as exc:
+                return SkillInstallResult(success=False, error=str(exc))
+            except Exception as exc:
                 return SkillInstallResult(
                     success=False,
-                    error=output or f"SafeSkill CLI failed with exit {proc.returncode}",
+                    error=f"Failed to run SafeSkill CLI: {exc}",
+                )
+            output = (stdout + stderr).strip()
+            if returncode != 0:
+                return SkillInstallResult(
+                    success=False,
+                    error=output or f"SafeSkill CLI failed with exit {returncode}",
                 )
 
             imported = cls._import_staged_skill_dirs(staging, scope)
@@ -404,7 +460,7 @@ class SkillInstaller:
             return None
 
         try:
-            async with httpx.AsyncClient(timeout=20, follow_redirects=True) as client:
+            async with httpx.AsyncClient(timeout=_NETWORK_TIMEOUT_SEC, follow_redirects=True) as client:
                 resp = await client.get(f"https://skills.sh/{normalized}")
                 if resp.status_code != 200:
                     return None
@@ -492,7 +548,7 @@ class SkillInstaller:
 
         zip_url = f"https://wry-manatee-359.convex.site/api/v1/download?slug={name}"
         try:
-            async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+            async with httpx.AsyncClient(timeout=_NETWORK_TIMEOUT_SEC, follow_redirects=True) as client:
                 resp = await client.get(zip_url)
                 if resp.status_code == 404:
                     return SkillInstallResult(
@@ -633,34 +689,56 @@ class SkillInstaller:
             candidate_paths = [""]
 
         errors: List[str] = []
-        async with httpx.AsyncClient(
-            timeout=30,
-            follow_redirects=True,
-            headers={"Accept": "application/vnd.github+json"},
-        ) as client:
-            for branch in ("main", "master"):
-                for dir_path in candidate_paths:
-                    result = await cls._download_github_dir(
-                        client, owner, repo, branch, dir_path, scope
-                    )
-                    if result.success:
-                        return result
-                    if result.error:
-                        errors.append(result.error)
+        try:
+            async with httpx.AsyncClient(
+                timeout=_NETWORK_TIMEOUT_SEC,
+                follow_redirects=True,
+                headers={"Accept": "application/vnd.github+json"},
+            ) as client:
+                for branch in ("main", "master"):
+                    for dir_path in candidate_paths:
+                        result = await cls._download_github_dir(
+                            client, owner, repo, branch, dir_path, scope
+                        )
+                        if result.success:
+                            return result
+                        if result.error:
+                            errors.append(result.error)
 
-            # Unauthenticated GitHub Contents API can return 403 rate-limit
-            # errors while raw.githubusercontent.com still works. In that case
-            # install the SKILL.md directly instead of reporting a misleading
-            # "directory not found" error.
-            for branch in ("main", "master"):
-                for dir_path in candidate_paths:
-                    result = await cls._download_github_skill_md_raw(
-                        client, owner, repo, branch, dir_path, scope
+                # Unauthenticated GitHub Contents API can return 403 rate-limit
+                # errors while raw.githubusercontent.com still works. In that case
+                # install the SKILL.md directly instead of reporting a misleading
+                # "directory not found" error.
+                for branch in ("main", "master"):
+                    for dir_path in candidate_paths:
+                        result = await cls._download_github_skill_md_raw(
+                            client, owner, repo, branch, dir_path, scope
+                        )
+                        if result.success:
+                            return result
+                        if result.error:
+                            errors.append(result.error)
+
+                skill_hint = Path(subpath).name if subpath else None
+                for branch in ("main", "master"):
+                    result = await cls._download_github_archive_skill(
+                        client,
+                        owner,
+                        repo,
+                        branch,
+                        candidate_paths,
+                        skill_hint,
+                        scope,
                     )
                     if result.success:
                         return result
                     if result.error:
                         errors.append(result.error)
+        except Exception as exc:
+            return SkillInstallResult(
+                success=False,
+                error=f"GitHub download failed for {owner}/{repo}: {exc}",
+            )
 
         if errors and any("GitHub API 403" in error for error in errors):
             return SkillInstallResult(
@@ -675,6 +753,111 @@ class SkillInstaller:
         return SkillInstallResult(
             success=False,
             error=f"Could not find a skill directory in GitHub repo: {owner}/{repo}",
+        )
+
+    @classmethod
+    async def _download_github_archive_skill(
+        cls,
+        client: Any,
+        owner: str,
+        repo: str,
+        branch: str,
+        candidate_paths: list[str],
+        skill_hint: Optional[str],
+        scope: str,
+    ) -> SkillInstallResult:
+        """Download a GitHub zip archive and import the matching skill directory."""
+        archive_url = f"https://codeload.github.com/{owner}/{repo}/zip/refs/heads/{branch}"
+        resp = await client.get(archive_url)
+        if resp.status_code != 200:
+            return SkillInstallResult(
+                success=False,
+                error=f"GitHub archive HTTP {resp.status_code} for {archive_url}",
+            )
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+                return cls._import_skill_from_github_zip(
+                    zf,
+                    owner,
+                    repo,
+                    branch,
+                    candidate_paths,
+                    skill_hint,
+                    scope,
+                )
+        except zipfile.BadZipFile:
+            return SkillInstallResult(
+                success=False,
+                error=f"GitHub archive for {owner}/{repo}@{branch} is not a valid ZIP file",
+            )
+
+    @classmethod
+    def _import_skill_from_github_zip(
+        cls,
+        zf: zipfile.ZipFile,
+        owner: str,
+        repo: str,
+        branch: str,
+        candidate_paths: list[str],
+        skill_hint: Optional[str],
+        scope: str,
+    ) -> SkillInstallResult:
+        normalized_candidates = {path.strip("/") for path in candidate_paths}
+        skill_hint = (skill_hint or "").strip()
+        skill_mds = [name for name in zf.namelist() if name.endswith("/SKILL.md")]
+
+        for skill_md in skill_mds:
+            parts = Path(skill_md).parts
+            if len(parts) < 2:
+                continue
+            skill_dir = "/".join(parts[:-1])
+            relative_dir = "/".join(parts[1:-1])
+            dir_name = parts[-2]
+            try:
+                content = zf.read(skill_md).decode("utf-8")
+            except Exception:
+                continue
+            data = Skill._parse_frontmatter(content)
+            name = (data.get("name") or dir_name).strip()
+            if not name or not Skill._is_valid_name(name):
+                continue
+
+            if relative_dir not in normalized_candidates:
+                if not skill_hint or (name != skill_hint and dir_name != skill_hint):
+                    continue
+
+            skill_root = _resolve_install_root(scope) / name
+            skill_root.mkdir(parents=True, exist_ok=True)
+            prefix = f"{skill_dir}/"
+            file_count = 0
+            for member in zf.namelist():
+                if not member.startswith(prefix) or member.endswith("/"):
+                    continue
+                rel_path = member[len(prefix):]
+                if not rel_path:
+                    continue
+                dest = (skill_root / rel_path).resolve()
+                if not str(dest).startswith(str(skill_root.resolve())):
+                    continue
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(zf.read(member))
+                file_count += 1
+
+            Skill.clear_cache()
+            return SkillInstallResult(
+                success=True,
+                skill_name=name,
+                location=str(skill_root / "SKILL.md"),
+                message=(
+                    f"Skill '{name}' installed to {skill_root} "
+                    f"from GitHub archive {owner}/{repo}@{branch} ({file_count} files)"
+                ),
+            )
+
+        return SkillInstallResult(
+            success=False,
+            error=f"No matching SKILL.md found in GitHub archive for {owner}/{repo}@{branch}",
         )
 
     @classmethod
@@ -852,7 +1035,7 @@ class SkillInstaller:
             )
 
         try:
-            async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+            async with httpx.AsyncClient(timeout=_NETWORK_TIMEOUT_SEC, follow_redirects=True) as client:
                 resp = await client.get(url)
                 if resp.status_code != 200:
                     return SkillInstallResult(

--- a/flocks/tool/agent/task.py
+++ b/flocks/tool/agent/task.py
@@ -34,6 +34,7 @@ sibling tool calls in one assistant turn for parallel work.
     name="task",
     description=DESCRIPTION,
     category=ToolCategory.SYSTEM,
+    native=False,
     parameters=[
         ToolParameter(
             name="description",

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -680,7 +680,7 @@ class ToolRegistry:
         category: ToolCategory = ToolCategory.CUSTOM,
         parameters: Optional[List[ToolParameter]] = None,
         requires_confirmation: bool = False,
-        native: bool = False,
+        native: Optional[bool] = None,
         always_load: Optional[bool] = None,
         tags: Optional[List[str]] = None,
         enabled: bool = True,
@@ -688,11 +688,11 @@ class ToolRegistry:
         """
         Decorator to register a function as a tool.
 
-        ``native`` defaults to False (safe default).  Built-in tools get
-        ``native=True`` in bulk by ``_register_builtin_tools()`` after all
-        built-in modules are imported, so callers don't need to pass it
-        explicitly.  User plugin Python files that use this decorator will
-        correctly stay ``native=False``.
+        ``native=None`` means the loading context decides. Built-in tools get
+        ``native=True`` in bulk by ``_register_builtin_tools()`` only when the
+        decorator did not explicitly pass ``native``. User plugin Python files
+        that use this decorator still default to ``native=False`` unless their
+        loading path marks them project-level.
 
         Usage:
             @ToolRegistry.register_function(
@@ -704,18 +704,20 @@ class ToolRegistry:
                 ...
         """
         def decorator(func: ToolHandler) -> ToolHandler:
-            info = ToolInfo(
-                name=name,
-                description=description,
-                description_cn=description_cn,
-                category=category,
-                parameters=parameters or [],
-                requires_confirmation=requires_confirmation,
-                native=native,
-                always_load=always_load,
-                tags=list(tags or []),
-                enabled=enabled,
-            )
+            info_kwargs: Dict[str, Any] = {
+                "name": name,
+                "description": description,
+                "description_cn": description_cn,
+                "category": category,
+                "parameters": parameters or [],
+                "requires_confirmation": requires_confirmation,
+                "always_load": always_load,
+                "tags": list(tags or []),
+                "enabled": enabled,
+            }
+            if native is not None:
+                info_kwargs["native"] = native
+            info = ToolInfo(**info_kwargs)
             tool = Tool(info=info, handler=func)
             cls.register(tool)
             return func
@@ -1468,23 +1470,18 @@ class ToolRegistry:
                 except ImportError as e:
                     log.warn("builtin_tools.import_failed", {"module": f"{package}.{mod_name}", "error": str(e)})
 
-        # Mark every tool registered during this call as native=True, except
-        # for built-in modules that should remain non-native by policy.
-        # This is done in bulk here so individual @register_function call
-        # sites don't need to pass native=True, and user plugin files using
-        # the same decorator won't be misclassified.
-        builtin_native_exceptions = {
-            "lsp",
-            "task",
-            "list_providers",
-            "add_provider",
-            "add_model",
-        }
+        # Mark built-in tools native=True only when the decorator did not
+        # explicitly declare native. This keeps the default convenient for
+        # built-ins while preserving native=False for management tools that
+        # should be discovered through tool_search.
         for name in set(cls._tools.keys()) - before:
-            if name in builtin_native_exceptions:
-                cls._tools[name].info.native = False
+            tool = cls._tools[name]
+            fields_set = getattr(tool.info, "model_fields_set", None)
+            if fields_set is None:
+                fields_set = getattr(tool.info, "__fields_set__", set())
+            if "native" in fields_set:
                 continue
-            cls._tools[name].info.native = True
+            tool.info.native = True
 
         # Sample tools for testing (only register if not already registered)
         if "get_time" not in cls._tools:

--- a/flocks/tool/skill/flocks_skills.py
+++ b/flocks/tool/skill/flocks_skills.py
@@ -91,6 +91,30 @@ _SUBCOMMAND_ENUM = ["find", "install", "status", "install-deps", "remove"]
 _READ_ONLY_SUBCOMMANDS = frozenset({"find", "status"})
 
 
+def _parse_install_args(args: str) -> tuple[Optional[str], str]:
+    tokens = shlex.split(args.strip()) if args.strip() else []
+    source: Optional[str] = None
+    scope = "global"
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == "--scope" and i + 1 < len(tokens):
+            scope = tokens[i + 1]
+            i += 2
+            continue
+        if token.startswith("--scope="):
+            scope = token.split("=", 1)[1]
+            i += 1
+            continue
+        if token in {"--yes", "-y"}:
+            i += 1
+            continue
+        if source is None:
+            source = token
+        i += 1
+    return source, scope
+
+
 def _flocks_executable() -> Optional[str]:
     """Locate the `flocks` CLI on PATH."""
     return shutil.which("flocks")
@@ -139,6 +163,54 @@ async def flocks_skills(
                 f"Unknown subcommand: {subcommand!r}. "
                 f"Allowed: {', '.join(sorted(_ALLOWED_SUBCOMMANDS))}"
             ),
+        )
+
+    if subcommand == "install":
+        source, scope = _parse_install_args(args)
+        if not source:
+            return ToolResult(
+                success=False,
+                error="install requires a source, e.g. github:owner/repo/skill-name",
+            )
+        if scope not in {"global", "project"}:
+            return ToolResult(
+                success=False,
+                error="install --scope must be 'global' or 'project'",
+            )
+        await ctx.ask(
+            permission="bash",
+            patterns=[f"flocks skills install {source} --scope {scope} --yes"],
+            always=["*flocks skills *"],
+            metadata={"subcommand": subcommand},
+        )
+        try:
+            from flocks.skill.installer import SkillInstaller
+
+            result = await SkillInstaller.install_from_source(
+                source,
+                scope=scope,
+                yes=True,
+            )
+        except Exception as exc:
+            return ToolResult(
+                success=False,
+                error=f"Skill install failed: {exc}",
+                title="flocks skills install",
+            )
+        if not result.success:
+            return ToolResult(
+                success=False,
+                error=result.error or result.message or "Skill install failed",
+                title="flocks skills install",
+            )
+        return ToolResult(
+            success=True,
+            output={
+                "message": result.message,
+                "skill_name": result.skill_name,
+                "location": result.location,
+            },
+            title="flocks skills install",
         )
 
     flocks_bin = _flocks_executable()

--- a/flocks/tool/system/session_manage.py
+++ b/flocks/tool/system/session_manage.py
@@ -25,15 +25,25 @@ log = Log.create(service="tool.session_manage")
 SESSION_MANAGE_ACTIONS = ["list", "get", "create", "update", "delete", "archive"]
 
 SESSION_MANAGE_DESCRIPTION = """\
-管理 Flocks Session 元数据。
+Manage Flocks Session metadata.
+
+Use this tool when the user wants to list, inspect, create, rename, update,
+delete, archive, or restore a Flocks session. Also use it when the user asks to
+change/switch/update the model or provider used by a session.
 
 Use `action` to choose the operation:
-- list: 列出 session；可用 project_id/status/category/limit/offset 过滤或分页
-- get: 获取单个 session；需要 session_id
-- create: 创建 session；可传 title/project_id/directory/agent/parent_id
-- update: 更新 session；需要 session_id，可传 title/agent/model/provider/memory_enabled
-- delete: 软删除 session 及其子 session；需要 session_id，会请求确认
-- archive: 归档或取消归档 session；需要 session_id，archive=false 表示恢复 active
+- list: list sessions; filter or paginate with project_id/status/category/limit/offset.
+  If the target session_id is unknown, call list first.
+- get: get one session; requires session_id.
+- create: create a session; supports title/project_id/directory/agent/parent_id.
+- update: update session metadata; requires session_id. Supports title, agent,
+  model, provider, and memory_enabled. For requests like "change this session to
+  gpt-5" or "update the session model", use action=update with model, and set
+  provider too when the user specifies one.
+- delete: soft-delete a session and its child sessions; requires session_id and
+  confirmation.
+- archive: archive or restore a session; requires session_id. Set archive=false
+  to restore an archived session to active.
 """
 
 
@@ -43,7 +53,10 @@ SESSION_MANAGE_PARAMETERS = [
         type=ParameterType.STRING,
         required=True,
         enum=SESSION_MANAGE_ACTIONS,
-        description="要执行的 session 操作：list/get/create/update/delete/archive",
+        description=(
+            "Session operation: list/get/create/update/delete/archive. Use update "
+            "to change a session's title, agent, model, provider, or memory setting."
+        ),
     ),
     ToolParameter(
         name="session_id",
@@ -99,7 +112,7 @@ SESSION_MANAGE_PARAMETERS = [
         name="agent",
         type=ParameterType.STRING,
         required=False,
-        description="create/update 的 agent 类型",
+        description="Agent type for create/update.",
     ),
     ToolParameter(
         name="parent_id",
@@ -111,13 +124,19 @@ SESSION_MANAGE_PARAMETERS = [
         name="model",
         type=ParameterType.STRING,
         required=False,
-        description="update 的 model ID",
+        description=(
+            "Model ID to set during update, for example when the user asks to "
+            "change/switch/update the model used by a session."
+        ),
     ),
     ToolParameter(
         name="provider",
         type=ParameterType.STRING,
         required=False,
-        description="update 的 provider ID",
+        description=(
+            "Provider ID to set during update, for example openai/anthropic/local. "
+            "Use with model when the target model's provider is specified or known."
+        ),
     ),
     ToolParameter(
         name="memory_enabled",
@@ -140,6 +159,7 @@ SESSION_MANAGE_PARAMETERS = [
     description=SESSION_MANAGE_DESCRIPTION,
     category=ToolCategory.SYSTEM,
     parameters=SESSION_MANAGE_PARAMETERS,
+    native=True,
 )
 async def session_manage(
     ctx: ToolContext,

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -50,6 +50,15 @@ class MockProviderWithoutCatalog(OpenAIBaseProvider):
 
 class TestOpenAIBaseProviderGetModels:
     """Test suite for get_models() method."""
+
+    def test_default_http_timeout_values(self):
+        """OpenAI-style providers share fail-fast read and long write timeouts."""
+        timeout = openai_base_module.DEFAULT_HTTP_TIMEOUT
+
+        assert timeout.connect == 30.0
+        assert timeout.read == 180.0
+        assert timeout.write == 1800.0
+        assert timeout.pool == 60.0
     
     def test_get_models_with_catalog_success(self):
         """Test get_models() returns configured models."""
@@ -371,10 +380,10 @@ class TestOpenAIBaseProviderConfiguration:
         timeout_arg = kwargs["timeout"]
         # Either an httpx.Timeout instance or compatible object: assert the
         # connect/read/write components rather than equality so future tweaks
-        # to non-essential pool/write durations don't break the test.
+        # to non-essential pool durations don't break the test.
         assert getattr(timeout_arg, "connect", None) == 30.0
-        assert getattr(timeout_arg, "read", None) == 600.0
-        assert getattr(timeout_arg, "write", None) == 600.0
+        assert getattr(timeout_arg, "read", None) == 180.0
+        assert getattr(timeout_arg, "write", None) == 1800.0
 
         mock_async_openai.assert_called_once_with(
             api_key="test-api-key",

--- a/tests/session/test_retry.py
+++ b/tests/session/test_retry.py
@@ -94,6 +94,13 @@ class TestRetryable:
         result = SessionRetry.retryable(error)
         assert result is not None
 
+    def test_string_message_connection_error_not_retryable(self):
+        error = {
+            "name": "APIConnectionError",
+            "data": {"message": "Connection error."},
+        }
+        assert SessionRetry.retryable(error) is None
+
     def test_empty_error_returns_none(self):
         assert SessionRetry.retryable({}) is None
 

--- a/tests/session/test_retry.py
+++ b/tests/session/test_retry.py
@@ -94,12 +94,14 @@ class TestRetryable:
         result = SessionRetry.retryable(error)
         assert result is not None
 
-    def test_string_message_connection_error_not_retryable(self):
+    def test_string_message_connection_error_pattern(self):
         error = {
             "name": "APIConnectionError",
             "data": {"message": "Connection error."},
         }
-        assert SessionRetry.retryable(error) is None
+        result = SessionRetry.retryable(error)
+        assert result is not None
+        assert SessionRetry.is_connection_error(error) is True
 
     def test_empty_error_returns_none(self):
         assert SessionRetry.retryable({}) is None

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -251,12 +251,13 @@ class TestExceptionToErrorDict:
         result = runner._exception_to_error_dict(exc)
         assert result["data"]["isRetryable"] is True
 
-    def test_connection_error_exception_is_not_retryable(self):
+    def test_connection_error_exception_is_retryable(self):
         runner = _make_runner()
         exc = Exception("Connection error.")
         result = runner._exception_to_error_dict(exc)
-        assert result["name"] == "Exception"
-        assert result["data"].get("isRetryable") is not True
+        assert result["name"] == "APIError"
+        assert result["data"]["isRetryable"] is True
+        assert result["data"]["displayMessage"] == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
 
     def test_exception_with_status_code_429(self):
         runner = _make_runner()
@@ -2217,6 +2218,60 @@ async def test_process_step_invalidates_chat_cache_for_queued_messages(monkeypat
 
     assert result.action == "stop"
     assert result.content == "done"
+
+
+@pytest.mark.asyncio
+async def test_process_step_limits_connection_error_retries(monkeypatch):
+    runner = _make_runner("ses_runner_connection_error")
+    runner.callbacks = RunnerCallbacks(on_error=AsyncMock())
+
+    last_user = UserMessageInfo(
+        id="msg_user_connection_error",
+        sessionID=runner.session.id,
+        role="user",
+        time={"created": 1_000},
+        agent="rex",
+        model={"providerID": "bailian", "modelID": "deepseek-v4-flash"},
+    )
+    agent = SimpleNamespace(name="rex", steps=None, mode="primary", prompt="", tools=[])
+    provider = MagicMock()
+    provider.is_configured.return_value = True
+    assistant_msg = SimpleNamespace(id="msg_assistant_connection_error")
+    update_mock = AsyncMock(return_value=None)
+    call_count = 0
+
+    async def fake_call_llm(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise Exception("Connection error.")
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
+    monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        runner,
+        "_to_chat_messages",
+        AsyncMock(return_value=[SimpleNamespace(role="user", content="hi")]),
+    )
+    monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="hi"))
+    monkeypatch.setattr(runner_mod.Message, "create", AsyncMock(return_value=assistant_msg))
+    monkeypatch.setattr(runner_mod.Message, "update", update_mock)
+    monkeypatch.setattr(runner_mod.SessionRetry, "sleep", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner, "_call_llm", fake_call_llm)
+
+    result = await runner._process_step([last_user], last_user)
+
+    assert call_count == 4
+    assert result.action == "stop"
+    assert result.error == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
+    runner.callbacks.on_error.assert_awaited_with(runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE)
+
+    final_update = update_mock.await_args_list[-1].kwargs
+    assert final_update["finish"] == "error"
+    assert final_update["error"]["data"]["message"] == "Connection error."
+    assert final_update["error"]["data"]["displayMessage"] == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -251,6 +251,13 @@ class TestExceptionToErrorDict:
         result = runner._exception_to_error_dict(exc)
         assert result["data"]["isRetryable"] is True
 
+    def test_connection_error_exception_is_not_retryable(self):
+        runner = _make_runner()
+        exc = Exception("Connection error.")
+        result = runner._exception_to_error_dict(exc)
+        assert result["name"] == "Exception"
+        assert result["data"].get("isRetryable") is not True
+
     def test_exception_with_status_code_429(self):
         runner = _make_runner()
         exc = Exception("Rate limited")

--- a/tests/skill/test_installer.py
+++ b/tests/skill/test_installer.py
@@ -528,6 +528,51 @@ class TestInstallFromSource:
             / "checklist.md"
         ).exists()
 
+    @pytest.mark.asyncio
+    async def test_github_archive_fallback_rejects_zip_slip_members(self, tmp_skills_dir: Path):
+        skill_content = (
+            "---\n"
+            "name: demo\n"
+            "description: Demo skill\n"
+            "---\n"
+            "# Demo\n"
+        )
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zf:
+            zf.writestr("repo-main/demo/SKILL.md", skill_content)
+            zf.writestr("repo-main/demo/../demo2/pwned.txt", "pwned")
+
+        class Resp:
+            def __init__(self, status_code: int, text: str = "", content: bytes = b""):
+                self.status_code = status_code
+                self.text = text
+                self.content = content
+
+            def json(self):
+                return []
+
+        class Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def get(self, url: str):
+                if "codeload.github.com" in url:
+                    return Resp(200, content=zip_buffer.getvalue())
+                return Resp(404, "not found")
+
+        with (
+            patch("flocks.skill.installer._user_skills_root", return_value=tmp_skills_dir),
+            patch("httpx.AsyncClient", return_value=Client()),
+        ):
+            result = await SkillInstaller.install_from_source("github:owner/repo/demo")
+
+        assert result.success is True
+        assert (tmp_skills_dir / "demo" / "SKILL.md").exists()
+        assert not (tmp_skills_dir / "demo2" / "pwned.txt").exists()
+
 
 # ---------------------------------------------------------------------------
 # SkillInstaller._build_install_command

--- a/tests/skill/test_installer.py
+++ b/tests/skill/test_installer.py
@@ -2,9 +2,12 @@
 Tests for flocks.skill.installer and eligibility checking.
 """
 
+import asyncio
 import os
 import shutil
 import tempfile
+import io
+import zipfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -312,6 +315,37 @@ class TestInstallFromSource:
         assert (tmp_skills_dir / "demo" / "SKILL.md").exists()
 
     @pytest.mark.asyncio
+    async def test_skills_sh_cli_timeout_returns_error(self):
+        with (
+            patch("flocks.skill.installer.shutil.which", return_value="/usr/bin/npx"),
+            patch.object(
+                SkillInstaller,
+                "_run_subprocess",
+                AsyncMock(side_effect=TimeoutError("Command timed out after 45s")),
+            ),
+        ):
+            result = await SkillInstaller._install_from_skills_sh_cli(
+                "owner/repo/demo",
+                "global",
+                yes=True,
+            )
+
+        assert result.success is False
+        assert "timed out" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_install_from_source_overall_timeout_returns_error(self):
+        async def fake_wait_for(awaitable, timeout):
+            awaitable.close()
+            raise asyncio.TimeoutError()
+
+        with patch("flocks.skill.installer.asyncio.wait_for", fake_wait_for):
+            result = await SkillInstaller.install_from_source("github:owner/repo/demo")
+
+        assert result.success is False
+        assert "timed out" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
     async def test_safeskill_requires_npx(self, tmp_skills_dir):
         with patch("flocks.skill.installer.shutil.which", return_value=None):
             result = await SkillInstaller.install_from_source("safeskill:test")
@@ -434,6 +468,65 @@ class TestInstallFromSource:
         assert result.skill_name == "web-design-guidelines"
         assert "raw GitHub SKILL.md fallback" in result.message
         assert (tmp_skills_dir / "web-design-guidelines" / "SKILL.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_github_archive_fallback_finds_skill_by_name(self, tmp_skills_dir: Path):
+        skill_content = (
+            "---\n"
+            "name: improve-codebase-architecture\n"
+            "description: Improve codebase architecture\n"
+            "---\n"
+            "# Improve Codebase Architecture\n"
+        )
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zf:
+            zf.writestr(
+                "skills-main/skills/engineering/improve-codebase-architecture/SKILL.md",
+                skill_content,
+            )
+            zf.writestr(
+                "skills-main/skills/engineering/improve-codebase-architecture/references/checklist.md",
+                "checklist",
+            )
+
+        class Resp:
+            def __init__(self, status_code: int, text: str = "", content: bytes = b""):
+                self.status_code = status_code
+                self.text = text
+                self.content = content
+
+            def json(self):
+                return []
+
+        class Client:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def get(self, url: str):
+                if "codeload.github.com" in url:
+                    return Resp(200, content=zip_buffer.getvalue())
+                return Resp(404, "not found")
+
+        with (
+            patch("flocks.skill.installer._user_skills_root", return_value=tmp_skills_dir),
+            patch("httpx.AsyncClient", return_value=Client()),
+        ):
+            result = await SkillInstaller.install_from_source(
+                "github:mattpocock/skills/improve-codebase-architecture"
+            )
+
+        assert result.success is True
+        assert result.skill_name == "improve-codebase-architecture"
+        assert "GitHub archive" in result.message
+        assert (
+            tmp_skills_dir
+            / "improve-codebase-architecture"
+            / "references"
+            / "checklist.md"
+        ).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tool/test_builtin_management_tools.py
+++ b/tests/tool/test_builtin_management_tools.py
@@ -30,6 +30,15 @@ def test_lsp_remains_non_native_by_default() -> None:
     assert tool.info.native is False
 
 
+def test_task_remains_non_native_when_declared() -> None:
+    ToolRegistry.init()
+
+    tool = ToolRegistry.get("task")
+
+    assert tool is not None
+    assert tool.info.native is False
+
+
 def test_model_config_tools_remain_non_native_by_default() -> None:
     ToolRegistry.init()
 
@@ -37,3 +46,12 @@ def test_model_config_tools_remain_non_native_by_default() -> None:
         tool = ToolRegistry.get(name)
         assert tool is not None
         assert tool.info.native is False
+
+
+def test_session_manage_remains_native_when_declared() -> None:
+    ToolRegistry.init()
+
+    tool = ToolRegistry.get("session_manage")
+
+    assert tool is not None
+    assert tool.info.native is True

--- a/tests/tool/test_flocks_skills.py
+++ b/tests/tool/test_flocks_skills.py
@@ -72,14 +72,27 @@ async def test_all_allowed_subcommands_accepted():
     )
 
     proc = make_proc(stdout=b"ok", returncode=0)
+    from flocks.skill.installer import SkillInstallResult
 
     with (
         patch("flocks.tool.skill.flocks_skills._flocks_executable", return_value="/usr/local/bin/flocks"),
         patch("flocks.tool.skill.flocks_skills.asyncio.create_subprocess_exec", return_value=proc),
+        patch(
+            "flocks.skill.installer.SkillInstaller.install_from_source",
+            AsyncMock(
+                return_value=SkillInstallResult(
+                    success=True,
+                    skill_name="demo",
+                    location="/tmp/demo/SKILL.md",
+                    message="installed",
+                )
+            ),
+        ),
     ):
         for sub in _ALLOWED_SUBCOMMANDS:
             ctx = make_ctx()
-            result = await flocks_skills(ctx, subcommand=sub, args="")
+            args = "github:owner/repo/demo" if sub == "install" else ""
+            result = await flocks_skills(ctx, subcommand=sub, args=args)
             assert result.success is True, f"subcommand {sub!r} should succeed"
             if sub in _READ_ONLY_SUBCOMMANDS:
                 ctx.ask.assert_not_called()
@@ -159,12 +172,12 @@ async def test_remove_appends_yes_for_non_interactive_tool_calls():
 @pytest.mark.asyncio
 async def test_nonzero_exit_returns_failure():
     from flocks.tool.skill.flocks_skills import flocks_skills
+    from flocks.skill.installer import SkillInstallResult
 
     ctx = make_ctx()
-    proc = make_proc(stderr=b"skill not found\n", returncode=1)
-    with (
-        patch("flocks.tool.skill.flocks_skills._flocks_executable", return_value="/usr/bin/flocks"),
-        patch("flocks.tool.skill.flocks_skills.asyncio.create_subprocess_exec", return_value=proc),
+    with patch(
+        "flocks.skill.installer.SkillInstaller.install_from_source",
+        AsyncMock(return_value=SkillInstallResult(success=False, error="skill not found")),
     ):
         result = await flocks_skills(ctx, subcommand="install", args="github:bad/source")
 
@@ -174,7 +187,29 @@ async def test_nonzero_exit_returns_failure():
 
 
 @pytest.mark.asyncio
-async def test_timeout_kills_process():
+async def test_install_timeout_returns_failure():
+    from flocks.tool.skill.flocks_skills import flocks_skills
+    from flocks.skill.installer import SkillInstallResult
+
+    ctx = make_ctx()
+    with patch(
+        "flocks.skill.installer.SkillInstaller.install_from_source",
+        AsyncMock(
+            return_value=SkillInstallResult(
+                success=False,
+                error="Command timed out after 45s",
+            )
+        ),
+    ):
+        result = await flocks_skills(ctx, subcommand="install", args="clawhub:slow-skill")
+
+    assert result.success is False
+    assert "timed out" in (result.error or "").lower()
+    ctx.ask.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_remove_timeout_kills_process():
     from flocks.tool.skill.flocks_skills import flocks_skills
 
     ctx = make_ctx()
@@ -187,7 +222,7 @@ async def test_timeout_kills_process():
         patch("flocks.tool.skill.flocks_skills._flocks_executable", return_value="/usr/bin/flocks"),
         patch("flocks.tool.skill.flocks_skills.asyncio.create_subprocess_exec", return_value=proc),
     ):
-        result = await flocks_skills(ctx, subcommand="install", args="clawhub:slow-skill")
+        result = await flocks_skills(ctx, subcommand="remove", args="old-skill")
 
     assert result.success is False
     assert "timed out" in (result.error or "").lower()

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -13,6 +13,7 @@ import {
   default as SessionChat,
   getEditingActionBarClassName,
   getMessageBubbleClassName,
+  getMessageErrorText,
   getMessageGroupClassName,
   getRenderableFileUrl,
   getRegenerateTruncateTarget,
@@ -409,6 +410,56 @@ describe('shouldRenderMessage', () => {
       finish: 'error',
       error: { code: 'SessionError', message: 'Provider failed' },
     }))).toBe(true);
+  });
+});
+
+describe('getMessageErrorText', () => {
+  it('extracts nested provider error messages', () => {
+    expect(getMessageErrorText(makeMessage({
+      id: 'assistant-error',
+      error: {
+        name: 'APIConnectionError',
+        data: { message: 'Connection error.' },
+      } as any,
+    }))).toBe('Connection error.');
+  });
+
+  it('falls back to the error code', () => {
+    expect(getMessageErrorText(makeMessage({
+      id: 'assistant-error',
+      error: { code: 'SessionError' } as any,
+    }))).toBe('SessionError');
+  });
+});
+
+describe('SessionChat error rendering', () => {
+  it('renders empty assistant error messages instead of the thinking indicator', () => {
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'assistant-error',
+          role: 'assistant',
+          parts: [],
+          finish: 'error',
+          error: {
+            name: 'APIConnectionError',
+            data: { message: 'Connection error.' },
+          } as any,
+        }),
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    const { container } = render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    expect(screen.getByText('Connection error.')).toBeInTheDocument();
+    expect(container.querySelectorAll('.animate-bounce')).toHaveLength(0);
   });
 });
 

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -816,6 +816,88 @@ describe('SessionChat fallback polling', () => {
       vi.useRealTimers();
     }
   });
+
+  it('finishes streaming when only the local active tool ref is stale', async () => {
+    vi.useFakeTimers();
+    const refetch = vi.fn();
+    const onStreamingDone = vi.fn();
+    try {
+      useSessionMessagesMock.mockReturnValue({
+        messages: [
+          makeMessage({
+            id: 'assistant-1',
+            finish: 'stop',
+            parts: [
+              { id: 'text-1', type: 'text', text: 'done' } as Message['parts'][number],
+            ],
+          }),
+        ],
+        loading: false,
+        refetch,
+        addMessage: vi.fn(),
+        updateMessage: vi.fn(),
+        updateMessagePart: vi.fn(),
+        replaceMessageText: vi.fn(),
+        truncateAfterMessage: vi.fn(),
+      });
+      clientGetMock.mockImplementation((url: string) => {
+        if (url === '/api/session/sess-1/message') {
+          return Promise.resolve({
+            data: [
+              {
+                info: {
+                  id: 'assistant-1',
+                  sessionID: 'sess-1',
+                  role: 'assistant',
+                  finish: 'stop',
+                },
+                parts: [
+                  { id: 'text-1', type: 'text', text: 'done' },
+                ],
+              },
+            ],
+          });
+        }
+        if (url === '/api/session/status') {
+          return Promise.resolve({ data: { 'sess-1': { type: 'idle' } } });
+        }
+        return Promise.resolve({ data: {} });
+      });
+
+      render(React.createElement(SessionChat, {
+        sessionId: 'sess-1',
+        live: true,
+        onStreamingDone,
+      }));
+      act(() => {
+        useSSEOptionsRef.current.onEvent({
+          type: 'session.status',
+          properties: { sessionID: 'sess-1', status: { type: 'busy' } },
+        });
+        useSSEOptionsRef.current.onEvent({
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              id: 'tool-1',
+              messageID: 'assistant-1',
+              sessionID: 'sess-1',
+              type: 'tool',
+              state: { status: 'running' },
+            },
+          },
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+
+      expect(refetch).toHaveBeenCalled();
+      expect(onStreamingDone).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('areChatMessagePartsRenderEqual', () => {

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -19,6 +19,8 @@ import {
   getStandaloneThinkingBubbleClassName,
   getUserAvatarContainerClassName,
   getUserAvatarSpacerClassName,
+  hasActiveToolPart,
+  isActiveSessionStatus,
   listUploadedDocumentPaths,
   shouldRenderMessage,
   shouldRefetchFinishedMessage,
@@ -36,6 +38,7 @@ const sessionApiUpdateMessagePartMock = vi.fn();
 const sessionApiResendMessageMock = vi.fn();
 const sessionApiRegenerateMessageMock = vi.fn();
 const useSessionMessagesMock = vi.fn();
+const useSSEOptionsRef = vi.hoisted(() => ({ current: null as any }));
 const tMock = (key: string) => ({
   'chat.placeholder': '请输入消息',
   'chat.emptyText': '暂无消息',
@@ -82,7 +85,10 @@ vi.mock('@/hooks/useSessions', () => ({
 }));
 
 vi.mock('@/hooks/useSSE', () => ({
-  useSSE: () => ({ status: 'connected' }),
+  useSSE: (options: any) => {
+    useSSEOptionsRef.current = options;
+    return { status: 'connected' };
+  },
 }));
 
 vi.mock('@/hooks/useReasoningToggle', () => ({
@@ -152,6 +158,7 @@ beforeEach(() => {
   sessionApiResendMessageMock.mockResolvedValue({});
   sessionApiRegenerateMessageMock.mockResolvedValue({});
   pendingQuestionsHookMock.fetchPendingQuestions.mockResolvedValue(undefined);
+  useSSEOptionsRef.current = null;
   useSessionMessagesMock.mockReturnValue({
     messages: [],
     loading: false,
@@ -655,6 +662,95 @@ describe('shouldRefetchFinishedMessage', () => {
       finishedMessageId: 'assistant-2',
       abortedMessageId: 'assistant-1',
     })).toBe(true);
+  });
+});
+
+describe('streaming activity helpers', () => {
+  it('detects pending and running tool parts as active', () => {
+    expect(hasActiveToolPart([
+      { id: 'tool-1', type: 'tool', state: { status: 'pending' } } as Message['parts'][number],
+    ])).toBe(true);
+    expect(hasActiveToolPart([
+      { id: 'tool-1', type: 'tool', state: { status: 'running' } } as Message['parts'][number],
+    ])).toBe(true);
+  });
+
+  it('does not treat completed or error tool parts as active', () => {
+    expect(hasActiveToolPart([
+      { id: 'tool-1', type: 'tool', state: { status: 'completed' } } as Message['parts'][number],
+      { id: 'tool-2', type: 'tool', state: { status: 'error' } } as Message['parts'][number],
+    ])).toBe(false);
+  });
+
+  it('keeps busy, compacting, and retry session statuses active', () => {
+    expect(isActiveSessionStatus({ type: 'busy' })).toBe(true);
+    expect(isActiveSessionStatus({ type: 'compacting' })).toBe(true);
+    expect(isActiveSessionStatus({ type: 'retry' })).toBe(true);
+    expect(isActiveSessionStatus({ type: 'idle' })).toBe(false);
+    expect(isActiveSessionStatus(undefined)).toBe(false);
+  });
+});
+
+describe('SessionChat fallback polling', () => {
+  it('does not finish streaming while fetched messages still contain a running tool', async () => {
+    vi.useFakeTimers();
+    const refetch = vi.fn();
+    const onStreamingDone = vi.fn();
+    try {
+      useSessionMessagesMock.mockReturnValue({
+        messages: [
+          makeMessage({
+            id: 'assistant-1',
+            finish: 'tool-calls',
+            parts: [
+              { id: 'tool-1', type: 'tool', state: { status: 'running' } } as Message['parts'][number],
+            ],
+          }),
+        ],
+        loading: false,
+        refetch,
+        addMessage: vi.fn(),
+        updateMessage: vi.fn(),
+        updateMessagePart: vi.fn(),
+        replaceMessageText: vi.fn(),
+        truncateAfterMessage: vi.fn(),
+      });
+      clientGetMock.mockResolvedValueOnce({
+        data: [
+          {
+            info: {
+              id: 'assistant-1',
+              sessionID: 'sess-1',
+              role: 'assistant',
+              finish: 'tool-calls',
+            },
+            parts: [
+              { id: 'tool-1', type: 'tool', state: { status: 'running' } },
+            ],
+          },
+        ],
+      });
+
+      render(React.createElement(SessionChat, {
+        sessionId: 'sess-1',
+        live: true,
+        onStreamingDone,
+      }));
+      act(() => {
+        useSSEOptionsRef.current.onEvent({
+          type: 'session.status',
+          properties: { sessionID: 'sess-1', status: { type: 'busy' } },
+        });
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(refetch).not.toHaveBeenCalled();
+      expect(onStreamingDone).not.toHaveBeenCalled();
+      expect(clientGetMock).toHaveBeenCalledWith('/api/session/sess-1/message');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -414,6 +414,19 @@ describe('shouldRenderMessage', () => {
 });
 
 describe('getMessageErrorText', () => {
+  it('prefers user-facing display messages over raw provider errors', () => {
+    expect(getMessageErrorText(makeMessage({
+      id: 'assistant-error',
+      error: {
+        message: 'Connection error.',
+        data: {
+          displayMessage: 'Model is unavailable. Please check the provider connection and model configuration.',
+          message: 'Connection error.',
+        },
+      } as any,
+    }))).toBe('Model is unavailable. Please check the provider connection and model configuration.');
+  });
+
   it('extracts nested provider error messages', () => {
     expect(getMessageErrorText(makeMessage({
       id: 'assistant-error',

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -567,6 +567,19 @@ export function shouldRenderMessage(message: Pick<Message, 'role' | 'parts' | 'f
   return true;
 }
 
+export function getMessageErrorText(message: Pick<Message, 'error'>): string {
+  const error = message.error as any;
+  if (!error) return '';
+  if (typeof error === 'string') return error;
+  if (typeof error.message === 'string' && error.message.trim()) return error.message;
+  if (typeof error.data?.message === 'string' && error.data.message.trim()) {
+    return error.data.message;
+  }
+  if (typeof error.code === 'string' && error.code.trim()) return error.code;
+  if (typeof error.name === 'string' && error.name.trim()) return error.name;
+  return 'Message failed';
+}
+
 export function getUserAvatarContainerClassName(compact: boolean): string {
   return `pointer-events-none absolute left-full top-0 ml-2.5 translate-y-1/2 flex items-center justify-end ${
     compact ? 'h-7' : 'h-8'
@@ -3001,6 +3014,7 @@ function ChatMessageBubbleInner({
   const editingActionBarClass = getEditingActionBarClassName();
   const iconButtonClass = 'group/action relative inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200/80 bg-white/80 text-gray-400 transition-colors duration-150 hover:border-gray-300 hover:text-gray-700 disabled:opacity-40 disabled:cursor-not-allowed';
   const tooltipClass = 'pointer-events-none absolute bottom-full left-1/2 z-10 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-[11px] font-medium text-white opacity-0 shadow-sm transition-opacity duration-150 group-hover/action:opacity-100';
+  const messageErrorText = isUser ? '' : getMessageErrorText(message);
 
   const avatarSize = compact ? 'w-7 h-7 text-xs' : 'w-8 h-8 text-sm';
 
@@ -3026,11 +3040,18 @@ function ChatMessageBubbleInner({
             {t('chat.sending')}
           </div>
         ) : (
-          <div className="flex items-center gap-1 py-1" aria-label={t('chat.thinking')}>
-            <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce [animation-delay:-0.3s]" />
-            <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce [animation-delay:-0.15s]" />
-            <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce" />
-          </div>
+          messageErrorText ? (
+            <div className="flex items-start gap-2 py-1 text-sm text-red-700" role="alert">
+              <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-500" />
+              <span className="whitespace-pre-wrap break-words">{messageErrorText}</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1 py-1" aria-label={t('chat.thinking')}>
+              <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce [animation-delay:-0.3s]" />
+              <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce [animation-delay:-0.15s]" />
+              <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce" />
+            </div>
+          )
         )
       )}
 

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -2132,9 +2132,10 @@ export default function SessionChat({
         const lastMsg = msgs[msgs.length - 1];
         if (lastMsg?.info?.role === 'assistant' && (lastMsg.info.finish || lastMsg.info.time?.completed)) {
           const hasFetchedActiveTool = msgs.some((msg) => hasActiveToolPart(msg.parts));
-          if (hasFetchedActiveTool || activeToolPartIdsRef.current.size > 0) {
+          if (hasFetchedActiveTool) {
             return;
           }
+          activeToolPartIdsRef.current.clear();
           const statusRes = await client.get('/api/session/status');
           const status = statusRes.data?.[sessionId];
           if (isActiveSessionStatus(status)) {

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -518,6 +518,21 @@ export function shouldRefetchFinishedMessage({
   return !finishedMessageId || !abortedMessageId || finishedMessageId !== abortedMessageId;
 }
 
+export function isActiveToolPart(part?: Pick<MessagePart, 'type' | 'state'> | null): boolean {
+  return (
+    (part?.type === 'tool' || part?.type === 'toolCall') &&
+    (part.state?.status === 'pending' || part.state?.status === 'running')
+  );
+}
+
+export function hasActiveToolPart(parts?: Array<Pick<MessagePart, 'type' | 'state'>> | null): boolean {
+  return parts?.some(isActiveToolPart) ?? false;
+}
+
+export function isActiveSessionStatus(status?: { type?: string } | null): boolean {
+  return status?.type === 'busy' || status?.type === 'compacting' || status?.type === 'retry';
+}
+
 export function getEditingActionBarClassName(): string {
   return 'mt-3 flex w-full items-center justify-end gap-1.5';
 }
@@ -866,6 +881,7 @@ export default function SessionChat({
   const [input, setInput] = useState<string>(() => readChatDraft(sessionId));
   const [sending, setSending] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
+  const activeToolPartIdsRef = useRef<Set<string>>(new Set());
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
   // Lightbox preview for composer thumbnails. Shares the same overlay
@@ -1077,6 +1093,7 @@ export default function SessionChat({
       if (type === 'session.cleared' && properties.sessionID === sessionId) {
         abortingRef.current = false;
         sessionBusyRef.current = false;
+        activeToolPartIdsRef.current.clear();
         abortedMessageIdRef.current = null;
         setIsStreaming(false);
         refetch();
@@ -1101,6 +1118,7 @@ export default function SessionChat({
           setCompactionStages([]);
         } else if (statusType === 'idle') {
           sessionBusyRef.current = false;
+          activeToolPartIdsRef.current.clear();
           setIsStreaming(false);
           setIsCompacting(false);
           isCompactingRef.current = false;
@@ -1120,7 +1138,7 @@ export default function SessionChat({
           // would replace the visible partial response with an empty message.
           if (shouldRefetch) {
             refetch();
-            if (!sessionBusyRef.current) {
+            if (!sessionBusyRef.current && activeToolPartIdsRef.current.size === 0) {
               setIsStreaming(false);
             }
           }
@@ -1134,6 +1152,15 @@ export default function SessionChat({
           setIsStreaming(true);
         }
       } else if (type === 'message.part.updated' && properties.part?.sessionID === sessionId) {
+        const part = properties.part as Pick<MessagePart, 'id' | 'type' | 'state'>;
+        if (part.id) {
+          if (isActiveToolPart(part)) {
+            activeToolPartIdsRef.current.add(part.id);
+            if (!abortingRef.current) setIsStreaming(true);
+          } else {
+            activeToolPartIdsRef.current.delete(part.id);
+          }
+        }
         updateMessagePart(properties.part, properties.delta);
         scrollToBottom();
       } else if (type === 'question.asked' && properties.sessionID === sessionId) {
@@ -1181,6 +1208,7 @@ export default function SessionChat({
         setCompactionStages([]);
         abortingRef.current = false;
         sessionBusyRef.current = false;
+        activeToolPartIdsRef.current.clear();
         onError?.(properties.error?.message || t('chat.placeholder'));
       }
     },
@@ -2074,6 +2102,15 @@ export default function SessionChat({
         const msgs: any[] = res.data || [];
         const lastMsg = msgs[msgs.length - 1];
         if (lastMsg?.info?.role === 'assistant' && (lastMsg.info.finish || lastMsg.info.time?.completed)) {
+          const hasFetchedActiveTool = msgs.some((msg) => hasActiveToolPart(msg.parts));
+          if (hasFetchedActiveTool || activeToolPartIdsRef.current.size > 0) {
+            return;
+          }
+          const statusRes = await client.get('/api/session/status');
+          const status = statusRes.data?.[sessionId];
+          if (isActiveSessionStatus(status)) {
+            return;
+          }
           refetch();
           setIsStreaming(false);
         }

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -571,6 +571,9 @@ export function getMessageErrorText(message: Pick<Message, 'error'>): string {
   const error = message.error as any;
   if (!error) return '';
   if (typeof error === 'string') return error;
+  if (typeof error.data?.displayMessage === 'string' && error.data.displayMessage.trim()) {
+    return error.data.displayMessage;
+  }
   if (typeof error.message === 'string' && error.message.trim()) return error.message;
   if (typeof error.data?.message === 'string' && error.data.message.trim()) {
     return error.data.message;

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -989,6 +989,7 @@ export default function SessionChat({
     clearAll: clearPendingQuestions,
   } = usePendingQuestions();
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContentRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isAtBottomRef = useRef(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -1287,6 +1288,18 @@ export default function SessionChat({
   useEffect(() => {
     scrollToBottom();
   }, [messages, scrollToBottom]);
+
+  useEffect(() => {
+    if (!isStreaming && !sending && !isCompacting) return;
+    const target = messagesContentRef.current;
+    if (!target || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(() => {
+      scrollToBottom();
+    });
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [isStreaming, sending, isCompacting, scrollToBottom]);
 
   // Auto-resize textarea
   const autoResize = useCallback(() => {
@@ -2356,7 +2369,7 @@ export default function SessionChat({
             <div className="text-center py-8 text-gray-400 text-sm">{effectiveEmptyText}</div>
           )
         ) : (
-          <div className={msgListClass}>
+          <div ref={messagesContentRef} className={msgListClass}>
             {merged.map((msg, i) => {
               if (skipIndices.has(i)) return null;
               // If this position is a redirect, render the summary message here
@@ -2484,8 +2497,6 @@ export default function SessionChat({
             )}
           </div>
         )}
-        <div ref={messagesEndRef} className="h-0 flex-shrink-0" />
-
         {/* Conversation bottom slot: lives inside the scrollable conversation area. */}
         {conversationBottomSlot && !hideInput && (
           <div className="sticky bottom-0 z-10 -mx-1 mt-auto translate-y-4 pt-1 bg-gradient-to-t from-gray-50 via-gray-50/95 to-transparent">
@@ -2506,6 +2517,7 @@ export default function SessionChat({
             </div>
           </div>
         )}
+        <div ref={messagesEndRef} className="h-0 flex-shrink-0" />
       </div>
 
       {/* Suggestions — shown before user sends any message */}

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -165,6 +165,33 @@ describe('updateMessagePart scheduling', () => {
     expect(result.current.messages[0].parentID).toBe('msg-1');
   });
 
+  it('keeps assistant error info from fetched messages', async () => {
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: [{
+        info: {
+          id: 'msg-error',
+          sessionID: 'sess-1',
+          role: 'assistant',
+          finish: 'error',
+          error: {
+            name: 'APIConnectionError',
+            data: { message: 'Connection error.' },
+          },
+          time: { created: 123 },
+        },
+        parts: [],
+      }],
+    } as any);
+
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+
+    await act(async () => {});
+
+    expect(result.current.messages).toHaveLength(1);
+    expect((result.current.messages[0].error as any).data.message).toBe('Connection error.');
+    expect(result.current.messages[0].finish).toBe('error');
+  });
+
   it('first appearance of a new part updates messages state immediately', async () => {
     const { result } = renderHook(() => useSessionMessages('sess-1'));
     // Wait for the initial fetchMessages effect to settle so it doesn't wipe state

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -214,6 +214,7 @@ export function useSessionMessages(sessionId?: string) {
         model: msg.info.model,
         timestamp: msg.info.time?.created || Date.now(),
         finish: msg.info.finish || null,
+        error: msg.info.error || null,
         compacted: msg.info.compacted || null,
       }));
       


### PR DESCRIPTION
## Summary
- Add bounded timeouts and GitHub archive fallback for skill installation paths
- Preserve explicit native tool flags while defaulting built-in tools to native
- Keep SessionChat streaming state active while tool calls or active session states are still running

## Verification
- uv run pytest tests/skill/test_installer.py tests/tool/test_flocks_skills.py tests/tool/test_builtin_management_tools.py tests/tool/test_session_manage_tool.py
- npm run test:run -- SessionChat.test.ts
- npm run build
- git diff --check dev...HEAD