### PR TITLE
fix(session): handle multimodal image paths across platforms

### DIFF
--- a/flocks/channel/inbound/dispatcher.py
+++ b/flocks/channel/inbound/dispatcher.py
@@ -1142,8 +1142,9 @@ class InboundDispatcher:
         import mimetypes
         import os
         from pathlib import Path
-        from urllib.parse import unquote, urlparse
+        from urllib.parse import urlparse
 
+        from flocks.session.utils.file_extractor import file_url_to_path
         from flocks.session.message import FilePart, Message, MessageRole
 
         create_kwargs: dict = dict(
@@ -1197,8 +1198,8 @@ class InboundDispatcher:
                 })
             elif scheme in ("", "file"):
                 # Local file already downloaded by the channel plugin (e.g. weixin).
-                # file:// URIs may have URL-encoded paths (e.g. Chinese filenames).
-                local_path = unquote(parsed.path) if scheme == "file" else msg.media_url
+                # file:// URIs may have URL-encoded or Windows drive paths.
+                local_path = file_url_to_path(msg.media_url) if scheme == "file" else msg.media_url
                 if not os.path.isfile(local_path):
                     log.warning("dispatcher.inbound_media_missing", {
                         "channel_id": msg.channel_id,

--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -57,6 +57,7 @@
         "family": "minimax",
         "capabilities": {
           "supports_tools": true,
+          "supports_vision": true,
           "supports_reasoning": true,
           "interleaved": {
             "field": "reasoning_details",

--- a/flocks/provider/sdk/google.py
+++ b/flocks/provider/sdk/google.py
@@ -3,6 +3,7 @@ Google (Gemini) provider implementation - High Quality Version
 """
 
 import os
+import base64
 import json
 import re
 from typing import List, AsyncIterator, Optional, Dict, Any
@@ -18,6 +19,20 @@ from flocks.provider.provider import (
 from flocks.utils.log import Log
 
 log = Log.create(service="provider.google")
+
+
+def _image_block_to_gemini_part(block: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Convert a Flocks internal image block to a Gemini inline_data part."""
+    data = block.get("data")
+    mime = block.get("mimeType")
+    if not data or not mime:
+        return None
+    return {
+        "inline_data": {
+            "data": data,
+            "mime_type": mime,
+        }
+    }
 
 
 class GoogleProvider(BaseProvider):
@@ -132,12 +147,16 @@ class GoogleProvider(BaseProvider):
                         elif p.type == "file":
                             mime = getattr(p, "mime", "")
                             if mime.startswith("image/"):
-                                parts.append({
-                                    "inline_data": {
-                                        "data": p.url.split(",")[-1] if "," in p.url else p.url,
-                                        "mime_type": mime
-                                    }
-                                })
+                                from flocks.session.utils.file_extractor import read_file_part_bytes
+
+                                data = read_file_part_bytes(getattr(p, "url", ""))
+                                if data:
+                                    parts.append({
+                                        "inline_data": {
+                                            "data": base64.b64encode(data).decode("utf-8"),
+                                            "mime_type": mime,
+                                        }
+                                    })
 
                     gemini_role = "model" if role == "assistant" else "user"
                     if parts:
@@ -179,6 +198,10 @@ class GoogleProvider(BaseProvider):
                     for p in msg.content:
                         if isinstance(p, dict) and p.get("type") == "text":
                             parts.append({"text": p["text"]})
+                        elif isinstance(p, dict) and p.get("type") == "image":
+                            image_part = _image_block_to_gemini_part(p)
+                            if image_part:
+                                parts.append(image_part)
                 
                 if msg.tool_calls:
                     for tc in msg.tool_calls:

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -2443,7 +2443,7 @@ async def _process_session_message(
             unique_name = f"{Identifier.create('part')}{ext}"
             target = uploads_root / unique_name
             target.write_bytes(raw_bytes)
-            return f"file://{target.resolve()}"
+            return target.resolve().as_uri()
         except Exception as exc:
             log.warn("session.message.file_part.materialize_failed", {
                 "sessionID": sessionID,
@@ -2937,7 +2937,7 @@ def _materialize_data_url_part(
                 ext = "." + tail.lower()
         target = uploads_root / f"{Identifier.create('part')}{ext}"
         target.write_bytes(raw_bytes)
-        return f"file://{target.resolve()}"
+        return target.resolve().as_uri()
     except Exception as exc:
         log.warn("session.prompt_queue.materialize_failed", {
             "sessionID": session_id,

--- a/flocks/session/utils/file_extractor.py
+++ b/flocks/session/utils/file_extractor.py
@@ -12,7 +12,7 @@ import io
 import logging
 from pathlib import Path
 from typing import Optional
-from urllib.parse import unquote, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 _log = logging.getLogger(__name__)
 
@@ -34,6 +34,7 @@ _TEXT_EXTRACTABLE_MIMES = frozenset(
 
 _DEFAULT_MAX_CHARS = 12_000
 _DEFAULT_MAX_PAGES = 20
+_LOCAL_DOWNLOAD_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 def file_url_to_path(url: str) -> str:
@@ -47,8 +48,29 @@ def file_url_to_path(url: str) -> str:
     return path
 
 
+def file_download_url_to_path(url: str) -> Optional[str]:
+    """Extract the local file path from the WebUI file download URL."""
+    parsed = urlparse(url)
+    if parsed.hostname and parsed.hostname not in _LOCAL_DOWNLOAD_HOSTS:
+        return None
+    if parsed.path != "/api/file/download":
+        return None
+    path_values = parse_qs(parsed.query).get("path")
+    if not path_values:
+        return None
+    return path_values[0]
+
+
+def _read_local_path(path: str) -> Optional[bytes]:
+    try:
+        return Path(path).read_bytes()
+    except Exception as e:
+        _log.debug("read_file_part_bytes: file read failed: %s (path=%s)", e, path)
+        return None
+
+
 def read_file_part_bytes(url: str) -> Optional[bytes]:
-    """Read raw bytes from a data URI or file:// URL.
+    """Read raw bytes from a data URI, file:// URL, or local download URL.
 
     Returns None when the URL is empty, has an unsupported scheme, or the
     underlying read fails.
@@ -63,12 +85,10 @@ def read_file_part_bytes(url: str) -> Optional[bytes]:
             _log.debug("read_file_part_bytes: data URI decode failed: %s", e)
             return None
     if url.startswith("file://"):
-        path = file_url_to_path(url)
-        try:
-            return Path(path).read_bytes()
-        except Exception as e:
-            _log.debug("read_file_part_bytes: file read failed: %s (path=%s)", e, path)
-            return None
+        return _read_local_path(file_url_to_path(url))
+    path = file_download_url_to_path(url)
+    if path:
+        return _read_local_path(path)
     return None
 
 
@@ -154,6 +174,7 @@ def extract_file_text(
 __all__ = [
     "extract_pdf_text_from_bytes",
     "extract_file_text",
+    "file_download_url_to_path",
     "file_url_to_path",
     "is_text_extractable_mime",
     "read_file_part_bytes",

--- a/tests/channel/test_channel.py
+++ b/tests/channel/test_channel.py
@@ -839,6 +839,55 @@ class TestFeishuNativeCommands:
         assert stored_part.mime == "image/png"
         assert stored_part.url == "file:///tmp/diagram.png"
 
+    @pytest.mark.asyncio
+    async def test_append_user_message_accepts_windows_file_uri(self, monkeypatch):
+        from flocks.channel.inbound.dispatcher import InboundDispatcher
+        from flocks.config.config import ChannelConfig
+
+        created_message = SimpleNamespace(id="message_user_1")
+        store_part = AsyncMock()
+        paths_checked: list[str] = []
+
+        def fake_isfile(path: str) -> bool:
+            paths_checked.append(path)
+            return path == "C:/Users/demo/Pictures/channel image.png"
+
+        monkeypatch.setattr(
+            "flocks.session.message.Message.create",
+            AsyncMock(return_value=created_message),
+        )
+        monkeypatch.setattr(
+            "flocks.session.message.Message.store_part",
+            store_part,
+        )
+        monkeypatch.setattr(
+            "flocks.session.message.Message.parts",
+            AsyncMock(return_value=[]),
+        )
+        monkeypatch.setattr("os.path.isfile", fake_isfile)
+
+        await InboundDispatcher._append_user_message(
+            "session_1",
+            "[图片消息]",
+            InboundMessage(
+                channel_id="weixin",
+                account_id="default",
+                message_id="msg_1",
+                sender_id="user_1",
+                chat_type=ChatType.DIRECT,
+                media_url="file:///C:/Users/demo/Pictures/channel%20image.png",
+                media_mime="image/png",
+            ),
+            ChannelConfig(enabled=True),
+        )
+
+        assert paths_checked == ["C:/Users/demo/Pictures/channel image.png"]
+        store_part.assert_awaited_once()
+        stored_part = store_part.await_args.args[2]
+        assert stored_part.type == "file"
+        assert stored_part.filename == "channel image.png"
+        assert stored_part.mime == "image/png"
+
 
 class TestMultimodalInput:
     @pytest.mark.asyncio

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -266,6 +266,11 @@ class TestCuratedCatalogModels:
         qwen = next(m for m in models if m.id == "qwen3.6-plus")
         assert qwen.capabilities.supports_vision is True
 
+        m3 = next(m for m in models if m.id == "minimax-m3")
+        assert m3.capabilities.supports_vision is True
+        assert m3.capabilities.supports_reasoning is True
+        assert m3.capabilities.interleaved["field"] == "reasoning_details"
+
         flash_cn = next(m for m in models if m.id == "deepseek-v4-flash")
         assert flash_cn.pricing.input == 1.0
         assert flash_cn.pricing.output == 2.0

--- a/tests/provider/test_google_gemini_fixes.py
+++ b/tests/provider/test_google_gemini_fixes.py
@@ -19,8 +19,10 @@ Targeted regression tests for the three issues raised in the PR review of
 
 from __future__ import annotations
 
+import base64
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import quote
 
 import pytest
 
@@ -454,6 +456,83 @@ class TestSessionIdForwarding:
             "history would be duplicated"
         )
         assert "memory user" in all_text, "fallback did not emit in-memory message"
+
+    def test_convert_messages_db_image_file_part_reads_bytes(self, tmp_path):
+        provider = GoogleProvider()
+        image_path = tmp_path / "screenshot.png"
+        image_path.write_bytes(b"png-bytes")
+
+        mwp = MagicMock()
+        mwp.info = MagicMock(role="user")
+        part = MagicMock()
+        part.type = "file"
+        part.mime = "image/png"
+        part.url = image_path.as_uri()
+        mwp.parts = [part]
+
+        with patch("flocks.session.message.MessageSync") as mock_ms:
+            mock_ms.list_with_parts.return_value = [mwp]
+
+            _system, gemini_msgs = provider._convert_messages(
+                [ChatMessage(role="user", content="fallback")],
+                session_id="ses_with_image",
+            )
+
+        inline = gemini_msgs[0]["parts"][0]["inline_data"]
+        assert inline["mime_type"] == "image/png"
+        assert inline["data"] == base64.b64encode(b"png-bytes").decode("utf-8")
+
+    def test_convert_messages_db_download_url_image_file_part_reads_bytes(self, tmp_path):
+        provider = GoogleProvider()
+        image_path = tmp_path / "screenshot.png"
+        image_path.write_bytes(b"png-bytes")
+
+        mwp = MagicMock()
+        mwp.info = MagicMock(role="user")
+        part = MagicMock()
+        part.type = "file"
+        part.mime = "image/png"
+        part.url = f"/api/file/download?path={quote(image_path.as_posix(), safe='')}"
+        mwp.parts = [part]
+
+        with patch("flocks.session.message.MessageSync") as mock_ms:
+            mock_ms.list_with_parts.return_value = [mwp]
+
+            _system, gemini_msgs = provider._convert_messages(
+                [ChatMessage(role="user", content="fallback")],
+                session_id="ses_with_download_url_image",
+            )
+
+        inline = gemini_msgs[0]["parts"][0]["inline_data"]
+        assert inline["mime_type"] == "image/png"
+        assert inline["data"] == base64.b64encode(b"png-bytes").decode("utf-8")
+
+    def test_convert_messages_in_memory_image_block_is_preserved(self):
+        provider = GoogleProvider()
+
+        _system, gemini_msgs = provider._convert_messages(
+            [
+                ChatMessage(
+                    role="user",
+                    content=[
+                        {"type": "text", "text": "what is this?"},
+                        {
+                            "type": "image",
+                            "mimeType": "image/png",
+                            "data": base64.b64encode(b"png-bytes").decode("utf-8"),
+                        },
+                    ],
+                )
+            ],
+            session_id=None,
+        )
+
+        parts = gemini_msgs[0]["parts"]
+        assert parts[0] == {"text": "what is this?"}
+        assert parts[1]["inline_data"] == {
+            "data": base64.b64encode(b"png-bytes").decode("utf-8"),
+            "mime_type": "image/png",
+        }
 
     @pytest.mark.asyncio
     async def test_chat_stream_passes_session_id_to_convert_messages(self):

--- a/tests/server/test_input_dispatcher.py
+++ b/tests/server/test_input_dispatcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -294,6 +295,30 @@ class TestSessionRoutesUseDispatcher:
 
 
 class TestPromptQueueRoutes:
+    def test_materialize_queued_data_url_returns_readable_file_uri(self, monkeypatch, tmp_path):
+        from flocks.server.routes import session as session_routes
+        from flocks.session.utils.file_extractor import read_file_part_bytes
+
+        class FakeWorkspace:
+            def resolve_workspace_path(self, rel_path: str):
+                return tmp_path / rel_path
+
+        monkeypatch.setattr(
+            "flocks.workspace.manager.WorkspaceManager.get_instance",
+            lambda: FakeWorkspace(),
+        )
+        data_url = "data:image/png;base64," + base64.b64encode(b"png-bytes").decode()
+
+        url = session_routes._materialize_data_url_part(
+            "ses_windows_uri",
+            data_url,
+            "image/png",
+            "screenshot.png",
+        )
+
+        assert url.startswith("file://")
+        assert read_file_part_bytes(url) == b"png-bytes"
+
     @pytest.mark.asyncio
     async def test_prompt_async_queues_when_session_running_without_creating_message(self, monkeypatch):
         from flocks.server.routes import session as session_routes

--- a/tests/session/test_file_extractor.py
+++ b/tests/session/test_file_extractor.py
@@ -11,11 +11,13 @@ Covers pure-function utilities:
 import base64
 import tempfile
 from pathlib import Path
+from urllib.parse import quote
 
 import pytest
 
 from flocks.session.utils.file_extractor import (
     extract_file_text,
+    file_download_url_to_path,
     file_url_to_path,
     is_text_extractable_mime,
     read_file_part_bytes,
@@ -75,9 +77,62 @@ class TestReadFilePartBytes:
         path = file_url_to_path("file:///C:/Users/demo/Pictures/channel%20image.png")
         assert path == "C:/Users/demo/Pictures/channel image.png"
 
+    def test_macos_file_url_path_is_decoded(self):
+        path = file_url_to_path("file:///Users/demo/Pictures/channel%20image.png")
+        assert path == "/Users/demo/Pictures/channel image.png"
+
+    def test_linux_file_url_path_is_decoded(self):
+        path = file_url_to_path("file:///home/demo/Pictures/channel%20image.png")
+        assert path == "/home/demo/Pictures/channel image.png"
+
     def test_unc_file_url_path_preserves_host(self):
         path = file_url_to_path("file://server/share/channel%20image.png")
         assert path == "//server/share/channel image.png"
+
+    def test_download_url_path_is_extracted(self):
+        path = file_download_url_to_path(
+            "/api/file/download?path=C%3A%2FUsers%2Fdemo%2FPictures%2Fchannel%20image.png"
+        )
+        assert path == "C:/Users/demo/Pictures/channel image.png"
+
+    def test_macos_download_url_path_is_extracted(self):
+        path = file_download_url_to_path(
+            "/api/file/download?path=%2FUsers%2Fdemo%2FPictures%2Fchannel%20image.png"
+        )
+        assert path == "/Users/demo/Pictures/channel image.png"
+
+    def test_linux_download_url_path_is_extracted(self):
+        path = file_download_url_to_path(
+            "/api/file/download?path=%2Fhome%2Fdemo%2FPictures%2Fchannel%20image.png"
+        )
+        assert path == "/home/demo/Pictures/channel image.png"
+
+    def test_unc_download_url_path_is_extracted(self):
+        path = file_download_url_to_path(
+            "/api/file/download?path=%2F%2Fserver%2Fshare%2Fchannel%20image.png"
+        )
+        assert path == "//server/share/channel image.png"
+
+    def test_download_url_reads_file(self, tmp_path):
+        test_file = tmp_path / "channel image.png"
+        test_file.write_bytes(b"image bytes")
+        url = f"/api/file/download?path={quote(test_file.as_posix(), safe='')}"
+        result = read_file_part_bytes(url)
+        assert result == b"image bytes"
+
+    def test_absolute_download_url_reads_file(self, tmp_path):
+        test_file = tmp_path / "channel image.png"
+        test_file.write_bytes(b"image bytes")
+        url = f"http://localhost:5173/api/file/download?path={quote(test_file.as_posix(), safe='')}"
+        result = read_file_part_bytes(url)
+        assert result == b"image bytes"
+
+    def test_external_download_url_is_not_treated_as_local_file(self, tmp_path):
+        test_file = tmp_path / "secret.txt"
+        test_file.write_bytes(b"secret")
+        url = f"https://example.com/api/file/download?path={quote(test_file.as_posix(), safe='')}"
+        assert file_download_url_to_path(url) is None
+        assert read_file_part_bytes(url) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize local file and WebUI download URLs before reading multimodal image bytes
- persist uploaded data URLs with platform-correct file URIs
- preserve Gemini image inputs from both stored file parts and in-memory image blocks
- align channel inbound local file handling with shared file URI parsing

## Tests
- .venv/bin/python -m pytest tests/session/test_file_extractor.py tests/server/routes/test_file_routes.py tests/server/test_input_dispatcher.py::TestPromptQueueRoutes::test_materialize_queued_data_url_returns_readable_file_uri tests/provider/test_google_gemini_fixes.py tests/channel/test_channel.py::TestFeishuNativeCommands::test_append_user_message_accepts_windows_file_uri tests/channel/test_channel.py::TestMultimodalInput tests/channel/test_channel.py::TestDownloadChannelMediaRouting
- .venv/bin/ruff check flocks/session/utils/file_extractor.py tests/session/test_file_extractor.py flocks/provider/sdk/google.py tests/provider/test_google_gemini_fixes.py flocks/channel/inbound/dispatcher.py tests/channel/test_channel.py flocks/server/routes/session.py tests/server/test_input_dispatcher.py
- npm run test:run -- src/utils/imageUpload.test.ts src/components/common/SessionChat.test.ts