### PR TITLE
Add WebUI dark mode support

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -5,6 +5,22 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Flocks - AI Native SecOps Platform</title>
+    <script>
+      (function () {
+        try {
+          var theme = localStorage.getItem('flocks_theme');
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          if (theme === 'dark' || (!theme && prefersDark)) {
+            document.documentElement.classList.add('dark');
+            document.documentElement.style.colorScheme = 'dark';
+          } else {
+            document.documentElement.style.colorScheme = 'light';
+          }
+        } catch (error) {
+          document.documentElement.style.colorScheme = 'light';
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -4,17 +4,20 @@ import { ToastProvider } from './components/common/Toast'
 import { ConfirmProvider } from './components/common/ConfirmDialog'
 import { BackendStatusBanner } from './components/common/BackendStatusBanner'
 import { AuthProvider } from './contexts/AuthContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 
 export default function App() {
   return (
     <ToastProvider>
       <ConfirmProvider>
-        <BrowserRouter>
-          <AuthProvider>
-            <BackendStatusBanner />
-            <Routes />
-          </AuthProvider>
-        </BrowserRouter>
+        <ThemeProvider>
+          <BrowserRouter>
+            <AuthProvider>
+              <BackendStatusBanner />
+              <Routes />
+            </AuthProvider>
+          </BrowserRouter>
+        </ThemeProvider>
       </ConfirmProvider>
     </ToastProvider>
   )

--- a/webui/src/components/common/BackendStatusBanner.tsx
+++ b/webui/src/components/common/BackendStatusBanner.tsx
@@ -13,13 +13,13 @@ export function BackendStatusBanner() {
   const getBannerStyle = () => {
     switch (status) {
       case 'connecting':
-        return 'bg-yellow-50 border-yellow-200 text-yellow-800';
+        return 'bg-yellow-50 border-yellow-200 text-yellow-800 dark:border-amber-500/35 dark:bg-amber-500/15 dark:text-amber-100';
       case 'disconnected':
-        return 'bg-red-50 border-red-200 text-red-800';
+        return 'bg-red-50 border-red-200 text-red-800 dark:border-red-400/30 dark:bg-red-500/15 dark:text-red-100';
       case 'error':
-        return 'bg-red-50 border-red-200 text-red-800';
+        return 'bg-red-50 border-red-200 text-red-800 dark:border-red-400/30 dark:bg-red-500/15 dark:text-red-100';
       default:
-        return 'bg-gray-50 border-gray-200 text-gray-800';
+        return 'bg-gray-50 border-gray-200 text-gray-800 dark:border-[#4a5563] dark:bg-[#303842] dark:text-[#d7dee8]';
     }
   };
 
@@ -72,7 +72,7 @@ export function BackendStatusBanner() {
           
           <button
             onClick={checkHealth}
-            className="px-4 py-2 bg-white/50 hover:bg-white/80 rounded-lg text-sm font-medium transition-colors duration-200 flex items-center space-x-2"
+            className="px-4 py-2 bg-white/50 hover:bg-white/80 rounded-lg text-sm font-medium transition-colors duration-200 flex items-center space-x-2 dark:bg-[#46515e]/70 dark:hover:bg-[#5a6573]"
           >
             <RefreshCw className="w-4 h-4" />
             <span>{t('backend.retry')}</span>

--- a/webui/src/components/common/ChatGuideDock.tsx
+++ b/webui/src/components/common/ChatGuideDock.tsx
@@ -99,7 +99,7 @@ export default function ChatGuideDock({
           data-testid="chat-guide-expanded-panel"
           className="absolute bottom-full left-0 right-0 z-30 mb-2 h-56 max-h-[calc(100vh-12rem)] overflow-hidden rounded-xl border border-zinc-200 bg-white/95 p-2 shadow-lg backdrop-blur"
         >
-          <div className="flex h-full flex-col gap-3 overflow-y-auto pr-1 [scrollbar-width:thin] [scrollbar-color:#d4d4d8_transparent]">
+          <div className="flex h-full flex-col gap-3 overflow-y-auto pr-1 [scrollbar-width:thin] [scrollbar-color:#d4d4d8_transparent] dark:[scrollbar-color:#545d68_transparent]">
             {actionGroups.map((group, groupIndex) => (
               <section key={group.title || `group-${groupIndex}`} className="min-w-0">
                 {shouldShowGroupTitle && group.title && (

--- a/webui/src/components/common/ChatPromptSelectors.tsx
+++ b/webui/src/components/common/ChatPromptSelectors.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Bot, ChevronDown, Cpu, Info, Plus } from 'lucide-react';
+import { Bot, ChevronDown, Cpu, Info } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import type { Agent } from '@/api/agent';
@@ -224,16 +224,16 @@ function SelectorTooltipOverlay({ tooltip }: { tooltip: SelectorTooltip | null }
   if (!tooltip) return null;
   return (
     <div
-      className="pointer-events-none fixed z-[80] w-56 -translate-x-full -translate-y-1/2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[11px] leading-relaxed text-zinc-700 shadow-md"
+      className="pointer-events-none fixed z-[80] w-56 -translate-x-full -translate-y-1/2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[11px] leading-relaxed text-zinc-700 shadow-md dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:shadow-xl dark:shadow-black/30"
       style={{ left: tooltip.x, top: tooltip.y }}
     >
-      <div className="mb-0.5 font-semibold text-zinc-800">{tooltip.title}</div>
+      <div className="mb-0.5 font-semibold text-zinc-800 dark:text-zinc-100">{tooltip.title}</div>
       {tooltip.lines.map((line, index) => (
-        <div key={`${tooltip.title}-${index}`} className={index === 0 ? '' : 'mt-1 break-all text-zinc-500'}>
+        <div key={`${tooltip.title}-${index}`} className={index === 0 ? '' : 'mt-1 break-all text-zinc-500 dark:text-zinc-400'}>
           {line}
         </div>
       ))}
-      <div className="absolute left-full top-1/2 -translate-y-1/2 border-4 border-transparent border-l-zinc-200" />
+      <div className="absolute left-full top-1/2 -translate-y-1/2 border-4 border-transparent border-l-zinc-200 dark:border-l-zinc-800" />
     </div>
   );
 }
@@ -253,7 +253,7 @@ export function ChatAgentDisplay({
 
   return (
     <div
-      className="flex h-7 w-auto max-w-[150px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600"
+      className="flex h-7 w-auto max-w-[150px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 dark:text-zinc-300"
       title={t('agentPicker.title')}
     >
       <Bot className="h-3 w-3 shrink-0" />
@@ -315,7 +315,7 @@ export function ChatAgentPicker({
       <button
         type="button"
         onClick={() => setOpen((value) => !value)}
-        className="flex h-7 w-auto max-w-[150px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900"
+        className="flex h-7 w-auto max-w-[150px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
         title={t('agentPicker.title')}
       >
         <Bot className="h-3 w-3 shrink-0" />
@@ -325,12 +325,12 @@ export function ChatAgentPicker({
         <ChevronDown className={`h-3 w-3 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
       {open && (
-        <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm">
-          <div className="flex items-center justify-between gap-2 border-b border-zinc-100 px-2.5 py-1.5">
+        <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-xl dark:shadow-black/30">
+          <div className="flex items-center justify-between gap-2 border-b border-zinc-100 px-2.5 py-1.5 dark:border-zinc-800">
             <div className="min-w-0">
-              <div className="text-xs font-semibold text-zinc-700">{t('agentPicker.title')}</div>
+              <div className="text-xs font-semibold text-zinc-700 dark:text-zinc-100">{t('agentPicker.title')}</div>
               <div
-                className="truncate text-[10px] text-zinc-400"
+                className="truncate text-[10px] text-zinc-400 dark:text-zinc-500"
                 onPointerEnter={(event) => showTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
                 onMouseEnter={(event) => showTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
                 onMouseOver={(event) => showTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
@@ -341,7 +341,7 @@ export function ChatAgentPicker({
               </div>
             </div>
             {showSourceFilter && (
-              <div className="inline-flex shrink-0 items-center rounded-md border border-zinc-200 bg-white p-0.5 text-[10px]">
+              <div className="inline-flex shrink-0 items-center rounded-md border border-zinc-200 bg-white p-0.5 text-[10px] dark:border-zinc-800 dark:bg-zinc-950">
                 {(['all', 'builtin', 'custom'] as AgentSourceFilter[]).map((filter) => (
                   <button
                     key={filter}
@@ -349,8 +349,8 @@ export function ChatAgentPicker({
                     onClick={() => setSourceFilter(filter)}
                     className={`rounded px-1.5 py-0.5 transition-colors ${
                       sourceFilter === filter
-                        ? 'bg-zinc-100 text-zinc-900'
-                        : 'text-zinc-500 hover:bg-zinc-50 hover:text-zinc-800'
+                        ? 'bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50'
+                        : 'text-zinc-500 hover:bg-zinc-50 hover:text-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100'
                     }`}
                   >
                     {t(`agentPicker.filter.${filter}`)}
@@ -372,21 +372,21 @@ export function ChatAgentPicker({
                     onClick={() => { onSelectAgent(agent.name); setOpen(false); }}
                     className={`w-full min-w-0 rounded-md px-2 py-1.5 text-left transition-colors ${
                       selectedAgent === agent.name
-                        ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa]'
-                        : 'hover:bg-zinc-50 text-zinc-700'
+                        ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa] dark:bg-zinc-800 dark:text-zinc-50 dark:shadow-[inset_2px_0_0_#539bf5]'
+                        : 'hover:bg-zinc-50 text-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50'
                     }`}
                   >
                     <div className="flex min-w-0 items-center gap-2">
-                      <Bot className={`h-3 w-3 shrink-0 ${selectedAgent === agent.name ? 'text-zinc-600' : 'text-zinc-400'}`} />
-                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900">
+                      <Bot className={`h-3 w-3 shrink-0 ${selectedAgent === agent.name ? 'text-zinc-600 dark:text-zinc-200' : 'text-zinc-400 dark:text-zinc-500'}`} />
+                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">
                         {displayName}
                       </span>
                       <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium ${
                         agent.mode === 'primary'
-                          ? 'bg-zinc-100 text-zinc-600'
+                          ? 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
                           : agent.native
-                            ? 'bg-zinc-100 text-zinc-600'
-                            : 'bg-teal-50 text-teal-600'
+                            ? 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
+                            : 'bg-teal-50 text-teal-600 dark:bg-teal-950/40 dark:text-teal-200'
                       }`}>
                         {agent.mode === 'primary'
                           ? t('agentPicker.badge.primary')
@@ -397,7 +397,7 @@ export function ChatAgentPicker({
                       <div className="ml-auto flex shrink-0 items-center gap-1">
                         {primaryDesc && (
                           <span
-                            className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200"
+                            className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200 dark:hover:bg-zinc-700"
                             onMouseDown={(event) => { event.preventDefault(); event.stopPropagation(); }}
                             onClick={(event) => { event.preventDefault(); event.stopPropagation(); }}
                             onPointerEnter={(event) => showTooltip(event.currentTarget, displayName, [primaryDesc])}
@@ -406,7 +406,7 @@ export function ChatAgentPicker({
                             onMouseLeave={hideTooltip}
                             onPointerLeave={hideTooltip}
                           >
-                            <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500" />
+                            <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-300" />
                           </span>
                         )}
                       </div>
@@ -430,13 +430,11 @@ export function ChatModelPicker({
   loading,
   selectedModelOption,
   onSelectModel,
-  onAddModel,
 }: {
   groupedOptions: ChatModelProviderGroup[];
   loading: boolean;
   selectedModelOption: ChatModelOption | null;
   onSelectModel: (option: ChatModelOption) => void;
-  onAddModel: () => void;
 }) {
   const { t } = useTranslation('session');
   const [open, setOpen] = useState(false);
@@ -463,7 +461,7 @@ export function ChatModelPicker({
         type="button"
         onClick={() => setOpen((value) => !value)}
         disabled={loading || !hasOptions}
-        className="flex h-7 w-[132px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-50"
+        className="flex h-7 w-[132px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
         title={selectedModelOption ? `${selectedModelOption.providerName} / ${selectedModelOption.modelID}` : t('modelPicker.empty')}
       >
         <Cpu className="h-3 w-3 shrink-0" />
@@ -473,10 +471,10 @@ export function ChatModelPicker({
         <ChevronDown className={`h-3 w-3 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
       {open && (
-        <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm">
-          <div className="border-b border-zinc-100 px-2.5 py-1.5">
-            <div className="text-xs font-semibold text-zinc-700">{t('modelPicker.title')}</div>
-            <div className="truncate text-[10px] text-zinc-400">{t('modelPicker.hint')}</div>
+        <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-xl dark:shadow-black/30">
+          <div className="border-b border-zinc-100 px-2.5 py-1.5 dark:border-zinc-800">
+            <div className="text-xs font-semibold text-zinc-700 dark:text-zinc-100">{t('modelPicker.title')}</div>
+            <div className="truncate text-[10px] text-zinc-400 dark:text-zinc-500">{t('modelPicker.hint')}</div>
           </div>
           <div className="h-[13.5rem] overflow-y-auto p-1.5">
             {loading ? (
@@ -484,9 +482,9 @@ export function ChatModelPicker({
             ) : groupedOptions.length > 0 ? (
               groupedOptions.map((group) => (
                 <div key={group.providerID} className="py-1 first:pt-0 last:pb-0">
-                  <div className="sticky top-0 z-10 flex items-center justify-between gap-2 bg-white/95 px-1.5 py-1 text-[10px] font-semibold text-zinc-500 backdrop-blur">
+                  <div className="sticky top-0 z-10 flex items-center justify-between gap-2 bg-white/95 px-1.5 py-1 text-[10px] font-semibold text-zinc-500 backdrop-blur dark:bg-zinc-900/95 dark:text-zinc-400">
                     <span className="truncate">{group.providerName}</span>
-                    <span className="shrink-0 rounded bg-zinc-50 px-1.5 py-0.5 text-[9px] text-zinc-500">
+                    <span className="shrink-0 rounded bg-zinc-50 px-1.5 py-0.5 text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-300">
                       {t('modelPicker.count', { count: group.models.length })}
                     </span>
                   </div>
@@ -501,21 +499,21 @@ export function ChatModelPicker({
                         }}
                         className={`w-full rounded-md px-2 py-1.5 text-left transition-colors ${
                           selectedModelOption?.key === option.key
-                            ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa]'
-                            : 'text-zinc-700 hover:bg-zinc-50'
+                            ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa] dark:bg-zinc-800 dark:text-zinc-50 dark:shadow-[inset_2px_0_0_#539bf5]'
+                            : 'text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50'
                         }`}
                       >
                         <div className="flex min-w-0 items-center gap-2">
-                          <Cpu className={`h-3 w-3 shrink-0 ${selectedModelOption?.key === option.key ? 'text-zinc-600' : 'text-zinc-400'}`} />
-                          <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900">{option.label}</span>
+                          <Cpu className={`h-3 w-3 shrink-0 ${selectedModelOption?.key === option.key ? 'text-zinc-600 dark:text-zinc-200' : 'text-zinc-400 dark:text-zinc-500'}`} />
+                          <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">{option.label}</span>
                           {option.supportsVision === true && (
-                            <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 text-[9px] font-medium text-zinc-600">
+                            <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 text-[9px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
                               {t('modelPicker.vision')}
                             </span>
                           )}
                           <div className="ml-auto flex shrink-0 items-center gap-1">
                             <span
-                              className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200"
+                              className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200 dark:hover:bg-zinc-700"
                               onMouseDown={(event) => { event.preventDefault(); event.stopPropagation(); }}
                               onClick={(event) => { event.preventDefault(); event.stopPropagation(); }}
                               onPointerEnter={(event) => showTooltip(event.currentTarget, option.label, [option.pricingLabel, option.contextLabel])}
@@ -524,7 +522,7 @@ export function ChatModelPicker({
                               onMouseLeave={hideTooltip}
                               onPointerLeave={hideTooltip}
                             >
-                              <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500" />
+                              <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-300" />
                             </span>
                           </div>
                         </div>
@@ -536,20 +534,6 @@ export function ChatModelPicker({
             ) : (
               <div className="p-3 text-center text-xs text-zinc-500">{t('modelPicker.empty')}</div>
             )}
-          </div>
-          <div className="border-t border-zinc-100 p-1.5">
-            <button
-              type="button"
-              onClick={() => {
-                setOpen(false);
-                hideTooltip();
-                onAddModel();
-              }}
-              className="flex w-full items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900"
-            >
-              <Plus className="h-3 w-3" />
-              {t('modelPicker.addModel')}
-            </button>
           </div>
         </div>
       )}

--- a/webui/src/components/common/LanguageSwitcher.tsx
+++ b/webui/src/components/common/LanguageSwitcher.tsx
@@ -27,7 +27,7 @@ export default function LanguageSwitcher({ collapsed = false }: LanguageSwitcher
     return (
       <button
         onClick={toggleLanguage}
-        className="flex items-center justify-center w-8 h-8 rounded-lg text-zinc-400 hover:text-zinc-600 hover:bg-white/60 transition-colors"
+        className="flex items-center justify-center w-8 h-8 rounded-lg text-zinc-400 hover:text-zinc-600 hover:bg-white/60 transition-colors dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
         title={t('switchLanguage')}
       >
         <Globe className="w-4 h-4" />
@@ -43,8 +43,8 @@ export default function LanguageSwitcher({ collapsed = false }: LanguageSwitcher
           onClick={() => handleChange(code)}
           className={`px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
             currentLang === code
-              ? 'bg-white text-zinc-900 shadow-sm'
-              : 'text-zinc-500 hover:bg-white/60 hover:text-zinc-800'
+              ? 'bg-white text-zinc-900 shadow-sm dark:bg-zinc-800 dark:text-zinc-50'
+              : 'text-zinc-500 hover:bg-white/60 hover:text-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100'
           }`}
         >
           {label}

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -573,6 +573,19 @@ describe('SessionChat instruction display text', () => {
   });
 });
 
+describe('SessionChat composer controls', () => {
+  it('keeps the disabled send button visible in dark mode', () => {
+    const { container } = render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    const disabledButtons = Array.from(container.querySelectorAll('button:disabled'));
+    const sendButton = disabledButtons.find((button) => button.querySelector('svg'));
+
+    expect(sendButton?.className).toContain('dark:bg-[#46515e]');
+    expect(sendButton?.className).toContain('dark:text-[#b8c2cc]');
+    expect(sendButton?.className).toContain('dark:border-[#5a6573]');
+  });
+});
+
 describe('shouldRenderMessage', () => {
   it('keeps active empty assistant messages eligible for the thinking indicator', () => {
     expect(shouldRenderMessage(makeMessage({

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -346,12 +346,9 @@ describe('buildContextUsageBreakdown', () => {
 });
 
 describe('getMessageBubbleClassName', () => {
-  // The bubble's max width is owned by its outer container (`max-w-[80%]` for
-  // user, `w-full` for assistant; see SessionChat.tsx), so the inner bubble
-  // only controls its own intrinsic sizing (`w-auto` vs `w-full`).  Previously
-  // the inner bubble also pinned `max-w-2xl`, but the unified chat redesign
-  // moved that responsibility outward.  Tests here therefore assert width
-  // semantics, not the legacy `max-w-2xl` literal.
+  // The message column owns the available width, so the inner bubble only
+  // controls intrinsic sizing (`w-auto` vs `w-full`). Tests here therefore
+  // assert width semantics, not legacy max-width literals.
   it('keeps non-editing user bubbles auto-sized in full layout', () => {
     const className = getMessageBubbleClassName({
       compact: false,
@@ -386,26 +383,26 @@ describe('getMessageBubbleClassName', () => {
 });
 
 describe('getMessageGroupClassName', () => {
-  it('caps full-layout user messages at 80% width', () => {
+  it('caps full-layout user messages at 88% width', () => {
     const className = getMessageGroupClassName({
       compact: false,
       isUser: true,
       isEditing: false,
     });
 
-    expect(className).toContain('max-w-[80%]');
+    expect(className).toContain('max-w-[88%]');
     expect(className).toContain('w-fit');
   });
 
-  it('expands editing user messages to the 80% container width', () => {
+  it('expands editing user messages to the full content width', () => {
     const className = getMessageGroupClassName({
       compact: false,
       isUser: true,
       isEditing: true,
     });
 
-    expect(className).toContain('w-[80%]');
-    expect(className).toContain('max-w-[80%]');
+    expect(className).toContain('w-full');
+    expect(className).toContain('max-w-full');
   });
 
   it('keeps assistant messages full width in full layout', () => {

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -558,7 +558,7 @@ function ContextUsageRing({
         onClick={() => setOpen((value) => !value)}
       >
         <svg className="absolute inset-0 h-6 w-6 -rotate-90" viewBox="0 0 24 24" aria-hidden="true">
-          <circle cx="12" cy="12" r={radius} fill="none" strokeWidth="2" className="stroke-zinc-200" />
+          <circle cx="12" cy="12" r={radius} fill="none" strokeWidth="2" className="stroke-zinc-200 dark:stroke-zinc-800" />
           <circle
             cx="12"
             cy="12"
@@ -577,24 +577,24 @@ function ContextUsageRing({
         <div
           role="menu"
           aria-label={t('chat.contextUsage.title')}
-          className="absolute bottom-full right-0 z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white text-zinc-800 shadow-sm"
+          className="absolute bottom-full right-0 z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white text-zinc-800 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-200 dark:shadow-xl dark:shadow-black/30"
         >
-          <div className="border-b border-zinc-100 px-2.5 py-1.5">
+          <div className="border-b border-zinc-100 px-2.5 py-1.5 dark:border-zinc-800">
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0">
-                <div className="truncate text-xs font-semibold text-zinc-700">{t('chat.contextUsage.title')}</div>
-                <div className="truncate text-[10px] text-zinc-400">
+                <div className="truncate text-xs font-semibold text-zinc-700 dark:text-zinc-100">{t('chat.contextUsage.title')}</div>
+                <div className="truncate text-[10px] text-zinc-400 dark:text-zinc-500">
                   {t('chat.contextUsage.tokens', {
                     used: formatTokenCount(usedTokens),
                     total: formatTokenCount(totalTokens),
                   })}
                 </div>
               </div>
-              <span className="shrink-0 rounded bg-zinc-50 px-1.5 py-0.5 text-[10px] font-medium text-zinc-500">
+              <span className="shrink-0 rounded bg-zinc-50 px-1.5 py-0.5 text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-300">
                 {t('chat.contextUsage.full', { percent: clamped })}
               </span>
             </div>
-            <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-zinc-100">
+            <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
               <div
                 className="flex h-full overflow-hidden rounded-full"
                 style={{ width: `${clamped}%` }}
@@ -618,15 +618,15 @@ function ContextUsageRing({
               <div
                 key={segment.key}
                 role="menuitem"
-                className="flex min-w-0 items-center justify-between gap-3 rounded-md px-2 py-1.5 text-xs text-zinc-700"
+                className="flex min-w-0 items-center justify-between gap-3 rounded-md px-2 py-1.5 text-xs text-zinc-700 dark:text-zinc-300"
               >
                 <div className="flex min-w-0 items-center gap-2">
                   <span className={`h-3 w-3 shrink-0 rounded-[3px] ${segment.colorClass}`} />
-                  <span className="truncate font-medium text-zinc-800">
+                  <span className="truncate font-medium text-zinc-800 dark:text-zinc-100">
                     {getContextUsageLabel(t, segment.key)}
                   </span>
                 </div>
-                <span className={segment.included ? 'shrink-0 text-zinc-600' : 'shrink-0 text-zinc-400'}>
+                <span className={segment.included ? 'shrink-0 text-zinc-600 dark:text-zinc-300' : 'shrink-0 text-zinc-400 dark:text-zinc-500'}>
                   {segment.included
                     ? formatTokenCount(segment.tokens)
                     : t('chat.contextUsage.excludedTokens', { tokens: formatTokenCount(segment.tokens) })}
@@ -820,8 +820,8 @@ export function getMessageBubbleClassName({
   if (compact) {
     return `max-w-[90%] px-4 py-3 rounded-[20px] text-sm break-words shadow-sm ${
       isUser
-        ? 'bg-sky-50 border border-sky-100 text-zinc-900'
-        : 'bg-white border border-zinc-200/90'
+        ? 'bg-sky-50 border border-sky-100 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50 dark:shadow-none'
+        : 'bg-white border border-zinc-200/90 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100 dark:shadow-none'
     }`;
   }
 
@@ -831,13 +831,13 @@ export function getMessageBubbleClassName({
 
   return `${widthClass} px-5 py-4 rounded-[24px] text-sm break-words shadow-sm ${
     isUser
-      ? 'bg-sky-50 border border-sky-100 text-zinc-900'
-      : 'bg-white border border-zinc-200/90'
+      ? 'bg-sky-50 border border-sky-100 text-zinc-900 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50 dark:shadow-none'
+      : 'bg-white border border-zinc-200/90 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100 dark:shadow-none'
   }`;
 }
 
 export function getInstructionDisplayBubbleClassName(compact: boolean): string {
-  return `${compact ? 'px-2.5 py-1.5' : 'px-3 py-2'} rounded-lg border border-rose-100 bg-rose-50/80 text-sm text-rose-700 shadow-none`;
+  return `${compact ? 'px-2.5 py-1.5' : 'px-3 py-2'} rounded-lg border border-rose-100 bg-rose-50/80 text-sm text-rose-700 shadow-none dark:border-rose-500/30 dark:bg-rose-950/30 dark:text-rose-200`;
 }
 
 export function getMessageGroupClassName({
@@ -857,7 +857,7 @@ export function getMessageGroupClassName({
     return isEditing ? 'w-full max-w-[90%]' : 'w-fit max-w-[90%]';
   }
 
-  return isEditing ? 'w-[80%] max-w-[80%]' : 'w-fit max-w-[80%]';
+  return isEditing ? 'w-full max-w-full' : 'w-fit max-w-[88%]';
 }
 
 export function getCompactionDividerClassName(compact: boolean): string {
@@ -1116,40 +1116,40 @@ function QueuedPromptPanel({
   if (items.length === 0) return null;
 
   return (
-    <div className="mb-2 rounded-xl border border-zinc-200 bg-zinc-950/[0.02] overflow-hidden">
+    <div className="mb-2 overflow-hidden rounded-xl border border-zinc-200 bg-zinc-950/[0.02] dark:border-zinc-800 dark:bg-zinc-900/60">
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-zinc-600 hover:bg-zinc-100/70 transition-colors"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-zinc-600 transition-colors hover:bg-zinc-100/70 dark:text-zinc-300 dark:hover:bg-zinc-800"
       >
         <ChevronDown className={`h-3.5 w-3.5 transition-transform ${expanded ? '' : '-rotate-90'}`} />
         <span>{t('chat.queue.count', { count: items.length })}</span>
       </button>
       {expanded && (
-        <div className="max-h-40 overflow-y-auto border-t border-zinc-200">
+        <div className="max-h-40 overflow-y-auto border-t border-zinc-200 dark:border-zinc-800">
           {items.map((item) => {
             const isEditing = editingId === item.id;
             const isBusy = actionId === item.id || item.status === 'executing';
             const text = getQueuedPromptText(item);
             const instructionLabel = parseInstructionDisplayText(text);
             return (
-              <div key={item.id} className="flex items-start gap-2 px-3 py-2 border-b border-zinc-100 last:border-b-0">
-                <div className="mt-1 h-2 w-2 rounded-full border border-zinc-400 flex-shrink-0" />
+              <div key={item.id} className="flex items-start gap-2 border-b border-zinc-100 px-3 py-2 last:border-b-0 dark:border-zinc-800">
+                <div className="mt-1 h-2 w-2 flex-shrink-0 rounded-full border border-zinc-400 dark:border-zinc-500" />
                 <div className="min-w-0 flex-1">
                   {isEditing ? (
                     <textarea
                       value={editingText}
                       onChange={(event) => onEditChange(event.target.value)}
-                      className="w-full resize-none rounded-lg border border-zinc-200 bg-white px-2 py-1.5 text-xs text-zinc-800 outline-none focus:border-zinc-300 focus:ring-2 focus:ring-zinc-100"
+                      className="w-full resize-none rounded-lg border border-zinc-200 bg-white px-2 py-1.5 text-xs text-zinc-800 outline-none focus:border-zinc-300 focus:ring-2 focus:ring-zinc-100 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100 dark:focus:border-zinc-700 dark:focus:ring-zinc-800/70"
                       rows={2}
                     />
                   ) : (
                     instructionLabel ? (
-                      <span className="inline-flex max-w-full items-center truncate rounded-md border border-rose-100 bg-rose-50 px-2 py-1 text-xs font-semibold leading-none text-rose-700">
+                      <span className="inline-flex max-w-full items-center truncate rounded-md border border-rose-100 bg-rose-50 px-2 py-1 text-xs font-semibold leading-none text-rose-700 dark:border-rose-500/30 dark:bg-rose-950/30 dark:text-rose-200">
                         {instructionLabel}
                       </span>
                     ) : (
-                      <div className="line-clamp-2 text-xs text-zinc-700">{text || t('chat.queue.attachmentOnly')}</div>
+                      <div className="line-clamp-2 text-xs text-zinc-700 dark:text-zinc-300">{text || t('chat.queue.attachmentOnly')}</div>
                     )
                   )}
                 </div>
@@ -1160,7 +1160,7 @@ function QueuedPromptPanel({
                         type="button"
                         onClick={() => onEditSave(item)}
                         disabled={isBusy || !editingText.trim()}
-                        className="rounded p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 disabled:opacity-40"
+                        className="rounded p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 disabled:opacity-40 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
                         title={t('chat.save')}
                       >
                         <Save className="h-3.5 w-3.5" />
@@ -1169,7 +1169,7 @@ function QueuedPromptPanel({
                         type="button"
                         onClick={onEditCancel}
                         disabled={isBusy}
-                        className="rounded p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 disabled:opacity-40"
+                        className="rounded p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 disabled:opacity-40 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
                         title={t('chat.cancel')}
                       >
                         <X className="h-3.5 w-3.5" />
@@ -1181,7 +1181,7 @@ function QueuedPromptPanel({
                         type="button"
                         onClick={() => onEditStart(item)}
                         disabled={isBusy}
-                        className="rounded p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 disabled:opacity-40"
+                        className="rounded p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 disabled:opacity-40 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
                         title={t('chat.queue.edit')}
                       >
                         <Pencil className="h-3.5 w-3.5" />
@@ -1190,7 +1190,7 @@ function QueuedPromptPanel({
                         type="button"
                         onClick={() => onRunNow(item)}
                         disabled={isBusy}
-                        className="rounded p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 disabled:opacity-40"
+                        className="rounded p-1 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800 disabled:opacity-40 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
                         title={t('chat.queue.runNow')}
                       >
                         <ArrowUp className="h-3.5 w-3.5" />
@@ -1199,7 +1199,7 @@ function QueuedPromptPanel({
                         type="button"
                         onClick={() => onRemove(item)}
                         disabled={isBusy}
-                        className="rounded p-1 text-zinc-500 hover:bg-red-50 hover:text-red-600 disabled:opacity-40"
+                        className="rounded p-1 text-zinc-500 hover:bg-red-50 hover:text-red-600 disabled:opacity-40 dark:text-zinc-400 dark:hover:bg-red-950/40 dark:hover:text-red-300"
                         title={t('chat.queue.remove')}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
@@ -2801,12 +2801,12 @@ export default function SessionChat({
 
   // ── Styling based on compact mode ──
   const msgAreaClass = compact
-    ? 'relative flex flex-col flex-1 min-h-0 overflow-y-auto bg-gray-50 px-4 py-4'
-    : 'relative flex flex-col flex-1 min-h-0 overflow-y-auto bg-gray-50 py-6';
+    ? 'relative flex flex-col flex-1 min-h-0 overflow-y-auto bg-gray-50 px-4 py-4 dark:bg-zinc-950'
+    : 'relative flex flex-col flex-1 min-h-0 overflow-y-auto bg-gray-50 py-6 dark:bg-zinc-950';
 
   const msgListClass = compact
     ? fullWidth ? 'space-y-3 w-full px-4' : 'space-y-3'
-    : fullWidth ? 'space-y-5 w-full px-5' : 'space-y-5 w-[min(76%,64rem)] mx-auto pl-4 pr-8';
+    : fullWidth ? 'space-y-5 w-full px-5' : 'space-y-5 w-[min(76%,64rem)] mx-auto px-6';
 
   return (
     <div className={`flex flex-col min-h-0 ${className}`}>
@@ -2874,20 +2874,20 @@ export default function SessionChat({
             {/* Compacting indicator with live progress stages */}
             {isCompacting && (
               <div className={`group relative ${!compact ? 'w-full' : ''} flex`}>
-                <div className={`flex gap-2.5 ${getMessageGroupClassName({ compact, isUser: false, isEditing: false })}`}>
+                <div className={compact ? `flex gap-2.5 ${getMessageGroupClassName({ compact, isUser: false, isEditing: false })}` : 'flex w-full min-w-0'}>
                   <span
-                    className={`inline-flex items-center justify-center rounded-full bg-red-500 text-white font-bold shadow-sm ring-2 ring-white flex-shrink-0 ${
+                    className={`inline-flex items-center justify-center rounded-full bg-red-500 text-white font-bold shadow-sm ring-2 ring-white flex-shrink-0 dark:ring-zinc-950 ${
                       compact ? 'w-7 h-7 text-xs' : 'w-8 h-8 text-sm'
-                    }`}
+                    } ${compact ? '' : 'absolute -left-10 top-1'}`}
                   >
                     {formatAgentName(pendingAgentName).charAt(0).toUpperCase()}
                   </span>
                   <div className="flex flex-col items-start flex-1 min-w-0">
                     <div className={`flex items-center gap-2 ${compact ? 'h-7' : 'h-8'}`}>
-                      <span className="text-xs font-semibold text-zinc-700">{formatAgentName(pendingAgentName)}</span>
+                      <span className="text-xs font-semibold text-zinc-700 dark:text-zinc-300">{formatAgentName(pendingAgentName)}</span>
                     </div>
                     <div className="flex flex-col min-w-0 w-full">
-                      <div className={`${compact ? 'max-w-[90%] px-4 py-3 rounded-[20px]' : 'w-full px-5 py-4 rounded-[24px]'} text-sm break-words shadow-sm bg-amber-50 border border-amber-200`}>
+                      <div className={`${compact ? 'max-w-[90%] px-4 py-3 rounded-[20px]' : 'w-full px-5 py-4 rounded-[24px]'} text-sm break-words shadow-sm bg-amber-50 border border-amber-200 dark:border-amber-500/35 dark:bg-amber-950/30 dark:shadow-none`}>
                         <div className="flex items-center gap-2 text-sm text-amber-700">
                           <Loader2 className="w-4 h-4 animate-spin text-amber-500" />
                           <span>{compactingMessage || t('chat.compacting')}</span>
@@ -2932,17 +2932,17 @@ export default function SessionChat({
             {/* Standalone thinking indicator when no incomplete message exists */}
             {(isStreaming || sending) && !isCompacting && !(messages.length > 0 && messages[messages.length - 1].role === 'assistant' && !messages[messages.length - 1].finish) && (
               <div className={`group relative ${!compact ? 'w-full' : ''} flex`}>
-                <div className={`flex gap-2.5 ${getMessageGroupClassName({ compact, isUser: false, isEditing: false })}`}>
+                <div className={compact ? `flex gap-2.5 ${getMessageGroupClassName({ compact, isUser: false, isEditing: false })}` : 'flex w-full min-w-0'}>
                   <span
-                    className={`inline-flex items-center justify-center rounded-full bg-red-500 text-white font-bold shadow-sm ring-2 ring-white flex-shrink-0 ${
+                    className={`inline-flex items-center justify-center rounded-full bg-red-500 text-white font-bold shadow-sm ring-2 ring-white flex-shrink-0 dark:ring-zinc-950 ${
                       compact ? 'w-7 h-7 text-xs' : 'w-8 h-8 text-sm'
-                    }`}
+                    } ${compact ? '' : 'absolute -left-10 top-1'}`}
                   >
                     {formatAgentName(pendingAgentName).charAt(0).toUpperCase()}
                   </span>
                   <div className="flex flex-col items-start flex-1 min-w-0">
                     <div className={`flex items-center gap-2 ${compact ? 'h-7' : 'h-8'}`}>
-                      <span className="text-xs font-semibold text-zinc-700">{formatAgentName(pendingAgentName)}</span>
+                      <span className="text-xs font-semibold text-zinc-700 dark:text-zinc-300">{formatAgentName(pendingAgentName)}</span>
                     </div>
                     <div className="flex flex-col min-w-0 w-full">
                       <div className={getStandaloneThinkingBubbleClassName(compact)}>
@@ -2966,7 +2966,7 @@ export default function SessionChat({
 
       {/* Suggestions — shown before user sends any message */}
       {suggestions && suggestions.length > 0 && !hasUserMessage && !hideInput && (
-        <div className="flex-shrink-0 px-3 pt-2.5 pb-2 border-t border-gray-100 bg-white">
+        <div className="flex-shrink-0 px-3 pt-2.5 pb-2 border-t border-gray-100 bg-white dark:border-zinc-800 dark:bg-zinc-950">
           <div className="flex items-center gap-1.5 mb-2">
             <span className="text-xs font-medium text-gray-400">{t('chat.suggestions')}</span>
           </div>
@@ -2987,8 +2987,8 @@ export default function SessionChat({
 
       {/* Follow-up input */}
       {!hideInput && (
-        <div className={`flex-shrink-0 bg-white ${compact ? 'px-4 py-3' : 'py-4'}`}>
-          <div className={`relative min-w-0 ${!compact ? (fullWidth ? 'w-full px-5' : 'w-[min(76%,64rem)] mx-auto pr-8 pl-[58px]') : ''}`}>
+        <div className={`flex-shrink-0 bg-white ${compact ? 'px-4 py-3' : 'py-4'} dark:bg-zinc-950`}>
+          <div className={`relative min-w-0 ${!compact ? (fullWidth ? 'w-full px-5' : 'w-[min(76%,64rem)] mx-auto px-6') : ''}`}>
             {conversationBottomSlot && (
               <div className="mb-2 min-w-0">
                 {typeof conversationBottomSlot === 'function'
@@ -3056,20 +3056,20 @@ export default function SessionChat({
               onDrop={handleComposerDrop}
               className={`rounded-2xl border transition-all ${
                 isCompacting
-                  ? 'border-amber-200 bg-amber-50/30'
+                  ? 'border-amber-200 bg-amber-50/30 dark:border-amber-500/35 dark:bg-amber-950/25'
                   : isDragOver
-                    ? 'border-sky-300 bg-sky-50/60 ring-4 ring-sky-100'
+                    ? 'border-sky-300 bg-sky-50/60 ring-4 ring-sky-100 dark:border-sky-500/50 dark:bg-sky-950/35 dark:ring-sky-500/10'
                     : isStreaming
-                      ? 'border-zinc-200 bg-zinc-50'
-                      : 'border-zinc-200 bg-zinc-50 hover:border-zinc-300 focus-within:border-zinc-300 focus-within:bg-white focus-within:ring-4 focus-within:ring-zinc-100'
+                      ? 'border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900/70'
+                      : 'border-zinc-200 bg-zinc-50 hover:border-zinc-300 focus-within:border-zinc-300 focus-within:bg-white focus-within:ring-4 focus-within:ring-zinc-100 dark:border-zinc-800 dark:bg-zinc-900/70 dark:hover:border-zinc-700 dark:focus-within:border-zinc-700 dark:focus-within:bg-zinc-900 dark:focus-within:ring-zinc-800/60'
               }`}
             >
                 {/* Node reference chip */}
                 {nodeRef && (
                   <div className="flex items-center gap-1.5 px-3 pt-2.5 pb-1">
                     <span className="w-1.5 h-1.5 rounded-full bg-slate-400 flex-shrink-0" />
-                    <code className="text-[11px] font-mono font-semibold text-slate-700 truncate flex-1">{nodeRef.id}</code>
-                    <span className="text-[10px] text-slate-400 flex-shrink-0">{nodeRef.type}</span>
+                    <code className="text-[11px] font-mono font-semibold text-slate-700 truncate flex-1 dark:text-slate-200">{nodeRef.id}</code>
+                    <span className="text-[10px] text-slate-400 flex-shrink-0 dark:text-slate-500">{nodeRef.type}</span>
                     {onNodeRefDismiss && (
                       <button
                         onClick={onNodeRefDismiss}
@@ -3096,7 +3096,7 @@ export default function SessionChat({
                           <div
                             key={attachment.id}
                             className={`relative flex-shrink-0 rounded-lg border overflow-hidden ${
-                              isUploading ? 'border-sky-200 bg-sky-50' : 'border-gray-200 bg-gray-50'
+                              isUploading ? 'border-sky-200 bg-sky-50 dark:border-sky-500/35 dark:bg-sky-950/30' : 'border-gray-200 bg-gray-50 dark:border-zinc-800 dark:bg-zinc-900'
                             }`}
                           >
                             {isUploading ? (
@@ -3134,7 +3134,7 @@ export default function SessionChat({
                               ? 'border-red-200 bg-red-50 text-red-700'
                               : isUploading
                                 ? 'border-sky-200 bg-sky-50 text-sky-700'
-                                : 'border-gray-200 bg-gray-50 text-gray-700'
+                                : 'border-gray-200 bg-gray-50 text-gray-700 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-200'
                           }`}
                         >
                           {isUploading ? (
@@ -3224,8 +3224,8 @@ export default function SessionChat({
                             ? t('chat.placeholderNodeRef', { nodeId: nodeRef.id })
                             : effectivePlaceholder
                     }
-                    className={`w-full resize-none outline-none bg-transparent text-sm placeholder-zinc-400 ${
-                      sending ? 'text-zinc-400 cursor-not-allowed' : 'text-zinc-900'
+                    className={`w-full resize-none outline-none bg-transparent text-sm placeholder-zinc-400 dark:placeholder-zinc-600 ${
+                      sending ? 'text-zinc-400 cursor-not-allowed dark:text-zinc-500' : 'text-zinc-900 dark:text-zinc-100'
                     }`}
                     style={{
                       minHeight: `${effectiveComposerTextareaMinHeight}px`,
@@ -3248,7 +3248,7 @@ export default function SessionChat({
                     <Paperclip className="h-4 w-4" />
                   </button>
 
-                  <div className="mx-1 h-4 w-px shrink-0 bg-zinc-200" />
+                  <div className="mx-1 h-4 w-px shrink-0 bg-zinc-200 dark:bg-zinc-800" />
 
                   {toolbarSlot}
 
@@ -3297,7 +3297,7 @@ export default function SessionChat({
                       className={`inline-flex h-8 w-8 items-center justify-center rounded-full transition-all ${
                         canSend
                           ? 'bg-sky-500 text-white hover:bg-sky-600 shadow-sm hover:shadow'
-                          : 'bg-zinc-200 text-zinc-400 cursor-not-allowed'
+                          : 'bg-zinc-200 text-zinc-400 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-600'
                       }`}
                     >
                       {sending || hasUploadingFiles ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowUp className="w-4 h-4" strokeWidth={2.5} />}
@@ -3344,10 +3344,10 @@ function AgentMentionDropdown({
 
   return (
     <div
-      className="absolute bottom-full left-0 right-0 mb-1 z-50 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg"
+      className="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-xl dark:shadow-black/30"
       onMouseDown={(e) => e.preventDefault()}
     >
-      <div className="border-b border-gray-100 bg-gray-50 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400">
+      <div className="border-b border-gray-100 bg-gray-50 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-gray-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-500">
         {t('chat.mention.title')}
       </div>
       <div ref={listRef} className="max-h-64 overflow-y-auto p-1">
@@ -3360,17 +3360,17 @@ function AgentMentionDropdown({
               onClick={() => onSelect(agent)}
               onMouseDown={(e) => e.preventDefault()}
               className={`flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors ${
-                idx === selectedIndex ? 'bg-sky-50 text-sky-800' : 'text-gray-800 hover:bg-gray-50'
+                idx === selectedIndex ? 'bg-sky-50 text-sky-800 dark:bg-sky-950/45 dark:text-sky-100' : 'text-gray-800 hover:bg-gray-50 dark:text-zinc-200 dark:hover:bg-zinc-800'
               }`}
             >
-              <Bot className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+              <Bot className="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-zinc-500" />
               <span className="shrink-0 font-mono text-sm font-semibold">@{agent.name}</span>
-              <span className="min-w-0 truncate text-xs text-gray-500">{desc}</span>
+              <span className="min-w-0 truncate text-xs text-gray-500 dark:text-zinc-400">{desc}</span>
             </button>
           );
         })}
       </div>
-      <div className="flex gap-3 border-t border-gray-100 bg-gray-50 px-3 py-1 text-[10px] text-gray-400">
+      <div className="flex gap-3 border-t border-gray-100 bg-gray-50 px-3 py-1 text-[10px] text-gray-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-500">
         <span><kbd className="font-mono">↑↓</kbd> {t('chat.mention.navigate')}</span>
         <span><kbd className="font-mono">Enter</kbd>/<kbd className="font-mono">Tab</kbd> {t('chat.mention.select')}</span>
       </div>
@@ -3475,18 +3475,18 @@ function ChatMessageBubbleInner({
   const messageGroupClass = getMessageGroupClassName({ compact, isUser, isEditing });
   const actionBarClass = `flex items-center gap-1.5`;
   const editingActionBarClass = getEditingActionBarClassName();
-  const iconButtonClass = 'group/action relative inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200/80 bg-white/80 text-gray-400 transition-colors duration-150 hover:border-gray-300 hover:text-gray-700 disabled:opacity-40 disabled:cursor-not-allowed';
+  const iconButtonClass = 'group/action relative inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200/80 bg-white/80 text-gray-400 transition-colors duration-150 hover:border-gray-300 hover:text-gray-700 disabled:opacity-40 disabled:cursor-not-allowed dark:border-zinc-800 dark:bg-zinc-900/80 dark:text-zinc-500 dark:hover:border-zinc-700 dark:hover:text-zinc-200';
   const tooltipClass = 'pointer-events-none absolute bottom-full left-1/2 z-10 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-[11px] font-medium text-white opacity-0 shadow-sm transition-opacity duration-150 group-hover/action:opacity-100';
   const messageErrorText = isUser ? '' : getMessageErrorText(message);
 
   const avatarSize = compact ? 'w-7 h-7 text-xs' : 'w-8 h-8 text-sm';
 
   const avatar = isUser ? (
-    <span className={`inline-flex items-center justify-center rounded-full bg-gradient-to-b from-sky-400 to-blue-500 text-white shadow-sm ring-2 ring-white flex-shrink-0 ${avatarSize}`}>
+    <span className={`inline-flex items-center justify-center rounded-full bg-gradient-to-b from-sky-400 to-blue-500 text-white shadow-sm ring-2 ring-white flex-shrink-0 dark:ring-zinc-950 ${avatarSize}`}>
       <User className={compact ? 'w-3 h-3' : 'w-3.5 h-3.5'} />
     </span>
   ) : (
-    <span className={`inline-flex items-center justify-center rounded-full bg-red-500 text-white font-bold shadow-sm ring-2 ring-white flex-shrink-0 ${avatarSize}`}>
+    <span className={`inline-flex items-center justify-center rounded-full bg-red-500 text-white font-bold shadow-sm ring-2 ring-white flex-shrink-0 dark:ring-zinc-950 ${avatarSize}`}>
       {agentName.charAt(0).toUpperCase()}
     </span>
   );
@@ -3857,6 +3857,27 @@ function ChatMessageBubbleInner({
   ) : null;
 
   if (isUser) {
+    if (!compact) {
+      return (
+        <div className="group relative flex w-full min-w-0 justify-end">
+          <div className={`flex min-w-0 flex-col items-end ${isEditing ? 'w-full' : 'max-w-[88%]'}`}>
+            {bubble}
+            {footer}
+          </div>
+          <div className="absolute -right-10 top-1">
+            {avatar}
+          </div>
+          {previewImage && (
+            <ImageLightbox
+              src={previewImage.url}
+              alt={previewImage.alt}
+              onClose={() => setPreviewImage(null)}
+            />
+          )}
+        </div>
+      );
+    }
+
     return (
       <div className={`group relative ${!compact ? 'w-full' : ''} flex min-w-0 justify-end`}>
         <div className={`flex min-w-0 items-start justify-end gap-2 ${messageGroupClass}`}>
@@ -3879,13 +3900,41 @@ function ChatMessageBubbleInner({
     );
   }
 
+  if (!compact) {
+    return (
+      <div className="group relative flex w-full min-w-0">
+        <div className="absolute -left-10 top-1">
+          {avatar}
+        </div>
+        <div className="flex w-full min-w-0 flex-col items-start">
+          <div className={`flex items-center gap-2 ${headerHeight}`}>
+            <span className="text-xs font-semibold text-zinc-700 dark:text-zinc-300">
+              {agentName}
+            </span>
+          </div>
+          <div className="flex w-full min-w-0 flex-col">
+            {bubble}
+            {footer}
+          </div>
+        </div>
+        {previewImage && (
+          <ImageLightbox
+            src={previewImage.url}
+            alt={previewImage.alt}
+            onClose={() => setPreviewImage(null)}
+          />
+        )}
+      </div>
+    );
+  }
+
   return (
-    <div className={`group relative ${!compact ? 'w-full' : ''} flex`}>
+    <div className="group relative flex">
       <div className={`flex gap-2.5 ${messageGroupClass}`}>
         {avatar}
         <div className="flex flex-col items-start flex-1 min-w-0">
           <div className={`flex items-center gap-2 ${headerHeight}`}>
-            <span className="text-xs font-semibold text-zinc-700">
+            <span className="text-xs font-semibold text-zinc-700 dark:text-zinc-300">
               {agentName}
             </span>
           </div>

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -3297,7 +3297,7 @@ export default function SessionChat({
                       className={`inline-flex h-8 w-8 items-center justify-center rounded-full transition-all ${
                         canSend
                           ? 'bg-sky-500 text-white hover:bg-sky-600 shadow-sm hover:shadow'
-                          : 'bg-zinc-200 text-zinc-400 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-600'
+                          : 'cursor-not-allowed border border-zinc-300 bg-zinc-200 text-zinc-400 dark:border-[#5a6573] dark:bg-[#46515e] dark:text-[#b8c2cc]'
                       }`}
                     >
                       {sending || hasUploadingFiles ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArrowUp className="w-4 h-4" strokeWidth={2.5} />}

--- a/webui/src/components/common/ThemeToggle.tsx
+++ b/webui/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { Moon, Sun } from 'lucide-react';
+import { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ThemeContext } from '@/contexts/ThemeContext';
+
+interface ThemeToggleProps {
+  collapsed?: boolean;
+}
+
+export default function ThemeToggle({ collapsed = false }: ThemeToggleProps) {
+  const { theme, toggleTheme } = useContext(ThemeContext);
+  const { t } = useTranslation('nav');
+  const isDark = theme === 'dark';
+  const Icon = isDark ? Sun : Moon;
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      title={isDark ? t('switchToLightTheme') : t('switchToDarkTheme')}
+      aria-label={isDark ? t('switchToLightTheme') : t('switchToDarkTheme')}
+      aria-pressed={isDark}
+      className={`
+        flex items-center justify-center rounded-lg transition-colors
+        text-zinc-500 hover:bg-white/70 hover:text-zinc-900
+        dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100
+        ${collapsed ? 'h-8 w-8' : 'h-8 w-8'}
+      `}
+    >
+      <Icon className="h-4 w-4" />
+    </button>
+  );
+}

--- a/webui/src/components/layout/AuthLayout.tsx
+++ b/webui/src/components/layout/AuthLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import ThemeToggle from '@/components/common/ThemeToggle';
 
 const LANGUAGES = [
   { code: 'en-US', label: 'EN' },
@@ -16,14 +17,14 @@ export default function AuthLayout({ children }: AuthLayoutProps) {
   const currentLang = i18n.language;
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
+    <div className="min-h-screen bg-gray-50 flex flex-col dark:bg-[#252c35]">
       <div className="flex justify-end px-4 pt-4">
         <div
-          className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2 py-1 shadow-sm"
+          className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2 py-1 shadow-sm dark:border-[#4a5563] dark:bg-[#303842]"
           role="group"
           aria-label={t('switchLanguage')}
         >
-          <Globe className="mx-1 h-3.5 w-3.5 text-gray-400" aria-hidden />
+          <Globe className="mx-1 h-3.5 w-3.5 text-gray-400 dark:text-[#9aa7b4]" aria-hidden />
           {LANGUAGES.map(({ code, label }) => (
             <button
               key={code}
@@ -31,13 +32,15 @@ export default function AuthLayout({ children }: AuthLayoutProps) {
               onClick={() => i18n.changeLanguage(code)}
               className={`px-2.5 py-1 text-xs font-medium rounded-full transition-colors ${
                 currentLang === code
-                  ? 'bg-slate-900 text-white'
-                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
+                  ? 'bg-slate-900 text-white dark:bg-[#46515e] dark:text-white'
+                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-[#b8c2cc] dark:hover:bg-[#3a434e] dark:hover:text-white'
               }`}
             >
               {label}
             </button>
           ))}
+          <div className="ml-1 h-5 w-px bg-gray-200 dark:bg-[#4a5563]" />
+          <ThemeToggle />
         </div>
       </div>
       <div className="flex-1 flex items-center justify-center p-6">

--- a/webui/src/components/layout/Layout.tsx
+++ b/webui/src/components/layout/Layout.tsx
@@ -25,6 +25,7 @@ import {
 import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '@/components/common/LanguageSwitcher';
+import ThemeToggle from '@/components/common/ThemeToggle';
 // Modals are only rendered after the user clicks/triggers them; pulling them
 // into the eager Layout chunk costs ~1.7k LOC + i18n keys + lucide icons that
 // the home page never needs. To keep the lazy split effective, we don't
@@ -478,7 +479,7 @@ export default function Layout() {
     : productName;
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-zinc-950 dark:text-zinc-100">
       {/* Modals render lazily — fallback={null} keeps the chunk download
           invisible to the user (they're already triggering an async UI). */}
       <Suspense fallback={null}>
@@ -509,14 +510,14 @@ export default function Layout() {
 
       {sidebarOpen && (
         <div
-          className="fixed inset-0 bg-gray-600 bg-opacity-75 z-40 lg:hidden"
+          className="fixed inset-0 bg-gray-600 bg-opacity-75 z-40 lg:hidden dark:bg-black dark:bg-opacity-75"
           onClick={() => setSidebarOpen(false)}
         />
       )}
 
       <aside
         className={`
-          fixed inset-y-0 left-0 z-50 bg-zinc-100 border-r border-zinc-200
+          fixed inset-y-0 left-0 z-50 bg-zinc-100 border-r border-zinc-200 dark:bg-zinc-950 dark:border-zinc-800
           transition-all duration-300 ease-in-out
           lg:translate-x-0
           ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
@@ -525,20 +526,20 @@ export default function Layout() {
       >
         <div className="flex flex-col h-full overflow-hidden">
           {/* Logo */}
-          <div className={`flex items-center h-16 border-b border-zinc-200 flex-shrink-0 ${collapsed ? 'justify-center px-2' : 'pl-6 pr-4'}`}>
+          <div className={`flex items-center h-16 border-b border-zinc-200 flex-shrink-0 dark:border-zinc-800 ${collapsed ? 'justify-center px-2' : 'pl-6 pr-4'}`}>
             {collapsed ? (
               <div
-                className="w-8 h-8 rounded-lg border border-zinc-200 bg-white flex items-center justify-center flex-shrink-0 shadow-sm"
+                className="w-8 h-8 rounded-lg border border-zinc-200 bg-white flex items-center justify-center flex-shrink-0 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
                 title={productName}
               >
-                <Sparkles className="w-4 h-4 text-zinc-500" />
+                <Sparkles className="w-4 h-4 text-zinc-500 dark:text-zinc-300" />
               </div>
             ) : (
               <>
-                <span className="flex-1 min-w-0 text-xl font-bold text-zinc-900 whitespace-nowrap">{productName}</span>
+                <span className="flex-1 min-w-0 text-xl font-bold text-zinc-900 whitespace-nowrap dark:text-zinc-50">{productName}</span>
                 <button
                   onClick={() => setSidebarOpen(false)}
-                  className="lg:hidden p-1 text-zinc-400 hover:text-zinc-600 rounded flex-shrink-0"
+                  className="lg:hidden p-1 text-zinc-400 hover:text-zinc-600 rounded flex-shrink-0 dark:hover:text-zinc-100"
                 >
                   <X className="w-5 h-5" />
                 </button>
@@ -551,11 +552,11 @@ export default function Layout() {
             {navigation.map((section) => (
               <div key={section.name} className="mb-6">
                 {!collapsed && section.name && (
-                  <h3 className="px-3 mb-2 text-xs font-semibold text-zinc-400 uppercase tracking-wider whitespace-nowrap">
+                  <h3 className="px-3 mb-2 text-xs font-semibold text-zinc-400 uppercase tracking-wider whitespace-nowrap dark:text-zinc-500">
                     {section.name}
                   </h3>
                 )}
-                {collapsed && <div className="mb-1 border-t border-zinc-200 first:border-none" />}
+                {collapsed && <div className="mb-1 border-t border-zinc-200 first:border-none dark:border-zinc-800" />}
                 <div className="space-y-0.5">
                   {section.items.map((item) => {
                     const isActive = location.pathname === item.href
@@ -570,13 +571,13 @@ export default function Layout() {
                           flex items-center rounded-lg transition-all duration-150
                           ${collapsed ? 'justify-center p-2.5' : 'px-3 py-2 text-sm font-medium'}
                           ${isActive
-                            ? 'bg-white text-zinc-900 shadow-sm'
-                            : 'text-zinc-600 hover:bg-white/60 hover:text-zinc-900'
+                            ? 'bg-white text-zinc-900 shadow-sm dark:bg-zinc-800 dark:text-zinc-50'
+                            : 'text-zinc-600 hover:bg-white/60 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-900 dark:hover:text-zinc-50'
                           }
                         `}
                       >
                         <item.icon
-                          className={`flex-shrink-0 w-5 h-5 ${collapsed ? '' : 'mr-3'} ${isActive ? 'text-zinc-700' : 'text-zinc-400'}`}
+                          className={`flex-shrink-0 w-5 h-5 ${collapsed ? '' : 'mr-3'} ${isActive ? 'text-zinc-700 dark:text-zinc-100' : 'text-zinc-400 dark:text-zinc-500'}`}
                         />
                         {!collapsed && (
                           <span className="truncate">{item.name}</span>
@@ -590,41 +591,44 @@ export default function Layout() {
           </nav>
 
           {/* Bottom: Language switcher + version */}
-          <div className={`border-t border-zinc-200 flex-shrink-0 ${collapsed ? 'p-2 flex flex-col items-center gap-2' : 'p-4'}`}>
-            <LanguageSwitcher collapsed={collapsed} />
+          <div className={`border-t border-zinc-200 flex-shrink-0 dark:border-zinc-800 ${collapsed ? 'p-2 flex flex-col items-center gap-2' : 'p-4'}`}>
+            <div className={`flex ${collapsed ? 'flex-col items-center gap-2' : 'items-center gap-2'}`}>
+              <LanguageSwitcher collapsed={collapsed} />
+              <ThemeToggle collapsed={collapsed} />
+            </div>
             {!collapsed && (
               <>
                 {hasUpdate && canManageUpdates ? (
                   <button
                     onClick={() => setShowUpdate(true)}
-                    className="mt-3 w-full rounded-xl border border-amber-200 bg-gradient-to-r from-amber-50 via-orange-50 to-rose-50 px-3 py-2 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
+                    className="mt-3 w-full rounded-xl border border-amber-200 bg-gradient-to-r from-amber-50 via-orange-50 to-rose-50 px-3 py-2 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md dark:border-amber-500/30 dark:from-amber-950/60 dark:via-orange-950/50 dark:to-rose-950/50"
                   >
                     <div className="flex items-center gap-2 text-sm">
-                      <span className="min-w-0 flex-1 truncate font-semibold text-amber-900">
+                      <span className="min-w-0 flex-1 truncate font-semibold text-amber-900 dark:text-amber-100">
                         {t('newVersion')} {formatUpdateVersion(latestVersion) || ''}
                       </span>
                       <span className="inline-flex flex-shrink-0 items-center rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white shadow-sm">
                         {t('updateNow')}
                       </span>
                     </div>
-                    <div className="mt-1 text-xs text-amber-700">
+                    <div className="mt-1 text-xs text-amber-700 dark:text-amber-300">
                       {currentVersionLabel}
                     </div>
-                    <div className="mt-0.5 text-xs font-medium text-amber-900">
+                    <div className="mt-0.5 text-xs font-medium text-amber-900 dark:text-amber-100">
                       AI Native SecOps Platform
                     </div>
                   </button>
                 ) : (
                   <button
                     onClick={() => setShowUpdate(true)}
-                    className="w-full text-left mt-3 group rounded-lg px-1 py-1 hover:bg-white/60 transition-colors"
+                    className="w-full text-left mt-3 group rounded-lg px-1 py-1 hover:bg-white/60 transition-colors dark:hover:bg-zinc-900"
                   >
                     <div className="flex items-center gap-1.5">
-                      <span className="text-xs font-medium text-zinc-500 group-hover:text-zinc-800 transition-colors">
+                      <span className="text-xs font-medium text-zinc-500 group-hover:text-zinc-800 transition-colors dark:text-zinc-400 dark:group-hover:text-zinc-100">
                         {productName} {displayVersion || '...'}
                       </span>
                     </div>
-                    <div className="mt-0.5 text-xs text-zinc-400">AI Native SecOps Platform</div>
+                    <div className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">AI Native SecOps Platform</div>
                   </button>
                 )}
               </>
@@ -635,8 +639,8 @@ export default function Layout() {
                 title={hasUpdate && canManageUpdates ? t('hasNewVersion', { version: formatUpdateVersion(latestVersion) || '' }) : t('versionInfo')}
                 className={`relative rounded-xl p-2 transition-colors ${
                   hasUpdate && canManageUpdates
-                    ? 'bg-amber-50 text-amber-600 hover:bg-amber-100'
-                    : 'text-zinc-400 hover:text-zinc-600 hover:bg-white/60'
+                    ? 'bg-amber-50 text-amber-600 hover:bg-amber-100 dark:bg-amber-950/50 dark:text-amber-300 dark:hover:bg-amber-900/60'
+                    : 'text-zinc-400 hover:text-zinc-600 hover:bg-white/60 dark:hover:bg-zinc-900 dark:hover:text-zinc-100'
                 }`}
               >
                 {hasUpdate && canManageUpdates ? <ArrowUpCircle className="w-4 h-4" /> : <Sparkles className="w-4 h-4" />}
@@ -659,6 +663,7 @@ export default function Layout() {
             w-3 h-20 items-center justify-center
             bg-zinc-200 hover:bg-zinc-300 border border-r-0 border-zinc-200 rounded-l-lg
             text-zinc-400 hover:text-zinc-600
+            dark:bg-zinc-900 dark:hover:bg-zinc-800 dark:border-zinc-800 dark:text-zinc-500 dark:hover:text-zinc-100
             transition-all duration-200
           "
           title={collapsed ? t('expandNav') : t('collapseNav')}
@@ -671,7 +676,7 @@ export default function Layout() {
       <div className={`lg:hidden fixed top-0 left-0 z-30 flex items-center h-16 px-4 ${sidebarOpen ? 'hidden' : ''}`}>
         <button
           onClick={() => setSidebarOpen(true)}
-          className="p-2 text-gray-500 hover:text-gray-700 bg-white rounded-lg shadow-sm border border-gray-200"
+          className="p-2 text-gray-500 hover:text-gray-700 bg-white rounded-lg shadow-sm border border-gray-200 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
         >
           <Menu className="w-5 h-5" />
         </button>
@@ -681,7 +686,7 @@ export default function Layout() {
       <div
         className={`flex flex-col h-screen transition-all duration-300 ${collapsed ? 'lg:pl-16' : 'lg:pl-52'}`}
       >
-        <main className="flex-1 overflow-hidden bg-gray-50">
+        <main className="flex-1 overflow-hidden bg-gray-50 dark:bg-zinc-950">
           {isFullScreenPage ? (
             <Outlet />
           ) : (

--- a/webui/src/contexts/ThemeContext.test.tsx
+++ b/webui/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,100 @@
+import React, { useContext } from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ThemeContext, ThemeProvider } from './ThemeContext';
+
+function ThemeProbe() {
+  const { theme, toggleTheme, setTheme } = useContext(ThemeContext);
+
+  return (
+    <div>
+      <span data-testid="theme-value">{theme}</span>
+      <button type="button" onClick={toggleTheme}>
+        toggle
+      </button>
+      <button type="button" onClick={() => setTheme('dark')}>
+        set dark
+      </button>
+    </div>
+  );
+}
+
+function mockPreferredScheme(matchesDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)' ? matchesDark : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.colorScheme = '';
+    mockPreferredScheme(false);
+  });
+
+  it('uses system dark preference when no stored theme exists', async () => {
+    mockPreferredScheme(true);
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass('dark');
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+    await waitFor(() => expect(localStorage.getItem('flocks_theme')).toBe('dark'));
+  });
+
+  it('prefers the stored theme over system preference', async () => {
+    localStorage.setItem('flocks_theme', 'light');
+    mockPreferredScheme(true);
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark');
+    expect(document.documentElement.style.colorScheme).toBe('light');
+    await waitFor(() => expect(localStorage.getItem('flocks_theme')).toBe('light'));
+  });
+
+  it('toggles and persists the dark class on the document root', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark');
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'toggle' }));
+    });
+
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('dark');
+    expect(document.documentElement).toHaveClass('dark');
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+    await waitFor(() => expect(localStorage.getItem('flocks_theme')).toBe('dark'));
+  });
+});

--- a/webui/src/contexts/ThemeContext.tsx
+++ b/webui/src/contexts/ThemeContext.tsx
@@ -1,0 +1,63 @@
+import { createContext, useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const THEME_STORAGE_KEY = 'flocks_theme';
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => undefined,
+  setTheme: () => undefined,
+});
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+
+  const storage = window.localStorage;
+  const stored = typeof storage?.getItem === 'function' ? storage.getItem(THEME_STORAGE_KEY) : null;
+  if (stored === 'light' || stored === 'dark') return stored;
+
+  if (typeof window.matchMedia !== 'function') return 'light';
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  root.classList.toggle('dark', theme === 'dark');
+  root.style.colorScheme = theme;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useLayoutEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window.localStorage?.setItem === 'function') {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((nextTheme: Theme) => {
+    setThemeState(nextTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => (current === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = useMemo(() => ({ theme, toggleTheme, setTheme }), [setTheme, theme, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export { ThemeContext };

--- a/webui/src/locales/en-US/nav.json
+++ b/webui/src/locales/en-US/nav.json
@@ -23,6 +23,8 @@
   "expandNav": "Expand navigation",
   "collapseNav": "Collapse navigation",
   "switchLanguage": "Switch Language",
+  "switchToDarkTheme": "Switch to dark mode",
+  "switchToLightTheme": "Switch to light mode",
   "newVersion": "New Version",
   "hasNewVersion": "New version {{version}}",
   "versionInfo": "Flocks version info",

--- a/webui/src/locales/zh-CN/nav.json
+++ b/webui/src/locales/zh-CN/nav.json
@@ -23,6 +23,8 @@
   "expandNav": "展开导航",
   "collapseNav": "收起导航",
   "switchLanguage": "切换语言",
+  "switchToDarkTheme": "切换到深色模式",
+  "switchToLightTheme": "切换到浅色模式",
   "newVersion": "新版本",
   "hasNewVersion": "有新版本 {{version}}",
   "versionInfo": "Flocks 版本信息",

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -1215,8 +1215,8 @@ function GroupSidebar({ groups, devices, selectedGroupId, onSelect, onRename, on
 
                   {/* Hover action buttons */}
                   <div
-                    className="absolute right-1 inset-y-0 hidden group-hover/room:flex items-center gap-0.5 pl-4"
-                    style={{ background: `linear-gradient(to right, transparent, ${isSelected ? '#eff6ff' : '#f4f4f5'} 35%)` }}
+                    className="device-room-actions-fade absolute right-1 inset-y-0 hidden group-hover/room:flex items-center gap-0.5 pl-4"
+                    data-selected={isSelected ? 'true' : 'false'}
                   >
                     <button
                       onClick={(e) => startEdit(group, e)}

--- a/webui/src/pages/Login/index.tsx
+++ b/webui/src/pages/Login/index.tsx
@@ -34,25 +34,25 @@ export default function LoginPage() {
     <AuthLayout>
       <form
         onSubmit={onSubmit}
-        className="w-full max-w-md bg-white border border-gray-200 rounded-xl p-6 shadow-sm space-y-4"
+        className="w-full max-w-md bg-white border border-gray-200 rounded-xl p-6 shadow-sm space-y-4 dark:border-[#4a5563] dark:bg-[#303842] dark:shadow-xl dark:shadow-black/20"
       >
         <div>
-          <h1 className="text-xl font-semibold text-gray-900">{t('login.title')}</h1>
-          <p className="text-sm text-gray-500 mt-1">{t('login.description')}</p>
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-[#d7dee8]">{t('login.title')}</h1>
+          <p className="text-sm text-gray-500 mt-1 dark:text-[#b8c2cc]">{t('login.description')}</p>
         </div>
         <div>
-          <label className="text-sm text-gray-700 block mb-1">{t('fields.username')}</label>
+          <label className="text-sm text-gray-700 block mb-1 dark:text-[#d7dee8]">{t('fields.username')}</label>
           <input
             value={username}
             onChange={(e) => setUsername(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 outline-none focus:border-blue-500"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 outline-none focus:border-blue-500 dark:border-[#4a5563] dark:bg-[#252c35] dark:text-[#d7dee8] dark:placeholder:text-[#9aa7b4] dark:focus:border-[#539bf5]"
             placeholder={t('fields.usernamePlaceholder')}
             autoComplete="username"
             required
           />
         </div>
         <div>
-          <label className="text-sm text-gray-700 block mb-1">{t('fields.password')}</label>
+          <label className="text-sm text-gray-700 block mb-1 dark:text-[#d7dee8]">{t('fields.password')}</label>
           <PasswordInput
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -62,27 +62,27 @@ export default function LoginPage() {
           />
         </div>
         {error && (
-          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2 dark:border-red-400/30 dark:bg-red-500/15 dark:text-red-200">
             {error}
           </div>
         )}
         <button
           type="submit"
           disabled={submitting}
-          className="w-full bg-slate-900 text-white rounded-lg py-2.5 font-medium hover:bg-slate-800 disabled:opacity-60"
+          className="w-full bg-slate-900 text-white rounded-lg py-2.5 font-medium hover:bg-slate-800 disabled:opacity-60 dark:bg-[#46515e] dark:hover:bg-[#5a6573]"
         >
           {submitting ? t('actions.loggingIn') : t('actions.login')}
         </button>
-        <div className="space-y-2 text-xs text-gray-500 border-t border-gray-100 pt-3">
+        <div className="space-y-2 text-xs text-gray-500 border-t border-gray-100 pt-3 dark:border-[#4a5563] dark:text-[#b8c2cc]">
           <div>
             {t('login.recoverUsername')}
             {' '}
-            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-gray-700">flocks admin list-users</code>
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-gray-700 dark:bg-[#46515e] dark:text-[#d7dee8]">flocks admin list-users</code>
           </div>
           <div>
             {t('login.recoverPassword')}
             {' '}
-            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-gray-700">flocks admin generate-one-time-password --username admin</code>
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-gray-700 dark:bg-[#46515e] dark:text-[#d7dee8]">flocks admin generate-one-time-password --username admin</code>
           </div>
         </div>
       </form>

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -693,10 +693,10 @@ export default function SessionPage() {
   }
 
   return (
-    <div className="h-full w-full flex overflow-hidden">
+    <div className="h-full w-full flex overflow-hidden bg-gray-50 dark:bg-zinc-950">
       {/* ── Sidebar ── */}
       <div
-        className={`bg-white border-r border-gray-100 flex flex-col transition-all duration-300 flex-shrink-0 h-full overflow-hidden ${
+        className={`bg-white border-r border-gray-100 flex flex-col transition-all duration-300 flex-shrink-0 h-full overflow-hidden dark:border-zinc-800 dark:bg-zinc-950 ${
           sidebarCollapsed ? 'w-0' : 'w-64'
         }`}
       >
@@ -709,7 +709,7 @@ export default function SessionPage() {
             <button
               onClick={handleCreateSession}
               disabled={creating}
-              className="w-full pl-8 pr-3 py-2 text-left bg-white border border-gray-200 text-gray-700 rounded-lg hover:bg-gray-50 hover:border-gray-300 shadow-sm hover:shadow transition-all disabled:opacity-60 disabled:cursor-not-allowed text-sm font-medium"
+              className="w-full pl-8 pr-3 py-2 text-left bg-white border border-gray-200 text-gray-700 rounded-lg hover:bg-gray-50 hover:border-gray-300 shadow-sm hover:shadow transition-all disabled:opacity-60 disabled:cursor-not-allowed text-sm font-medium dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:border-zinc-700 dark:hover:bg-zinc-800"
             >
               {t('newSession')}
             </button>
@@ -720,7 +720,7 @@ export default function SessionPage() {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder={t('filterConversations', 'Filter conversations...')}
-              className="w-full pl-8 pr-3 py-1.5 text-sm bg-gray-100 rounded-lg border-0 outline-none focus:bg-gray-200 transition-colors placeholder:text-gray-400 text-gray-700"
+              className="w-full pl-8 pr-3 py-1.5 text-sm bg-gray-100 rounded-lg border-0 outline-none focus:bg-gray-200 transition-colors placeholder:text-gray-400 text-gray-700 dark:bg-zinc-900 dark:text-zinc-200 dark:placeholder:text-zinc-600 dark:focus:bg-zinc-800"
             />
           </div>
         </div>
@@ -748,7 +748,7 @@ export default function SessionPage() {
 
               return (
               <div key={key}>
-                <div className="px-4 pt-4 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wide select-none">
+                <div className="px-4 pt-4 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wide select-none dark:text-zinc-600">
                   {t(labelKey, labelKey)}
                 </div>
                 {visibleItems.map((session) => (
@@ -757,10 +757,10 @@ export default function SessionPage() {
                     onClick={() => selectMode ? handleToggleCheck(session.id) : setSelectedSessionId(session.id)}
                     className={`group relative mx-2 mb-1 px-3 py-2.5 rounded-xl border cursor-pointer transition-all duration-150 ${
                       !selectMode && selectedSessionId === session.id
-                        ? 'bg-gray-100 border-gray-300 shadow-sm'
+                        ? 'bg-gray-100 border-gray-300 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none'
                         : selectMode && checkedIds.has(session.id)
-                        ? 'bg-blue-50 border-blue-200'
-                        : 'border-gray-100 hover:border-gray-200 hover:bg-gray-50 hover:shadow-sm'
+                        ? 'bg-blue-50 border-blue-200 dark:border-blue-500/40 dark:bg-blue-950/30'
+                        : 'border-gray-100 hover:border-gray-200 hover:bg-gray-50 hover:shadow-sm dark:border-transparent dark:hover:border-zinc-800 dark:hover:bg-zinc-900 dark:hover:shadow-none'
                     }`}
                   >
                     {/* Title row */}
@@ -797,12 +797,12 @@ export default function SessionPage() {
                           }}
                           placeholder={t('renamePlaceholder')}
                           disabled={renameSubmitting}
-                          className="w-full min-w-0 rounded border border-blue-300 bg-white px-1.5 py-0.5 text-sm text-gray-900 outline-none focus:border-blue-400"
+                          className="w-full min-w-0 rounded border border-blue-300 bg-white px-1.5 py-0.5 text-sm text-gray-900 outline-none focus:border-blue-400 dark:border-blue-500/50 dark:bg-zinc-950 dark:text-zinc-100"
                           aria-label={t('rename')}
                           data-session-rename-input
                         />
                       ) : (
-                        <h3 className="font-semibold text-gray-900 truncate text-sm flex items-center gap-1.5">
+                        <h3 className="font-semibold text-gray-900 truncate text-sm flex items-center gap-1.5 dark:text-zinc-100">
                           <span className="truncate">{session.title}</span>
                           {session.isShared && (
                             <span className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-700">
@@ -814,7 +814,7 @@ export default function SessionPage() {
                     </div>
                     {/* Timestamp row */}
                     {session.time?.updated && renamingSessionId !== session.id && (
-                      <p className="mt-1 text-xs text-gray-400 truncate pl-0.5">
+                      <p className="mt-1 text-xs text-gray-400 truncate pl-0.5 dark:text-zinc-500">
                         {formatSessionDate(session.time.updated)}
                       </p>
                     )}
@@ -837,8 +837,8 @@ export default function SessionPage() {
                           title={t('moreActions')}
                           aria-label={t('moreActions')}
                           aria-expanded={openMenuSessionId === session.id}
-                          className={`p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-200 transition-all ${
-                            openMenuSessionId === session.id ? 'opacity-100 text-gray-600 bg-gray-200' : 'opacity-0 group-hover:opacity-100'
+                          className={`p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-200 transition-all dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 ${
+                            openMenuSessionId === session.id ? 'opacity-100 text-gray-600 bg-gray-200 dark:bg-zinc-800 dark:text-zinc-200' : 'opacity-0 group-hover:opacity-100'
                           }`}
                         >
                           <MoreHorizontal className="w-3.5 h-3.5" />
@@ -874,7 +874,7 @@ export default function SessionPage() {
 
         {/* Bottom：批量操作栏 / 批量选择入口 */}
         {sessions.length > 0 && (
-          <div className="border-t border-gray-100 px-3 pt-3 pb-4 flex-shrink-0">
+          <div className="border-t border-gray-100 px-3 pt-3 pb-4 flex-shrink-0 dark:border-zinc-800">
             {selectMode ? (
               <div className="grid grid-cols-3 gap-1.5">
                 <button
@@ -914,11 +914,11 @@ export default function SessionPage() {
       {/* ── Main area ── */}
       <div className="flex-1 flex flex-col overflow-hidden h-full min-w-0">
         {/* Header */}
-        <div className="px-6 h-12 border-b border-gray-200 bg-white flex items-center justify-between flex-shrink-0 relative">
+        <div className="px-6 h-12 border-b border-gray-200 bg-white flex items-center justify-between flex-shrink-0 relative dark:border-zinc-800 dark:bg-zinc-950/95">
           <div className="absolute left-4 top-1/2 -translate-y-1/2">
             <button
               onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-              className="p-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 shadow-sm hover:shadow-md transition-all duration-200"
+              className="p-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 shadow-sm hover:shadow-md transition-all duration-200 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:shadow-none"
               title={sidebarCollapsed ? t('showHistory') : t('hideHistory')}
             >
               {sidebarCollapsed ? <PanelLeft className="w-5 h-5" /> : <PanelLeftClose className="w-5 h-5" />}
@@ -926,7 +926,7 @@ export default function SessionPage() {
           </div>
 
           <div className="flex items-center gap-3 ml-14">
-            <h2 className="text-base font-semibold text-gray-900">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-zinc-100">
               {selectedSession?.title || t('newSession')}
             </h2>
           </div>
@@ -962,7 +962,7 @@ export default function SessionPage() {
               <button
                 type="button"
                 onClick={() => setShowAgentOptions(!showAgentOptions)}
-                className="flex h-7 w-auto max-w-[150px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900"
+                className="flex h-7 w-auto max-w-[150px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
                 title={t('agentPicker.title')}
               >
                 <Bot className="h-3 w-3 shrink-0" />
@@ -972,12 +972,12 @@ export default function SessionPage() {
                 <ChevronDown className={`h-3 w-3 shrink-0 transition-transform ${showAgentOptions ? 'rotate-180' : ''}`} />
               </button>
               {showAgentOptions && (
-                <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm">
-                  <div className="flex items-center justify-between gap-2 border-b border-zinc-100 px-2.5 py-1.5">
+                <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-xl dark:shadow-black/30">
+                  <div className="flex items-center justify-between gap-2 border-b border-zinc-100 px-2.5 py-1.5 dark:border-zinc-800">
                     <div className="min-w-0">
-                      <div className="text-xs font-semibold text-zinc-700">{t('agentPicker.title')}</div>
+                      <div className="text-xs font-semibold text-zinc-700 dark:text-zinc-100">{t('agentPicker.title')}</div>
                       <div
-                        className="truncate text-[10px] text-zinc-400"
+                        className="truncate text-[10px] text-zinc-400 dark:text-zinc-500"
                         onPointerEnter={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
                         onMouseEnter={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
                         onMouseOver={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
@@ -987,7 +987,7 @@ export default function SessionPage() {
                         {t('agentPicker.hint')}
                       </div>
                     </div>
-                    <div className="inline-flex shrink-0 items-center rounded-md border border-zinc-200 bg-white p-0.5 text-[10px]">
+                    <div className="inline-flex shrink-0 items-center rounded-md border border-zinc-200 bg-white p-0.5 text-[10px] dark:border-zinc-800 dark:bg-zinc-950">
                       {(['all', 'builtin', 'custom'] as AgentSourceFilter[]).map((filter) => (
                         <button
                           key={filter}
@@ -995,8 +995,8 @@ export default function SessionPage() {
                           onClick={() => setAgentSourceFilter(filter)}
                           className={`rounded px-1.5 py-0.5 transition-colors ${
                             agentSourceFilter === filter
-                              ? 'bg-zinc-100 text-zinc-900'
-                              : 'text-zinc-500 hover:bg-zinc-50 hover:text-zinc-800'
+                              ? 'bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50'
+                              : 'text-zinc-500 hover:bg-zinc-50 hover:text-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100'
                           }`}
                         >
                           {t(`agentPicker.filter.${filter}`)}
@@ -1017,21 +1017,21 @@ export default function SessionPage() {
                           onClick={() => { setSelectedAgent(agent.name); setShowAgentOptions(false); }}
                           className={`w-full min-w-0 rounded-md px-2 py-1.5 text-left transition-colors ${
                             selectedAgent === agent.name
-                              ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa]'
-                              : 'hover:bg-zinc-50 text-zinc-700'
+                              ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa] dark:bg-zinc-800 dark:text-zinc-50 dark:shadow-[inset_2px_0_0_#539bf5]'
+                              : 'hover:bg-zinc-50 text-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50'
                           }`}
                         >
                           <div className="flex min-w-0 items-center gap-2">
-                            <Bot className={`h-3 w-3 shrink-0 ${selectedAgent === agent.name ? 'text-zinc-600' : 'text-zinc-400'}`} />
-                            <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900">
+                            <Bot className={`h-3 w-3 shrink-0 ${selectedAgent === agent.name ? 'text-zinc-600 dark:text-zinc-200' : 'text-zinc-400 dark:text-zinc-500'}`} />
+                            <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">
                               {displayName}
                             </span>
                             <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium ${
                               agent.mode === 'primary'
-                                ? 'bg-zinc-100 text-zinc-600'
+                                ? 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
                                 : agent.native
-                                  ? 'bg-zinc-100 text-zinc-600'
-                                  : 'bg-teal-50 text-teal-600'
+                                  ? 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
+                                  : 'bg-teal-50 text-teal-600 dark:bg-teal-950/40 dark:text-teal-300'
                             }`}>
                               {agent.mode === 'primary'
                                 ? t('agentPicker.badge.primary')
@@ -1042,7 +1042,7 @@ export default function SessionPage() {
                             <div className="ml-auto flex shrink-0 items-center gap-1">
                               {primaryDesc && (
                                 <span
-                                  className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200"
+                                  className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200 dark:hover:bg-zinc-700"
                                   onMouseDown={(event) => { event.preventDefault(); event.stopPropagation(); }}
                                   onClick={(event) => { event.preventDefault(); event.stopPropagation(); }}
                                   onPointerEnter={(event) => showSelectorTooltip(event.currentTarget, displayName, [primaryDesc])}
@@ -1051,7 +1051,7 @@ export default function SessionPage() {
                                   onMouseLeave={() => setSelectorTooltip(null)}
                                   onPointerLeave={() => setSelectorTooltip(null)}
                                 >
-                                  <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500" />
+                                  <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-300" />
                                 </span>
                               )}
                             </div>
@@ -1073,7 +1073,7 @@ export default function SessionPage() {
                 type="button"
                 onClick={() => setShowModelOptions(!showModelOptions)}
                 disabled={loadingProviders || loadingEnabledModels || chatModelOptions.length === 0}
-                className="flex h-7 w-[132px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex h-7 w-[132px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
                 title={selectedModelOption ? `${selectedModelOption.providerName} / ${selectedModelOption.modelID}` : t('modelPicker.empty')}
               >
                 <Cpu className="h-3 w-3 shrink-0" />
@@ -1083,10 +1083,10 @@ export default function SessionPage() {
                 <ChevronDown className={`h-3 w-3 shrink-0 transition-transform ${showModelOptions ? 'rotate-180' : ''}`} />
               </button>
               {showModelOptions && (
-                <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm">
-                  <div className="border-b border-zinc-100 px-2.5 py-1.5">
-                    <div className="text-xs font-semibold text-zinc-700">{t('modelPicker.title')}</div>
-                    <div className="truncate text-[10px] text-zinc-400">{t('modelPicker.hint')}</div>
+                <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-xl dark:shadow-black/30">
+                  <div className="border-b border-zinc-100 px-2.5 py-1.5 dark:border-zinc-800">
+                    <div className="text-xs font-semibold text-zinc-700 dark:text-zinc-100">{t('modelPicker.title')}</div>
+                    <div className="truncate text-[10px] text-zinc-400 dark:text-zinc-500">{t('modelPicker.hint')}</div>
                   </div>
                   <div className="h-[13.5rem] overflow-y-auto p-1.5">
                     {loadingProviders || loadingEnabledModels ? (
@@ -1094,9 +1094,9 @@ export default function SessionPage() {
                     ) : groupedChatModelOptions.length > 0 ? (
                       groupedChatModelOptions.map((group) => (
                         <div key={group.providerID} className="py-1 first:pt-0 last:pb-0">
-                          <div className="sticky top-0 z-10 flex items-center justify-between gap-2 bg-white/95 px-1.5 py-1 text-[10px] font-semibold text-zinc-500 backdrop-blur">
+                          <div className="sticky top-0 z-10 flex items-center justify-between gap-2 bg-white/95 px-1.5 py-1 text-[10px] font-semibold text-zinc-500 backdrop-blur dark:bg-zinc-900/95 dark:text-zinc-400">
                             <span className="truncate">{group.providerName}</span>
-                            <span className="shrink-0 rounded bg-zinc-50 px-1.5 py-0.5 text-[9px] text-zinc-500">
+                            <span className="shrink-0 rounded bg-zinc-50 px-1.5 py-0.5 text-[9px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
                               {t('modelPicker.count', { count: group.models.length })}
                             </span>
                           </div>
@@ -1108,21 +1108,21 @@ export default function SessionPage() {
                                 onClick={() => void handleSelectModel(option)}
                                 className={`w-full rounded-md px-2 py-1.5 text-left transition-colors ${
                                   selectedModelOption?.key === option.key
-                                    ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa]'
-                                    : 'text-zinc-700 hover:bg-zinc-50'
+                                    ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa] dark:bg-zinc-800 dark:text-zinc-50 dark:shadow-[inset_2px_0_0_#539bf5]'
+                                    : 'text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50'
                                 }`}
                               >
                                 <div className="flex min-w-0 items-center gap-2">
-                                  <Cpu className={`h-3 w-3 shrink-0 ${selectedModelOption?.key === option.key ? 'text-zinc-600' : 'text-zinc-400'}`} />
-                                  <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900">{option.label}</span>
+                                  <Cpu className={`h-3 w-3 shrink-0 ${selectedModelOption?.key === option.key ? 'text-zinc-600 dark:text-zinc-200' : 'text-zinc-400 dark:text-zinc-500'}`} />
+                                  <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">{option.label}</span>
                                   {option.supportsVision === true && (
-                                    <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 text-[9px] font-medium text-zinc-600">
+                                    <span className="shrink-0 rounded bg-zinc-100 px-1.5 py-0.5 text-[9px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
                                       {t('modelPicker.vision')}
                                     </span>
                                   )}
                                   <div className="ml-auto flex shrink-0 items-center gap-1">
                                     <span
-                                      className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200"
+                                      className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200 dark:hover:bg-zinc-700"
                                       onMouseDown={(event) => { event.preventDefault(); event.stopPropagation(); }}
                                       onClick={(event) => { event.preventDefault(); event.stopPropagation(); }}
                                       onPointerEnter={(event) => showSelectorTooltip(event.currentTarget, option.label, [option.pricingLabel, option.contextLabel])}
@@ -1131,7 +1131,7 @@ export default function SessionPage() {
                                       onMouseLeave={() => setSelectorTooltip(null)}
                                       onPointerLeave={() => setSelectorTooltip(null)}
                                     >
-                                      <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500" />
+                                      <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-300" />
                                     </span>
                                   </div>
                                 </div>
@@ -1144,20 +1144,6 @@ export default function SessionPage() {
                       <div className="p-3 text-center text-xs text-zinc-500">{t('modelPicker.empty')}</div>
                     )}
                   </div>
-                  <div className="border-t border-zinc-100 p-1.5">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setShowModelOptions(false);
-                        setSelectorTooltip(null);
-                        navigate('/models');
-                      }}
-                      className="flex w-full items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900"
-                    >
-                      <Plus className="h-3 w-3" />
-                      {t('modelPicker.addModel')}
-                    </button>
-                  </div>
                 </div>
               )}
             </div>
@@ -1167,16 +1153,16 @@ export default function SessionPage() {
 
       {selectorTooltip && (
         <div
-          className="pointer-events-none fixed z-[80] w-56 -translate-x-full -translate-y-1/2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[11px] leading-relaxed text-zinc-700 shadow-md"
+          className="pointer-events-none fixed z-[80] w-56 -translate-x-full -translate-y-1/2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[11px] leading-relaxed text-zinc-700 shadow-md dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300 dark:shadow-xl dark:shadow-black/30"
           style={{ left: selectorTooltip.x, top: selectorTooltip.y }}
         >
-          <div className="mb-0.5 font-semibold text-zinc-800">{selectorTooltip.title}</div>
+          <div className="mb-0.5 font-semibold text-zinc-800 dark:text-zinc-100">{selectorTooltip.title}</div>
           {selectorTooltip.lines.map((line, index) => (
-            <div key={`${selectorTooltip.title}-${index}`} className={index === 0 ? '' : 'mt-1 break-all text-zinc-500'}>
+            <div key={`${selectorTooltip.title}-${index}`} className={index === 0 ? '' : 'mt-1 break-all text-zinc-500 dark:text-zinc-400'}>
               {line}
             </div>
           ))}
-          <div className="absolute left-full top-1/2 -translate-y-1/2 border-4 border-transparent border-l-zinc-200" />
+          <div className="absolute left-full top-1/2 -translate-y-1/2 border-4 border-transparent border-l-zinc-200 dark:border-l-zinc-800" />
         </div>
       )}
 
@@ -1187,14 +1173,14 @@ export default function SessionPage() {
         if (!session) return null;
         return (
           <div
-            className="fixed z-50 w-36 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+            className="fixed z-50 w-36 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-zinc-800 dark:bg-zinc-900"
             style={{ top: menuAnchor.top, right: menuAnchor.right }}
             data-session-menu-portal
             onClick={(e) => e.stopPropagation()}
           >
             <button
               onClick={(e) => { e.stopPropagation(); handleStartRename(session.id, session.title); setOpenMenuSessionId(null); setMenuAnchor(null); }}
-              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors dark:text-zinc-200 dark:hover:bg-zinc-800"
             >
               <PencilLine className="w-3.5 h-3.5" />
               <span>{t('rename')}</span>
@@ -1202,7 +1188,7 @@ export default function SessionPage() {
             <button
               onClick={(e) => { e.stopPropagation(); void handleDownloadSession(session.id, session.title); setOpenMenuSessionId(null); setMenuAnchor(null); }}
               disabled={downloadingSessionId === session.id}
-              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-200 dark:hover:bg-zinc-800"
             >
               <Download className="w-3.5 h-3.5" />
               <span>{t('downloadJson')}</span>
@@ -1210,16 +1196,16 @@ export default function SessionPage() {
             <button
               onClick={(e) => { e.stopPropagation(); setOpenMenuSessionId(null); setMenuAnchor(null); void handleShareSession(session.id, !session.isShared); }}
               disabled={session.canWrite === false}
-              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-200 dark:hover:bg-zinc-800"
             >
               <Share2 className="w-3.5 h-3.5" />
               <span>{session.isShared ? t('unshareAction') : t('shareAction')}</span>
             </button>
-            <div className="mx-2.5 my-1 border-t border-gray-100" />
+            <div className="mx-2.5 my-1 border-t border-gray-100 dark:border-zinc-800" />
             <button
               onClick={(e) => { e.stopPropagation(); setOpenMenuSessionId(null); setMenuAnchor(null); void handleDeleteSession(session.id); }}
               disabled={session.canDelete === false}
-              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-red-600 hover:bg-red-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-red-600 hover:bg-red-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-300 dark:hover:bg-red-950/40"
             >
               <Trash2 className="w-3.5 h-3.5" />
               <span>{t('deleteAction')}</span>
@@ -1240,30 +1226,30 @@ function WelcomeScreen({ onSuggestion }: { onSuggestion: (text: string) => void 
       <div className="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-br from-slate-700 to-slate-900 flex items-center justify-center shadow-lg">
         <Sparkles className="w-10 h-10 text-white" />
       </div>
-      <h3 className="text-xl font-bold text-gray-900 mb-3">{t('welcome.title')}</h3>
-      <p className="text-sm text-gray-600 mb-8">{t('welcome.description')}</p>
+      <h3 className="text-xl font-bold text-gray-900 mb-3 dark:text-zinc-50">{t('welcome.title')}</h3>
+      <p className="text-sm text-gray-600 mb-8 dark:text-zinc-400">{t('welcome.description')}</p>
 
       <div className="flex flex-wrap gap-3 justify-center">
         <button
           onClick={() => onSuggestion(t('welcome.alertTriageSuggestion'))}
-          className="flex items-center gap-2 px-5 py-3 bg-white border-2 border-gray-200 rounded-xl hover:border-slate-400 hover:bg-slate-50 transition-all duration-200 shadow-sm hover:shadow-md"
+          className="flex items-center gap-2 px-5 py-3 bg-white border-2 border-gray-200 rounded-xl hover:border-slate-400 hover:bg-slate-50 transition-all duration-200 shadow-sm hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-slate-500/70 dark:hover:bg-zinc-800 dark:hover:shadow-none"
         >
           <Shield className="w-5 h-5 text-slate-600" />
-          <span className="font-medium text-gray-700">{t('welcome.alertTriage')}</span>
+          <span className="font-medium text-gray-700 dark:text-zinc-200">{t('welcome.alertTriage')}</span>
         </button>
         <button
           onClick={() => onSuggestion(t('welcome.threatHuntingSuggestion'))}
-          className="flex items-center gap-2 px-5 py-3 bg-white border-2 border-gray-200 rounded-xl hover:border-orange-400 hover:bg-orange-50 transition-all duration-200 shadow-sm hover:shadow-md"
+          className="flex items-center gap-2 px-5 py-3 bg-white border-2 border-gray-200 rounded-xl hover:border-orange-400 hover:bg-orange-50 transition-all duration-200 shadow-sm hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-orange-500/70 dark:hover:bg-orange-950/30 dark:hover:shadow-none"
         >
           <Search className="w-5 h-5 text-orange-600" />
-          <span className="font-medium text-gray-700">{t('welcome.threatHunting')}</span>
+          <span className="font-medium text-gray-700 dark:text-zinc-200">{t('welcome.threatHunting')}</span>
         </button>
         <button
           onClick={() => onSuggestion(t('welcome.incidentResponseSuggestion'))}
-          className="flex items-center gap-2 px-5 py-3 bg-white border-2 border-gray-200 rounded-xl hover:border-amber-400 hover:bg-amber-50 transition-all duration-200 shadow-sm hover:shadow-md"
+          className="flex items-center gap-2 px-5 py-3 bg-white border-2 border-gray-200 rounded-xl hover:border-amber-400 hover:bg-amber-50 transition-all duration-200 shadow-sm hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-amber-500/70 dark:hover:bg-amber-950/30 dark:hover:shadow-none"
         >
           <AlertTriangle className="w-5 h-5 text-amber-600" />
-          <span className="font-medium text-gray-700">{t('welcome.incidentResponse')}</span>
+          <span className="font-medium text-gray-700 dark:text-zinc-200">{t('welcome.incidentResponse')}</span>
         </button>
       </div>
     </div>

--- a/webui/src/pages/Skill/index.tsx
+++ b/webui/src/pages/Skill/index.tsx
@@ -20,6 +20,7 @@ import LoadingSpinner from '@/components/common/LoadingSpinner';
 import EmptyState from '@/components/common/EmptyState';
 import { useToast } from '@/components/common/Toast';
 import { skillAPI, Skill } from '@/api/skill';
+import { EnabledBadge } from '@/pages/Tool/components/badges';
 import SkillSheet from './SkillSheet';
 import SkillInstallDialog from './SkillInstallDialog';
 
@@ -605,8 +606,8 @@ function SkillRow({ skill, isSelected, installingDeps, toggling, onSelect, onIns
   return (
     <tr
       className={`transition-colors ${
-        skill.disabled ? 'opacity-50' : 'hover:bg-gray-50'
-      } ${isSelected ? 'bg-slate-50' : ''}`}
+        skill.disabled ? 'bg-gray-50/40 dark:bg-zinc-900/30' : 'hover:bg-gray-50 dark:hover:bg-zinc-900/60'
+      } ${isSelected ? 'bg-slate-50 dark:bg-zinc-900/80' : ''}`}
     >
       {/* 类型列 */}
       <td className="px-4 py-3">
@@ -664,7 +665,7 @@ function SkillRow({ skill, isSelected, installingDeps, toggling, onSelect, onIns
 
       {/* 启用开关列：控制 skill 是否注入 Agent System Prompt */}
       <td className="px-4 py-3">
-        <ToggleSwitch
+        <SkillEnabledControl
           enabled={enabled}
           loading={toggling}
           title={enabled ? t('toggle.enabledTip') : t('toggle.disabledTip')}
@@ -709,7 +710,7 @@ function SkillRow({ skill, isSelected, installingDeps, toggling, onSelect, onIns
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
-function ToggleSwitch({ enabled, loading, title, onChange }: {
+function SkillEnabledControl({ enabled, loading, title, onChange }: {
   enabled: boolean;
   loading: boolean;
   title?: string;
@@ -720,22 +721,18 @@ function ToggleSwitch({ enabled, loading, title, onChange }: {
       type="button"
       role="switch"
       aria-checked={enabled}
+      aria-label={title}
       onClick={onChange}
       disabled={loading}
       title={title}
-      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border-2 border-transparent
-        transition-colors duration-150 focus:outline-none disabled:cursor-wait
-        ${enabled ? 'bg-slate-700' : 'bg-gray-200'}`}
+      className="relative inline-flex rounded-full transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-75"
     >
-      {loading
-        ? <Loader2 className="absolute inset-0 m-auto w-3 h-3 text-white animate-spin" />
-        : (
-          <span className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow
-            transform transition-transform duration-150
-            ${enabled ? 'translate-x-4' : 'translate-x-0'}`}
-          />
-        )
-      }
+      <EnabledBadge enabled={enabled} />
+      {loading && (
+        <span className="absolute inset-0 inline-flex items-center justify-center rounded-full bg-white/70 dark:bg-zinc-900/70">
+          <Loader2 className="w-3 h-3 animate-spin text-gray-500 dark:text-zinc-300" />
+        </span>
+      )}
     </button>
   );
 }

--- a/webui/src/pages/WorkflowCreate/CreateChatTab.tsx
+++ b/webui/src/pages/WorkflowCreate/CreateChatTab.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { AlertCircle, Bot } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import SessionChat, {
   buildInstructionDisplayText,
   type PromptDisplayOptions,
@@ -69,7 +68,6 @@ export default function CreateChatTab({
   onLaunchRequestHandled,
 }: CreateChatTabProps) {
   const { t } = useTranslation('workflow');
-  const navigate = useNavigate();
   const defaultSupportsVision = useDefaultModelVision();
   const guideSectionTitle = t('create.chat.guideSectionTitle');
   const caseSectionTitle = t('create.chat.caseSectionTitle');
@@ -320,7 +318,6 @@ export default function CreateChatTab({
           loading={loadingChatModels}
           selectedModelOption={selectedModelOption}
           onSelectModel={(option) => setSelectedModelKey(option.key)}
-          onAddModel={() => navigate('/models')}
         />
       }
       conversationBottomSlot={({ sendPrompt, sending, streaming }) => (

--- a/webui/src/pages/WorkflowDetail/FlowCanvas.tsx
+++ b/webui/src/pages/WorkflowDetail/FlowCanvas.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, memo, type ReactNode } from 'react';
+import { useState, useCallback, useContext, useEffect, useMemo, useRef, memo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ReactFlow,
@@ -19,6 +19,7 @@ import {
 import '@xyflow/react/dist/style.css';
 import { Code2, Zap, GitBranch, RotateCw, RotateCcw, X, ChevronRight, ChevronUp, ChevronDown, Wrench, Sparkles, Globe, Workflow, ZoomIn, ZoomOut, Scan } from 'lucide-react';
 import { WorkflowJSON, WorkflowNode as APINode } from '@/api/workflow';
+import { ThemeContext } from '@/contexts/ThemeContext';
 import {
   buildWorkflowGraphLayout,
   WORKFLOW_GRAPH_NODE_WIDTH,
@@ -471,13 +472,15 @@ function NodeDetailModal({ node, isStart, onClose }: NodeDetailModalProps) {
 // Layout builder
 // ─────────────────────────────────────────────
 
-const EDGE_THEME: Record<WorkflowGraphEdgeRoute['kind'], {
+type FlowEdgeTheme = Record<WorkflowGraphEdgeRoute['kind'], {
   stroke: string;
   label: string;
   labelBg: string;
   strokeWidth: number;
   strokeDasharray?: string;
-}> = {
+}>;
+
+const LIGHT_EDGE_THEME: FlowEdgeTheme = {
   default: {
     stroke: '#94a3b8',
     label: '#64748b',
@@ -505,9 +508,38 @@ const EDGE_THEME: Record<WorkflowGraphEdgeRoute['kind'], {
   },
 };
 
+const DARK_EDGE_THEME: FlowEdgeTheme = {
+  default: {
+    stroke: '#5a6573',
+    label: '#b8c2cc',
+    labelBg: '#303842',
+    strokeWidth: 1.7,
+  },
+  branch: {
+    stroke: '#f59e0b',
+    label: '#fbbf24',
+    labelBg: '#3d3424',
+    strokeWidth: 2.2,
+  },
+  loop: {
+    stroke: '#a78bfa',
+    label: '#c4b5fd',
+    labelBg: '#363047',
+    strokeWidth: 2,
+  },
+  back: {
+    stroke: '#5a6573',
+    label: '#b8c2cc',
+    labelBg: '#303842',
+    strokeWidth: 1.8,
+    strokeDasharray: '6 5',
+  },
+};
+
 function buildLayout(
   workflowJson: WorkflowJSON,
-  onNodeClick: (nodeId: string) => void
+  onNodeClick: (nodeId: string) => void,
+  edgeTheme: FlowEdgeTheme
 ): { nodes: Node[]; edges: Edge[] } {
   const diagram = buildWorkflowGraphLayout(workflowJson);
   const startId = workflowJson.start || workflowJson.nodes[0]?.id;
@@ -534,7 +566,7 @@ function buildLayout(
   const edges: Edge[] = workflowJson.edges.map((edge, idx) => {
     const id = workflowGraphEdgeId(edge, idx);
     const route = diagram.edgeRoutes[id] ?? { kind: 'default' as const };
-    const theme = EDGE_THEME[route.kind];
+    const theme = edgeTheme[route.kind];
 
     return {
       id,
@@ -596,7 +628,7 @@ function buildLayout(
           type: 'smoothstep',
           animated: Boolean(trigger.enabled),
           markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
-          style: { stroke: '#7dd3fc', strokeWidth: 1.5, strokeDasharray: '5 4' },
+          style: { stroke: edgeTheme.branch.stroke, strokeWidth: 1.5, strokeDasharray: '5 4' },
         });
       }
     });
@@ -623,10 +655,10 @@ function CanvasControlButton({
       type="button"
       onClick={onClick}
       aria-label={label}
-      className="group relative flex h-8 w-full items-center justify-center text-slate-500 transition-colors hover:bg-slate-50 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-red-100"
+      className="group relative flex h-8 w-full items-center justify-center text-slate-500 transition-colors hover:bg-slate-50 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-red-100 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50 dark:focus:ring-zinc-700"
     >
       {children}
-      <span className="pointer-events-none absolute right-full top-1/2 z-20 mr-2 -translate-y-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[11px] font-medium text-white opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+      <span className="pointer-events-none absolute right-full top-1/2 z-20 mr-2 -translate-y-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[11px] font-medium text-white opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 dark:bg-zinc-800 dark:text-zinc-50">
         {label}
       </span>
     </button>
@@ -651,7 +683,10 @@ export interface FlowCanvasProps {
 
 function FlowCanvasInner({ workflowJson, editable = false, onNodeClick: externalOnNodeClick, layoutKey }: FlowCanvasProps) {
   const { t } = useTranslation('workflow');
+  const { theme } = useContext(ThemeContext);
   const { fitView, zoomIn, zoomOut } = useReactFlow();
+  const isDark = theme === 'dark';
+  const edgeTheme = useMemo(() => (isDark ? DARK_EDGE_THEME : LIGHT_EDGE_THEME), [isDark]);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [controlsCollapsed, setControlsCollapsed] = useState(false);
   const [showMiniMap, setShowMiniMap] = useState(false);
@@ -696,7 +731,7 @@ function FlowCanvasInner({ workflowJson, editable = false, onNodeClick: external
   const [edges, setEdges] = useEdgesState<Edge>([]);
 
   const applyLayout = useCallback((options: { reveal?: boolean } = {}) => {
-    const { nodes: newNodes, edges: newEdges } = buildLayout(workflowJson, handleNodeClick);
+    const { nodes: newNodes, edges: newEdges } = buildLayout(workflowJson, handleNodeClick, edgeTheme);
     setNodes(newNodes);
     setEdges(newEdges);
     if (options.reveal) {
@@ -704,7 +739,7 @@ function FlowCanvasInner({ workflowJson, editable = false, onNodeClick: external
     }
     // Re-fit after layout (small delay lets ReactFlow measure node sizes first)
     setTimeout(() => fitView({ padding: 0.2 }), 60);
-  }, [workflowJson, handleNodeClick, setNodes, setEdges, fitView, revealMiniMap]);
+  }, [workflowJson, handleNodeClick, edgeTheme, setNodes, setEdges, fitView, revealMiniMap]);
 
   const resetLayout = useCallback(() => {
     applyLayout({ reveal: true });
@@ -760,7 +795,7 @@ function FlowCanvasInner({ workflowJson, editable = false, onNodeClick: external
         fitViewOptions={{ padding: 0.2 }}
         proOptions={{ hideAttribution: true }}
       >
-        <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#e2e8f0" />
+        <Background variant={BackgroundVariant.Dots} gap={20} size={1} color={isDark ? '#5a6573' : '#e2e8f0'} />
         {showMiniMap && (
           <MiniMap
             nodeColor={(node) => {
@@ -773,15 +808,15 @@ function FlowCanvasInner({ workflowJson, editable = false, onNodeClick: external
               const d = node.data as unknown as ViewNodeData | undefined;
               return colors[d?.nodeType ?? ''] ?? '#94a3b8';
             }}
-            className="!rounded-lg !border !border-slate-200 !bg-white/95 !shadow-none"
-            maskColor="rgba(241, 245, 249, 0.68)"
+            className="!rounded-lg !border !border-slate-200 !bg-white/95 !shadow-none dark:!border-zinc-700 dark:!bg-zinc-900"
+            maskColor={isDark ? 'rgba(34, 39, 46, 0.72)' : 'rgba(241, 245, 249, 0.68)'}
           />
         )}
       </ReactFlow>
 
       <div className="absolute right-4 top-4 z-20 flex w-9 flex-col items-stretch gap-1 overflow-visible">
         {!controlsCollapsed && (
-          <div className="flex w-full flex-col divide-y divide-slate-100 overflow-visible rounded-lg border border-slate-200 bg-white/90 backdrop-blur">
+          <div className="flex w-full flex-col divide-y divide-slate-100 overflow-visible rounded-lg border border-slate-200 bg-white/90 backdrop-blur dark:divide-zinc-800 dark:border-zinc-700 dark:bg-zinc-900/90">
             <CanvasControlButton label={t('detail.flowControls.zoomIn')} onClick={handleZoomIn}>
               <ZoomIn className="h-4 w-4" strokeWidth={1.8} />
             </CanvasControlButton>
@@ -800,7 +835,7 @@ function FlowCanvasInner({ workflowJson, editable = false, onNodeClick: external
           type="button"
           onClick={() => setControlsCollapsed((prev) => !prev)}
           aria-label={t(controlsCollapsed ? 'detail.flowControls.expand' : 'detail.flowControls.collapse')}
-          className="flex h-8 w-full items-center justify-center rounded-lg border border-slate-200 bg-white/90 text-slate-500 backdrop-blur transition-colors hover:bg-slate-50 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-red-100"
+          className="flex h-8 w-full items-center justify-center rounded-lg border border-slate-200 bg-white/90 text-slate-500 backdrop-blur transition-colors hover:bg-slate-50 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-red-100 dark:border-zinc-700 dark:bg-zinc-900/90 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50 dark:focus:ring-zinc-700"
         >
           {controlsCollapsed ? (
             <ChevronDown className="h-4 w-4" strokeWidth={1.8} />

--- a/webui/src/pages/WorkflowDetail/NodeInfoPanel.tsx
+++ b/webui/src/pages/WorkflowDetail/NodeInfoPanel.tsx
@@ -169,11 +169,11 @@ function ExpandedCodeEditor({
   }, [lineNumbers.length]);
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 overflow-hidden rounded-xl border border-[#30363d] bg-[#0d1117]">
+    <div className="flex h-full min-h-0 min-w-0 overflow-hidden rounded-xl border border-[#4a5563] bg-[#252c35]">
       <div
         aria-hidden="true"
         data-testid="expanded-code-line-numbers"
-        className="flex-shrink-0 overflow-hidden select-none border-r border-[#30363d] bg-[#0b0f14] px-3 py-3 text-right font-mono text-[12px] leading-relaxed text-[#6e7681]"
+        className="flex-shrink-0 overflow-hidden select-none border-r border-[#4a5563] bg-[#20262d] px-3 py-3 text-right font-mono text-[12px] leading-relaxed text-[#9aa7b4]"
       >
         <div ref={lineNumberTrackRef}>
           {lineNumbers.map((lineNumber) => (
@@ -190,7 +190,7 @@ function ExpandedCodeEditor({
         onScroll={syncLineNumberOffset}
         rows={24}
         wrap="off"
-        className="h-full min-h-0 min-w-0 w-full resize-none overflow-auto bg-[#0d1117] px-4 py-3 font-mono text-[12px] leading-relaxed text-[#e6edf3] focus:outline-none focus:ring-2 focus:ring-red-400"
+        className="h-full min-h-0 min-w-0 w-full resize-none overflow-auto bg-[#252c35] px-4 py-3 font-mono text-[12px] leading-relaxed text-[#d7dee8] focus:outline-none focus:ring-2 focus:ring-[#539bf5]"
         placeholder={placeholder}
         spellCheck={false}
       />
@@ -699,7 +699,7 @@ export default function NodeInfoPanel({ node, workflow, latestExecution, width =
                 onChange={(e) => set('code', e.target.value)}
                 rows={12}
                 className="w-full px-2.5 py-2.5 rounded-lg text-[11px] font-mono resize-y focus:outline-none focus:ring-2 focus:ring-red-400
-                           bg-[#0d1117] text-[#e6edf3] border border-[#30363d] leading-relaxed"
+                           bg-[#252c35] text-[#d7dee8] border border-[#4a5563] leading-relaxed"
                 placeholder={t('detail.nodeInfo.codePlaceholder')}
                 spellCheck={false}
               />
@@ -847,7 +847,7 @@ export default function NodeInfoPanel({ node, workflow, latestExecution, width =
                 {t('detail.nodeInfo.closeExpandedEditor')}
               </button>
             </div>
-            <div className="flex-1 min-h-0 min-w-0 bg-[#0d1117] p-4">
+            <div className="flex-1 min-h-0 min-w-0 bg-[#252c35] p-4">
               <ExpandedCodeEditor
                 value={form.code ?? ''}
                 onChange={(value) => set('code', value)}

--- a/webui/src/pages/WorkflowDetail/tabs/ChatTab.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/ChatTab.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import { AlertCircle, Bot, Clock, Plus } from 'lucide-react';
 import SessionChat, {
   NodeRef,
@@ -80,7 +79,6 @@ export default function ChatTab({
   onNodeRefDismiss,
 }: ChatTabProps) {
   const { t, i18n } = useTranslation('workflow');
-  const navigate = useNavigate();
   const workflowDisplayName = getWorkflowDisplayName(workflow, i18n?.language);
   const defaultSupportsVision = useDefaultModelVision();
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
@@ -469,7 +467,6 @@ export default function ChatTab({
               loading={loadingChatModels}
               selectedModelOption={selectedModelOption}
               onSelectModel={(option) => setSelectedModelKey(option.key)}
-              onAddModel={() => navigate('/models')}
             />
           }
           conversationBottomSlot={({ sendPrompt, sending, streaming }) => (

--- a/webui/src/pages/WorkflowEditor/index.tsx
+++ b/webui/src/pages/WorkflowEditor/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useContext, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
@@ -32,6 +32,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { workflowAPI, Workflow, WorkflowExecution, WorkflowJSON, WorkflowNode as APINode } from '@/api/workflow';
+import { ThemeContext } from '@/contexts/ThemeContext';
 import { extractErrorMessage } from '@/utils/error';
 import {
   buildWorkflowGraphLayout,
@@ -92,13 +93,15 @@ const nodeMiniMapColors: Record<string, string> = {
   subworkflow: '#fb923c',
 };
 
-const edgeTheme: Record<WorkflowGraphEdgeRoute['kind'], {
+type EdgeTheme = Record<WorkflowGraphEdgeRoute['kind'], {
   stroke: string;
   label: string;
   labelBg: string;
   strokeWidth: number;
   strokeDasharray?: string;
-}> = {
+}>;
+
+const LIGHT_EDGE_THEME: EdgeTheme = {
   default: {
     stroke: '#94a3b8',
     label: '#64748b',
@@ -126,10 +129,39 @@ const edgeTheme: Record<WorkflowGraphEdgeRoute['kind'], {
   },
 };
 
+const DARK_EDGE_THEME: EdgeTheme = {
+  default: {
+    stroke: '#5a6573',
+    label: '#b8c2cc',
+    labelBg: '#303842',
+    strokeWidth: 1.8,
+  },
+  branch: {
+    stroke: '#f59e0b',
+    label: '#fbbf24',
+    labelBg: '#3d3424',
+    strokeWidth: 2.2,
+  },
+  loop: {
+    stroke: '#a78bfa',
+    label: '#c4b5fd',
+    labelBg: '#363047',
+    strokeWidth: 2,
+  },
+  back: {
+    stroke: '#5a6573',
+    label: '#b8c2cc',
+    labelBg: '#303842',
+    strokeWidth: 1.8,
+    strokeDasharray: '6 5',
+  },
+};
+
 function buildReactFlowEdge(
   edge: WorkflowJSON['edges'][number],
   index: number,
-  route: WorkflowGraphEdgeRoute = { kind: 'default' }
+  route: WorkflowGraphEdgeRoute = { kind: 'default' },
+  edgeTheme: EdgeTheme = LIGHT_EDGE_THEME
 ): Edge {
   const theme = edgeTheme[route.kind];
 
@@ -166,7 +198,7 @@ function buildReactFlowEdge(
 }
 
 // 将后端数据转换为 ReactFlow 格式
-function convertToReactFlowFormat(workflowJson: WorkflowJSON): { nodes: Node[]; edges: Edge[] } {
+function convertToReactFlowFormat(workflowJson: WorkflowJSON, edgeTheme: EdgeTheme = LIGHT_EDGE_THEME): { nodes: Node[]; edges: Edge[] } {
   const diagram = buildWorkflowGraphLayout(workflowJson);
   const nodes: Node[] = workflowJson.nodes.map((node) => ({
     id: node.id,
@@ -204,7 +236,7 @@ function convertToReactFlowFormat(workflowJson: WorkflowJSON): { nodes: Node[]; 
   }));
 
   const edges: Edge[] = workflowJson.edges.map((edge, index) =>
-    buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)])
+    buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)], edgeTheme)
   );
 
   return { nodes, edges };
@@ -251,7 +283,7 @@ interface EdgeData {
   const?: Record<string, any>;
 }
 
-function applyGraphSemantics(nodes: Node[], edges: Edge[], workflow: Workflow): { nodes: Node[]; edges: Edge[] } {
+function applyGraphSemantics(nodes: Node[], edges: Edge[], workflow: Workflow, edgeTheme: EdgeTheme = LIGHT_EDGE_THEME): { nodes: Node[]; edges: Edge[] } {
   const workflowJson = convertToWorkflowJSON(nodes, edges, workflow);
   const diagram = buildWorkflowGraphLayout(workflowJson);
   const updatedNodes = nodes.map((node) => ({
@@ -262,7 +294,7 @@ function applyGraphSemantics(nodes: Node[], edges: Edge[], workflow: Workflow): 
     },
   }));
   const updatedEdges = workflowJson.edges.map((edge, index) =>
-    buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)])
+    buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)], edgeTheme)
   );
 
   return { nodes: updatedNodes, edges: updatedEdges };
@@ -327,8 +359,11 @@ function convertToWorkflowJSON(nodes: Node[], edges: Edge[], workflow: Workflow)
 
 export default function WorkflowEditor() {
   const { t, i18n } = useTranslation('workflow');
+  const { theme } = useContext(ThemeContext);
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const isDark = theme === 'dark';
+  const edgeTheme = useMemo(() => (isDark ? DARK_EDGE_THEME : LIGHT_EDGE_THEME), [isDark]);
 
   const [workflow, setWorkflow] = useState<Workflow | null>(null);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
@@ -358,6 +393,13 @@ export default function WorkflowEditor() {
       setExecutionStopping(false);
     }
   }, [currentExecution]);
+
+  useEffect(() => {
+    if (!workflow) return;
+    const refreshed = applyGraphSemantics(nodes, edges, workflow, edgeTheme);
+    setNodes(refreshed.nodes);
+    setEdges(refreshed.edges);
+  }, [edgeTheme]);
 
   useEffect(() => {
     if (!id || !showExecutionPanel || !currentExecution?.id || currentExecution.status !== 'running') {
@@ -397,7 +439,7 @@ export default function WorkflowEditor() {
       const response = await workflowAPI.get(id!);
       setWorkflow(response.data);
       
-      const { nodes: flowNodes, edges: flowEdges } = convertToReactFlowFormat(response.data.workflowJson);
+      const { nodes: flowNodes, edges: flowEdges } = convertToReactFlowFormat(response.data.workflowJson, edgeTheme);
       setNodes(flowNodes);
       setEdges(flowEdges);
     } catch (error: any) {
@@ -452,13 +494,13 @@ export default function WorkflowEditor() {
           );
 
           if (!workflow) return nextEdges;
-          const refreshed = applyGraphSemantics(nodes, nextEdges, workflow);
+          const refreshed = applyGraphSemantics(nodes, nextEdges, workflow, edgeTheme);
           setNodes(refreshed.nodes);
           return refreshed.edges;
         }
       );
     },
-    [nodes, setEdges, setNodes, workflow]
+    [edgeTheme, nodes, setEdges, setNodes, workflow]
   );
 
   // 节点点击事件 - 显示属性面板
@@ -481,11 +523,11 @@ export default function WorkflowEditor() {
       const nextEdges = applyEdgeChanges(changes, eds);
       if (!workflow) return nextEdges;
 
-      const refreshed = applyGraphSemantics(nodes, nextEdges, workflow);
+      const refreshed = applyGraphSemantics(nodes, nextEdges, workflow, edgeTheme);
       setNodes(refreshed.nodes);
       return refreshed.edges;
     });
-  }, [nodes, setEdges, setNodes, workflow]);
+  }, [edgeTheme, nodes, setEdges, setNodes, workflow]);
 
   // 添加新节点
   const handleAddNode = useCallback((type: string) => {
@@ -547,13 +589,13 @@ export default function WorkflowEditor() {
       });
 
       if (!workflow) return updatedEdges;
-      const refreshed = applyGraphSemantics(nodes, updatedEdges, workflow);
+      const refreshed = applyGraphSemantics(nodes, updatedEdges, workflow, edgeTheme);
       setNodes(refreshed.nodes);
       return refreshed.edges;
     });
     setShowEdgePropertyPanel(false);
     setSelectedEdge(null);
-  }, [nodes, setEdges, setNodes, workflow]);
+  }, [edgeTheme, nodes, setEdges, setNodes, workflow]);
 
   // 删除选中的节点或边（键盘事件）
   useEffect(() => {
@@ -574,7 +616,7 @@ export default function WorkflowEditor() {
             const nextEdges = eds.filter((edge) => !edge.selected);
             if (!workflow) return nextEdges;
 
-            const refreshed = applyGraphSemantics(nodes, nextEdges, workflow);
+            const refreshed = applyGraphSemantics(nodes, nextEdges, workflow, edgeTheme);
             setNodes(refreshed.nodes);
             return refreshed.edges;
           });
@@ -596,7 +638,7 @@ export default function WorkflowEditor() {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [nodes, edges, setNodes, setEdges, workflow]);
+  }, [edgeTheme, nodes, edges, setNodes, setEdges, workflow]);
 
   // 自动布局
   const handleAutoLayout = () => {
@@ -614,7 +656,7 @@ export default function WorkflowEditor() {
     }));
 
     const updatedEdges = workflowJson.edges.map((edge, index) =>
-      buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)])
+      buildReactFlowEdge(edge, index, diagram.edgeRoutes[workflowGraphEdgeId(edge, index)], edgeTheme)
     );
 
     setNodes(updatedNodes);
@@ -760,19 +802,19 @@ export default function WorkflowEditor() {
   }
 
   return (
-    <div className="h-screen flex flex-col bg-gray-50">
+    <div className="h-screen flex flex-col bg-gray-50 dark:bg-zinc-950">
       {/* 顶部工具栏 */}
-      <div className="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+      <div className="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between dark:border-zinc-800 dark:bg-zinc-950">
         <div className="flex items-center gap-4">
           <button
             onClick={() => navigate('/workflows')}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 hover:bg-gray-100 rounded-lg transition-colors dark:text-zinc-300 dark:hover:bg-zinc-800"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
           <div>
-            <h1 className="text-xl font-semibold text-gray-900">{getWorkflowDisplayName(workflow, i18n.language)}</h1>
-            <p className="text-sm text-gray-500">{workflow.description || t('editor.noDescription')}</p>
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-zinc-100">{getWorkflowDisplayName(workflow, i18n.language)}</h1>
+            <p className="text-sm text-gray-500 dark:text-zinc-400">{workflow.description || t('editor.noDescription')}</p>
           </div>
           {validationResult && (
             <div className="flex items-center gap-2">
@@ -792,7 +834,7 @@ export default function WorkflowEditor() {
           <button
             onClick={() => setShowNodeToolbar(!showNodeToolbar)}
             className={`flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg transition-colors ${
-              showNodeToolbar ? 'bg-red-50 text-red-700 border-red-500' : 'text-gray-700 bg-white hover:bg-gray-50'
+              showNodeToolbar ? 'bg-red-50 text-red-700 border-red-500 dark:bg-red-950/30 dark:text-red-200 dark:border-red-500/40' : 'text-gray-700 bg-white hover:bg-gray-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800'
             }`}
           >
             <Trash2 className="w-4 h-4" />
@@ -800,21 +842,21 @@ export default function WorkflowEditor() {
           </button>
           <button
             onClick={handleAutoLayout}
-            className="flex items-center gap-2 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-2 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
           >
             <Layout className="w-4 h-4" />
             {t('editor.autoLayout')}
           </button>
           <button
             onClick={handleValidate}
-            className="flex items-center gap-2 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-2 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
           >
             <CheckCircle className="w-4 h-4" />
             {t('editor.validate')}
           </button>
           <button
             onClick={handleExport}
-            className="flex items-center gap-2 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-2 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
           >
             <FileJson className="w-4 h-4" />
             {t('editor.export')}
@@ -907,32 +949,33 @@ export default function WorkflowEditor() {
           attributionPosition="bottom-left"
           deleteKeyCode={null}
         >
-          <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
+          <Background variant={BackgroundVariant.Dots} gap={12} size={1} color={isDark ? '#5a6573' : '#e2e8f0'} />
           <Controls />
           <MiniMap
             nodeColor={(node) => {
               return nodeMiniMapColors[node.type as keyof typeof nodeMiniMapColors] ?? '#94a3b8';
             }}
-            style={{ backgroundColor: '#f9fafb' }}
+            maskColor={isDark ? 'rgba(34, 39, 46, 0.72)' : 'rgba(241, 245, 249, 0.68)'}
+            style={{ backgroundColor: isDark ? '#303842' : '#f9fafb' }}
           />
           
           {/* 图例 */}
-          <Panel position="top-left" className="bg-white rounded-lg shadow-lg p-4">
-            <h3 className="text-sm font-semibold text-gray-900 mb-3">{t('editor.nodeTypesLabel')}</h3>
+          <Panel position="top-left" className="bg-white rounded-lg shadow-lg p-4 dark:border dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-xl dark:shadow-black/30">
+            <h3 className="text-sm font-semibold text-gray-900 mb-3 dark:text-zinc-100">{t('editor.nodeTypesLabel')}</h3>
             <div className="space-y-2">
               {Object.entries(nodeColors).map(([type, colors]) => (
                 <div key={type} className="flex items-center gap-2">
                   <div className={`w-4 h-4 rounded border-2 ${colors.border} ${colors.bg}`} />
-                  <span className="text-xs text-gray-700 capitalize">{type}</span>
+                  <span className="text-xs text-gray-700 capitalize dark:text-zinc-300">{type}</span>
                 </div>
               ))}
             </div>
           </Panel>
 
           {/* 统计信息 */}
-          <Panel position="top-right" className="bg-white rounded-lg shadow-lg p-4">
-            <h3 className="text-sm font-semibold text-gray-900 mb-3">{t('editor.statsLabel')}</h3>
-            <div className="space-y-2 text-xs text-gray-600">
+          <Panel position="top-right" className="bg-white rounded-lg shadow-lg p-4 dark:border dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-xl dark:shadow-black/30">
+            <h3 className="text-sm font-semibold text-gray-900 mb-3 dark:text-zinc-100">{t('editor.statsLabel')}</h3>
+            <div className="space-y-2 text-xs text-gray-600 dark:text-zinc-300">
               <div className="flex justify-between gap-4">
                 <span>{t('editor.nodeCountLabel')}</span>
                 <span className="font-medium">{nodes.length}</span>

--- a/webui/src/pages/Workspace/index.tsx
+++ b/webui/src/pages/Workspace/index.tsx
@@ -373,12 +373,12 @@ function FilesTab() {
             </div>
           ) : (
             <table className="w-full text-sm">
-              <thead className="bg-gray-50 sticky top-0">
+              <thead className="sticky top-0 bg-gray-50 dark:bg-zinc-900/95">
                 <tr>
-                  <th className="text-left px-4 py-2 text-xs font-medium text-gray-500 w-8"></th>
-                  <th className="text-left px-2 py-2 text-xs font-medium text-gray-500">{t('files.columns.name')}</th>
-                  <th className="text-right px-4 py-2 text-xs font-medium text-gray-500 w-24">{t('files.columns.size')}</th>
-                  <th className="text-right px-4 py-2 text-xs font-medium text-gray-500 w-36">{t('files.columns.modified')}</th>
+                  <th className="w-8 px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-zinc-500"></th>
+                  <th className="px-2 py-2 text-left text-xs font-medium text-gray-500 dark:text-zinc-500">{t('files.columns.name')}</th>
+                  <th className="w-24 px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-zinc-500">{t('files.columns.size')}</th>
+                  <th className="w-36 px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-zinc-500">{t('files.columns.modified')}</th>
                   <th className="w-20"></th>
                 </tr>
               </thead>
@@ -388,17 +388,19 @@ function FilesTab() {
                     key={item.path}
                     onClick={() => handleSelectNode(item)}
                     className={`group border-t border-gray-50 cursor-pointer transition-colors ${
-                      panel.node?.path === item.path ? 'bg-slate-100' : 'hover:bg-gray-50'
+                      panel.node?.path === item.path
+                        ? 'bg-slate-100 dark:bg-zinc-800/70'
+                        : 'hover:bg-gray-50 dark:hover:bg-zinc-900/70'
                     }`}
                   >
                     <td className="px-4 py-2 text-sm">{fileIcon(item)}</td>
-                    <td className="px-2 py-2 font-medium text-gray-800 truncate max-w-0">
+                    <td className="max-w-0 truncate px-2 py-2 font-medium text-gray-800 dark:text-zinc-100">
                       <span className="block truncate">{item.name}</span>
                     </td>
-                    <td className="px-4 py-2 text-right text-gray-400 tabular-nums whitespace-nowrap">
+                    <td className="whitespace-nowrap px-4 py-2 text-right tabular-nums text-gray-400 dark:text-zinc-500">
                       {item.type === 'file' ? formatBytes(item.size ?? 0) : '—'}
                     </td>
-                    <td className="px-4 py-2 text-right text-gray-400 text-xs whitespace-nowrap">
+                    <td className="whitespace-nowrap px-4 py-2 text-right text-xs text-gray-400 dark:text-zinc-500">
                       {formatDate(item.modified_at)}
                     </td>
                     <td className="px-2 py-2">

--- a/webui/src/routes/index.tsx
+++ b/webui/src/routes/index.tsx
@@ -65,15 +65,15 @@ export function Routes() {
   if (error) {
     return (
       <AuthLayout>
-        <div className="w-full max-w-lg bg-white border border-gray-200 rounded-xl p-6 shadow-sm space-y-4">
+        <div className="w-full max-w-lg bg-white border border-gray-200 rounded-xl p-6 shadow-sm space-y-4 dark:border-[#4a5563] dark:bg-[#303842] dark:shadow-xl dark:shadow-black/20">
           <div>
-            <h1 className="text-xl font-semibold text-gray-900">{t('error.systemUnknownTitle')}</h1>
-            <p className="text-sm text-gray-500 mt-1">{error}</p>
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-[#d7dee8]">{t('error.systemUnknownTitle')}</h1>
+            <p className="text-sm text-gray-500 mt-1 dark:text-[#b8c2cc]">{error}</p>
           </div>
           <button
             type="button"
             onClick={() => void refresh()}
-            className="bg-slate-900 text-white rounded-lg px-4 py-2 font-medium hover:bg-slate-800"
+            className="bg-slate-900 text-white rounded-lg px-4 py-2 font-medium hover:bg-slate-800 dark:bg-[#46515e] dark:hover:bg-[#5a6573]"
           >
             {t('error.retry')}
           </button>

--- a/webui/src/styles/index.css
+++ b/webui/src/styles/index.css
@@ -193,90 +193,1344 @@
   }
 }
 
-/* Dark-mode compatibility for existing neutral Tailwind utilities. */
-.dark .bg-white {
-  background-color: #18181b;
+/* VS Code / GitHub Dark Dimmed inspired compatibility for existing Tailwind utilities. */
+.dark {
+  --flocks-dark-accent: #539bf5;
+  --flocks-dark-app: #252c35;
+  --flocks-dark-surface: #303842;
+  --flocks-dark-surface-soft: #3a434e;
+  --flocks-dark-surface-raised: #46515e;
+  --flocks-dark-border: #4a5563;
+  --flocks-dark-border-strong: #5a6573;
+  --flocks-dark-text: #d7dee8;
+  --flocks-dark-text-muted: #b8c2cc;
+  --flocks-dark-text-subtle: #9aa7b4;
+  --flocks-dark-placeholder: rgb(184 194 204 / 0.78);
+  --flocks-dark-shadow: 0 18px 48px rgb(28 33 40 / 0.38);
+  background-color: var(--flocks-dark-app);
+  color: var(--flocks-dark-text);
+}
+
+.dark body,
+.dark #root {
+  background-color: var(--flocks-dark-app);
+  color: var(--flocks-dark-text);
+}
+
+.dark ::selection {
+  background-color: rgb(83 155 245 / 0.32);
+  color: #ffffff;
+}
+
+.dark .bg-white,
+.dark .bg-white\/95,
+.dark .bg-white\/90,
+.dark .bg-white\/80,
+.dark .bg-white\/70,
+.dark .bg-white\/60,
+.dark .bg-white\/50,
+.dark .bg-white\/40 {
+  background-color: var(--flocks-dark-surface);
+}
+
+.dark .disabled\:bg-white\/50:disabled {
+  background-color: rgb(48 56 66 / 0.55);
+}
+
+.dark .disabled\:bg-gray-50:disabled,
+.dark .disabled\:bg-zinc-50:disabled,
+.dark .disabled\:bg-slate-50:disabled {
+  background-color: rgb(48 56 66 / 0.62);
+}
+
+.dark .disabled\:bg-gray-200:disabled,
+.dark .disabled\:bg-zinc-200:disabled,
+.dark .disabled\:bg-slate-200:disabled,
+.dark .disabled\:bg-gray-300:disabled,
+.dark .disabled\:bg-zinc-300:disabled,
+.dark .disabled\:bg-slate-300:disabled {
+  background-color: var(--flocks-dark-surface-raised);
+}
+
+.dark .disabled\:hover\:bg-white:disabled:hover,
+.dark .disabled\:hover\:bg-gray-50:disabled:hover,
+.dark .disabled\:hover\:bg-zinc-50:disabled:hover,
+.dark .disabled\:hover\:bg-slate-50:disabled:hover {
+  background-color: var(--flocks-dark-surface);
+}
+
+.dark .disabled\:text-gray-400:disabled,
+.dark .disabled\:text-zinc-400:disabled,
+.dark .disabled\:text-slate-400:disabled,
+.dark .disabled\:text-gray-500:disabled,
+.dark .disabled\:text-zinc-500:disabled,
+.dark .disabled\:text-slate-500:disabled {
+  color: var(--flocks-dark-text-subtle);
+}
+
+.dark .disabled\:hover\:text-slate-600:disabled:hover,
+.dark .disabled\:hover\:text-gray-600:disabled:hover,
+.dark .disabled\:hover\:text-zinc-600:disabled:hover {
+  color: var(--flocks-dark-text-subtle);
+}
+
+.dark .disabled\:border-gray-200:disabled,
+.dark .disabled\:border-zinc-200:disabled,
+.dark .disabled\:border-slate-200:disabled {
+  border-color: var(--flocks-dark-border);
 }
 
 .dark .bg-gray-50,
-.dark .bg-zinc-50 {
-  background-color: #09090b;
+.dark .bg-zinc-50,
+.dark .bg-slate-50 {
+  background-color: var(--flocks-dark-app);
 }
 
 .dark .bg-gray-100,
-.dark .bg-zinc-100 {
-  background-color: #18181b;
+.dark .bg-zinc-100,
+.dark .bg-slate-100 {
+  background-color: var(--flocks-dark-surface-soft);
 }
 
 .dark .bg-gray-200,
-.dark .bg-zinc-200 {
-  background-color: #27272a;
+.dark .bg-zinc-200,
+.dark .bg-slate-200,
+.dark .bg-gray-300,
+.dark .bg-zinc-300 {
+  background-color: var(--flocks-dark-surface-raised);
+}
+
+.dark .bg-zinc-900,
+.dark .bg-gray-900,
+.dark .bg-slate-900,
+.dark .bg-zinc-950,
+.dark .bg-gray-950,
+.dark .bg-slate-950 {
+  background-color: var(--flocks-dark-surface) !important;
+}
+
+.dark button.bg-slate-700,
+.dark button.bg-slate-800,
+.dark button.bg-slate-900,
+.dark a.bg-slate-700,
+.dark a.bg-slate-800,
+.dark a.bg-slate-900,
+.dark .bg-slate-700.text-white,
+.dark .bg-slate-800.text-white,
+.dark .bg-slate-900.text-white,
+.dark .bg-gray-900.text-white,
+.dark .bg-zinc-800.text-white,
+.dark .bg-zinc-900.text-white {
+  background-color: var(--flocks-dark-surface-raised);
+  border-color: var(--flocks-dark-border-strong);
+  color: #ffffff;
+}
+
+.dark button.hover\:bg-slate-800:hover,
+.dark button.hover\:bg-slate-900:hover,
+.dark a.hover\:bg-slate-800:hover,
+.dark a.hover\:bg-slate-900:hover,
+.dark .hover\:bg-slate-800:hover,
+.dark .hover\:bg-slate-900:hover,
+.dark .hover\:bg-gray-900:hover,
+.dark .hover\:bg-zinc-900:hover {
+  background-color: #46515e;
+}
+
+.dark pre.bg-gray-900,
+.dark pre.bg-zinc-950,
+.dark code.bg-gray-900,
+.dark code.bg-zinc-950,
+.dark .font-mono.bg-gray-900,
+.dark .font-mono.bg-zinc-950,
+.dark .bg-gray-900.text-green-400,
+.dark .bg-zinc-950.text-green-400,
+.dark .bg-gray-900.text-gray-300,
+.dark .bg-zinc-950.text-zinc-300 {
+  background-color: #20262d;
+}
+
+.dark .bg-zinc-900\/70,
+.dark .bg-zinc-900\/80,
+.dark .bg-zinc-900\/95 {
+  background-color: rgb(48 56 66 / 0.96);
+}
+
+.dark .bg-zinc-950\/30,
+.dark .bg-zinc-950\/40,
+.dark .bg-zinc-950\/60 {
+  background-color: rgb(37 44 53 / 0.88);
+}
+
+.dark .dark\:bg-zinc-950,
+.dark .dark\:bg-gray-950,
+.dark .dark\:bg-slate-950 {
+  background-color: var(--flocks-dark-app) !important;
+}
+
+.dark .dark\:bg-zinc-950\/95,
+.dark .dark\:bg-gray-950\/95,
+.dark .dark\:bg-slate-950\/95 {
+  background-color: rgb(37 44 53 / 0.96) !important;
+}
+
+.dark .dark\:bg-zinc-900,
+.dark .dark\:bg-gray-900,
+.dark .dark\:bg-slate-900 {
+  background-color: var(--flocks-dark-surface) !important;
+}
+
+.dark .dark\:bg-zinc-900\/60,
+.dark .dark\:bg-zinc-900\/70,
+.dark .dark\:bg-zinc-900\/80,
+.dark .dark\:bg-zinc-900\/95 {
+  background-color: rgb(48 56 66 / 0.96) !important;
+}
+
+.dark .dark\:bg-zinc-800,
+.dark .dark\:bg-gray-800,
+.dark .dark\:bg-slate-800 {
+  background-color: var(--flocks-dark-surface-raised) !important;
+}
+
+.dark .dark\:bg-zinc-800\/50,
+.dark .dark\:bg-zinc-800\/60,
+.dark .dark\:bg-zinc-800\/70,
+.dark .dark\:bg-zinc-800\/80,
+.dark .dark\:bg-gray-800\/50,
+.dark .dark\:bg-gray-800\/60,
+.dark .dark\:bg-gray-800\/70,
+.dark .dark\:bg-gray-800\/80,
+.dark .dark\:bg-slate-800\/50,
+.dark .dark\:bg-slate-800\/60,
+.dark .dark\:bg-slate-800\/70,
+.dark .dark\:bg-slate-800\/80 {
+  background-color: rgb(70 81 94 / 0.72) !important;
+}
+
+.dark .dark\:hover\:bg-zinc-900:hover,
+.dark .dark\:hover\:bg-zinc-800:hover,
+.dark .dark\:hover\:bg-gray-900:hover,
+.dark .dark\:hover\:bg-gray-800:hover,
+.dark .dark\:focus\:bg-zinc-900:focus,
+.dark .dark\:focus\:bg-zinc-800:focus,
+.dark .dark\:focus-within\:bg-zinc-900:focus-within,
+.dark .dark\:focus-within\:bg-zinc-800:focus-within {
+  background-color: var(--flocks-dark-surface-raised) !important;
+}
+
+.dark .dark\:bg-sky-950\/30,
+.dark .dark\:bg-sky-950\/35,
+.dark .dark\:bg-sky-950\/45,
+.dark .dark\:bg-blue-950\/30,
+.dark .dark\:bg-blue-950\/40 {
+  background-color: rgb(83 155 245 / 0.16);
+}
+
+.dark .dark\:bg-amber-950\/25,
+.dark .dark\:bg-amber-950\/30,
+.dark .dark\:bg-amber-950\/40,
+.dark .dark\:bg-amber-950\/50,
+.dark .dark\:bg-orange-950\/30,
+.dark .dark\:bg-orange-950\/50,
+.dark .dark\:hover\:bg-amber-900\/60:hover {
+  background-color: rgb(217 119 6 / 0.16);
+}
+
+.dark .dark\:bg-red-950\/30,
+.dark .dark\:bg-red-950\/40,
+.dark .dark\:bg-rose-950\/30,
+.dark .dark\:bg-rose-950\/40,
+.dark .dark\:bg-rose-950\/50,
+.dark .dark\:hover\:bg-red-950\/40:hover {
+  background-color: rgb(220 38 38 / 0.14);
+}
+
+.dark .dark\:bg-green-950\/30,
+.dark .dark\:bg-green-950\/40,
+.dark .dark\:bg-teal-950\/30,
+.dark .dark\:bg-teal-950\/40,
+.dark .dark\:bg-cyan-950\/30,
+.dark .dark\:bg-cyan-950\/40 {
+  background-color: rgb(22 163 74 / 0.14);
+}
+
+.dark .dark\:bg-purple-950\/30,
+.dark .dark\:bg-purple-950\/40,
+.dark .dark\:bg-violet-950\/30,
+.dark .dark\:bg-violet-950\/40,
+.dark .dark\:bg-indigo-950\/30,
+.dark .dark\:bg-indigo-950\/40 {
+  background-color: rgb(124 58 237 / 0.16);
 }
 
 .dark .hover\:bg-white\/60:hover,
 .dark .hover\:bg-white\/70:hover,
+.dark .hover\:bg-white\/80:hover,
+.dark .hover\:bg-white:hover,
 .dark .hover\:bg-gray-50:hover,
 .dark .hover\:bg-zinc-50:hover,
 .dark .hover\:bg-gray-100:hover,
-.dark .hover\:bg-zinc-100:hover {
-  background-color: #27272a;
+.dark .hover\:bg-zinc-100:hover,
+.dark .hover\:bg-gray-200:hover,
+.dark .hover\:bg-gray-200\/60:hover,
+.dark .hover\:bg-zinc-200:hover,
+.dark .hover\:bg-zinc-200\/60:hover,
+.dark .hover\:bg-zinc-100\/70:hover,
+.dark .hover\:bg-slate-50:hover,
+.dark .hover\:bg-slate-100:hover {
+  background-color: var(--flocks-dark-surface-raised);
+}
+
+.dark .focus\:bg-white:focus,
+.dark .focus\:bg-gray-200:focus,
+.dark .focus-within\:bg-white:focus-within {
+  background-color: var(--flocks-dark-surface);
+}
+
+.dark .bg-sky-50,
+.dark .bg-sky-50\/80,
+.dark .bg-sky-50\/60,
+.dark .bg-blue-50,
+.dark .bg-blue-50\/40,
+.dark .bg-blue-50\/60 {
+  background-color: rgb(83 155 245 / 0.16);
+}
+
+.dark .bg-amber-50,
+.dark .bg-amber-50\/30,
+.dark .bg-amber-50\/60,
+.dark .bg-amber-50\/70,
+.dark .bg-orange-50,
+.dark .bg-orange-50\/60,
+.dark .bg-yellow-50,
+.dark .bg-yellow-100,
+.dark .bg-yellow-200 {
+  background-color: rgb(217 119 6 / 0.16);
+}
+
+.dark .bg-red-50,
+.dark .bg-red-50\/30,
+.dark .bg-red-50\/40,
+.dark .bg-red-50\/50,
+.dark .bg-red-100\/80,
+.dark .bg-red-500\/10,
+.dark .bg-red-500\/15,
+.dark .bg-red-600\/5,
+.dark .bg-red-600\/10 {
+  background-color: rgb(220 38 38 / 0.14);
+}
+
+.dark .bg-green-50,
+.dark .bg-green-50\/50,
+.dark .bg-emerald-50,
+.dark .bg-emerald-50\/50,
+.dark .bg-emerald-500\/15,
+.dark .bg-emerald-100,
+.dark .bg-lime-50 {
+  background-color: rgb(22 163 74 / 0.16);
+}
+
+.dark .bg-gray-50\/60,
+.dark .bg-gray-50\/70,
+.dark .bg-gray-50\/80,
+.dark .bg-zinc-50\/60,
+.dark .bg-zinc-50\/70,
+.dark .bg-slate-50\/70 {
+  background-color: rgb(48 56 66 / 0.76);
+}
+
+.dark .bg-purple-50,
+.dark .bg-purple-50\/50,
+.dark .bg-purple-50\/60,
+.dark .bg-purple-100,
+.dark .bg-violet-50,
+.dark .bg-violet-100,
+.dark .bg-fuchsia-50,
+.dark .bg-indigo-50,
+.dark .bg-indigo-100 {
+  background-color: rgb(124 58 237 / 0.16);
+}
+
+.dark .bg-teal-50,
+.dark .bg-teal-100,
+.dark .bg-cyan-50,
+.dark .bg-cyan-100 {
+  background-color: rgb(20 184 166 / 0.14);
+}
+
+.dark .bg-pink-50,
+.dark .bg-pink-100,
+.dark .bg-rose-50,
+.dark .bg-rose-50\/80,
+.dark .bg-rose-100 {
+  background-color: rgb(244 63 94 / 0.14);
+}
+
+.dark .hover\:bg-sky-50:hover,
+.dark .hover\:bg-blue-50:hover,
+.dark .hover\:bg-blue-50\/30:hover,
+.dark .hover\:bg-blue-50\/40:hover,
+.dark .hover\:bg-sky-100:hover,
+.dark .hover\:bg-blue-100:hover,
+.dark .hover\:bg-amber-50:hover,
+.dark .hover\:bg-amber-50\/30:hover,
+.dark .hover\:bg-orange-50:hover,
+.dark .hover\:bg-yellow-50:hover,
+.dark .hover\:bg-amber-100:hover,
+.dark .hover\:bg-orange-100:hover,
+.dark .hover\:bg-red-50:hover,
+.dark .hover\:bg-red-100:hover,
+.dark .hover\:bg-red-400\/10:hover,
+.dark .hover\:bg-red-500\/20:hover,
+.dark .hover\:bg-red-500\/25:hover,
+.dark .hover\:bg-green-50:hover,
+.dark .hover\:bg-emerald-50:hover,
+.dark .hover\:bg-emerald-50\/80:hover,
+.dark .hover\:bg-emerald-500\/25:hover,
+.dark .hover\:bg-green-100:hover,
+.dark .hover\:bg-yellow-100:hover,
+.dark .hover\:bg-purple-50:hover,
+.dark .hover\:bg-violet-50:hover,
+.dark .hover\:bg-purple-100:hover,
+.dark .hover\:bg-violet-100:hover,
+.dark .hover\:bg-teal-50:hover,
+.dark .hover\:bg-cyan-50:hover,
+.dark .hover\:bg-teal-100:hover,
+.dark .hover\:bg-cyan-100:hover,
+.dark .hover\:bg-indigo-50:hover,
+.dark .hover\:bg-pink-50:hover,
+.dark .hover\:bg-rose-50:hover,
+.dark .hover\:bg-pink-100:hover,
+.dark .hover\:bg-rose-50\/70:hover,
+.dark .hover\:bg-rose-50\/80:hover,
+.dark .hover\:bg-rose-100:hover {
+  background-color: var(--flocks-dark-surface-raised);
+}
+
+.dark .group:hover .group-hover\:bg-sky-100,
+.dark .group:hover .group-hover\:bg-blue-50,
+.dark .group:hover .group-hover\:bg-blue-100,
+.dark .group:hover .group-hover\:bg-emerald-100,
+.dark .group:hover .group-hover\:bg-violet-100,
+.dark .group:hover .group-hover\:bg-zinc-100 {
+  background-color: var(--flocks-dark-surface-raised);
+}
+
+.dark .from-white,
+.dark .from-slate-50,
+.dark .from-gray-50,
+.dark .from-zinc-50 {
+  --tw-gradient-from: var(--flocks-dark-surface-soft) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(58 67 78 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.dark .via-white,
+.dark .via-slate-50,
+.dark .via-gray-50,
+.dark .via-zinc-50 {
+  --tw-gradient-to: rgb(48 56 66 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--flocks-dark-surface) var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+.dark .to-white,
+.dark .to-slate-50,
+.dark .to-gray-50,
+.dark .to-zinc-50 {
+  --tw-gradient-to: var(--flocks-dark-surface) var(--tw-gradient-to-position);
+}
+
+.dark .from-amber-50,
+.dark .from-orange-50 {
+  --tw-gradient-from: rgb(217 119 6 / 0.18) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(217 119 6 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.dark .via-amber-50,
+.dark .via-orange-50 {
+  --tw-gradient-to: rgb(217 119 6 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), rgb(217 119 6 / 0.16) var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+.dark .to-amber-50,
+.dark .to-orange-50,
+.dark .to-yellow-50 {
+  --tw-gradient-to: rgb(217 119 6 / 0.16) var(--tw-gradient-to-position);
+}
+
+.dark .from-emerald-50 {
+  --tw-gradient-from: rgb(22 163 74 / 0.16) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(22 163 74 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.dark .via-teal-50 {
+  --tw-gradient-to: rgb(20 184 166 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), rgb(20 184 166 / 0.14) var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+.dark .to-cyan-50 {
+  --tw-gradient-to: rgb(20 184 166 / 0.14) var(--tw-gradient-to-position);
+}
+
+.dark .via-rose-50 {
+  --tw-gradient-to: rgb(220 38 38 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), rgb(220 38 38 / 0.14) var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+.dark .to-rose-50 {
+  --tw-gradient-to: rgb(220 38 38 / 0.14) var(--tw-gradient-to-position);
+}
+
+.dark .from-purple-50 {
+  --tw-gradient-from: rgb(124 58 237 / 0.16) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(124 58 237 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.dark .to-purple-50 {
+  --tw-gradient-to: rgb(124 58 237 / 0.16) var(--tw-gradient-to-position);
+}
+
+.dark .from-red-50,
+.dark .from-rose-50 {
+  --tw-gradient-from: rgb(220 38 38 / 0.16) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(220 38 38 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.dark .from-purple-100 {
+  --tw-gradient-from: rgb(124 58 237 / 0.16) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(124 58 237 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.dark .to-purple-100 {
+  --tw-gradient-to: rgb(124 58 237 / 0.16) var(--tw-gradient-to-position);
+}
+
+.dark .to-red-50,
+.dark .to-red-100,
+.dark .to-rose-100 {
+  --tw-gradient-to: rgb(220 38 38 / 0.14) var(--tw-gradient-to-position);
 }
 
 .dark .border-gray-100,
+.dark .border-gray-50,
 .dark .border-zinc-100,
+.dark .border-slate-100,
+.dark .border-white,
+.dark .border-white\/80,
+.dark .border-white\/70,
+.dark .border-white\/60,
 .dark .border-gray-200,
 .dark .border-zinc-200,
-.dark .divide-gray-200 > :not([hidden]) ~ :not([hidden]),
-.dark .divide-zinc-200 > :not([hidden]) ~ :not([hidden]) {
-  border-color: #27272a;
-}
-
+.dark .border-slate-200,
 .dark .border-gray-300,
-.dark .border-zinc-300 {
-  border-color: #3f3f46;
+.dark .border-zinc-300,
+.dark .border-slate-300,
+.dark .border-gray-200\/80,
+.dark .border-zinc-200\/80,
+.dark .border-zinc-200\/90,
+.dark .border-zinc-200\/60,
+.dark .border-zinc-200\/70,
+.dark .border-l-gray-300,
+.dark .border-l-zinc-200,
+.dark .border-t-white,
+.dark .border-t-zinc-200,
+.dark .divide-gray-100 > :not([hidden]) ~ :not([hidden]),
+.dark .divide-gray-50 > :not([hidden]) ~ :not([hidden]),
+.dark .divide-zinc-100 > :not([hidden]) ~ :not([hidden]),
+.dark .divide-gray-200 > :not([hidden]) ~ :not([hidden]),
+.dark .divide-zinc-200 > :not([hidden]) ~ :not([hidden]),
+.dark .divide-slate-100 > :not([hidden]) ~ :not([hidden]),
+.dark .divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--flocks-dark-border) !important;
 }
 
+.dark .border-gray-400,
+.dark .border-gray-500,
+.dark .border-gray-600,
+.dark .border-zinc-400,
+.dark .border-slate-400,
+.dark .border-slate-500,
+.dark .border-slate-600,
+.dark .focus\:border-gray-300:focus,
+.dark .focus\:border-zinc-300:focus,
+.dark .focus\:border-slate-400:focus,
+.dark .focus-within\:border-zinc-300:focus-within,
+.dark .hover\:border-gray-300:hover,
+.dark .hover\:border-gray-200:hover,
+.dark .hover\:border-zinc-300:hover,
+.dark .hover\:border-gray-400:hover,
+.dark .hover\:border-zinc-400:hover,
+.dark .hover\:border-slate-300:hover,
+.dark .hover\:border-slate-400:hover {
+  border-color: var(--flocks-dark-border-strong) !important;
+}
+
+.dark .dark\:border-zinc-950,
+.dark .dark\:border-zinc-900,
+.dark .dark\:border-zinc-800,
+.dark .dark\:border-gray-950,
+.dark .dark\:border-gray-900,
+.dark .dark\:border-gray-800,
+.dark .dark\:border-slate-950,
+.dark .dark\:border-slate-900,
+.dark .dark\:border-slate-800,
+.dark .dark\:divide-zinc-900 > :not([hidden]) ~ :not([hidden]),
+.dark .dark\:divide-zinc-800 > :not([hidden]) ~ :not([hidden]),
+.dark .dark\:divide-gray-900 > :not([hidden]) ~ :not([hidden]),
+.dark .dark\:divide-gray-800 > :not([hidden]) ~ :not([hidden]),
+.dark .dark\:divide-slate-900 > :not([hidden]) ~ :not([hidden]),
+.dark .dark\:divide-slate-800 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--flocks-dark-border) !important;
+}
+
+.dark .dark\:border-zinc-700,
+.dark .dark\:border-zinc-600,
+.dark .dark\:border-gray-700,
+.dark .dark\:border-gray-600,
+.dark .dark\:border-slate-700,
+.dark .dark\:border-slate-600,
+.dark .dark\:hover\:border-zinc-700:hover,
+.dark .dark\:hover\:border-zinc-600:hover,
+.dark .dark\:hover\:border-gray-700:hover,
+.dark .dark\:hover\:border-gray-600:hover {
+  border-color: var(--flocks-dark-border-strong) !important;
+}
+
+.dark .hover\:border-blue-300:hover,
+.dark .hover\:border-blue-200:hover,
+.dark .hover\:border-blue-400:hover,
+.dark .hover\:border-purple-300:hover,
+.dark .hover\:border-purple-400:hover {
+  border-color: rgb(96 165 250 / 0.42);
+}
+
+.dark .hover\:border-sky-200:hover {
+  border-color: rgb(59 130 246 / 0.34);
+}
+
+.dark .hover\:border-amber-400:hover,
+.dark .hover\:border-amber-200:hover,
+.dark .hover\:border-orange-400:hover,
+.dark .hover\:border-yellow-400:hover {
+  border-color: rgb(245 158 11 / 0.42);
+}
+
+.dark .hover\:border-emerald-200:hover,
+.dark .hover\:border-emerald-300:hover,
+.dark .hover\:border-emerald-400:hover {
+  border-color: rgb(52 211 153 / 0.4);
+}
+
+.dark .hover\:border-red-200:hover,
+.dark .hover\:border-red-300:hover,
+.dark .hover\:border-rose-200:hover {
+  border-color: rgb(244 63 94 / 0.4);
+}
+
+.dark .hover\:border-violet-200:hover {
+  border-color: rgb(139 92 246 / 0.34);
+}
+
+.dark .border-sky-100,
+.dark .border-sky-200,
+.dark .border-sky-300,
+.dark .border-sky-400,
+.dark .border-sky-600,
+.dark .border-blue-100,
+.dark .border-blue-200,
+.dark .border-blue-300,
+.dark .border-cyan-400,
+.dark .focus\:border-blue-300:focus,
+.dark .focus\:border-blue-400:focus,
+.dark .focus\:border-blue-500:focus {
+  border-color: rgb(83 155 245 / 0.46);
+}
+
+.dark .border-amber-100,
+.dark .border-amber-200,
+.dark .border-amber-300,
+.dark .border-amber-400,
+.dark .border-yellow-200,
+.dark .border-yellow-500,
+.dark .border-orange-100,
+.dark .border-orange-200,
+.dark .border-orange-300,
+.dark .border-orange-400 {
+  border-color: rgb(245 158 11 / 0.34);
+}
+
+.dark .border-red-100,
+.dark .border-red-200,
+.dark .border-red-300,
+.dark .border-red-400\/40,
+.dark .border-red-600,
+.dark .border-l-red-400,
+.dark .border-l-red-500,
+.dark .border-t-red-600,
+.dark .focus\:border-red-400:focus,
+.dark .focus\:border-red-500:focus,
+.dark .focus-within\:border-red-500:focus-within,
+.dark .border-rose-100,
+.dark .border-rose-200,
+.dark .border-rose-300,
+.dark .border-pink-100,
+.dark .border-pink-200,
+.dark .border-pink-300,
+.dark .border-pink-400,
+.dark .border-pink-500 {
+  border-color: rgb(244 63 94 / 0.32);
+}
+
+.dark .border-green-100,
+.dark .border-green-200,
+.dark .border-green-300,
+.dark .border-green-400,
+.dark .border-green-500,
+.dark .border-l-green-400,
+.dark .border-l-green-500,
+.dark .border-emerald-100,
+.dark .border-emerald-200,
+.dark .border-emerald-300,
+.dark .border-emerald-400,
+.dark .border-lime-400,
+.dark .border-teal-100,
+.dark .border-teal-200,
+.dark .border-teal-300,
+.dark .border-teal-400,
+.dark .border-teal-500,
+.dark .border-cyan-100,
+.dark .border-cyan-200,
+.dark .border-cyan-300 {
+  border-color: rgb(34 197 94 / 0.3);
+}
+
+.dark .border-purple-100,
+.dark .border-purple-200,
+.dark .border-purple-300,
+.dark .border-purple-500,
+.dark .border-purple-600,
+.dark .focus\:border-purple-500:focus,
+.dark .border-violet-100,
+.dark .border-violet-200,
+.dark .border-violet-300,
+.dark .border-violet-400,
+.dark .border-violet-500,
+.dark .border-fuchsia-400,
+.dark .border-indigo-100,
+.dark .border-indigo-200,
+.dark .border-indigo-300,
+.dark .border-indigo-400 {
+  border-color: rgb(139 92 246 / 0.34);
+}
+
+.dark .dark\:border-zinc-900,
+.dark .dark\:border-zinc-800,
+.dark .dark\:border-gray-800,
+.dark .dark\:border-slate-800 {
+  border-color: var(--flocks-dark-border);
+}
+
+.dark .dark\:border-zinc-700,
+.dark .dark\:border-gray-700,
+.dark .dark\:border-slate-700,
+.dark .dark\:hover\:border-zinc-700:hover,
+.dark .dark\:focus\:border-zinc-700:focus,
+.dark .dark\:focus-within\:border-zinc-700:focus-within {
+  border-color: var(--flocks-dark-border-strong);
+}
+
+.dark .dark\:ring-zinc-800,
+.dark .dark\:focus\:ring-zinc-800:focus,
+.dark .dark\:focus-within\:ring-zinc-800:focus-within {
+  --tw-ring-color: rgb(90 101 115 / 0.72);
+}
+
+.dark .dark\:border-sky-500\/35,
+.dark .dark\:border-sky-500\/40,
+.dark .dark\:border-sky-500\/50,
+.dark .dark\:border-blue-500\/35,
+.dark .dark\:border-blue-500\/40,
+.dark .dark\:border-blue-500\/50 {
+  border-color: rgb(83 155 245 / 0.46);
+}
+
+.dark .dark\:border-amber-500\/30,
+.dark .dark\:border-amber-500\/35,
+.dark .dark\:border-amber-500\/40,
+.dark .dark\:border-orange-500\/35,
+.dark .dark\:border-orange-500\/40 {
+  border-color: rgb(245 158 11 / 0.34);
+}
+
+.dark .dark\:border-red-500\/30,
+.dark .dark\:border-red-500\/35,
+.dark .dark\:border-red-500\/40,
+.dark .dark\:border-rose-500\/30,
+.dark .dark\:border-rose-500\/35,
+.dark .dark\:border-rose-500\/40 {
+  border-color: rgb(244 63 94 / 0.32);
+}
+
+.dark .text-gray-950,
+.dark .text-zinc-950,
+.dark .text-slate-950,
 .dark .text-gray-900,
 .dark .text-zinc-900,
+.dark .text-slate-900,
 .dark .text-gray-800,
-.dark .text-zinc-800 {
-  color: #f4f4f5;
+.dark .text-zinc-800,
+.dark .text-slate-800 {
+  color: var(--flocks-dark-text);
 }
 
 .dark .text-gray-700,
 .dark .text-zinc-700,
+.dark .text-slate-700,
 .dark .text-gray-600,
-.dark .text-zinc-600 {
-  color: #d4d4d8;
+.dark .text-zinc-600,
+.dark .text-slate-600 {
+  color: var(--flocks-dark-text-muted);
 }
 
 .dark .text-gray-500,
 .dark .text-zinc-500,
+.dark .text-slate-500,
 .dark .text-gray-400,
-.dark .text-zinc-400 {
-  color: #a1a1aa;
+.dark .text-zinc-400,
+.dark .text-slate-400,
+.dark .text-gray-300,
+.dark .text-zinc-300,
+.dark .text-slate-300 {
+  color: var(--flocks-dark-text-subtle);
 }
 
 .dark .hover\:text-gray-900:hover,
 .dark .hover\:text-zinc-900:hover,
+.dark .hover\:text-slate-900:hover,
 .dark .hover\:text-gray-800:hover,
 .dark .hover\:text-zinc-800:hover,
+.dark .hover\:text-slate-800:hover,
 .dark .hover\:text-gray-700:hover,
 .dark .hover\:text-zinc-700:hover,
+.dark .hover\:text-slate-700:hover,
 .dark .hover\:text-gray-600:hover,
-.dark .hover\:text-zinc-600:hover {
-  color: #fafafa;
+.dark .hover\:text-zinc-600:hover,
+.dark .hover\:text-slate-600:hover {
+  color: #ffffff;
+}
+
+.dark .text-sky-500,
+.dark .text-sky-600,
+.dark .text-sky-700,
+.dark .text-sky-800,
+.dark .text-blue-500,
+.dark .text-blue-600,
+.dark .text-blue-700,
+.dark .text-blue-800 {
+  color: #6cb6ff;
+}
+
+.dark .text-amber-500,
+.dark .text-amber-600,
+.dark .text-amber-700,
+.dark .text-amber-700\/80,
+.dark .text-amber-800,
+.dark .text-amber-950,
+.dark .text-yellow-500,
+.dark .text-yellow-600,
+.dark .text-yellow-700,
+.dark .text-yellow-800,
+.dark .text-orange-500,
+.dark .text-orange-600,
+.dark .text-orange-700,
+.dark .text-orange-800,
+.dark .text-orange-400 {
+  color: #fbbf24;
+}
+
+.dark .text-red-300,
+.dark .text-red-400,
+.dark .text-red-500,
+.dark .text-red-600,
+.dark .text-red-700,
+.dark .text-rose-400,
+.dark .text-rose-500,
+.dark .text-rose-600,
+.dark .text-rose-700,
+.dark .text-pink-500,
+.dark .text-pink-600,
+.dark .text-pink-700 {
+  color: #fda4af;
+}
+
+.dark .text-green-500,
+.dark .text-green-600,
+.dark .text-green-700,
+.dark .text-emerald-200,
+.dark .text-emerald-300,
+.dark .text-emerald-500,
+.dark .text-emerald-600,
+.dark .text-emerald-700,
+.dark .text-emerald-800,
+.dark .text-emerald-900,
+.dark .text-lime-700,
+.dark .text-teal-500,
+.dark .text-teal-600,
+.dark .text-teal-700,
+.dark .text-cyan-500,
+.dark .text-cyan-600,
+.dark .text-cyan-700 {
+  color: #86efac;
+}
+
+.dark .text-purple-500,
+.dark .text-purple-600,
+.dark .text-purple-700,
+.dark .text-purple-800,
+.dark .text-violet-500,
+.dark .text-violet-600,
+.dark .text-violet-700,
+.dark .text-violet-800,
+.dark .text-fuchsia-700,
+.dark .text-indigo-500,
+.dark .text-indigo-600,
+.dark .text-indigo-700 {
+  color: #c4b5fd;
+}
+
+.dark .bg-emerald-50.text-emerald-900,
+.dark .bg-emerald-50.text-emerald-950,
+.dark .bg-emerald-50 .text-emerald-900,
+.dark .bg-emerald-50 .text-emerald-950,
+.dark .from-emerald-50 .text-emerald-950 {
+  color: #d1fae5;
+}
+
+.dark .dark\:text-zinc-50,
+.dark .dark\:text-zinc-100,
+.dark .dark\:text-gray-50,
+.dark .dark\:text-gray-100,
+.dark .dark\:text-slate-50,
+.dark .dark\:text-slate-100 {
+  color: var(--flocks-dark-text);
+}
+
+.dark .dark\:text-zinc-200,
+.dark .dark\:text-zinc-300,
+.dark .dark\:text-gray-200,
+.dark .dark\:text-gray-300,
+.dark .dark\:text-slate-200,
+.dark .dark\:text-slate-300 {
+  color: var(--flocks-dark-text-muted);
+}
+
+.dark .dark\:text-zinc-400,
+.dark .dark\:text-zinc-500,
+.dark .dark\:text-zinc-600,
+.dark .dark\:text-gray-400,
+.dark .dark\:text-gray-500,
+.dark .dark\:text-gray-600,
+.dark .dark\:text-slate-400,
+.dark .dark\:text-slate-500,
+.dark .dark\:text-slate-600 {
+  color: var(--flocks-dark-text-subtle);
+}
+
+.dark .dark\:hover\:text-zinc-50:hover,
+.dark .dark\:hover\:text-zinc-100:hover,
+.dark .dark\:hover\:text-zinc-200:hover,
+.dark .dark\:hover\:text-gray-50:hover,
+.dark .dark\:hover\:text-gray-100:hover,
+.dark .dark\:hover\:text-gray-200:hover {
+  color: #ffffff;
+}
+
+.dark .hover\:text-sky-900:hover,
+.dark .hover\:text-blue-800:hover,
+.dark .hover\:text-blue-900:hover,
+.dark .hover\:text-amber-900:hover,
+.dark .hover\:text-orange-900:hover,
+.dark .hover\:text-red-600:hover,
+.dark .hover\:text-red-500:hover,
+.dark .hover\:text-red-700:hover,
+.dark .hover\:text-red-800:hover,
+.dark .hover\:text-red-900:hover,
+.dark .hover\:text-green-700:hover,
+.dark .hover\:text-green-800:hover,
+.dark .hover\:text-green-900:hover,
+.dark .hover\:text-emerald-700:hover,
+.dark .hover\:text-emerald-900:hover,
+.dark .hover\:text-purple-700:hover,
+.dark .hover\:text-violet-700:hover,
+.dark .hover\:text-teal-700:hover,
+.dark .hover\:text-cyan-700:hover,
+.dark .hover\:text-indigo-700:hover,
+.dark .hover\:text-pink-700:hover,
+.dark .hover\:text-rose-500:hover,
+.dark .hover\:text-rose-600:hover,
+.dark .hover\:text-rose-700:hover {
+  color: #ffffff;
+}
+
+.dark .group:hover .group-hover\:text-gray-500,
+.dark .group:hover .group-hover\:text-zinc-400,
+.dark .group:hover .group-hover\:text-zinc-500,
+.dark .group:hover .group-hover\:text-zinc-800,
+.dark .group:hover .group-hover\:text-slate-700,
+.dark .group:hover .group-hover\:text-zinc-900,
+.dark .group\/sec:hover .group-hover\/sec\:text-zinc-900,
+.dark .group\/name:hover .group-hover\/name\:text-slate-700,
+.dark .group\/name:hover .group-hover\/name\:text-blue-700,
+.dark .group\/name:hover .group-hover\/name\:text-purple-700 {
+  color: #ffffff;
+}
+
+.dark .group:hover .dark\:group-hover\:text-zinc-100,
+.dark .group:hover .dark\:group-hover\:text-zinc-300 {
+  color: #ffffff;
+}
+
+.dark .group:hover .group-hover\:text-rose-400,
+.dark .group:hover .group-hover\:text-sky-400,
+.dark .group:hover .group-hover\:text-violet-400,
+.dark .group:hover .group-hover\:text-emerald-400,
+.dark .group:hover .group-hover\:text-blue-400,
+.dark .group:hover .group-hover\:text-blue-500,
+.dark .group:hover .group-hover\:text-amber-500 {
+  color: var(--flocks-dark-text);
+}
+
+.dark .shadow,
+.dark .shadow-sm,
+.dark .shadow-md,
+.dark .shadow-lg,
+.dark .shadow-xl,
+.dark .shadow-2xl {
+  --tw-shadow-color: rgb(0 0 0 / 0.28);
+  box-shadow: var(--flocks-dark-shadow);
+}
+
+.dark .dark\:shadow-black\/10,
+.dark .dark\:shadow-black\/20,
+.dark .dark\:shadow-black\/30,
+.dark .dark\:shadow-black\/40 {
+  --tw-shadow-color: rgb(28 33 40 / 0.32);
+  box-shadow: var(--flocks-dark-shadow);
+}
+
+.dark .hover\:shadow:hover,
+.dark .hover\:shadow-sm:hover,
+.dark .hover\:shadow-md:hover,
+.dark .hover\:shadow-lg:hover {
+  --tw-shadow-color: rgb(0 0 0 / 0.32);
+  box-shadow: var(--flocks-dark-shadow);
+}
+
+.dark .shadow-none,
+.dark .hover\:shadow-none:hover {
+  box-shadow: none;
+}
+
+.dark .ring-white,
+.dark .ring-gray-100,
+.dark .ring-zinc-100,
+.dark .ring-slate-100,
+.dark .ring-gray-200,
+.dark .ring-zinc-200,
+.dark .ring-slate-200,
+.dark .dark\:ring-zinc-950,
+.dark .dark\:ring-gray-950,
+.dark .dark\:ring-slate-950 {
+  --tw-ring-color: var(--flocks-dark-border);
+}
+
+.dark .focus\:ring-gray-100:focus,
+.dark .focus\:ring-zinc-100:focus,
+.dark .focus\:ring-slate-100:focus,
+.dark .focus\:ring-gray-200:focus,
+.dark .focus\:ring-zinc-200:focus,
+.dark .focus\:ring-slate-200:focus,
+.dark .focus-within\:ring-gray-100:focus-within,
+.dark .focus-within\:ring-zinc-100:focus-within,
+.dark .focus-within\:ring-slate-100:focus-within {
+  --tw-ring-color: rgb(90 101 115 / 0.72);
+}
+
+.dark .focus\:ring-slate-400:focus,
+.dark .focus\:ring-slate-300:focus,
+.dark .focus\:ring-gray-400:focus,
+.dark .focus\:ring-zinc-400:focus,
+.dark .focus\:ring-red-300:focus,
+.dark .focus\:ring-red-400:focus,
+.dark .focus\:ring-red-400\/50:focus,
+.dark .focus\:ring-red-500:focus,
+.dark .focus\:ring-blue-100:focus,
+.dark .focus\:ring-blue-300:focus,
+.dark .focus\:ring-blue-400:focus,
+.dark .focus\:ring-green-300:focus,
+.dark .focus\:ring-green-400:focus,
+.dark .focus\:ring-purple-100:focus,
+.dark .focus\:ring-purple-500:focus,
+.dark .focus\:ring-violet-500:focus,
+.dark .focus\:ring-pink-500:focus,
+.dark .focus\:ring-teal-500:focus,
+.dark .focus\:ring-orange-400:focus,
+.dark .focus\:ring-orange-500:focus,
+.dark .focus\:ring-emerald-100:focus,
+.dark .focus-within\:ring-red-100:focus-within,
+.dark .focus-within\:ring-red-500:focus-within,
+.dark .focus-within\:ring-zinc-300:focus-within {
+  --tw-ring-color: rgb(90 101 115 / 0.72);
+}
+
+.dark .ring-red-200,
+.dark .ring-red-300,
+.dark .ring-red-400,
+.dark .ring-slate-200,
+.dark .ring-slate-400,
+.dark .ring-green-400,
+.dark .ring-yellow-400,
+.dark .ring-orange-400,
+.dark .ring-purple-400,
+.dark .ring-violet-400,
+.dark .ring-pink-400,
+.dark .ring-teal-400 {
+  --tw-ring-color: rgb(90 101 115 / 0.72);
+}
+
+.dark .ring-offset-1,
+.dark .ring-offset-2,
+.dark .focus\:ring-offset-0:focus,
+.dark .focus\:ring-offset-1:focus {
+  --tw-ring-offset-color: var(--flocks-dark-app);
+}
+
+.dark .focus-visible\:outline-sky-500:focus-visible {
+  outline-color: rgb(83 155 245 / 0.78);
 }
 
 .dark input,
 .dark textarea,
 .dark select {
-  background-color: #18181b;
-  border-color: #3f3f46;
-  color: #f4f4f5;
+  background-color: var(--flocks-dark-surface);
+  border-color: var(--flocks-dark-border-strong);
+  color: var(--flocks-dark-text);
+}
+
+.dark textarea.bg-transparent {
+  background-color: transparent !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
 }
 
 .dark input::placeholder,
 .dark textarea::placeholder {
-  color: #71717a;
+  color: var(--flocks-dark-placeholder) !important;
+  opacity: 1;
+}
+
+.dark .placeholder-gray-300::placeholder,
+.dark .placeholder-zinc-300::placeholder,
+.dark .placeholder-slate-300::placeholder,
+.dark .placeholder-gray-400::placeholder,
+.dark .placeholder-zinc-400::placeholder,
+.dark .placeholder-slate-400::placeholder {
+  color: var(--flocks-dark-placeholder) !important;
+  opacity: 1;
+}
+
+.dark .dark\:placeholder\:text-zinc-500::placeholder,
+.dark .dark\:placeholder\:text-zinc-600::placeholder,
+.dark .dark\:placeholder\:text-gray-500::placeholder,
+.dark .dark\:placeholder\:text-gray-600::placeholder {
+  color: var(--flocks-dark-placeholder) !important;
+  opacity: 1;
+}
+
+.dark input:focus,
+.dark textarea:focus,
+.dark select:focus {
+  border-color: var(--flocks-dark-border-strong);
+  box-shadow: 0 0 0 3px rgb(83 155 245 / 0.12);
+}
+
+.dark textarea.bg-transparent:focus {
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.dark * {
+  scrollbar-color: #5a6573 #252c35 !important;
+}
+
+.dark *::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.dark *::-webkit-scrollbar-track {
+  background: #252c35;
+}
+
+.dark *::-webkit-scrollbar-thumb {
+  background: #5a6573;
+  border: 2px solid #252c35;
+  border-radius: 999px;
+}
+
+.dark *::-webkit-scrollbar-thumb:hover {
+  background: #687584;
+}
+
+.dark table {
+  color: var(--flocks-dark-text-muted);
+}
+
+.dark thead,
+.dark .prose thead {
+  background-color: var(--flocks-dark-surface-soft);
+}
+
+.dark tbody tr:hover,
+.dark .hover\:bg-gray-50:hover,
+.dark .hover\:bg-zinc-50:hover {
+  background-color: var(--flocks-dark-surface-raised);
+}
+
+.dark code,
+.dark .prose code {
+  background-color: var(--flocks-dark-surface-raised);
+  color: var(--flocks-dark-text);
+}
+
+.dark pre,
+.dark .prose pre {
+  background-color: #20262d;
+  border: 1px solid var(--flocks-dark-border);
+  color: var(--flocks-dark-text);
+}
+
+.dark .prose {
+  --tw-prose-body: var(--flocks-dark-text-muted);
+  --tw-prose-headings: var(--flocks-dark-text);
+  --tw-prose-lead: var(--flocks-dark-text-muted);
+  --tw-prose-links: #6cb6ff;
+  --tw-prose-bold: var(--flocks-dark-text);
+  --tw-prose-counters: var(--flocks-dark-text-subtle);
+  --tw-prose-bullets: var(--flocks-dark-text-subtle);
+  --tw-prose-hr: var(--flocks-dark-border);
+  --tw-prose-quotes: var(--flocks-dark-text);
+  --tw-prose-quote-borders: var(--flocks-dark-border-strong);
+  --tw-prose-captions: var(--flocks-dark-text-subtle);
+  --tw-prose-code: var(--flocks-dark-text);
+  --tw-prose-pre-code: var(--flocks-dark-text);
+  --tw-prose-pre-bg: #20262d;
+  --tw-prose-th-borders: var(--flocks-dark-border-strong);
+  --tw-prose-td-borders: var(--flocks-dark-border);
+  color: var(--flocks-dark-text-muted);
+}
+
+.dark .prose h1,
+.dark .prose h2,
+.dark .prose h3,
+.dark .prose h4,
+.dark .prose strong {
+  color: var(--flocks-dark-text);
+}
+
+.dark .prose h2,
+.dark .prose hr,
+.dark .prose th,
+.dark .prose td,
+.dark .prose details,
+.dark .prose details[open] summary {
+  border-color: var(--flocks-dark-border);
+}
+
+.dark .prose th,
+.dark .prose td {
+  color: var(--flocks-dark-text-muted);
+}
+
+.dark .prose tr:nth-child(even) td,
+.dark .prose details summary {
+  background-color: var(--flocks-dark-surface-soft);
+}
+
+.dark .prose details summary {
+  color: var(--flocks-dark-text-muted);
+}
+
+.dark .prose details summary:hover {
+  background-color: var(--flocks-dark-surface-raised);
+}
+
+.dark .prose a {
+  color: #6cb6ff;
+}
+
+.dark .react-flow,
+.dark .react-flow__renderer,
+.dark .react-flow__pane {
+  background-color: var(--flocks-dark-app);
+  color: var(--flocks-dark-text);
+}
+
+.dark .react-flow__node {
+  color: var(--flocks-dark-text);
+}
+
+.dark .react-flow__attribution {
+  background-color: rgb(48 56 66 / 0.86);
+  color: var(--flocks-dark-text-subtle);
+}
+
+.dark .react-flow__controls {
+  border: 1px solid var(--flocks-dark-border);
+  background-color: var(--flocks-dark-surface);
+  box-shadow: var(--flocks-dark-shadow);
+}
+
+.dark .react-flow__controls-button {
+  border-bottom-color: var(--flocks-dark-border);
+  background-color: var(--flocks-dark-surface);
+  color: var(--flocks-dark-text-muted);
+}
+
+.dark .react-flow__controls-button:hover {
+  background-color: var(--flocks-dark-surface-raised);
+  color: var(--flocks-dark-text);
+}
+
+.dark .react-flow__controls-button svg {
+  fill: currentColor;
+}
+
+.dark .react-flow__minimap {
+  border: 1px solid var(--flocks-dark-border) !important;
+  background-color: var(--flocks-dark-surface) !important;
+  box-shadow: var(--flocks-dark-shadow);
+}
+
+.device-room-actions-fade {
+  --device-room-action-fade: #f4f4f5;
+  background: linear-gradient(to right, transparent, var(--device-room-action-fade) 35%);
+}
+
+.device-room-actions-fade[data-selected='true'] {
+  --device-room-action-fade: #eff6ff;
+}
+
+.dark .device-room-actions-fade {
+  --device-room-action-fade: var(--flocks-dark-surface-soft);
+}
+
+.dark .device-room-actions-fade[data-selected='true'] {
+  --device-room-action-fade: rgb(37 99 235 / 0.16);
 }

--- a/webui/src/styles/index.css
+++ b/webui/src/styles/index.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-gray-50 text-gray-900;
+    @apply bg-gray-50 text-gray-900 dark:bg-zinc-950 dark:text-zinc-100;
   }
 }
 
@@ -191,4 +191,92 @@
   .prose-invert details[open] summary {
     @apply border-white/20;
   }
+}
+
+/* Dark-mode compatibility for existing neutral Tailwind utilities. */
+.dark .bg-white {
+  background-color: #18181b;
+}
+
+.dark .bg-gray-50,
+.dark .bg-zinc-50 {
+  background-color: #09090b;
+}
+
+.dark .bg-gray-100,
+.dark .bg-zinc-100 {
+  background-color: #18181b;
+}
+
+.dark .bg-gray-200,
+.dark .bg-zinc-200 {
+  background-color: #27272a;
+}
+
+.dark .hover\:bg-white\/60:hover,
+.dark .hover\:bg-white\/70:hover,
+.dark .hover\:bg-gray-50:hover,
+.dark .hover\:bg-zinc-50:hover,
+.dark .hover\:bg-gray-100:hover,
+.dark .hover\:bg-zinc-100:hover {
+  background-color: #27272a;
+}
+
+.dark .border-gray-100,
+.dark .border-zinc-100,
+.dark .border-gray-200,
+.dark .border-zinc-200,
+.dark .divide-gray-200 > :not([hidden]) ~ :not([hidden]),
+.dark .divide-zinc-200 > :not([hidden]) ~ :not([hidden]) {
+  border-color: #27272a;
+}
+
+.dark .border-gray-300,
+.dark .border-zinc-300 {
+  border-color: #3f3f46;
+}
+
+.dark .text-gray-900,
+.dark .text-zinc-900,
+.dark .text-gray-800,
+.dark .text-zinc-800 {
+  color: #f4f4f5;
+}
+
+.dark .text-gray-700,
+.dark .text-zinc-700,
+.dark .text-gray-600,
+.dark .text-zinc-600 {
+  color: #d4d4d8;
+}
+
+.dark .text-gray-500,
+.dark .text-zinc-500,
+.dark .text-gray-400,
+.dark .text-zinc-400 {
+  color: #a1a1aa;
+}
+
+.dark .hover\:text-gray-900:hover,
+.dark .hover\:text-zinc-900:hover,
+.dark .hover\:text-gray-800:hover,
+.dark .hover\:text-zinc-800:hover,
+.dark .hover\:text-gray-700:hover,
+.dark .hover\:text-zinc-700:hover,
+.dark .hover\:text-gray-600:hover,
+.dark .hover\:text-zinc-600:hover {
+  color: #fafafa;
+}
+
+.dark input,
+.dark textarea,
+.dark select {
+  background-color: #18181b;
+  border-color: #3f3f46;
+  color: #f4f4f5;
+}
+
+.dark input::placeholder,
+.dark textarea::placeholder {
+  color: #71717a;
 }

--- a/webui/src/test/setup.ts
+++ b/webui/src/test/setup.ts
@@ -2,6 +2,43 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
 import { afterEach } from 'vitest';
 
+function createStorageMock(): Storage {
+  let store: Record<string, string> = {};
+
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear() {
+      store = {};
+    },
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    key(index: number) {
+      return Object.keys(store)[index] ?? null;
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+  };
+}
+
+if (typeof globalThis.localStorage?.clear !== 'function') {
+  const storage = createStorageMock();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storage,
+    configurable: true,
+  });
+  Object.defineProperty(window, 'localStorage', {
+    value: storage,
+    configurable: true,
+  });
+}
+
 afterEach(() => {
   cleanup();
 });

--- a/webui/tailwind.config.js
+++ b/webui/tailwind.config.js
@@ -2,6 +2,7 @@ import typography from '@tailwindcss/typography'
 
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- add persisted WebUI theme support with no-flash dark-mode bootstrap and a sidebar theme toggle
- tune the dark theme toward a VS Code/GitHub Dark Dimmed blue-gray palette with broad Tailwind utility compatibility
- fix Session chat alignment, composer contrast, model selector content, skill status controls, workspace/table borders, auth/error states, and workflow canvas dark styling
- improve the disabled Session composer send button contrast in dark mode

## Validation
- npm run lint
- npm run test:run -- src/components/common/SessionChat.test.ts
- npm run test:run -- src/contexts/ThemeContext.test.tsx src/components/common/SessionChat.test.ts src/pages/Skill/index.test.tsx
- npm run build