### PR TITLE
fix(updater): preserve restart after upgrade disconnect

### DIFF
--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -13,6 +13,7 @@ The updater tries each source in turn and falls back to the next on failure.
 """
 
 import asyncio
+import contextlib
 import importlib.util
 import json
 import os
@@ -564,7 +565,8 @@ async def _await_ignoring_cancellation(awaitable):
             return await asyncio.shield(task)
         except asyncio.CancelledError:
             log.warning("updater.restart.critical_step_cancelled_ignored")
-            await asyncio.sleep(_CANCELLATION_RETRY_DELAY_SECONDS)
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(_CANCELLATION_RETRY_DELAY_SECONDS)
 
 
 def _dependency_sync_timeout_seconds() -> int:
@@ -3347,6 +3349,9 @@ def _build_restart_argv(install_root: Path | None = None) -> list[str]:
     Always uses the project ``.venv`` Python to ensure the restarted process
     runs in the same environment that ``uv sync`` just updated.
     """
+    if sys.platform == "win32":
+        return _build_service_restart_argv(install_root)
+
     rest = sys.argv[1:]
 
     clean_rest: list[str] = []
@@ -3364,10 +3369,7 @@ def _build_restart_argv(install_root: Path | None = None) -> list[str]:
         clean_rest.append(arg)
 
     repo_root = install_root or _get_repo_root()
-    if sys.platform == "win32":
-        venv_python = repo_root / ".venv" / "Scripts" / "python.exe"
-    else:
-        venv_python = repo_root / ".venv" / "bin" / "python"
+    venv_python = repo_root / ".venv" / "bin" / "python"
 
     if not venv_python.exists():
         raise FileNotFoundError(f"Restart runtime is missing: {venv_python}")

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -70,6 +70,8 @@ async def test_await_ignoring_cancellation_backs_off_on_repeated_cancellation(
 
     async def fake_sleep(delay: float) -> None:
         sleep_delays.append(delay)
+        if len(sleep_delays) == 1:
+            raise updater.asyncio.CancelledError
 
     async def critical_step() -> str:
         return "done"
@@ -704,7 +706,7 @@ async def test_download_archive_keeps_auth_header_for_non_gitee_sources(
     assert captured["headers"] == {"Authorization": "Bearer secret"}
 
 
-def test_build_restart_argv_uses_windows_venv_python(
+def test_build_restart_argv_uses_windows_service_restart(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -718,14 +720,34 @@ def test_build_restart_argv_uses_windows_venv_python(
         "argv",
         [r"C:\Users\worker\.local\bin\flocks", "start", "--reload", "--port", "8000"],
     )
+    monkeypatch.setattr(
+        updater,
+        "_current_service_config",
+        lambda: service_manager.ServiceConfig(
+            backend_host="127.0.0.1",
+            backend_port=8000,
+            frontend_host="127.0.0.1",
+            frontend_port=5173,
+            no_browser=True,
+            skip_frontend_build=True,
+        ),
+    )
 
     assert updater._build_restart_argv(tmp_path) == [
         str(tmp_path / ".venv" / "Scripts" / "python.exe"),
         "-m",
         "flocks.cli.main",
-        "start",
-        "--port",
+        "restart",
+        "--no-browser",
+        "--skip-webui-build",
+        "--server-host",
+        "127.0.0.1",
+        "--server-port",
         "8000",
+        "--webui-host",
+        "127.0.0.1",
+        "--webui-port",
+        "5173",
     ]
 
 
@@ -746,6 +768,38 @@ def test_build_restart_argv_uses_venv_python_on_non_windows(
         "-m",
         "flocks.cli.main",
         "start",
+    ]
+
+
+def test_build_restart_argv_uses_service_restart_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    python_exe = tmp_path / ".venv" / "Scripts" / "python.exe"
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setattr(
+        updater,
+        "_build_service_restart_argv",
+        lambda install_root=None: [
+            str(python_exe),
+            "-m",
+            "flocks.cli.main",
+            "restart",
+            "--no-browser",
+            "--skip-webui-build",
+        ],
+    )
+
+    assert updater._build_restart_argv(tmp_path) == [
+        str(python_exe),
+        "-m",
+        "flocks.cli.main",
+        "restart",
+        "--no-browser",
+        "--skip-webui-build",
     ]
 
 


### PR DESCRIPTION
## Summary
- keep post-handover upgrade work alive when the SSE client disconnects during restart
- route Windows self-upgrade restarts through the service manager to avoid backend port bind races
- add updater regression coverage for cancellation backoff and Windows restart argv

## Tests
- uv run pytest tests/updater/test_updater.py