### PR TITLE
Fix Windows image rendering and default workflow history

### DIFF
--- a/flocks/session/utils/file_extractor.py
+++ b/flocks/session/utils/file_extractor.py
@@ -17,21 +17,34 @@ from urllib.parse import unquote, urlparse
 _log = logging.getLogger(__name__)
 
 
-_TEXT_EXTRACTABLE_MIMES = frozenset({
-    "application/json",
-    "application/ld+json",
-    "application/xml",
-    "application/yaml",
-    "application/x-yaml",
-    "application/javascript",
-    "application/x-sh",
-    "application/x-shellscript",
-    "text/markdown",
-    "text/csv",
-})
+_TEXT_EXTRACTABLE_MIMES = frozenset(
+    {
+        "application/json",
+        "application/ld+json",
+        "application/xml",
+        "application/yaml",
+        "application/x-yaml",
+        "application/javascript",
+        "application/x-sh",
+        "application/x-shellscript",
+        "text/markdown",
+        "text/csv",
+    }
+)
 
 _DEFAULT_MAX_CHARS = 12_000
 _DEFAULT_MAX_PAGES = 20
+
+
+def file_url_to_path(url: str) -> str:
+    """Convert a ``file://`` URL to a local filesystem path string."""
+    parsed = urlparse(url)
+    path = unquote(parsed.path)
+    if len(path) >= 3 and path[0] == "/" and path[2] == ":" and path[1].isalpha():
+        path = path[1:]
+    if parsed.netloc and parsed.netloc.lower() != "localhost":
+        path = f"//{parsed.netloc}{path}"
+    return path
 
 
 def read_file_part_bytes(url: str) -> Optional[bytes]:
@@ -50,11 +63,11 @@ def read_file_part_bytes(url: str) -> Optional[bytes]:
             _log.debug("read_file_part_bytes: data URI decode failed: %s", e)
             return None
     if url.startswith("file://"):
-        parsed = urlparse(url)
+        path = file_url_to_path(url)
         try:
-            return Path(unquote(parsed.path)).read_bytes()
+            return Path(path).read_bytes()
         except Exception as e:
-            _log.debug("read_file_part_bytes: file read failed: %s (path=%s)", e, parsed.path)
+            _log.debug("read_file_part_bytes: file read failed: %s (path=%s)", e, path)
             return None
     return None
 
@@ -64,9 +77,7 @@ def is_text_extractable_mime(mime: str) -> bool:
     return mime.startswith("text/") or mime in _TEXT_EXTRACTABLE_MIMES
 
 
