### PR TITLE
Support configured OpenAI-compatible extra body

### DIFF
--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -71,6 +71,27 @@ def _resolve_reasoning_enabled(provider_id: str, model_id: str) -> Optional[bool
         return None
 
 
+def _resolve_default_extra_body(provider_id: str, model_id: str) -> Optional[Dict[str, Any]]:
+    """Read model-level OpenAI-compatible extra_body from flocks.json."""
+    try:
+        from flocks.provider.model_manager import get_model_manager
+
+        setting = get_model_manager().get_setting(provider_id, model_id)
+        if not setting:
+            return None
+
+        default_parameters = setting.default_parameters or {}
+        extra_body = default_parameters.get("extra_body")
+        return dict(extra_body) if isinstance(extra_body, dict) else None
+    except Exception as exc:
+        log.debug("options.extra_body_setting_lookup_failed", {
+            "provider_id": provider_id,
+            "model_id": model_id,
+            "error": str(exc),
+        })
+        return None
+
+
 def _lookup_raw_model_metadata(provider_id: str, model_id: str) -> Optional[Any]:
     """Return provider/model metadata without applying inferred defaults."""
     try:
@@ -269,6 +290,7 @@ def build_provider_options(
         if reasoning_enabled is not None
         else _resolve_reasoning_enabled(provider_id, model_id)
     )
+    configured_extra_body = _resolve_default_extra_body(provider_id, model_id)
     interleaved_enabled = interleaved_capability is not None
     if interleaved_enabled and reasoning_enabled is None:
         reasoning_enabled = True
@@ -322,11 +344,12 @@ def build_provider_options(
     # most reasoning_content models use enable_thinking, while MiniMax's
     # OpenAI-compatible interleaved format uses reasoning_split so the model
     # returns reasoning_details that can be replayed in later tool turns.
-    elif (
-        (interleaved_enabled or reasoning_enabled is True)
-        and reasoning_transport == REASONING_TRANSPORT_GENERIC_CHAT
+    elif reasoning_transport == REASONING_TRANSPORT_GENERIC_CHAT and (
+        configured_extra_body
+        or interleaved_enabled
+        or reasoning_enabled is True
     ):
-        extra_body = _build_generic_chat_extra_body(
+        extra_body = configured_extra_body or _build_generic_chat_extra_body(
             provider_id,
             model_id,
             interleaved_capability,
@@ -391,4 +414,3 @@ def _apply_max_tokens_from_config(
             "model_id": model_id,
             "max_tokens": model_info.capabilities.max_tokens,
         })
-

--- a/tests/provider/test_thinking_params.py
+++ b/tests/provider/test_thinking_params.py
@@ -347,6 +347,71 @@ class TestDispatchShape:
         )
         assert options["extra_body"]["enable_thinking"] is False
 
+    @pytest.mark.parametrize(
+        "configured_extra_body",
+        [
+            {"chat_template_kwargs": {"enable_thinking": True}},
+            {"chat_template_kwargs": {"thinking": True}},
+        ],
+    )
+    def test_configured_extra_body_overrides_auto_generic_shape(
+        self,
+        configured_extra_body: Dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """OpenAI-compatible users can declare provider-specific request bodies.
+
+        vLLM/SGLang thinking switches are nested under
+        ``chat_template_kwargs``.  If configured, Flocks should forward the
+        exact shape instead of adding its default ``enable_thinking`` flag for
+        qwen-style generic chat models.
+        """
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_default_extra_body",
+            lambda *_args, **_kw: configured_extra_body,
+        )
+
+        options = provider_options.build_provider_options(
+            "openai-compatible",
+            "qwen3-7b",
+            resolve_max_tokens=False,
+        )
+
+        assert options.get("extra_body") == configured_extra_body
+
+    @pytest.mark.parametrize(
+        "configured_extra_body",
+        [
+            {"chat_template_kwargs": {"enable_thinking": True}},
+            {"chat_template_kwargs": {"thinking": True}},
+        ],
+    )
+    def test_configured_extra_body_emits_without_interleaved_inference(
+        self,
+        configured_extra_body: Dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Explicit extra_body config should not depend on model-name inference."""
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_default_extra_body",
+            lambda *_args, **_kw: configured_extra_body,
+        )
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_interleaved_capability",
+            lambda *_args, **_kw: None,
+        )
+
+        options = provider_options.build_provider_options(
+            "openai-compatible",
+            "local-sglang-model",
+            resolve_max_tokens=False,
+        )
+
+        assert options.get("extra_body") == configured_extra_body
+
     def test_anthropic_transport_still_uses_thinking_field(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- allow model settings to provide OpenAI-compatible extra_body request parameters
- prefer configured extra_body over inferred generic-chat thinking payloads
- cover vLLM/SGLang chat_template_kwargs thinking shapes in provider option tests

## Tests
- .venv/bin/python -m pytest tests/provider/test_thinking_params.py