### PR TITLE
Fix updater restart argv handoff

### DIFF
--- a/flocks/updater/restart_handoff.py
+++ b/flocks/updater/restart_handoff.py
@@ -18,8 +18,9 @@ from typing import Sequence
 from flocks.cli import service_manager
 from flocks.utils.log import append_upgrade_text_log
 
-DEFAULT_PARENT_TIMEOUT_SECONDS = 30.0
+DEFAULT_PARENT_TIMEOUT_SECONDS = 20.0
 DEFAULT_PORT_TIMEOUT_SECONDS = 10.0
+POST_STOP_PORT_TIMEOUT_SECONDS = 20.0
 DEFAULT_POLL_INTERVAL_SECONDS = 0.25
 
 
@@ -76,7 +77,7 @@ def _ensure_backend_port_free(backend_port: int, backend_pid_file: Path) -> bool
         _record_handoff_log(f"backend_stop_failed port={backend_port} error={exc}")
         return False
 
-    return _wait_for_backend_port_free(backend_port)
+    return _wait_for_backend_port_free(backend_port, timeout_seconds=POST_STOP_PORT_TIMEOUT_SECONDS)
 
 
 def _cli_subcommand(argv: Sequence[str]) -> str | None:

--- a/flocks/updater/restart_handoff.py
+++ b/flocks/updater/restart_handoff.py
@@ -1,0 +1,178 @@
+"""Windows restart handoff helper for the self-updater.
+
+The updater process owns the backend port while it is spawning the restart
+command.  On Windows, starting the new backend before that process has fully
+exited can race with port release and fail with WinError 10048.  This helper is
+spawned instead; it waits for the old backend to exit, clears any remaining
+backend listener, and then starts the real restart command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import time
+from pathlib import Path
+from typing import Sequence
+
+from flocks.cli import service_manager
+from flocks.utils.log import append_upgrade_text_log
+
+DEFAULT_PARENT_TIMEOUT_SECONDS = 30.0
+DEFAULT_PORT_TIMEOUT_SECONDS = 10.0
+DEFAULT_POLL_INTERVAL_SECONDS = 0.25
+
+
+class _NullConsole:
+    def print(self, *args, **kwargs) -> None:
+        return None
+
+
+def _record_handoff_log(message: str) -> None:
+    append_upgrade_text_log(f"restart_handoff {message}")
+
+
+def _wait_for_parent_exit(
+    parent_pid: int,
+    *,
+    timeout_seconds: float = DEFAULT_PARENT_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not service_manager.pid_is_running(parent_pid):
+            return True
+        time.sleep(poll_interval_seconds)
+    return not service_manager.pid_is_running(parent_pid)
+
+
+def _backend_port_in_use(port: int) -> bool:
+    listeners = service_manager.port_owner_pids(port)
+    return service_manager.port_is_in_use(port, listeners)
+
+
+def _wait_for_backend_port_free(
+    port: int,
+    *,
+    timeout_seconds: float = DEFAULT_PORT_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not _backend_port_in_use(port):
+            return True
+        time.sleep(poll_interval_seconds)
+    return not _backend_port_in_use(port)
+
+
+def _ensure_backend_port_free(backend_port: int, backend_pid_file: Path) -> bool:
+    if _wait_for_backend_port_free(backend_port):
+        return True
+
+    _record_handoff_log(f"backend_port_still_in_use port={backend_port}; stopping backend")
+    try:
+        service_manager.stop_one(backend_port, backend_pid_file, "backend", _NullConsole())
+    except Exception as exc:
+        _record_handoff_log(f"backend_stop_failed port={backend_port} error={exc}")
+        return False
+
+    return _wait_for_backend_port_free(backend_port)
+
+
+def _cli_subcommand(argv: Sequence[str]) -> str | None:
+    for index, value in enumerate(argv[:-2]):
+        if value == "-m" and argv[index + 1] == "flocks.cli.main":
+            return argv[index + 2]
+    return None
+
+
+def _record_backend_runtime_if_direct_serve(
+    process: subprocess.Popen,
+    restart_argv: Sequence[str],
+    *,
+    backend_host: str,
+    backend_port: int,
+    backend_pid_file: Path,
+) -> None:
+    if _cli_subcommand(restart_argv) != "serve":
+        return
+
+    try:
+        service_manager.write_runtime_record(
+            backend_pid_file,
+            service_manager.process_runtime_record(
+                process,
+                host=backend_host,
+                port=backend_port,
+                command=restart_argv,
+            ),
+        )
+    except Exception as exc:
+        _record_handoff_log(f"backend_runtime_record_failed error={exc}")
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Flocks Windows restart handoff helper")
+    parser.add_argument("--parent-pid", type=int, required=True)
+    parser.add_argument("--backend-host", required=True)
+    parser.add_argument("--backend-port", type=int, required=True)
+    parser.add_argument("--frontend-host", required=True)
+    parser.add_argument("--frontend-port", type=int, required=True)
+    parser.add_argument("--backend-pid-file", required=True)
+    parser.add_argument("--install-root", required=True)
+    parser.add_argument("restart_argv", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.restart_argv and args.restart_argv[0] == "--":
+        args.restart_argv = args.restart_argv[1:]
+    return args
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    restart_argv = list(args.restart_argv)
+    if not restart_argv:
+        _record_handoff_log("missing_restart_argv")
+        return 2
+
+    _record_handoff_log(
+        "started "
+        f"parent_pid={args.parent_pid} backend={args.backend_host}:{args.backend_port} "
+        f"frontend={args.frontend_host}:{args.frontend_port}"
+    )
+
+    if not _wait_for_parent_exit(args.parent_pid):
+        _record_handoff_log(f"parent_exit_timeout parent_pid={args.parent_pid}")
+        return 1
+
+    backend_pid_file = Path(args.backend_pid_file)
+    if not _ensure_backend_port_free(args.backend_port, backend_pid_file):
+        _record_handoff_log(f"backend_port_unavailable port={args.backend_port}")
+        return 1
+
+    try:
+        process = subprocess.Popen(
+            restart_argv,
+            cwd=Path(args.install_root),
+            close_fds=True,
+        )
+    except OSError as exc:
+        _record_handoff_log(f"restart_spawn_failed error={exc}")
+        return 1
+
+    _record_backend_runtime_if_direct_serve(
+        process,
+        restart_argv,
+        backend_host=args.backend_host,
+        backend_port=args.backend_port,
+        backend_pid_file=backend_pid_file,
+    )
+    _record_handoff_log(f"restart_spawned pid={process.pid}")
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -3349,9 +3349,6 @@ def _build_restart_argv(install_root: Path | None = None) -> list[str]:
     Always uses the project ``.venv`` Python to ensure the restarted process
     runs in the same environment that ``uv sync`` just updated.
     """