-def truncate_extracted_text(
-    text: str, max_chars: int = _DEFAULT_MAX_CHARS
-) -> tuple[str, bool]:
+def truncate_extracted_text(text: str, max_chars: int = _DEFAULT_MAX_CHARS) -> tuple[str, bool]:
     """Strip and truncate *text* to *max_chars*.
 
     Returns ``(truncated_text, was_truncated)``.
@@ -141,9 +152,10 @@ def extract_file_text(
 
 
 __all__ = [
-    "read_file_part_bytes",
-    "is_text_extractable_mime",
-    "truncate_extracted_text",
     "extract_pdf_text_from_bytes",
     "extract_file_text",
+    "file_url_to_path",
+    "is_text_extractable_mime",
+    "read_file_part_bytes",
+    "truncate_extracted_text",
 ]

--- a/flocks/workflow/engine.py
+++ b/flocks/workflow/engine.py
@@ -144,7 +144,7 @@ class WorkflowEngine:
     mutate_workflow: bool = False
     workflow_path: Optional[str] = None
     node_timeout_s: Optional[float] = 300.0
-    history_mode: Literal["full", "summary"] = "full"
+    history_mode: Literal["full", "summary"] = "summary"
     _depth: int = 0
     max_parallel_workers: int = 4
     workflow_loader: Optional[Callable[[str], "Workflow"]] = field(default=None, repr=False)

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -296,7 +296,7 @@ def run_workflow(
     on_step_start: Optional[Any] = None,
     on_step_complete: Optional[Any] = None,
     max_parallel_workers: int = 4,
-    history_mode: Literal["full", "summary"] = "full",
+    history_mode: Literal["full", "summary"] = "summary",
     cancel: Optional[Callable[[], bool]] = None,
 ) -> RunWorkflowResult:
     # 确保日志已配置

--- a/tests/session/test_file_extractor.py
+++ b/tests/session/test_file_extractor.py
@@ -16,6 +16,7 @@ import pytest
 
 from flocks.session.utils.file_extractor import (
     extract_file_text,
+    file_url_to_path,
     is_text_extractable_mime,
     read_file_part_bytes,
     truncate_extracted_text,
@@ -25,6 +26,7 @@ from flocks.session.utils.file_extractor import (
 # ---------------------------------------------------------------------------
 # read_file_part_bytes
 # ---------------------------------------------------------------------------
+
 
 class TestReadFilePartBytes:
     def test_empty_string_returns_none(self):
@@ -69,46 +71,64 @@ class TestReadFilePartBytes:
         result = read_file_part_bytes(url)
         assert result == b"spaced content"
 
+    def test_windows_drive_file_url_path_does_not_keep_posix_prefix(self):
+        path = file_url_to_path("file:///C:/Users/demo/Pictures/channel%20image.png")
+        assert path == "C:/Users/demo/Pictures/channel image.png"
+
+    def test_unc_file_url_path_preserves_host(self):
+        path = file_url_to_path("file://server/share/channel%20image.png")
+        assert path == "//server/share/channel image.png"
+
 
 # ---------------------------------------------------------------------------
 # is_text_extractable_mime
 # ---------------------------------------------------------------------------
 
+
 class TestIsTextExtractableMime:
-    @pytest.mark.parametrize("mime", [
-        "text/plain",
-        "text/html",
-        "text/css",
-        "text/javascript",
-        "text/markdown",
-        "text/csv",
-        "text/xml",
-    ])
+    @pytest.mark.parametrize(
+        "mime",
+        [
+            "text/plain",
+            "text/html",
+            "text/css",
+            "text/javascript",
+            "text/markdown",
+            "text/csv",
+            "text/xml",
+        ],
+    )
     def test_text_prefix_is_extractable(self, mime):
         assert is_text_extractable_mime(mime) is True
 
-    @pytest.mark.parametrize("mime", [
-        "application/json",
-        "application/ld+json",
-        "application/xml",
-        "application/yaml",
-        "application/x-yaml",
-        "application/javascript",
-        "application/x-sh",
-        "application/x-shellscript",
-    ])
+    @pytest.mark.parametrize(
+        "mime",
+        [
+            "application/json",
+            "application/ld+json",
+            "application/xml",
+            "application/yaml",
+            "application/x-yaml",
+            "application/javascript",
+            "application/x-sh",
+            "application/x-shellscript",
+        ],
+    )
     def test_special_application_mimes_are_extractable(self, mime):
         assert is_text_extractable_mime(mime) is True
 
-    @pytest.mark.parametrize("mime", [
-        "image/png",
-        "image/jpeg",
-        "video/mp4",
-        "audio/mpeg",
-        "application/octet-stream",
-        "application/zip",
-        "application/pdf",  # PDF handled separately
-    ])
+    @pytest.mark.parametrize(
+        "mime",
+        [
+            "image/png",
+            "image/jpeg",
+            "video/mp4",
+            "audio/mpeg",
+            "application/octet-stream",
+            "application/zip",
+            "application/pdf",  # PDF handled separately
+        ],
+    )
     def test_binary_mimes_are_not_extractable(self, mime):
         assert is_text_extractable_mime(mime) is False
 
@@ -119,6 +139,7 @@ class TestIsTextExtractableMime:
 # ---------------------------------------------------------------------------
 # truncate_extracted_text
 # ---------------------------------------------------------------------------
+
 
 class TestTruncateExtractedText:
     def test_short_text_not_truncated(self):
@@ -166,6 +187,7 @@ class TestTruncateExtractedText:
 # ---------------------------------------------------------------------------
 # extract_file_text
 # ---------------------------------------------------------------------------
+
 
 class TestExtractFileText:
     def test_plain_text_file(self, tmp_path):

--- a/tests/workflow/test_workflow_history_mode.py
+++ b/tests/workflow/test_workflow_history_mode.py
@@ -50,6 +50,33 @@ def test_run_workflow_summary_history_does_not_retain_large_step_payloads() -> N
     assert result.history[1]["inputs"]["raw_alerts"]["count"] == 200
 
 
+def test_run_workflow_defaults_to_summary_history_mode() -> None:
+    workflow = {
+        "start": "produce",
+        "nodes": [
+            {
+                "id": "produce",
+                "type": "python",
+                "code": "outputs['items'] = [{'body': 'x' * 1000} for _ in range(200)]",
+            },
+        ],
+        "edges": [],
+    }
+
+    result = run_workflow(workflow=workflow, ensure_requirements=False)
+
+    assert result.status == "SUCCEEDED"
+    assert result.outputs["items"] == {
+        "_type": "list",
+        "count": 200,
+        "preview": [
+            {"_type": "dict", "keys": ["body"]},
+            {"_type": "dict", "keys": ["body"]},
+            {"_type": "dict", "keys": ["body"]},
+        ],
+    }
+
+
 def test_run_workflow_summary_outputs_do_not_retain_large_final_payloads() -> None:
     workflow = {
         "start": "final",
@@ -85,4 +112,3 @@ def test_python_runtime_can_cleanup_node_globals_after_execute() -> None:
     assert outputs == {"ok": True}
     assert "temporary_payload" not in runtime.globals
     assert runtime.globals["outputs"] == {"ok": True}
-

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -314,6 +314,18 @@ describe('getRenderableFileUrl', () => {
     );
   });
 
+  it('converts Windows file URLs without adding a POSIX root prefix', () => {
+    expect(getRenderableFileUrl('file:///C:/Users/demo/Pictures/channel%20image.png')).toBe(
+      '/api/file/download?path=C%3A%2FUsers%2Fdemo%2FPictures%2Fchannel%20image.png',
+    );
+  });
+
+  it('preserves UNC file URL hosts for Windows network paths', () => {
+    expect(getRenderableFileUrl('file://server/share/channel%20image.png')).toBe(
+      '/api/file/download?path=%2F%2Fserver%2Fshare%2Fchannel%20image.png',
+    );
+  });
+
   it('leaves browser-readable URLs unchanged', () => {
     expect(getRenderableFileUrl('https://example.com/image.png')).toBe('https://example.com/image.png');
     expect(getRenderableFileUrl('data:image/png;base64,abc')).toBe('data:image/png;base64,abc');

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -542,7 +542,12 @@ export function getRenderableFileUrl(url: string): string {
 
   try {
     const parsed = new URL(url);
-    const path = decodeURIComponent(parsed.pathname);
+    let path = decodeURIComponent(parsed.pathname);
+    if (/^\/[A-Za-z]:\//.test(path)) {
+      path = path.slice(1);
+    } else if (parsed.hostname) {
+      path = `//${parsed.hostname}${path}`;
+    }
     return `${getApiBase()}/api/file/download?path=${encodeURIComponent(path)}`;
   } catch {
     return url;


### PR DESCRIPTION
## Summary
- Fix file:// image rendering for Windows drive-letter and UNC paths in the web chat UI
- Normalize file:// paths consistently when extracting attached file bytes
- Change workflow execution history to default to summary mode and cover the default with regression tests

## Tests
- .venv/bin/python -m pytest tests/session/test_file_extractor.py tests/workflow/test_workflow_history_mode.py tests/workflow/test_workflow_exec_cache.py
- npm run test:run -- SessionChat.test.ts
- .venv/bin/ruff check flocks/session/utils/file_extractor.py tests/session/test_file_extractor.py flocks/workflow/runner.py flocks/workflow/engine.py tests/workflow/test_workflow_history_mode.py