-    if sys.platform == "win32":
-        return _build_service_restart_argv(install_root)
-
     rest = sys.argv[1:]
 
     clean_rest: list[str] = []
@@ -3369,7 +3366,10 @@ def _build_restart_argv(install_root: Path | None = None) -> list[str]:
         clean_rest.append(arg)
 
     repo_root = install_root or _get_repo_root()
-    venv_python = repo_root / ".venv" / "bin" / "python"
+    if sys.platform == "win32":
+        venv_python = repo_root / ".venv" / "Scripts" / "python.exe"
+    else:
+        venv_python = repo_root / ".venv" / "bin" / "python"
 
     if not venv_python.exists():
         raise FileNotFoundError(f"Restart runtime is missing: {venv_python}")

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -1704,35 +1704,6 @@ def _current_service_config():
     )
 
 
-def _build_service_restart_argv(install_root: Path | None = None) -> list[str]:
-    repo_root = install_root or _get_repo_root()
-    if sys.platform == "win32":
-        venv_python = repo_root / ".venv" / "Scripts" / "python.exe"
-    else:
-        venv_python = repo_root / ".venv" / "bin" / "python"
-
-    if not venv_python.exists():
-        raise FileNotFoundError(f"Restart runtime is missing: {venv_python}")
-
-    config = _current_service_config()
-    return [
-        str(venv_python),
-        "-m",
-        "flocks.cli.main",
-        "restart",
-        "--no-browser",
-        "--skip-webui-build",
-        "--server-host",
-        str(config.backend_host),
-        "--server-port",
-        str(config.backend_port),
-        "--webui-host",
-        str(config.frontend_host),
-        "--webui-port",
-        str(config.frontend_port),
-    ]
-
-
 def _spawn_detached_process(
     command: list[str],
     *,

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -3210,16 +3210,23 @@ async def perform_update(
             return
 
     if sys.platform == "win32":
-        log.info("updater.restart.spawn", {"argv": restart_argv})
         try:
+            handoff_argv = _build_windows_restart_handoff_argv(restart_argv, install_root)
+            log.info(
+                "updater.restart.handoff_spawn",
+                {
+                    "argv": handoff_argv,
+                    "restart_argv": restart_argv,
+                },
+            )
             subprocess.Popen(
-                restart_argv,
+                handoff_argv,
                 cwd=install_root,
                 close_fds=True,
             )
             os._exit(0)
-        except OSError as exc:
-            log.error("updater.restart.spawn_failed", {"error": str(exc)})
+        except Exception as exc:
+            log.error("updater.restart.handoff_spawn_failed", {"error": str(exc)})
             if handover_active:
                 try:
                     rollback_upgrade_handover()
@@ -3347,6 +3354,38 @@ def _build_restart_argv(install_root: Path | None = None) -> list[str]:
 
     log.info("updater.restart.force_venv", {"python": str(venv_python)})
     return [str(venv_python), "-m", "flocks.cli.main"] + clean_rest
+
+
+def _build_windows_restart_handoff_argv(restart_argv: list[str], install_root: Path) -> list[str]:
+    """Wrap the real restart command in a helper that waits for port release."""
+    from flocks.cli import service_manager
+
+    if not restart_argv:
+        raise ValueError("restart command is empty")
+
+    config = _current_service_config()
+    paths = service_manager.ensure_runtime_dirs()
+    return [
+        restart_argv[0],
+        "-m",
+        "flocks.updater.restart_handoff",
+        "--parent-pid",
+        str(os.getpid()),
+        "--backend-host",
+        str(config.backend_host),
+        "--backend-port",
+        str(config.backend_port),
+        "--frontend-host",
+        str(config.frontend_host),
+        "--frontend-port",
+        str(config.frontend_port),
+        "--backend-pid-file",
+        str(paths.backend_pid),
+        "--install-root",
+        str(install_root),
+        "--",
+        *restart_argv,
+    ]
 
 
 def _resolve_windows_restart_command(argv0: str, orig_argv: list[str]) -> list[str] | None:

--- a/tests/updater/test_restart_handoff.py
+++ b/tests/updater/test_restart_handoff.py
@@ -110,7 +110,11 @@ def test_ensure_backend_port_free_stops_backend_after_wait_timeout(monkeypatch, 
     backend_pid_file = tmp_path / "backend.pid"
 
     monkeypatch.setattr(restart_handoff, "_record_handoff_log", lambda message: events.append(f"log:{message}"))
-    monkeypatch.setattr(restart_handoff, "_wait_for_backend_port_free", lambda port: next(wait_results))
+    monkeypatch.setattr(
+        restart_handoff,
+        "_wait_for_backend_port_free",
+        lambda port, **kwargs: events.append(f"wait:{port}:{kwargs.get('timeout_seconds')}") or next(wait_results),
+    )
     monkeypatch.setattr(
         restart_handoff.service_manager,
         "stop_one",
@@ -119,6 +123,8 @@ def test_ensure_backend_port_free_stops_backend_after_wait_timeout(monkeypatch, 
 
     assert restart_handoff._ensure_backend_port_free(8000, backend_pid_file) is True
     assert events == [
+        "wait:8000:None",
         "log:backend_port_still_in_use port=8000; stopping backend",
         "stop:8000:backend.pid:backend",
+        "wait:8000:20.0",
     ]

--- a/tests/updater/test_restart_handoff.py
+++ b/tests/updater/test_restart_handoff.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from flocks.updater import restart_handoff
+
+
+def test_run_waits_for_parent_and_backend_port_before_spawning(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    restart_argv = ["python.exe", "-m", "flocks.cli.main", "serve", "--host", "127.0.0.1", "--port", "8000"]
+
+    monkeypatch.setattr(restart_handoff, "_record_handoff_log", lambda message: events.append(f"log:{message}"))
+    monkeypatch.setattr(
+        restart_handoff,
+        "_wait_for_parent_exit",
+        lambda parent_pid: events.append(f"wait-parent:{parent_pid}") or True,
+    )
+    monkeypatch.setattr(
+        restart_handoff,
+        "_ensure_backend_port_free",
+        lambda backend_port, backend_pid_file: events.append(f"free-port:{backend_port}:{backend_pid_file.name}") or True,
+    )
+    monkeypatch.setattr(
+        restart_handoff.subprocess,
+        "Popen",
+        lambda argv, cwd=None, close_fds=False: events.append(f"spawn:{list(argv)}:{cwd}:{close_fds}")
+        or SimpleNamespace(pid=4321),
+    )
+    monkeypatch.setattr(
+        restart_handoff,
+        "_record_backend_runtime_if_direct_serve",
+        lambda process, argv, **kwargs: events.append(f"record:{process.pid}:{list(argv)}:{kwargs['backend_port']}"),
+    )
+
+    code = restart_handoff.run(
+        [
+            "--parent-pid",
+            "1234",
+            "--backend-host",
+            "127.0.0.1",
+            "--backend-port",
+            "8000",
+            "--frontend-host",
+            "127.0.0.1",
+            "--frontend-port",
+            "5173",
+            "--backend-pid-file",
+            str(tmp_path / "backend.pid"),
+            "--install-root",
+            str(tmp_path),
+            "--",
+            *restart_argv,
+        ]
+    )
+
+    assert code == 0
+    assert events[1:] == [
+        "wait-parent:1234",
+        "free-port:8000:backend.pid",
+        f"spawn:{restart_argv}:{tmp_path}:True",
+        f"record:4321:{restart_argv}:8000",
+        "log:restart_spawned pid=4321",
+    ]
+
+
+def test_run_does_not_spawn_when_parent_exit_times_out(monkeypatch, tmp_path: Path) -> None:
+    events: list[str] = []
+
+    monkeypatch.setattr(restart_handoff, "_record_handoff_log", lambda message: events.append(f"log:{message}"))
+    monkeypatch.setattr(restart_handoff, "_wait_for_parent_exit", lambda parent_pid: False)
+    monkeypatch.setattr(
+        restart_handoff.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: events.append("spawn"),
+    )
+
+    code = restart_handoff.run(
+        [
+            "--parent-pid",
+            "1234",
+            "--backend-host",
+            "127.0.0.1",
+            "--backend-port",
+            "8000",
+            "--frontend-host",
+            "127.0.0.1",
+            "--frontend-port",
+            "5173",
+            "--backend-pid-file",
+            str(tmp_path / "backend.pid"),
+            "--install-root",
+            str(tmp_path),
+            "--",
+            "python.exe",
+            "-m",
+            "flocks.cli.main",
+            "serve",
+        ]
+    )
+
+    assert code == 1
+    assert events == ["log:started parent_pid=1234 backend=127.0.0.1:8000 frontend=127.0.0.1:5173", "log:parent_exit_timeout parent_pid=1234"]
+
+
+def test_ensure_backend_port_free_stops_backend_after_wait_timeout(monkeypatch, tmp_path: Path) -> None:
+    events: list[str] = []
+    wait_results = iter([False, True])
+    backend_pid_file = tmp_path / "backend.pid"
+
+    monkeypatch.setattr(restart_handoff, "_record_handoff_log", lambda message: events.append(f"log:{message}"))
+    monkeypatch.setattr(restart_handoff, "_wait_for_backend_port_free", lambda port: next(wait_results))
+    monkeypatch.setattr(
+        restart_handoff.service_manager,
+        "stop_one",
+        lambda port, pid_file, name, console: events.append(f"stop:{port}:{pid_file.name}:{name}"),
+    )
+
+    assert restart_handoff._ensure_backend_port_free(8000, backend_pid_file) is True
+    assert events == [
+        "log:backend_port_still_in_use port=8000; stopping backend",
+        "stop:8000:backend.pid:backend",
+    ]

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -706,7 +706,7 @@ async def test_download_archive_keeps_auth_header_for_non_gitee_sources(
     assert captured["headers"] == {"Authorization": "Bearer secret"}
 
 
-def test_build_restart_argv_uses_windows_service_restart(
+def test_build_restart_argv_uses_windows_venv_python(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -720,34 +720,14 @@ def test_build_restart_argv_uses_windows_service_restart(
         "argv",
         [r"C:\Users\worker\.local\bin\flocks", "start", "--reload", "--port", "8000"],
     )
-    monkeypatch.setattr(
-        updater,
-        "_current_service_config",
-        lambda: service_manager.ServiceConfig(
-            backend_host="127.0.0.1",
-            backend_port=8000,
-            frontend_host="127.0.0.1",
-            frontend_port=5173,
-            no_browser=True,
-            skip_frontend_build=True,
-        ),
-    )
 
     assert updater._build_restart_argv(tmp_path) == [
         str(tmp_path / ".venv" / "Scripts" / "python.exe"),
         "-m",
         "flocks.cli.main",
-        "restart",
-        "--no-browser",
-        "--skip-webui-build",
-        "--server-host",
-        "127.0.0.1",
-        "--server-port",
+        "start",
+        "--port",
         "8000",
-        "--webui-host",
-        "127.0.0.1",
-        "--webui-port",
-        "5173",
     ]
 
 
@@ -768,38 +748,6 @@ def test_build_restart_argv_uses_venv_python_on_non_windows(
         "-m",
         "flocks.cli.main",
         "start",
-    ]
-
-
-def test_build_restart_argv_uses_service_restart_on_windows(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    python_exe = tmp_path / ".venv" / "Scripts" / "python.exe"
-    python_exe.parent.mkdir(parents=True)
-    python_exe.write_text("", encoding="utf-8")
-
-    monkeypatch.setattr(updater.sys, "platform", "win32")
-    monkeypatch.setattr(
-        updater,
-        "_build_service_restart_argv",
-        lambda install_root=None: [
-            str(python_exe),
-            "-m",
-            "flocks.cli.main",
-            "restart",
-            "--no-browser",
-            "--skip-webui-build",
-        ],
-    )
-
-    assert updater._build_restart_argv(tmp_path) == [
-        str(python_exe),
-        "-m",
-        "flocks.cli.main",
-        "restart",
-        "--no-browser",
-        "--skip-webui-build",
     ]
 
 

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -3104,6 +3104,7 @@ async def test_perform_update_spawns_restart_process_on_windows(
     async def fake_validate_windows_restart_runtime(_install_root: Path) -> str | None:
         return None
 
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path / ".flocks"))
     monkeypatch.setattr(updater.sys, "platform", "win32")
     monkeypatch.setattr(updater, "_get_updater_config", fake_get_updater_config)
     monkeypatch.setattr(updater, "_get_repo_root", lambda: tmp_path / "install-root")
@@ -3131,8 +3132,18 @@ async def test_perform_update_spawns_restart_process_on_windows(
         async for _step in updater.perform_update("2026.4.1"):
             pass
 
-    assert popen_calls == [
-        ([r"C:\tool\python.exe", "-m", "flocks.cli.main", "start"], tmp_path / "install-root", True),
+    assert len(popen_calls) == 1
+    handoff_argv, cwd, close_fds = popen_calls[0]
+    assert cwd == tmp_path / "install-root"
+    assert close_fds is True
+    assert handoff_argv[:3] == [r"C:\tool\python.exe", "-m", "flocks.updater.restart_handoff"]
+    assert "--parent-pid" in handoff_argv
+    assert "--backend-port" in handoff_argv
+    assert handoff_argv[handoff_argv.index("--") + 1 :] == [
+        r"C:\tool\python.exe",
+        "-m",
+        "flocks.cli.main",
+        "start",
     ]
     assert events == ["handover"]
     assert "execv" not in events


### PR DESCRIPTION
## Summary
- restore updater restart argv reconstruction for CLI restarts
- add a Windows restart handoff helper that waits for the old backend to exit and frees the backend port before spawning the restart command
- cover restart handoff behavior and Windows updater restart paths with tests

## Tests
- .venv/bin/python -m pytest tests/updater/test_restart_handoff.py tests/updater/test_updater.py