### PR TITLE
feat: add persistent goal mode

### DIFF
--- a/flocks/command/command.py
+++ b/flocks/command/command.py
@@ -203,6 +203,17 @@ class Command:
                 visible_surfaces=("webui", "tui", "acp", "cli"),
             ),
             CommandDef(
+                name="goal",
+                description="Set a persistent session goal",
+                template="Set session goal: $ARGUMENTS",
+                agent="rex",
+                execution_kind="direct",
+                allow_attachments=False,
+                visible_surfaces=ALL_SURFACES,
+                requires_existing_session=True,
+                channel_safe=True,
+            ),
+            CommandDef(
                 name="model",
                 description="Change or inspect the current model",
                 template="Switch to model: $1",

--- a/flocks/command/direct.py
+++ b/flocks/command/direct.py
@@ -12,6 +12,7 @@ from flocks.agent.agent import AvailableAgent
 from flocks.agent.registry import Agent
 from flocks.command.command import Command, CommandInfo, CommandSurface
 from flocks.command.help import format_help
+from flocks.session.goal import GoalManager
 from flocks.skill.skill import Skill
 from flocks.tool.registry import ToolRegistry
 
@@ -134,6 +135,7 @@ async def run_direct_command(
     args: str = "",
     args_json: Optional[Any] = None,
     surface: Optional[CommandSurface] = None,
+    session_id: Optional[str] = None,
 ) -> DirectCommandResult:
     """Execute a direct command and return its result."""
     resolved = Command.resolve(name)
@@ -149,6 +151,27 @@ async def run_direct_command(
 
     if name == "clear":
         return DirectCommandResult(handled=True, clear_history=True)
+
+    if name == "goal":
+        if not session_id:
+            return DirectCommandResult(
+                handled=True,
+                success=False,
+                text="Usage: /goal requires an active session.",
+            )
+
+        try:
+            state = await GoalManager.set_goal(session_id, args)
+        except ValueError:
+            return DirectCommandResult(
+                handled=True,
+                success=False,
+                text="Usage: /goal <objective>",
+            )
+        return DirectCommandResult(
+            handled=True,
+            prompt=GoalManager.goal_prompt(state.objective),
+        )
 
     if name == "tools":
         if not args or args == "list":

--- a/flocks/command/handler.py
+++ b/flocks/command/handler.py
@@ -24,6 +24,7 @@ async def handle_slash_command(
     clear_screen: Optional[ClearScreen] = None,
     clear_history: Optional[ClearHistory] = None,
     surface: Optional[CommandSurface] = None,
+    session_id: Optional[str] = None,
 ) -> bool:
     """
     Handle supported slash commands.
@@ -56,11 +57,14 @@ async def handle_slash_command(
         args=parsed.args,
         args_json=parsed.args_json,
         surface=surface,
+        session_id=session_id,
     )
     if not result.handled:
         return False
 
     if result.prompt is not None:
+        if result.text:
+            await send_text(result.text)
         await send_prompt(result.prompt)
         return True
 

--- a/flocks/input/dispatcher.py
+++ b/flocks/input/dispatcher.py
@@ -122,9 +122,12 @@ async def dispatch_user_input(event: UserInputEvent, sink: OutputSink) -> Dispat
             clear_screen=clear_cb,
             clear_history=clear_history_cb,
             surface=sink.surface,
+            session_id=event.session_id,
         )
         if handled:
             if llm_prompts:
+                if direct_texts:
+                    await sink.publish_direct_response(event, "\n".join(direct_texts))
                 await sink.run_llm(
                     event,
                     llm_prompts[0],

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -96,6 +96,15 @@ class SessionTime(BaseModel):
     archived: Optional[int] = Field(None, description="Archive timestamp (ms)")
 
 
+class SessionGoalResponse(BaseModel):
+    """Persisted goal state shown by the WebUI composer banner."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    status: Literal["active", "paused", "completed", "blocked"] = Field(..., description="Goal status")
+    objective: str = Field(..., description="Goal objective")
+    reason: Optional[str] = Field(None, description="Last goal judge reason")
+
+
 class SessionResponse(BaseModel):
     """
     Session response - Flocks compatible
@@ -124,6 +133,7 @@ class SessionResponse(BaseModel):
     canWrite: bool = Field(False, description="Whether current user can continue this session")
     canDelete: bool = Field(False, description="Whether current user can delete this session")
     isShared: bool = Field(False, description="Whether this session is locally shared")
+    goal: Optional[SessionGoalResponse] = Field(None, description="Persisted session goal state")
 
 
 def _session_to_response(session: SessionModel) -> SessionResponse:
@@ -162,6 +172,26 @@ def _session_to_response(session: SessionModel) -> SessionResponse:
         canDelete=can_delete,
         isShared=is_shared,
     )
+
+
+async def _session_to_response_with_goal(session: SessionModel) -> SessionResponse:
+    """Convert SessionModel to SessionResponse and attach persisted goal state."""
+    response = _session_to_response(session)
+    try:
+        from flocks.session.goal import GoalManager
+
+        goal_state = await GoalManager.get(session.id)
+    except Exception as exc:
+        log.warn("session.goal.response_error", {"sessionID": session.id, "error": str(exc)})
+        goal_state = None
+
+    if goal_state is not None:
+        response.goal = SessionGoalResponse(
+            status=goal_state.status,
+            objective=goal_state.objective,
+            reason=goal_state.last_reason or goal_state.paused_reason,
+        )
+    return response
 
 
 def _require_session_read_access(session: SessionModel, user) -> None:
@@ -313,7 +343,7 @@ async def list_sessions(
         if limit is not None and len(filtered) >= limit:
             break
     
-    response = [_session_to_response(s) for s in filtered]
+    response = [await _session_to_response_with_goal(s) for s in filtered]
     log_route_timing(log, "session.list.complete", started_at=started_at, extra={
         "count": len(response),
         "roots": roots,
@@ -418,7 +448,7 @@ async def create_session(http_request: Request, request: Optional[SessionCreateR
         )
     except Exception:
         pass
-    return _session_to_response(session)
+    return await _session_to_response_with_goal(session)
 
 
 
@@ -440,7 +470,7 @@ async def get_session(sessionID: str, request: Request) -> SessionResponse:
             detail=f"Session {sessionID} not found"
         )
     _require_session_read_access(session, _current_user)
-    return _session_to_response(session)
+    return await _session_to_response_with_goal(session)
 
 
 @router.get(
@@ -479,7 +509,7 @@ async def get_session_children(sessionID: str, request: Request) -> List[Session
         )
     _require_session_read_access(session, current_user)
     children = await Session.children(session.project_id, sessionID)
-    return [_session_to_response(s) for s in children if SessionPolicy.can_read(s, current_user)]
+    return [await _session_to_response_with_goal(s) for s in children if SessionPolicy.can_read(s, current_user)]
 
 
 class TodoInfo(BaseModel):
@@ -670,7 +700,7 @@ async def update_session(
         )
     
     log.info("session.updated", {"session_id": sessionID})
-    return _session_to_response(session)
+    return await _session_to_response_with_goal(session)
 
 
 @router.post(
@@ -703,7 +733,7 @@ async def share_session_local(sessionID: str, http_request: Request) -> SessionR
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {sessionID} not found",
         )
-    return _session_to_response(session)
+    return await _session_to_response_with_goal(session)
 
 
 @router.post(
@@ -736,7 +766,7 @@ async def unshare_session_local(sessionID: str, http_request: Request) -> Sessio
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {sessionID} not found",
         )
-    return _session_to_response(session)
+    return await _session_to_response_with_goal(session)
 
 
 # =============================================================================
@@ -886,7 +916,7 @@ async def fork_session(sessionID: str, http_request: Request, request: Optional[
     forked = await Session.fork(session.project_id, sessionID, message_id)
     
     log.info("session.forked", {"from": sessionID, "to": forked.id})
-    return _session_to_response(forked)
+    return await _session_to_response_with_goal(forked)
 
 
 @router.get(
@@ -1024,7 +1054,7 @@ async def revert_session(sessionID: str, request: RevertRequest, http_request: R
     )
     
     log.info("session.reverted", {"session_id": sessionID, "message_id": request.messageID})
-    return _session_to_response(updated)
+    return await _session_to_response_with_goal(updated)
 
 
 @router.post(
@@ -1049,7 +1079,7 @@ async def unrevert_session(sessionID: str, http_request: Request) -> SessionResp
     updated = await SessionRevert.unrevert(session_id=sessionID)
     
     log.info("session.unreverted", {"session_id": sessionID})
-    return _session_to_response(updated)
+    return await _session_to_response_with_goal(updated)
 
 
 # =============================================================================

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -3337,7 +3337,18 @@ async def _dispatch_sse_input(sessionID: str, session, event, working_directory:
         session_control=_run_session_control,
         clear_history=_clear_history,
     )
-    await dispatch_user_input(event, sink)
+    result = await dispatch_user_input(event, sink)
+    if result.command_name == "goal" and result.action == "llm":
+        from flocks.session.goal import GoalManager
+
+        state = await GoalManager.get(sessionID)
+        if state is not None:
+            await publish_event("session.goal.updated", {
+                "sessionID": sessionID,
+                "status": state.status,
+                "objective": state.objective,
+                "reason": state.last_reason,
+            })
 
 
 class PromptQueueUpdateRequest(BaseModel):

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -3979,11 +3979,13 @@ async def _clear_session_history(sessionID: str) -> int:
         )
 
     from flocks.server.routes.event import publish_event
+    from flocks.session.goal import GoalManager
     from flocks.session.interaction_queue import InteractionQueue
     from flocks.session.message import Message
 
     await abort_session(sessionID)
     await InteractionQueue.clear(sessionID)
+    await GoalManager.clear(sessionID)
     try:
         await _publish_prompt_queue(sessionID)
     except Exception as exc:

--- a/flocks/session/goal.py
+++ b/flocks/session/goal.py
@@ -1,0 +1,218 @@
+"""Persistent session goals."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from flocks.storage.storage import Storage
+from flocks.utils.log import Log
+
+
+log = Log.create(service="session.goal")
+
+DEFAULT_GOAL_MAX_TURNS = 20
+GoalStatus = Literal["active", "paused", "completed", "blocked"]
+GoalVerdict = Literal["complete", "blocked", "continue", "inactive"]
+
+_COMPLETE_PATTERNS = (
+    re.compile(r"\bgoal\s+(?:complete|completed|achieved)\b", re.IGNORECASE),
+    re.compile(r"\bstanding\s+goal\s+(?:is\s+)?(?:complete|completed|achieved)\b", re.IGNORECASE),
+    re.compile(r"(?:目标|任务)已(?:经)?完成"),
+    re.compile(r"(?:目标|任务)完成"),
+)
+_BLOCKED_PATTERNS = (
+    re.compile(r"\bgoal\s+blocked\b", re.IGNORECASE),
+    re.compile(r"\bblocked\s+on\s+(?:the\s+)?goal\b", re.IGNORECASE),
+    re.compile(r"目标(?:已)?阻塞"),
+    re.compile(r"任务(?:已)?阻塞"),
+)
+
+
+class GoalState(BaseModel):
+    objective: str
+    status: GoalStatus = "active"
+    turns_used: int = 0
+    max_turns: int = DEFAULT_GOAL_MAX_TURNS
+    created_at: float = Field(default_factory=time.time)
+    updated_at: float = Field(default_factory=time.time)
+    last_verdict: Optional[GoalVerdict] = None
+    last_reason: Optional[str] = None
+    paused_reason: Optional[str] = None
+
+
+@dataclass
+class GoalDecision:
+    status: GoalStatus | None
+    verdict: GoalVerdict
+    should_continue: bool = False
+    continuation_prompt: Optional[str] = None
+    reason: str = ""
+    objective: Optional[str] = None
+
+
+def _goal_key(session_id: str) -> str:
+    return f"goal:{session_id}"
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _trim_reason(text: str, max_chars: int = 240) -> str:
+    normalized = " ".join((text or "").split())
+    if len(normalized) <= max_chars:
+        return normalized
+    return normalized[: max_chars - 3].rstrip() + "..."
+
+
+def _agent_self_report(last_response: str) -> tuple[GoalVerdict, str] | None:
+    text = last_response or ""
+    for pattern in _BLOCKED_PATTERNS:
+        if pattern.search(text):
+            return "blocked", _trim_reason(text) or "agent reported the goal is blocked"
+    for pattern in _COMPLETE_PATTERNS:
+        if pattern.search(text):
+            return "complete", _trim_reason(text) or "agent reported the goal is complete"
+    return None
+
+
+def judge_goal(last_response: str) -> tuple[GoalVerdict, str]:
+    """Conservative fallback judge used when the agent did not self-report."""
+    text = last_response or ""
+    lower = text.lower()
+    if "cannot proceed" in lower or "need user input" in lower:
+        return "blocked", _trim_reason(text) or "judge found the agent needs user input"
+    return "continue", "goal completion was not explicitly proven"
+
+
+class GoalManager:
+    """Session-scoped goal state and continuation policy."""
+
+    @classmethod
+    async def get(cls, session_id: str) -> Optional[GoalState]:
+        try:
+            data = await Storage.get(_goal_key(session_id))
+        except Exception as exc:
+            log.warn("goal.get.error", {"session_id": session_id, "error": str(exc)})
+            return None
+        if not data:
+            return None
+        try:
+            return GoalState(**data)
+        except Exception as exc:
+            log.warn("goal.get.invalid", {"session_id": session_id, "error": str(exc)})
+            return None
+
+    @classmethod
+    async def save(cls, session_id: str, state: GoalState) -> GoalState:
+        state.updated_at = _now()
+        await Storage.set(_goal_key(session_id), state.model_dump(exclude_none=True), "goal")
+        return state
+
+    @classmethod
+    async def set_goal(
+        cls,
+        session_id: str,
+        objective: str,
+        *,
+        max_turns: int = DEFAULT_GOAL_MAX_TURNS,
+    ) -> GoalState:
+        objective = (objective or "").strip()
+        if not objective:
+            raise ValueError("goal text is empty")
+        state = GoalState(
+            objective=objective,
+            status="active",
+            turns_used=0,
+            max_turns=max_turns if max_turns > 0 else DEFAULT_GOAL_MAX_TURNS,
+        )
+        return await cls.save(session_id, state)
+
+    @classmethod
+    def goal_prompt(cls, objective: str) -> str:
+        return (
+            "[Goal mode]\n"
+            f"Active goal: {objective}\n\n"
+            "Work toward the active goal. When the goal is genuinely complete, "
+            'explicitly state "Goal complete: ..." with the evidence. When blocked '
+            'and unable to proceed without user input, explicitly state "Goal blocked: ...". '
+            "Otherwise take the next concrete step and do not claim completion."
+        )
+
+    @classmethod
+    def continuation_prompt(cls, state: GoalState, reason: str) -> str:
+        reason = reason or "goal is still active"
+        return (
+            "[Continuing toward active goal]\n"
+            f"Goal: {state.objective}\n"
+            f"Reason to continue: {reason}\n\n"
+            "Take the next concrete step. If the goal is genuinely complete, "
+            'state "Goal complete: ..." with evidence. If blocked and unable '
+            'to proceed without user input, state "Goal blocked: ...".'
+        )
+
+    @classmethod
+    async def evaluate_after_turn(
+        cls,
+        session_id: str,
+        last_response: str,
+    ) -> GoalDecision:
+        state = await cls.get(session_id)
+        if state is None or state.status != "active":
+            return GoalDecision(
+                status=state.status if state else None,
+                verdict="inactive",
+                objective=state.objective if state else None,
+            )
+
+        state.turns_used += 1
+        report = _agent_self_report(last_response)
+        verdict, reason = report if report is not None else judge_goal(last_response)
+        state.last_verdict = verdict
+        state.last_reason = reason
+
+        if verdict == "complete":
+            state.status = "completed"
+            await cls.save(session_id, state)
+            return GoalDecision(
+                status=state.status,
+                verdict=verdict,
+                reason=reason,
+                objective=state.objective,
+            )
+
+        if verdict == "blocked":
+            state.status = "blocked"
+            await cls.save(session_id, state)
+            return GoalDecision(
+                status=state.status,
+                verdict=verdict,
+                reason=reason,
+                objective=state.objective,
+            )
+
+        if state.turns_used >= state.max_turns:
+            state.status = "paused"
+            state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
+            await cls.save(session_id, state)
+            return GoalDecision(
+                status=state.status,
+                verdict="continue",
+                reason=state.paused_reason,
+                objective=state.objective,
+            )
+
+        await cls.save(session_id, state)
+        return GoalDecision(
+            status=state.status,
+            verdict="continue",
+            should_continue=True,
+            continuation_prompt=cls.continuation_prompt(state, reason),
+            reason=reason,
+            objective=state.objective,
+        )

--- a/flocks/session/goal.py
+++ b/flocks/session/goal.py
@@ -27,11 +27,13 @@ GoalVerdict = Literal["complete", "blocked", "continue", "waiting", "inactive"]
 _MODEL_JUDGE_SYSTEM_PROMPT = """You are a strict goal completion judge.
 
 Return only valid JSON with exactly this shape:
-{"done": true|false, "reason": "one sentence"}
+{"verdict": "complete|blocked|waiting|continue", "reason": "one sentence"}
 
 Judging rules:
-- done=true only if the assistant's latest final response explicitly confirms the goal is complete, the requested deliverable is clearly produced, or the goal is impossible/blocked and the response clearly says why.
-- done=false if work remains, the assistant only made partial progress, the assistant asks the user for more input/clarification/approval, or the latest response is ambiguous.
+- verdict=complete only if the assistant's latest final response explicitly confirms the goal is complete or the requested deliverable is clearly produced.
+- verdict=blocked only if the latest response clearly says the goal cannot be completed and gives the specific blocker.
+- verdict=waiting if the assistant asks the user for more input, clarification, confirmation, approval, credentials, or any other user action before work can continue.
+- verdict=continue if work remains and the assistant can keep taking concrete steps without user input.
 - The reason must be concise and grounded only in the provided goal, user clarification, and latest response.
 - Keep the entire JSON response under 200 characters.
 - Do not include markdown, code fences, or any text outside the JSON object.
@@ -201,17 +203,14 @@ async def judge_goal_with_model(
     )
 
     payload = _extract_json_object(response.content)
-    done = payload.get("done")
+    verdict = str(payload.get("verdict") or "").strip().lower()
     reason = _trim_reason(str(payload.get("reason") or ""))
-    if not isinstance(done, bool):
-        raise ValueError("judge JSON field 'done' must be a boolean")
+    if verdict not in {"complete", "blocked", "waiting", "continue"}:
+        raise ValueError("judge JSON field 'verdict' must be one of complete, blocked, waiting, continue")
     if not reason:
         reason = "model judge returned no reason"
 
-    if not done:
-        return "continue", reason
-
-    return "complete", reason
+    return verdict, reason
 
 
 class GoalManager:
@@ -237,6 +236,15 @@ class GoalManager:
         state.updated_at = _now()
         await Storage.set(_goal_key(session_id), state.model_dump(exclude_none=True), "goal")
         return state
+
+    @classmethod
+    async def clear(cls, session_id: str) -> bool:
+        """Remove any persisted goal state for a session."""
+        try:
+            return await Storage.delete(_goal_key(session_id))
+        except Exception as exc:
+            log.warn("goal.clear.error", {"session_id": session_id, "error": str(exc)})
+            return False
 
     @classmethod
     async def set_goal(

--- a/flocks/session/goal.py
+++ b/flocks/session/goal.py
@@ -16,20 +16,47 @@ from flocks.utils.log import Log
 log = Log.create(service="session.goal")
 
 DEFAULT_GOAL_MAX_TURNS = 20
+JUDGE_RESPONSE_MAX_CHARS = 4096
 GoalStatus = Literal["active", "paused", "completed", "blocked"]
-GoalVerdict = Literal["complete", "blocked", "continue", "inactive"]
+GoalVerdict = Literal["complete", "blocked", "continue", "waiting", "inactive"]
 
-_COMPLETE_PATTERNS = (
-    re.compile(r"\bgoal\s+(?:complete|completed|achieved)\b", re.IGNORECASE),
-    re.compile(r"\bstanding\s+goal\s+(?:is\s+)?(?:complete|completed|achieved)\b", re.IGNORECASE),
-    re.compile(r"(?:目标|任务)已(?:经)?完成"),
-    re.compile(r"(?:目标|任务)完成"),
-)
 _BLOCKED_PATTERNS = (
     re.compile(r"\bgoal\s+blocked\b", re.IGNORECASE),
     re.compile(r"\bblocked\s+on\s+(?:the\s+)?goal\b", re.IGNORECASE),
+    re.compile(r"\b(?:cannot|can't|unable to)\s+(?:proceed|continue|complete)\b", re.IGNORECASE),
     re.compile(r"目标(?:已)?阻塞"),
     re.compile(r"任务(?:已)?阻塞"),
+    re.compile(r"(?:无法|不能)(?:继续|完成|推进)"),
+)
+_WAITING_PATTERNS = (
+    re.compile(r"\bneed(?:s)?\s+(?:user\s+)?(?:input|clarification|approval|confirmation)\b", re.IGNORECASE),
+    re.compile(r"\b(?:please|need to)\s+(?:clarify|confirm|choose|specify)\b", re.IGNORECASE),
+    re.compile(r"\bwaiting\s+(?:for|on)\s+(?:you|user|confirmation|clarification|input)\b", re.IGNORECASE),
+    re.compile(r"\buser\s+(?:hasn't|has not|must|needs? to)\s+(?:answer|confirm|clarify|choose|specify)\b", re.IGNORECASE),
+    re.compile(r"请(?:明确|确认|澄清|选择|说明)"),
+    re.compile(r"需要(?:用户|你)?(?:输入|确认|澄清|批准|明确|选择)"),
+    re.compile(r"等待(?:你|用户)?(?:确认|输入|澄清|回复|回答)"),
+)
+_NEGATED_DONE_PATTERNS = (
+    re.compile(r"\bnot\s+(?:complete|completed|done|finished|resolved|fixed)\b", re.IGNORECASE),
+    re.compile(r"\b(?:incomplete|unfinished|unresolved)\b", re.IGNORECASE),
+    re.compile(r"\b(?:still|not yet)\s+(?:need|needs|pending|remaining|todo|to do)\b", re.IGNORECASE),
+    re.compile(r"(?:尚未|还未|没有|未)(?:完成|解决|修复)"),
+)
+_FUTURE_WORK_PATTERNS = (
+    re.compile(r"\bnext\s+i\s+(?:will|need|should|plan)\b", re.IGNORECASE),
+    re.compile(r"\b(?:remaining|still need|need to|todo|to do|pending)\b", re.IGNORECASE),
+    re.compile(r"(?:下一步|还需要|仍需|待完成|未完成)"),
+)
+_DONE_PATTERNS = (
+    re.compile(r"\bgoal\s+(?:complete|completed|achieved)\b", re.IGNORECASE),
+    re.compile(r"\bstanding\s+goal\s+(?:is\s+)?(?:complete|completed|achieved)\b", re.IGNORECASE),
+    re.compile(r"\b(?:done|completed|finished|resolved|fixed|implemented|delivered)\b", re.IGNORECASE),
+    re.compile(r"\b(?:created|updated|added|removed|changed|verified)\b", re.IGNORECASE),
+    re.compile(r"\b(?:tests?|build|typecheck|lint)\s+(?:pass|passed|succeeded|is green)\b", re.IGNORECASE),
+    re.compile(r"(?:目标|任务)已(?:经)?完成"),
+    re.compile(r"(?:目标|任务)完成"),
+    re.compile(r"(?:已|已经)(?:完成|实现|修复|交付|验证)"),
 )
 
 
@@ -70,24 +97,37 @@ def _trim_reason(text: str, max_chars: int = 240) -> str:
     return normalized[: max_chars - 3].rstrip() + "..."
 
 
-def _agent_self_report(last_response: str) -> tuple[GoalVerdict, str] | None:
+def _judge_input(last_response: str) -> str:
     text = last_response or ""
-    for pattern in _BLOCKED_PATTERNS:
-        if pattern.search(text):
-            return "blocked", _trim_reason(text) or "agent reported the goal is blocked"
-    for pattern in _COMPLETE_PATTERNS:
-        if pattern.search(text):
-            return "complete", _trim_reason(text) or "agent reported the goal is complete"
-    return None
+    if len(text) <= JUDGE_RESPONSE_MAX_CHARS:
+        return text
+    return text[-JUDGE_RESPONSE_MAX_CHARS:]
 
 
-def judge_goal(last_response: str) -> tuple[GoalVerdict, str]:
-    """Conservative fallback judge used when the agent did not self-report."""
-    text = last_response or ""
-    lower = text.lower()
-    if "cannot proceed" in lower or "need user input" in lower:
-        return "blocked", _trim_reason(text) or "judge found the agent needs user input"
-    return "continue", "goal completion was not explicitly proven"
+def _matches_any(patterns: tuple[re.Pattern[str], ...], text: str) -> bool:
+    return any(pattern.search(text) for pattern in patterns)
+
+
+def judge_goal(objective: str, last_response: str) -> tuple[GoalVerdict, str]:
+    """Hermes-style local judge for the latest final response."""
+    text = _judge_input(last_response)
+    reason = _trim_reason(text)
+    if not text.strip():
+        return "continue", "judge received no final response"
+
+    if _matches_any(_WAITING_PATTERNS, text):
+        return "waiting", reason or "judge found the agent is waiting for user input"
+
+    if _matches_any(_BLOCKED_PATTERNS, text):
+        return "blocked", reason or "judge found the goal is blocked"
+
+    if _matches_any(_NEGATED_DONE_PATTERNS, text) or _matches_any(_FUTURE_WORK_PATTERNS, text):
+        return "continue", "judge found remaining work toward the goal"
+
+    if _matches_any(_DONE_PATTERNS, text):
+        return "complete", reason or f"judge found the goal is done: {objective}"
+
+    return "continue", "judge could not determine the goal is done"
 
 
 class GoalManager:
@@ -138,10 +178,9 @@ class GoalManager:
         return (
             "[Goal mode]\n"
             f"Active goal: {objective}\n\n"
-            "Work toward the active goal. When the goal is genuinely complete, "
-            'explicitly state "Goal complete: ..." with the evidence. When blocked '
-            'and unable to proceed without user input, explicitly state "Goal blocked: ...". '
-            "Otherwise take the next concrete step and do not claim completion."
+            "Work toward the active goal. Continue taking concrete steps until the goal "
+            "is complete or blocked. In your final response, make the current outcome "
+            "clear with evidence of completed work or the specific blocker."
         )
 
     @classmethod
@@ -151,9 +190,8 @@ class GoalManager:
             "[Continuing toward active goal]\n"
             f"Goal: {state.objective}\n"
             f"Reason to continue: {reason}\n\n"
-            "Take the next concrete step. If the goal is genuinely complete, "
-            'state "Goal complete: ..." with evidence. If blocked and unable '
-            'to proceed without user input, state "Goal blocked: ...".'
+            "Take the next concrete step. If the goal is complete or blocked, make "
+            "that outcome clear with evidence or the specific blocker."
         )
 
     @classmethod
@@ -171,8 +209,7 @@ class GoalManager:
             )
 
         state.turns_used += 1
-        report = _agent_self_report(last_response)
-        verdict, reason = report if report is not None else judge_goal(last_response)
+        verdict, reason = judge_goal(state.objective, last_response)
         state.last_verdict = verdict
         state.last_reason = reason
 
@@ -188,6 +225,15 @@ class GoalManager:
 
         if verdict == "blocked":
             state.status = "blocked"
+            await cls.save(session_id, state)
+            return GoalDecision(
+                status=state.status,
+                verdict=verdict,
+                reason=reason,
+                objective=state.objective,
+            )
+
+        if verdict == "waiting":
             await cls.save(session_id, state)
             return GoalDecision(
                 status=state.status,

--- a/flocks/session/goal.py
+++ b/flocks/session/goal.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import re
 import time
+import json
 from dataclasses import dataclass
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from flocks.provider.provider import ChatMessage, Provider
 from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 
@@ -17,47 +18,21 @@ log = Log.create(service="session.goal")
 
 DEFAULT_GOAL_MAX_TURNS = 20
 JUDGE_RESPONSE_MAX_CHARS = 4096
+JUDGE_MAX_TOKENS = 200
 GoalStatus = Literal["active", "paused", "completed", "blocked"]
 GoalVerdict = Literal["complete", "blocked", "continue", "waiting", "inactive"]
 
-_BLOCKED_PATTERNS = (
-    re.compile(r"\bgoal\s+blocked\b", re.IGNORECASE),
-    re.compile(r"\bblocked\s+on\s+(?:the\s+)?goal\b", re.IGNORECASE),
-    re.compile(r"\b(?:cannot|can't|unable to)\s+(?:proceed|continue|complete)\b", re.IGNORECASE),
-    re.compile(r"目标(?:已)?阻塞"),
-    re.compile(r"任务(?:已)?阻塞"),
-    re.compile(r"(?:无法|不能)(?:继续|完成|推进)"),
-)
-_WAITING_PATTERNS = (
-    re.compile(r"\bneed(?:s)?\s+(?:user\s+)?(?:input|clarification|approval|confirmation)\b", re.IGNORECASE),
-    re.compile(r"\b(?:please|need to)\s+(?:clarify|confirm|choose|specify)\b", re.IGNORECASE),
-    re.compile(r"\bwaiting\s+(?:for|on)\s+(?:you|user|confirmation|clarification|input)\b", re.IGNORECASE),
-    re.compile(r"\buser\s+(?:hasn't|has not|must|needs? to)\s+(?:answer|confirm|clarify|choose|specify)\b", re.IGNORECASE),
-    re.compile(r"请(?:明确|确认|澄清|选择|说明)"),
-    re.compile(r"需要(?:用户|你)?(?:输入|确认|澄清|批准|明确|选择)"),
-    re.compile(r"等待(?:你|用户)?(?:确认|输入|澄清|回复|回答)"),
-)
-_NEGATED_DONE_PATTERNS = (
-    re.compile(r"\bnot\s+(?:complete|completed|done|finished|resolved|fixed)\b", re.IGNORECASE),
-    re.compile(r"\b(?:incomplete|unfinished|unresolved)\b", re.IGNORECASE),
-    re.compile(r"\b(?:still|not yet)\s+(?:need|needs|pending|remaining|todo|to do)\b", re.IGNORECASE),
-    re.compile(r"(?:尚未|还未|没有|未)(?:完成|解决|修复)"),
-)
-_FUTURE_WORK_PATTERNS = (
-    re.compile(r"\bnext\s+i\s+(?:will|need|should|plan)\b", re.IGNORECASE),
-    re.compile(r"\b(?:remaining|still need|need to|todo|to do|pending)\b", re.IGNORECASE),
-    re.compile(r"(?:下一步|还需要|仍需|待完成|未完成)"),
-)
-_DONE_PATTERNS = (
-    re.compile(r"\bgoal\s+(?:complete|completed|achieved)\b", re.IGNORECASE),
-    re.compile(r"\bstanding\s+goal\s+(?:is\s+)?(?:complete|completed|achieved)\b", re.IGNORECASE),
-    re.compile(r"\b(?:done|completed|finished|resolved|fixed|implemented|delivered)\b", re.IGNORECASE),
-    re.compile(r"\b(?:created|updated|added|removed|changed|verified)\b", re.IGNORECASE),
-    re.compile(r"\b(?:tests?|build|typecheck|lint)\s+(?:pass|passed|succeeded|is green)\b", re.IGNORECASE),
-    re.compile(r"(?:目标|任务)已(?:经)?完成"),
-    re.compile(r"(?:目标|任务)完成"),
-    re.compile(r"(?:已|已经)(?:完成|实现|修复|交付|验证)"),
-)
+_MODEL_JUDGE_SYSTEM_PROMPT = """You are a strict goal completion judge.
+
+Return only valid JSON with exactly this shape:
+{"done": true|false, "reason": "one sentence"}
+
+Judging rules:
+- done=true only if the assistant's latest final response explicitly confirms the goal is complete, the requested deliverable is clearly produced, or the goal is impossible/blocked and the response clearly says why.
+- done=false if work remains, the assistant only made partial progress, the assistant asks the user for more input/clarification/approval, or the latest response is ambiguous.
+- The reason must be concise and grounded only in the provided goal and latest response.
+- Do not include markdown, code fences, or any text outside the JSON object.
+"""
 
 
 class GoalState(BaseModel):
@@ -104,30 +79,59 @@ def _judge_input(last_response: str) -> str:
     return text[-JUDGE_RESPONSE_MAX_CHARS:]
 
 
-def _matches_any(patterns: tuple[re.Pattern[str], ...], text: str) -> bool:
-    return any(pattern.search(text) for pattern in patterns)
+def _extract_json_object(text: str) -> dict:
+    """Parse a strict JSON object."""
+    raw = (text or "").strip()
+    if not raw:
+        raise ValueError("empty judge response")
+
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("judge response is not a JSON object")
+    return payload
 
 
-def judge_goal(objective: str, last_response: str) -> tuple[GoalVerdict, str]:
-    """Hermes-style local judge for the latest final response."""
-    text = _judge_input(last_response)
-    reason = _trim_reason(text)
-    if not text.strip():
-        return "continue", "judge received no final response"
+async def judge_goal_with_model(
+    objective: str,
+    last_response: str,
+    *,
+    provider_id: str,
+    model_id: str,
+) -> tuple[GoalVerdict, str]:
+    """Hermes-style model judge using the active session provider/model."""
+    provider = Provider.get(provider_id)
+    if provider is None:
+        raise RuntimeError(f"provider not found: {provider_id}")
 
-    if _matches_any(_WAITING_PATTERNS, text):
-        return "waiting", reason or "judge found the agent is waiting for user input"
+    response = await provider.chat(
+        model_id=model_id,
+        messages=[
+            ChatMessage(role="system", content=_MODEL_JUDGE_SYSTEM_PROMPT),
+            ChatMessage(
+                role="user",
+                content=(
+                    f"Goal:\n{objective}\n\n"
+                    "Latest assistant final response (truncated to the last 4KB):\n"
+                    f"{_judge_input(last_response)}"
+                ),
+            ),
+        ],
+        max_tokens=JUDGE_MAX_TOKENS,
+        temperature=0,
+    )
 
-    if _matches_any(_BLOCKED_PATTERNS, text):
-        return "blocked", reason or "judge found the goal is blocked"
+    payload = _extract_json_object(response.content)
+    done = payload.get("done")
+    reason = _trim_reason(str(payload.get("reason") or ""))
+    if not isinstance(done, bool):
+        raise ValueError("judge JSON field 'done' must be a boolean")
+    if not reason:
+        reason = "model judge returned no reason"
 
-    if _matches_any(_NEGATED_DONE_PATTERNS, text) or _matches_any(_FUTURE_WORK_PATTERNS, text):
-        return "continue", "judge found remaining work toward the goal"
+    if not done:
+        return "continue", reason
 
-    if _matches_any(_DONE_PATTERNS, text):
-        return "complete", reason or f"judge found the goal is done: {objective}"
-
-    return "continue", "judge could not determine the goal is done"
+    return "complete", reason
 
 
 class GoalManager:
@@ -178,6 +182,9 @@ class GoalManager:
         return (
             "[Goal mode]\n"
             f"Active goal: {objective}\n\n"
+            "If the active goal is ambiguous or underspecified, ask the user a "
+            "clarifying question using the question tool and wait for the answer "
+            "instead of continuing autonomously. "
             "Work toward the active goal. Continue taking concrete steps until the goal "
             "is complete or blocked. In your final response, make the current outcome "
             "clear with evidence of completed work or the specific blocker."
@@ -199,6 +206,10 @@ class GoalManager:
         cls,
         session_id: str,
         last_response: str,
+        *,
+        pending_user_input: bool = False,
+        provider_id: Optional[str] = None,
+        model_id: Optional[str] = None,
     ) -> GoalDecision:
         state = await cls.get(session_id)
         if state is None or state.status != "active":
@@ -209,7 +220,29 @@ class GoalManager:
             )
 
         state.turns_used += 1
-        verdict, reason = judge_goal(state.objective, last_response)
+        if pending_user_input:
+            verdict = "waiting"
+            reason = "session has a pending user question"
+        elif provider_id and model_id:
+            try:
+                verdict, reason = await judge_goal_with_model(
+                    state.objective,
+                    last_response,
+                    provider_id=provider_id,
+                    model_id=model_id,
+                )
+            except Exception as exc:
+                log.warn("goal.model_judge.failed", {
+                    "session_id": session_id,
+                    "provider_id": provider_id,
+                    "model_id": model_id,
+                    "error": str(exc),
+                })
+                verdict = "continue"
+                reason = "goal judge failed; continuing"
+        else:
+            verdict = "continue"
+            reason = "goal judge unavailable; continuing"
         state.last_verdict = verdict
         state.last_reason = reason
 

--- a/flocks/session/goal.py
+++ b/flocks/session/goal.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import time
 import json
+import time
 from dataclasses import dataclass
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from flocks.provider.options import build_provider_options
 from flocks.provider.provider import ChatMessage, Provider
 from flocks.storage.storage import Storage
 from flocks.utils.log import Log
@@ -18,7 +19,7 @@ log = Log.create(service="session.goal")
 
 DEFAULT_GOAL_MAX_TURNS = 20
 JUDGE_RESPONSE_MAX_CHARS = 4096
-JUDGE_MAX_TOKENS = 200
+JUDGE_MAX_TOKENS = 4096
 GoalStatus = Literal["active", "paused", "completed", "blocked"]
 GoalVerdict = Literal["complete", "blocked", "continue", "waiting", "inactive"]
 
@@ -31,6 +32,7 @@ Judging rules:
 - done=true only if the assistant's latest final response explicitly confirms the goal is complete, the requested deliverable is clearly produced, or the goal is impossible/blocked and the response clearly says why.
 - done=false if work remains, the assistant only made partial progress, the assistant asks the user for more input/clarification/approval, or the latest response is ambiguous.
 - The reason must be concise and grounded only in the provided goal and latest response.
+- Keep the entire JSON response under 200 characters.
 - Do not include markdown, code fences, or any text outside the JSON object.
 """
 
@@ -85,7 +87,10 @@ def _extract_json_object(text: str) -> dict:
     if not raw:
         raise ValueError("empty judge response")
 
-    payload = json.loads(raw)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"judge response was not strict JSON: {_trim_reason(raw)!r}") from exc
     if not isinstance(payload, dict):
         raise ValueError("judge response is not a JSON object")
     return payload
@@ -103,6 +108,9 @@ async def judge_goal_with_model(
     if provider is None:
         raise RuntimeError(f"provider not found: {provider_id}")
 
+    provider_options = build_provider_options(provider_id, model_id)
+    provider_options.pop("max_tokens", None)
+
     response = await provider.chat(
         model_id=model_id,
         messages=[
@@ -116,6 +124,7 @@ async def judge_goal_with_model(
                 ),
             ),
         ],
+        **provider_options,
         max_tokens=JUDGE_MAX_TOKENS,
         temperature=0,
     )
@@ -238,11 +247,11 @@ class GoalManager:
                     "model_id": model_id,
                     "error": str(exc),
                 })
-                verdict = "continue"
-                reason = "goal judge failed; continuing"
+                verdict = "waiting"
+                reason = "goal judge failed; waiting instead of continuing autonomously"
         else:
-            verdict = "continue"
-            reason = "goal judge unavailable; continuing"
+            verdict = "waiting"
+            reason = "goal judge unavailable; waiting instead of continuing autonomously"
         state.last_verdict = verdict
         state.last_reason = reason
 

--- a/flocks/session/goal.py
+++ b/flocks/session/goal.py
@@ -20,6 +20,7 @@ log = Log.create(service="session.goal")
 DEFAULT_GOAL_MAX_TURNS = 20
 JUDGE_RESPONSE_MAX_CHARS = 4096
 JUDGE_MAX_TOKENS = 4096
+GOAL_CLARIFICATION_MAX_CHARS = 2000
 GoalStatus = Literal["active", "paused", "completed", "blocked"]
 GoalVerdict = Literal["complete", "blocked", "continue", "waiting", "inactive"]
 
@@ -31,10 +32,23 @@ Return only valid JSON with exactly this shape:
 Judging rules:
 - done=true only if the assistant's latest final response explicitly confirms the goal is complete, the requested deliverable is clearly produced, or the goal is impossible/blocked and the response clearly says why.
 - done=false if work remains, the assistant only made partial progress, the assistant asks the user for more input/clarification/approval, or the latest response is ambiguous.
-- The reason must be concise and grounded only in the provided goal and latest response.
+- The reason must be concise and grounded only in the provided goal, user clarification, and latest response.
 - Keep the entire JSON response under 200 characters.
 - Do not include markdown, code fences, or any text outside the JSON object.
 """
+
+
+class GoalClarificationAnswer(BaseModel):
+    question: str
+    answer: str
+
+
+class GoalClarification(BaseModel):
+    answers: list[GoalClarificationAnswer]
+    text: str
+    created_at: float = Field(default_factory=time.time)
+    message_id: Optional[str] = None
+    call_id: Optional[str] = None
 
 
 class GoalState(BaseModel):
@@ -47,6 +61,7 @@ class GoalState(BaseModel):
     last_verdict: Optional[GoalVerdict] = None
     last_reason: Optional[str] = None
     paused_reason: Optional[str] = None
+    initial_clarification: Optional[GoalClarification] = None
 
 
 @dataclass
@@ -81,6 +96,61 @@ def _judge_input(last_response: str) -> str:
     return text[-JUDGE_RESPONSE_MAX_CHARS:]
 
 
+def _truncate_text(text: str, max_chars: int) -> str:
+    normalized = " ".join((text or "").split())
+    if len(normalized) <= max_chars:
+        return normalized
+    return normalized[: max_chars - 3].rstrip() + "..."
+
+
+def _format_goal_context(objective: str, clarification: Optional[GoalClarification]) -> str:
+    if clarification is None or not clarification.text.strip():
+        return objective
+    return (
+        f"Original goal:\n{objective}\n\n"
+        "Initial user clarification:\n"
+        f"{clarification.text}"
+    )
+
+
+def _format_answer(answer: object) -> str:
+    if isinstance(answer, list):
+        return ", ".join(str(item).strip() for item in answer if str(item).strip())
+    return str(answer or "").strip()
+
+
+def _build_clarification(
+    questions: list[dict],
+    answers: list[list[str]],
+    *,
+    message_id: Optional[str] = None,
+    call_id: Optional[str] = None,
+) -> Optional[GoalClarification]:
+    items: list[GoalClarificationAnswer] = []
+    lines: list[str] = []
+    for index, question in enumerate(questions):
+        question_text = str(question.get("question") or "").strip()
+        answer_text = _format_answer(answers[index] if index < len(answers) else [])
+        if not question_text and not answer_text:
+            continue
+        if not question_text:
+            question_text = f"Question {index + 1}"
+        if not answer_text:
+            answer_text = "Unanswered"
+        items.append(GoalClarificationAnswer(question=question_text, answer=answer_text))
+        lines.append(f'Q: {question_text}\nA: {answer_text}')
+
+    if not items:
+        return None
+
+    return GoalClarification(
+        answers=items,
+        text=_truncate_text("\n\n".join(lines), GOAL_CLARIFICATION_MAX_CHARS),
+        message_id=message_id,
+        call_id=call_id,
+    )
+
+
 def _extract_json_object(text: str) -> dict:
     """Parse a strict JSON object."""
     raw = (text or "").strip()
@@ -102,6 +172,7 @@ async def judge_goal_with_model(
     *,
     provider_id: str,
     model_id: str,
+    initial_clarification: Optional[GoalClarification] = None,
 ) -> tuple[GoalVerdict, str]:
     """Hermes-style model judge using the active session provider/model."""
     provider = Provider.get(provider_id)
@@ -118,7 +189,7 @@ async def judge_goal_with_model(
             ChatMessage(
                 role="user",
                 content=(
-                    f"Goal:\n{objective}\n\n"
+                    f"Goal:\n{_format_goal_context(objective, initial_clarification)}\n\n"
                     "Latest assistant final response (truncated to the last 4KB):\n"
                     f"{_judge_input(last_response)}"
                 ),
@@ -187,6 +258,33 @@ class GoalManager:
         return await cls.save(session_id, state)
 
     @classmethod
+    async def record_initial_clarification(
+        cls,
+        session_id: str,
+        questions: list[dict],
+        answers: list[list[str]],
+        *,
+        message_id: Optional[str] = None,
+        call_id: Optional[str] = None,
+    ) -> Optional[GoalState]:
+        """Persist the first successful user clarification for an active goal."""
+        state = await cls.get(session_id)
+        if state is None or state.status != "active" or state.initial_clarification is not None:
+            return state
+
+        clarification = _build_clarification(
+            questions,
+            answers,
+            message_id=message_id,
+            call_id=call_id,
+        )
+        if clarification is None:
+            return state
+
+        state.initial_clarification = clarification
+        return await cls.save(session_id, state)
+
+    @classmethod
     def goal_prompt(cls, objective: str) -> str:
         return (
             "[Goal mode]\n"
@@ -202,9 +300,16 @@ class GoalManager:
     @classmethod
     def continuation_prompt(cls, state: GoalState, reason: str) -> str:
         reason = reason or "goal is still active"
+        clarification = (
+            "\nInitial user clarification:\n"
+            f"{state.initial_clarification.text}\n"
+            if state.initial_clarification is not None and state.initial_clarification.text.strip()
+            else ""
+        )
         return (
             "[Continuing toward active goal]\n"
             f"Goal: {state.objective}\n"
+            f"{clarification}"
             f"Reason to continue: {reason}\n\n"
             "Take the next concrete step. If the goal is complete or blocked, make "
             "that outcome clear with evidence or the specific blocker."
@@ -239,6 +344,7 @@ class GoalManager:
                     last_response,
                     provider_id=provider_id,
                     model_id=model_id,
+                    initial_clarification=state.initial_clarification,
                 )
             except Exception as exc:
                 log.warn("goal.model_judge.failed", {

--- a/flocks/session/session_loop.py
+++ b/flocks/session/session_loop.py
@@ -1269,9 +1269,22 @@ class SessionLoop:
                             "error": str(exc),
                         })
                         last_response = getattr(last_message, "content", "") or ""
+                    pending_user_input = False
+                    try:
+                        from flocks.server.routes.question import has_pending_questions
+
+                        pending_user_input = has_pending_questions(ctx.session.id)
+                    except Exception as exc:
+                        log.warn("goal.pending_question_check.error", {
+                            "session_id": ctx.session.id,
+                            "error": str(exc),
+                        })
                     goal_decision = await GoalManager.evaluate_after_turn(
                         ctx.session.id,
                         str(last_response or ""),
+                        pending_user_input=pending_user_input,
+                        provider_id=ctx.provider_id,
+                        model_id=ctx.model_id,
                     )
                     if goal_decision.status in {"completed", "blocked", "paused"} and goal_decision.objective:
                         await cls._publish_runtime_event(callbacks, "session.goal.updated", {
@@ -1281,6 +1294,10 @@ class SessionLoop:
                             "reason": goal_decision.reason,
                         })
                     if goal_decision.should_continue and goal_decision.continuation_prompt:
+                        # Hermes-style goal continuation: append a plain
+                        # user-role prompt to history. Keep metadata for
+                        # observability, but do not mark the part synthetic so
+                        # it remains a normal conversation turn.
                         goal_user = await Message.create(
                             session_id=ctx.session.id,
                             role=MessageRole.USER,
@@ -1291,7 +1308,6 @@ class SessionLoop:
                                 "modelID": ctx.model_id,
                             },
                             provider=last_user.provider if hasattr(last_user, "provider") else ctx.provider_id,
-                            synthetic=True,
                             part_metadata={
                                 "goalContinuation": True,
                                 "goalVerdict": goal_decision.verdict,

--- a/flocks/session/session_loop.py
+++ b/flocks/session/session_loop.py
@@ -13,6 +13,7 @@ Ported from original SessionPrompt.loop() pattern.
 """
 
 import asyncio
+import inspect
 import time
 from typing import Optional, List, Dict, Any, Callable, Awaitable
 from dataclasses import dataclass, field
@@ -38,6 +39,7 @@ from flocks.session.lifecycle.compaction import (
 from flocks.session.lifecycle.compaction.compaction import _get_compaction_history
 from flocks.session.prompt import SessionPrompt
 from flocks.provider.provider import Provider
+from flocks.session.goal import GoalManager
 
 
 log = Log.create(service="session.loop")
@@ -1251,6 +1253,69 @@ class SessionLoop:
                         "last_assistant_id": last_message.id if last_message else None,
                     })
                     continue
+
+                if not step_result.error and last_message is not None:
+                    try:
+                        content_result = Message.get_text_content(last_message)
+                        last_response = (
+                            await content_result
+                            if inspect.isawaitable(content_result)
+                            else content_result
+                        )
+                    except Exception as exc:
+                        log.warn("goal.last_response.error", {
+                            "session_id": ctx.session.id,
+                            "message_id": getattr(last_message, "id", None),
+                            "error": str(exc),
+                        })
+                        last_response = getattr(last_message, "content", "") or ""
+                    goal_decision = await GoalManager.evaluate_after_turn(
+                        ctx.session.id,
+                        str(last_response or ""),
+                    )
+                    if goal_decision.status in {"completed", "blocked", "paused"} and goal_decision.objective:
+                        await cls._publish_runtime_event(callbacks, "session.goal.updated", {
+                            "sessionID": ctx.session.id,
+                            "status": goal_decision.status,
+                            "objective": goal_decision.objective,
+                            "reason": goal_decision.reason,
+                        })
+                    if goal_decision.should_continue and goal_decision.continuation_prompt:
+                        goal_user = await Message.create(
+                            session_id=ctx.session.id,
+                            role=MessageRole.USER,
+                            content=goal_decision.continuation_prompt,
+                            agent=last_user.agent if hasattr(last_user, "agent") else ctx.agent_name,
+                            model=last_user.model if hasattr(last_user, "model") else {
+                                "providerID": ctx.provider_id,
+                                "modelID": ctx.model_id,
+                            },
+                            provider=last_user.provider if hasattr(last_user, "provider") else ctx.provider_id,
+                            synthetic=True,
+                            part_metadata={
+                                "goalContinuation": True,
+                                "goalVerdict": goal_decision.verdict,
+                                "goalReason": goal_decision.reason,
+                            },
+                        )
+                        turn_state = set_turn_state(
+                            ctx.session.id,
+                            step=ctx.step,
+                            status="continued",
+                            continue_reason="goal",
+                            queued_message_detected=False,
+                        )
+                        await cls._publish_runtime_event(callbacks, "turn.continued", {
+                            **turn_state.model_dump(by_alias=True),
+                            "goalMessageID": goal_user.id,
+                            "goalVerdict": goal_decision.verdict,
+                        })
+                        log.info("loop.continuing_for_goal", {
+                            "session_id": ctx.session.id,
+                            "goal_message_id": goal_user.id,
+                            "reason": goal_decision.reason,
+                        })
+                        continue
 
                 stop_reason = step_result.error or (getattr(last_message, "finish", None) if last_message else None) or "stop"
                 turn_state = set_turn_state(

--- a/flocks/session/session_loop.py
+++ b/flocks/session/session_loop.py
@@ -1294,10 +1294,10 @@ class SessionLoop:
                             "reason": goal_decision.reason,
                         })
                     if goal_decision.should_continue and goal_decision.continuation_prompt:
-                        # Hermes-style goal continuation: append a plain
-                        # user-role prompt to history. Keep metadata for
-                        # observability, but do not mark the part synthetic so
-                        # it remains a normal conversation turn.
+                        # Hermes-style goal continuation: append a user-role
+                        # prompt to history so the model continues, while
+                        # marking the part synthetic so UIs do not treat it as
+                        # user-authored text.
                         goal_user = await Message.create(
                             session_id=ctx.session.id,
                             role=MessageRole.USER,
@@ -1308,6 +1308,7 @@ class SessionLoop:
                                 "modelID": ctx.model_id,
                             },
                             provider=last_user.provider if hasattr(last_user, "provider") else ctx.provider_id,
+                            synthetic=True,
                             part_metadata={
                                 "goalContinuation": True,
                                 "goalVerdict": goal_decision.verdict,

--- a/flocks/tool/question_handler.py
+++ b/flocks/tool/question_handler.py
@@ -15,7 +15,12 @@ from flocks.server.routes.question import (
     is_request_rejected,
     clear_request_state,
 )
-from flocks.tool.system.question import QuestionRejectedError, get_current_message_id, get_current_call_id
+from flocks.tool.system.question import (
+    QuestionRejectedError,
+    get_current_call_id,
+    get_current_message_id,
+    normalize_question_option,
+)
 
 
 log = Log.create(service="question-handler")
@@ -68,22 +73,18 @@ async def api_question_handler(
         # Convert options format for QuestionInfo
         options = []
         for opt in q.get("options", []):
-            if isinstance(opt, dict):
-                options.append({
-                    "label": str(opt.get("label", "")),
-                    "description": str(opt.get("description", "")),
-                })
-            elif isinstance(opt, str):
-                options.append({
-                    "label": opt,
-                    "description": "",
-                })
+            option = normalize_question_option(opt)
+            if option is not None:
+                options.append(option)
         
         # Build QuestionInfo
+        question_type = q.get("type", "choice")
+        if question_type == "choice" and not options:
+            question_type = "text"
         question_info = {
             "question": str(q.get("question", "")),
             "header": str(q.get("header", "")),
-            "type": q.get("type", "choice"),
+            "type": question_type,
             "options": options,
             "multiple": q.get("multiple", False),
             "placeholder": q.get("placeholder", ""),

--- a/flocks/tool/system/question.py
+++ b/flocks/tool/system/question.py
@@ -92,6 +92,40 @@ Question format:
 The user's answers will be returned for you to continue with."""
 
 
+_OPTION_LABEL_KEYS = ("label", "text", "title", "name", "value", "id", "key")
+_OPTION_DESCRIPTION_KEYS = ("description", "desc", "subtitle", "detail", "details")
+
+
+def _first_non_empty_string(data: Dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = data.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def normalize_question_option(opt: Any) -> Optional[Dict[str, str]]:
+    """Normalize LLM-produced choice options into the UI's label/description shape."""
+    if isinstance(opt, str):
+        label = opt.strip()
+        return {"label": label, "description": ""} if label else None
+
+    if not isinstance(opt, dict):
+        label = str(opt).strip() if opt is not None else ""
+        return {"label": label, "description": ""} if label else None
+
+    label = _first_non_empty_string(opt, _OPTION_LABEL_KEYS)
+    description = _first_non_empty_string(opt, _OPTION_DESCRIPTION_KEYS)
+    if not label and description:
+        label, description = description, ""
+    if not label:
+        return None
+    return {"label": label, "description": description}
+
+
 def _format_channel_question_text(questions: List[Dict[str, Any]]) -> str:
     """Render normalized questions as plain text for IM channels."""
     blocks: list[str] = []
@@ -352,16 +386,12 @@ async def question_tool(
 
         options = q.get("options", [])
         for opt in options:
-            if isinstance(opt, dict):
-                normalized["options"].append({
-                    "label": str(opt.get("label", "")),
-                    "description": opt.get("description", "")
-                })
-            elif isinstance(opt, str):
-                normalized["options"].append({
-                    "label": opt,
-                    "description": ""
-                })
+            option = normalize_question_option(opt)
+            if option is not None:
+                normalized["options"].append(option)
+
+        if normalized["type"] == "choice" and not normalized["options"]:
+            normalized["type"] = "text"
         
         normalized_questions.append(normalized)
     

--- a/flocks/tool/system/question.py
+++ b/flocks/tool/system/question.py
@@ -307,6 +307,13 @@ async def default_question_handler(
                             "type": "boolean",
                             "description": "For 'choice' type: allow selecting multiple options",
                         },
+                        "custom": {
+                            "type": "boolean",
+                            "description": (
+                                "For 'choice' type: allow a custom Other answer option. "
+                                "Defaults to true."
+                            ),
+                        },
                         "placeholder": {
                             "type": "string",
                             "description": "Placeholder/hint text for text, number, password, file inputs",
@@ -371,6 +378,7 @@ async def question_tool(
             "type": q.get("type", "choice"),
             "options": [],
             "multiple": q.get("multiple", False),
+            "custom": q.get("custom", True),
             "placeholder": q.get("placeholder", ""),
             "multiline": q.get("multiline", False),
         }
@@ -428,6 +436,21 @@ async def question_tool(
         ])
         
         output = f"User has answered your questions: {formatted}. You can now continue with the user's answers in mind."
+        try:
+            from flocks.session.goal import GoalManager
+
+            await GoalManager.record_initial_clarification(
+                ctx.session_id,
+                normalized_questions,
+                answers,
+                message_id=ctx.message_id,
+                call_id=ctx.call_id,
+            )
+        except Exception as e:
+            log.warn("question.goal_clarification_record_failed", {
+                "session_id": ctx.session_id,
+                "error": str(e),
+            })
         
         return ToolResult(
             success=True,

--- a/tests/command/test_handler_json_args.py
+++ b/tests/command/test_handler_json_args.py
@@ -39,6 +39,7 @@ async def test_handle_slash_command_forwards_structured_arguments():
         args='{"team":"blue"}',
         args_json={"team": "blue"},
         surface=None,
+        session_id=None,
     )
     send_text.assert_awaited_once_with("ok")
     send_prompt.assert_not_called()

--- a/tests/command/test_help_format.py
+++ b/tests/command/test_help_format.py
@@ -11,6 +11,7 @@ class TestHelpFormatting:
         names = {command.name for command in commands}
 
         assert "help" in names
+        assert "goal" in names
         assert "mcp" in names
         assert "model" not in names
         assert "status" not in names
@@ -49,6 +50,7 @@ class TestHelpFormatting:
         assert "/agents" in output
         assert "/workflows" in output
         assert "/mcp" in output
+        assert "/goal" not in output
         assert "/clear" not in output
         assert "/plan" not in output
         assert "/compact" not in output

--- a/tests/server/routes/test_session_routes.py
+++ b/tests/server/routes/test_session_routes.py
@@ -66,6 +66,24 @@ class TestSessionCRUD:
         assert resp.json()["category"] == "workflow"
 
     @pytest.mark.asyncio
+    async def test_get_session_includes_persisted_goal(self, client: AsyncClient):
+        """GET /api/session/{id} hydrates persisted goal state for the WebUI."""
+        from flocks.session.goal import GoalManager
+
+        create_resp = await client.post("/api/session", json={"title": "Goal Session"})
+        assert create_resp.status_code == status.HTTP_200_OK
+        session_id = create_resp.json()["id"]
+        await GoalManager.set_goal(session_id, "List built-in tools")
+
+        resp = await client.get(f"/api/session/{session_id}")
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.json()["goal"] == {
+            "status": "active",
+            "objective": "List built-in tools",
+            "reason": None,
+        }
+
+    @pytest.mark.asyncio
     async def test_list_sessions_empty(self, client: AsyncClient):
         """GET /api/session returns an empty list when no sessions exist."""
         resp = await client.get("/api/session")

--- a/tests/server/routes/test_session_routes.py
+++ b/tests/server/routes/test_session_routes.py
@@ -961,17 +961,25 @@ class TestSessionUtilities:
     @pytest.mark.asyncio
     async def test_clear_session(self, client: AsyncClient, session_id: str):
         """POST /api/session/{id}/clear removes messages."""
+        from flocks.session.goal import GoalManager
+
         # Add a message first
         await client.post(
             f"/api/session/{session_id}/message",
             json={"parts": [{"type": "text", "text": "msg"}], "noReply": True},
         )
+        await GoalManager.set_goal(session_id, "List built-in tools")
         clear_resp = await client.post(f"/api/session/{session_id}/clear")
         assert clear_resp.status_code == status.HTTP_200_OK
 
         # Messages should be gone
         list_resp = await client.get(f"/api/session/{session_id}/message")
         assert list_resp.json() == []
+        assert await GoalManager.get(session_id) is None
+
+        session_resp = await client.get(f"/api/session/{session_id}")
+        assert session_resp.status_code == status.HTTP_200_OK
+        assert session_resp.json()["goal"] is None
 
     @pytest.mark.asyncio
     async def test_clear_session_clears_prompt_queue(self, client: AsyncClient, session_id: str):

--- a/tests/server/test_input_dispatcher.py
+++ b/tests/server/test_input_dispatcher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -34,6 +34,15 @@ class TestParseSlashCommand:
         assert parsed is not None
         assert parsed.command_name == "restart"
         assert parsed.command_def is None
+
+    def test_goal_command_resolves(self):
+        parsed = parse_slash_command("/goal fix tests")
+        assert parsed is not None
+        assert parsed.command_name == "goal"
+        assert parsed.canonical_name == "goal"
+        assert parsed.args == "fix tests"
+        assert parsed.command_def is not None
+        assert parsed.command_def.execution_kind == "direct"
 
 
 class TestDispatchUserInput:
@@ -195,6 +204,55 @@ class TestDispatchUserInput:
 
         assert result.action == "rejected"
         assert "不支持附件" in direct[0]
+
+    @pytest.mark.asyncio
+    async def test_goal_requires_existing_session(self):
+        direct = []
+        sink = CallbackOutputSink(
+            "webui",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append([], (prompt, display)),
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            text="/goal fix tests",
+            parts=[{"type": "text", "text": "/goal fix tests"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "rejected"
+        assert "需要先有一个会话" in direct[0]
+
+    @pytest.mark.asyncio
+    async def test_goal_set_runs_llm_without_direct_ack(self, monkeypatch):
+        direct = []
+        llm = []
+        sink = CallbackOutputSink(
+            "webui",
+            direct_response=lambda _event, text: _append(direct, text),
+            run_llm=lambda _event, prompt, display: _append(llm, (prompt, display)),
+        )
+        monkeypatch.setattr(
+            "flocks.command.direct.GoalManager.set_goal",
+            AsyncMock(return_value=SimpleNamespace(objective="fix tests", max_turns=20)),
+        )
+        monkeypatch.setattr(
+            "flocks.command.direct.GoalManager.goal_prompt",
+            MagicMock(return_value="goal prompt"),
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_goal_dispatch",
+            text="/goal fix tests",
+            parts=[{"type": "text", "text": "/goal fix tests"}],
+        )
+
+        result = await dispatch_user_input(event, sink)
+
+        assert result.action == "llm"
+        assert direct == []
+        assert llm == [("goal prompt", "/goal fix tests")]
 
     @pytest.mark.asyncio
     async def test_channel_unsafe_command_is_rejected(self):

--- a/tests/session/test_goal.py
+++ b/tests/session/test_goal.py
@@ -18,7 +18,7 @@ async def test_goal_command_sets_state_and_prompt():
     assert result.text is None
     assert result.prompt is not None
     assert "Active goal: fix failing tests" in result.prompt
-    assert "Goal complete:" in result.prompt
+    assert "specific blocker" in result.prompt
 
     state = await GoalManager.get("goal_command_session")
 
@@ -42,13 +42,13 @@ async def test_goal_command_rejects_empty_objective():
 
 
 @pytest.mark.asyncio
-async def test_goal_evaluation_prefers_agent_self_report():
+async def test_goal_evaluation_completes_when_judge_finds_done():
     session_id = "goal_complete_session"
     await GoalManager.set_goal(session_id, "finish implementation")
 
     decision = await GoalManager.evaluate_after_turn(
         session_id,
-        "Goal complete: implementation and tests are done.",
+        "Implemented the feature, updated the tests, and the focused test suite passed.",
     )
     state = await GoalManager.get(session_id)
 
@@ -56,6 +56,41 @@ async def test_goal_evaluation_prefers_agent_self_report():
     assert decision.should_continue is False
     assert state is not None
     assert state.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_goal_evaluation_blocks_when_judge_finds_blocker():
+    session_id = "goal_blocked_session"
+    await GoalManager.set_goal(session_id, "finish implementation")
+
+    decision = await GoalManager.evaluate_after_turn(
+        session_id,
+        "I cannot proceed because the repository is unavailable.",
+    )
+    state = await GoalManager.get(session_id)
+
+    assert decision.verdict == "blocked"
+    assert decision.should_continue is False
+    assert state is not None
+    assert state.status == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_goal_evaluation_waits_when_agent_asks_for_clarification():
+    session_id = "goal_waiting_session"
+    await GoalManager.set_goal(session_id, "write tests 10 times")
+
+    decision = await GoalManager.evaluate_after_turn(
+        session_id,
+        "Please clarify what tests to write and where to place them.",
+    )
+    state = await GoalManager.get(session_id)
+
+    assert decision.verdict == "waiting"
+    assert decision.should_continue is False
+    assert state is not None
+    assert state.status == "active"
+    assert state.last_verdict == "waiting"
 
 
 @pytest.mark.asyncio
@@ -74,14 +109,31 @@ async def test_goal_evaluation_continues_until_budget_then_pauses():
 
 
 def test_judge_goal_is_conservative_fallback():
-    verdict, reason = judge_goal("I made progress but the work is not complete.")
+    verdict, reason = judge_goal("finish implementation", "I made progress but the work is not complete.")
 
     assert verdict == "continue"
-    assert reason == "goal completion was not explicitly proven"
+    assert reason == "judge found remaining work toward the goal"
 
 
-def test_judge_goal_does_not_complete_on_tests_only():
-    verdict, reason = judge_goal("All tests pass. Next I will push the branch.")
+def test_judge_goal_does_not_complete_when_response_mentions_next_step():
+    verdict, reason = judge_goal("ship branch", "All tests pass. Next I will push the branch.")
 
     assert verdict == "continue"
-    assert reason == "goal completion was not explicitly proven"
+    assert reason == "judge found remaining work toward the goal"
+
+
+def test_judge_goal_waits_on_user_clarification():
+    verdict, reason = judge_goal(
+        "write tests 10 times",
+        "I need to clarify what tests to write 10 times.",
+    )
+
+    assert verdict == "waiting"
+    assert "need to clarify" in reason
+
+
+def test_judge_goal_completes_on_obvious_delivery():
+    verdict, reason = judge_goal("fix tests", "Fixed the failing tests and verified pytest passed.")
+
+    assert verdict == "complete"
+    assert "Fixed the failing tests" in reason

--- a/tests/session/test_goal.py
+++ b/tests/session/test_goal.py
@@ -77,12 +77,24 @@ async def test_goal_records_only_first_initial_clarification():
 
 
 @pytest.mark.asyncio
+async def test_goal_clear_removes_persisted_state():
+    session_id = "goal_clear_session"
+    await GoalManager.set_goal(session_id, "make it work")
+
+    deleted = await GoalManager.clear(session_id)
+    state = await GoalManager.get(session_id)
+
+    assert deleted is True
+    assert state is None
+
+
+@pytest.mark.asyncio
 async def test_goal_evaluation_completes_when_judge_finds_done():
     session_id = "goal_complete_session"
     await GoalManager.set_goal(session_id, "finish implementation")
     provider = SimpleNamespace(
         chat=AsyncMock(return_value=SimpleNamespace(
-            content='{"done": true, "reason": "The final response says the implementation and tests are complete."}'
+            content='{"verdict": "complete", "reason": "The final response says the implementation and tests are complete."}'
         ))
     )
 
@@ -102,12 +114,12 @@ async def test_goal_evaluation_completes_when_judge_finds_done():
 
 
 @pytest.mark.asyncio
-async def test_goal_evaluation_completes_when_judge_finds_goal_unachievable():
+async def test_goal_evaluation_blocks_when_judge_finds_goal_unachievable():
     session_id = "goal_blocked_session"
     await GoalManager.set_goal(session_id, "finish implementation")
     provider = SimpleNamespace(
         chat=AsyncMock(return_value=SimpleNamespace(
-            content='{"done": true, "reason": "The repository is unavailable, so the goal is blocked."}'
+            content='{"verdict": "blocked", "reason": "The repository is unavailable, so the goal is blocked."}'
         ))
     )
 
@@ -120,10 +132,10 @@ async def test_goal_evaluation_completes_when_judge_finds_goal_unachievable():
         )
     state = await GoalManager.get(session_id)
 
-    assert decision.verdict == "complete"
+    assert decision.verdict == "blocked"
     assert decision.should_continue is False
     assert state is not None
-    assert state.status == "completed"
+    assert state.status == "blocked"
 
 
 @pytest.mark.asyncio
@@ -132,7 +144,7 @@ async def test_goal_evaluation_waits_when_agent_asks_for_clarification():
     await GoalManager.set_goal(session_id, "write tests 10 times")
     provider = SimpleNamespace(
         chat=AsyncMock(return_value=SimpleNamespace(
-            content='{"done": false, "reason": "The assistant is asking the user for clarification."}'
+            content='{"verdict": "waiting", "reason": "The assistant is asking the user for clarification."}'
         ))
     )
 
@@ -145,11 +157,12 @@ async def test_goal_evaluation_waits_when_agent_asks_for_clarification():
         )
     state = await GoalManager.get(session_id)
 
-    assert decision.verdict == "continue"
-    assert decision.should_continue is True
+    assert decision.verdict == "waiting"
+    assert decision.should_continue is False
+    assert decision.reason == "The assistant is asking the user for clarification."
     assert state is not None
     assert state.status == "active"
-    assert state.last_verdict == "continue"
+    assert state.last_verdict == "waiting"
 
 
 @pytest.mark.asyncio
@@ -178,7 +191,7 @@ async def test_goal_evaluation_continues_until_budget_then_pauses():
     state = await GoalManager.set_goal(session_id, "keep going", max_turns=1)
     provider = SimpleNamespace(
         chat=AsyncMock(return_value=SimpleNamespace(
-            content='{"done": false, "reason": "The work is not complete yet."}'
+            content='{"verdict": "continue", "reason": "The work is not complete yet."}'
         ))
     )
 
@@ -204,7 +217,7 @@ async def test_goal_evaluation_uses_model_judge_when_provider_model_are_availabl
     await GoalManager.set_goal(session_id, "finish implementation")
     provider = SimpleNamespace(
         chat=AsyncMock(return_value=SimpleNamespace(
-            content='{"done": true, "reason": "The final response says the implementation and tests are complete."}'
+            content='{"verdict": "complete", "reason": "The final response says the implementation and tests are complete."}'
         ))
     )
 
@@ -232,7 +245,7 @@ async def test_goal_model_judge_receives_initial_clarification():
     )
     provider = SimpleNamespace(
         chat=AsyncMock(return_value=SimpleNamespace(
-            content='{"done": false, "reason": "The response says more work remains."}'
+            content='{"verdict": "continue", "reason": "The response says more work remains."}'
         ))
     )
 
@@ -258,7 +271,7 @@ async def test_goal_model_judge_uses_provider_options_without_main_token_budget(
     await GoalManager.set_goal(session_id, "finish implementation")
     provider = SimpleNamespace(
         chat=AsyncMock(return_value=SimpleNamespace(
-            content='{"done": true, "reason": "The final response says the goal is complete."}'
+            content='{"verdict": "complete", "reason": "The final response says the goal is complete."}'
         ))
     )
 
@@ -288,7 +301,7 @@ async def test_goal_evaluation_continues_when_model_judge_says_not_done():
     await GoalManager.set_goal(session_id, "finish implementation")
     provider = SimpleNamespace(
         chat=AsyncMock(return_value=SimpleNamespace(
-            content='{"done": false, "reason": "The response says more work remains."}'
+            content='{"verdict": "continue", "reason": "The response says more work remains."}'
         ))
     )
 
@@ -304,6 +317,30 @@ async def test_goal_evaluation_continues_when_model_judge_says_not_done():
     assert decision.verdict == "continue"
     assert decision.should_continue is True
     assert decision.reason == "The response says more work remains."
+
+
+@pytest.mark.asyncio
+async def test_goal_evaluation_waits_when_model_judge_returns_legacy_done_schema():
+    session_id = "goal_legacy_done_schema_session"
+    await GoalManager.set_goal(session_id, "finish implementation")
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": false, "reason": "The assistant is asking the user for clarification."}'
+        ))
+    )
+
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "Please clarify which tests to run.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
+
+    provider.chat.assert_awaited_once()
+    assert decision.verdict == "waiting"
+    assert decision.should_continue is False
+    assert decision.reason == "goal judge failed; waiting instead of continuing autonomously"
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_goal.py
+++ b/tests/session/test_goal.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+
+from flocks.command.direct import run_direct_command
+from flocks.session.goal import GoalManager, judge_goal
+
+
+@pytest.mark.asyncio
+async def test_goal_command_sets_state_and_prompt():
+    result = await run_direct_command(
+        "goal",
+        args="fix failing tests",
+        session_id="goal_command_session",
+    )
+
+    assert result.handled is True
+    assert result.text is None
+    assert result.prompt is not None
+    assert "Active goal: fix failing tests" in result.prompt
+    assert "Goal complete:" in result.prompt
+
+    state = await GoalManager.get("goal_command_session")
+
+    assert state is not None
+    assert state.status == "active"
+    assert state.objective == "fix failing tests"
+
+
+@pytest.mark.asyncio
+async def test_goal_command_rejects_empty_objective():
+    result = await run_direct_command(
+        "goal",
+        args="",
+        session_id="goal_empty_session",
+    )
+
+    assert result.handled is True
+    assert result.success is False
+    assert result.text == "Usage: /goal <objective>"
+    assert result.prompt is None
+
+
+@pytest.mark.asyncio
+async def test_goal_evaluation_prefers_agent_self_report():
+    session_id = "goal_complete_session"
+    await GoalManager.set_goal(session_id, "finish implementation")
+
+    decision = await GoalManager.evaluate_after_turn(
+        session_id,
+        "Goal complete: implementation and tests are done.",
+    )
+    state = await GoalManager.get(session_id)
+
+    assert decision.verdict == "complete"
+    assert decision.should_continue is False
+    assert state is not None
+    assert state.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_goal_evaluation_continues_until_budget_then_pauses():
+    session_id = "goal_budget_session"
+    state = await GoalManager.set_goal(session_id, "keep going", max_turns=1)
+
+    decision = await GoalManager.evaluate_after_turn(session_id, "I made progress.")
+    state = await GoalManager.get(session_id)
+
+    assert decision.verdict == "continue"
+    assert decision.should_continue is False
+    assert state is not None
+    assert state.status == "paused"
+    assert state.paused_reason == "turn budget exhausted (1/1)"
+
+
+def test_judge_goal_is_conservative_fallback():
+    verdict, reason = judge_goal("I made progress but the work is not complete.")
+
+    assert verdict == "continue"
+    assert reason == "goal completion was not explicitly proven"
+
+
+def test_judge_goal_does_not_complete_on_tests_only():
+    verdict, reason = judge_goal("All tests pass. Next I will push the branch.")
+
+    assert verdict == "continue"
+    assert reason == "goal completion was not explicitly proven"

--- a/tests/session/test_goal.py
+++ b/tests/session/test_goal.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from flocks.command.direct import run_direct_command
-from flocks.session.goal import GoalManager
+from flocks.session.goal import JUDGE_MAX_TOKENS, GoalManager
 
 
 @pytest.mark.asyncio
@@ -190,6 +190,36 @@ async def test_goal_evaluation_uses_model_judge_when_provider_model_are_availabl
 
 
 @pytest.mark.asyncio
+async def test_goal_model_judge_uses_provider_options_without_main_token_budget():
+    session_id = "goal_model_judge_provider_options_session"
+    await GoalManager.set_goal(session_id, "finish implementation")
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": true, "reason": "The final response says the goal is complete."}'
+        ))
+    )
+
+    with patch("flocks.session.goal.Provider.get", return_value=provider), patch(
+        "flocks.session.goal.build_provider_options",
+        return_value={"extra_body": {"reasoning_split": True}, "max_tokens": 128000},
+    ) as build_options:
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "Goal is complete.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
+
+    build_options.assert_called_once_with("test-provider", "test-model")
+    provider.chat.assert_awaited_once()
+    kwargs = provider.chat.await_args.kwargs
+    assert kwargs["extra_body"] == {"reasoning_split": True}
+    assert kwargs["max_tokens"] == JUDGE_MAX_TOKENS
+    assert kwargs["temperature"] == 0
+    assert decision.verdict == "complete"
+
+
+@pytest.mark.asyncio
 async def test_goal_evaluation_continues_when_model_judge_says_not_done():
     session_id = "goal_model_judge_continue_session"
     await GoalManager.set_goal(session_id, "finish implementation")
@@ -214,7 +244,7 @@ async def test_goal_evaluation_continues_when_model_judge_says_not_done():
 
 
 @pytest.mark.asyncio
-async def test_goal_evaluation_continues_when_model_judge_fails():
+async def test_goal_evaluation_waits_when_model_judge_fails():
     session_id = "goal_model_judge_failure_session"
     await GoalManager.set_goal(session_id, "finish implementation")
     provider = SimpleNamespace(chat=AsyncMock(side_effect=RuntimeError("judge unavailable")))
@@ -228,9 +258,9 @@ async def test_goal_evaluation_continues_when_model_judge_fails():
         )
 
     provider.chat.assert_awaited_once()
-    assert decision.verdict == "continue"
-    assert decision.should_continue is True
-    assert decision.reason == "goal judge failed; continuing"
+    assert decision.verdict == "waiting"
+    assert decision.should_continue is False
+    assert decision.reason == "goal judge failed; waiting instead of continuing autonomously"
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_goal.py
+++ b/tests/session/test_goal.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from flocks.command.direct import run_direct_command
-from flocks.session.goal import GoalManager, judge_goal
+from flocks.session.goal import GoalManager
 
 
 @pytest.mark.asyncio
@@ -45,11 +48,19 @@ async def test_goal_command_rejects_empty_objective():
 async def test_goal_evaluation_completes_when_judge_finds_done():
     session_id = "goal_complete_session"
     await GoalManager.set_goal(session_id, "finish implementation")
-
-    decision = await GoalManager.evaluate_after_turn(
-        session_id,
-        "Implemented the feature, updated the tests, and the focused test suite passed.",
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": true, "reason": "The final response says the implementation and tests are complete."}'
+        ))
     )
+
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "Implemented the feature, updated the tests, and the focused test suite passed.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
     state = await GoalManager.get(session_id)
 
     assert decision.verdict == "complete"
@@ -59,35 +70,71 @@ async def test_goal_evaluation_completes_when_judge_finds_done():
 
 
 @pytest.mark.asyncio
-async def test_goal_evaluation_blocks_when_judge_finds_blocker():
+async def test_goal_evaluation_completes_when_judge_finds_goal_unachievable():
     session_id = "goal_blocked_session"
     await GoalManager.set_goal(session_id, "finish implementation")
-
-    decision = await GoalManager.evaluate_after_turn(
-        session_id,
-        "I cannot proceed because the repository is unavailable.",
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": true, "reason": "The repository is unavailable, so the goal is blocked."}'
+        ))
     )
+
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "I cannot proceed because the repository is unavailable.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
     state = await GoalManager.get(session_id)
 
-    assert decision.verdict == "blocked"
+    assert decision.verdict == "complete"
     assert decision.should_continue is False
     assert state is not None
-    assert state.status == "blocked"
+    assert state.status == "completed"
 
 
 @pytest.mark.asyncio
 async def test_goal_evaluation_waits_when_agent_asks_for_clarification():
     session_id = "goal_waiting_session"
     await GoalManager.set_goal(session_id, "write tests 10 times")
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": false, "reason": "The assistant is asking the user for clarification."}'
+        ))
+    )
+
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "Please clarify what tests to write and where to place them.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
+    state = await GoalManager.get(session_id)
+
+    assert decision.verdict == "continue"
+    assert decision.should_continue is True
+    assert state is not None
+    assert state.status == "active"
+    assert state.last_verdict == "continue"
+
+
+@pytest.mark.asyncio
+async def test_goal_evaluation_waits_when_runtime_has_pending_user_input():
+    session_id = "goal_pending_user_input_session"
+    await GoalManager.set_goal(session_id, "triage phishing email")
 
     decision = await GoalManager.evaluate_after_turn(
         session_id,
-        "Please clarify what tests to write and where to place them.",
+        "I made progress and can continue.",
+        pending_user_input=True,
     )
     state = await GoalManager.get(session_id)
 
     assert decision.verdict == "waiting"
     assert decision.should_continue is False
+    assert decision.reason == "session has a pending user question"
     assert state is not None
     assert state.status == "active"
     assert state.last_verdict == "waiting"
@@ -97,8 +144,19 @@ async def test_goal_evaluation_waits_when_agent_asks_for_clarification():
 async def test_goal_evaluation_continues_until_budget_then_pauses():
     session_id = "goal_budget_session"
     state = await GoalManager.set_goal(session_id, "keep going", max_turns=1)
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": false, "reason": "The work is not complete yet."}'
+        ))
+    )
 
-    decision = await GoalManager.evaluate_after_turn(session_id, "I made progress.")
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "I made progress.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
     state = await GoalManager.get(session_id)
 
     assert decision.verdict == "continue"
@@ -108,32 +166,88 @@ async def test_goal_evaluation_continues_until_budget_then_pauses():
     assert state.paused_reason == "turn budget exhausted (1/1)"
 
 
-def test_judge_goal_is_conservative_fallback():
-    verdict, reason = judge_goal("finish implementation", "I made progress but the work is not complete.")
-
-    assert verdict == "continue"
-    assert reason == "judge found remaining work toward the goal"
-
-
-def test_judge_goal_does_not_complete_when_response_mentions_next_step():
-    verdict, reason = judge_goal("ship branch", "All tests pass. Next I will push the branch.")
-
-    assert verdict == "continue"
-    assert reason == "judge found remaining work toward the goal"
-
-
-def test_judge_goal_waits_on_user_clarification():
-    verdict, reason = judge_goal(
-        "write tests 10 times",
-        "I need to clarify what tests to write 10 times.",
+@pytest.mark.asyncio
+async def test_goal_evaluation_uses_model_judge_when_provider_model_are_available():
+    session_id = "goal_model_judge_complete_session"
+    await GoalManager.set_goal(session_id, "finish implementation")
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": true, "reason": "The final response says the implementation and tests are complete."}'
+        ))
     )
 
-    assert verdict == "waiting"
-    assert "need to clarify" in reason
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "Implemented the feature and tests passed.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
+
+    provider.chat.assert_awaited_once()
+    assert decision.verdict == "complete"
+    assert decision.reason == "The final response says the implementation and tests are complete."
 
 
-def test_judge_goal_completes_on_obvious_delivery():
-    verdict, reason = judge_goal("fix tests", "Fixed the failing tests and verified pytest passed.")
+@pytest.mark.asyncio
+async def test_goal_evaluation_continues_when_model_judge_says_not_done():
+    session_id = "goal_model_judge_continue_session"
+    await GoalManager.set_goal(session_id, "finish implementation")
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": false, "reason": "The response says more work remains."}'
+        ))
+    )
 
-    assert verdict == "complete"
-    assert "Fixed the failing tests" in reason
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "I made progress.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
+
+    provider.chat.assert_awaited_once()
+    assert decision.verdict == "continue"
+    assert decision.should_continue is True
+    assert decision.reason == "The response says more work remains."
+
+
+@pytest.mark.asyncio
+async def test_goal_evaluation_continues_when_model_judge_fails():
+    session_id = "goal_model_judge_failure_session"
+    await GoalManager.set_goal(session_id, "finish implementation")
+    provider = SimpleNamespace(chat=AsyncMock(side_effect=RuntimeError("judge unavailable")))
+
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "Implemented the feature and tests passed.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
+
+    provider.chat.assert_awaited_once()
+    assert decision.verdict == "continue"
+    assert decision.should_continue is True
+    assert decision.reason == "goal judge failed; continuing"
+
+
+@pytest.mark.asyncio
+async def test_goal_evaluation_skips_model_judge_when_waiting_for_user_input():
+    session_id = "goal_model_judge_pending_input_session"
+    await GoalManager.set_goal(session_id, "finish implementation")
+    provider = SimpleNamespace(chat=AsyncMock())
+
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "Please provide more input.",
+            pending_user_input=True,
+            provider_id="test-provider",
+            model_id="test-model",
+        )
+
+    provider.chat.assert_not_awaited()
+    assert decision.verdict == "waiting"
+    assert decision.should_continue is False

--- a/tests/session/test_goal.py
+++ b/tests/session/test_goal.py
@@ -45,6 +45,38 @@ async def test_goal_command_rejects_empty_objective():
 
 
 @pytest.mark.asyncio
+async def test_goal_records_only_first_initial_clarification():
+    session_id = "goal_initial_clarification_session"
+    await GoalManager.set_goal(session_id, "make it work")
+
+    first_state = await GoalManager.record_initial_clarification(
+        session_id,
+        [{"question": "What should work?"}],
+        [["The MCP test connection button"]],
+        message_id="msg_question_1",
+        call_id="call_question_1",
+    )
+    second_state = await GoalManager.record_initial_clarification(
+        session_id,
+        [{"question": "Should I run tests?"}],
+        [["Yes"]],
+        message_id="msg_question_2",
+        call_id="call_question_2",
+    )
+
+    assert first_state is not None
+    assert second_state is not None
+    state = await GoalManager.get(session_id)
+    assert state is not None
+    assert state.initial_clarification is not None
+    assert state.initial_clarification.message_id == "msg_question_1"
+    assert state.initial_clarification.call_id == "call_question_1"
+    assert state.initial_clarification.answers[0].question == "What should work?"
+    assert state.initial_clarification.answers[0].answer == "The MCP test connection button"
+    assert "Should I run tests?" not in state.initial_clarification.text
+
+
+@pytest.mark.asyncio
 async def test_goal_evaluation_completes_when_judge_finds_done():
     session_id = "goal_complete_session"
     await GoalManager.set_goal(session_id, "finish implementation")
@@ -187,6 +219,37 @@ async def test_goal_evaluation_uses_model_judge_when_provider_model_are_availabl
     provider.chat.assert_awaited_once()
     assert decision.verdict == "complete"
     assert decision.reason == "The final response says the implementation and tests are complete."
+
+
+@pytest.mark.asyncio
+async def test_goal_model_judge_receives_initial_clarification():
+    session_id = "goal_model_judge_clarification_session"
+    await GoalManager.set_goal(session_id, "make it work")
+    await GoalManager.record_initial_clarification(
+        session_id,
+        [{"question": "What should work?"}],
+        [["The MCP test connection button should submit even with a blank saved name."]],
+    )
+    provider = SimpleNamespace(
+        chat=AsyncMock(return_value=SimpleNamespace(
+            content='{"done": false, "reason": "The response says more work remains."}'
+        ))
+    )
+
+    with patch("flocks.session.goal.Provider.get", return_value=provider):
+        decision = await GoalManager.evaluate_after_turn(
+            session_id,
+            "I made progress.",
+            provider_id="test-provider",
+            model_id="test-model",
+        )
+
+    provider.chat.assert_awaited_once()
+    judge_prompt = provider.chat.await_args.kwargs["messages"][1].content
+    assert "Original goal:\nmake it work" in judge_prompt
+    assert "Initial user clarification:" in judge_prompt
+    assert "The MCP test connection button should submit" in judge_prompt
+    assert decision.verdict == "continue"
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_abort_inject.py
+++ b/tests/session/test_session_abort_inject.py
@@ -420,7 +420,7 @@ class TestTurnLifecycle:
         assert result.action == "stop"
         create_message.assert_awaited_once()
         assert create_message.await_args.kwargs["content"] == "continue toward goal"
-        assert "synthetic" not in create_message.await_args.kwargs
+        assert create_message.await_args.kwargs["synthetic"] is True
         assert create_message.await_args.kwargs["part_metadata"]["goalContinuation"] is True
         event_names = [call.args[0] for call in event_callback.await_args_list]
         assert event_names == [

--- a/tests/session/test_session_abort_inject.py
+++ b/tests/session/test_session_abort_inject.py
@@ -433,6 +433,62 @@ class TestTurnLifecycle:
         assert continued_payload["goalMessageID"] == synthetic.id
 
     @pytest.mark.asyncio
+    async def test_run_loop_waits_for_user_input_after_goal_clarification(self):
+        session = SimpleNamespace(
+            id="turn_goal_waiting_session",
+            agent="rex",
+            directory="/tmp",
+            memory_enabled=False,
+        )
+        ctx = LoopContext(
+            session=session,
+            provider_id="test-provider",
+            model_id="test-model",
+            agent_name="rex",
+        )
+        user = self._make_msg("msg_001", "user")
+        assistant = self._make_msg("msg_002", "assistant", finish="stop")
+        ctx.session_ctx = SimpleNamespace(
+            get_messages=AsyncMock(side_effect=[
+                [user],
+                [user, assistant],
+            ])
+        )
+        event_callback = AsyncMock()
+        callbacks = LoopCallbacks(event_publish_callback=event_callback)
+
+        with patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ), patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ), patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            MagicMock(return_value="Please clarify what tests to write."),
+        ), patch(
+            "flocks.session.session_loop.Message.create",
+            AsyncMock(),
+        ) as create_message, patch(
+            "flocks.session.session_loop.GoalManager.evaluate_after_turn",
+            AsyncMock(return_value=GoalDecision(
+                status="active",
+                verdict="waiting",
+                should_continue=False,
+                reason="waiting for user clarification",
+            )),
+        ), patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(return_value=StepResult(action="stop")),
+        ):
+            result = await SessionLoop._run_loop(ctx, callbacks)
+
+        assert result.action == "stop"
+        create_message.assert_not_awaited()
+        event_names = [call.args[0] for call in event_callback.await_args_list]
+        assert event_names == ["turn.started", "turn.stopped"]
+
+    @pytest.mark.asyncio
     async def test_run_loop_publishes_goal_terminal_status(self):
         session = SimpleNamespace(
             id="turn_goal_done_session",

--- a/tests/session/test_session_abort_inject.py
+++ b/tests/session/test_session_abort_inject.py
@@ -373,14 +373,14 @@ class TestTurnLifecycle:
         )
         user = self._make_msg("msg_001", "user")
         assistant = self._make_msg("msg_002", "assistant", finish="stop")
-        synthetic = self._make_msg("msg_003", "user")
+        goal_user = self._make_msg("msg_003", "user")
         assistant_after_goal = self._make_msg("msg_004", "assistant", finish="stop")
         ctx.session_ctx = SimpleNamespace(
             get_messages=AsyncMock(side_effect=[
                 [user],
                 [user, assistant],
-                [user, assistant, synthetic],
-                [user, assistant, synthetic, assistant_after_goal],
+                [user, assistant, goal_user],
+                [user, assistant, goal_user, assistant_after_goal],
             ])
         )
         event_callback = AsyncMock()
@@ -407,7 +407,7 @@ class TestTurnLifecycle:
             MagicMock(return_value="still working"),
         ), patch(
             "flocks.session.session_loop.Message.create",
-            AsyncMock(return_value=synthetic),
+            AsyncMock(return_value=goal_user),
         ) as create_message, patch(
             "flocks.session.session_loop.GoalManager.evaluate_after_turn",
             AsyncMock(side_effect=goal_decisions),
@@ -420,6 +420,7 @@ class TestTurnLifecycle:
         assert result.action == "stop"
         create_message.assert_awaited_once()
         assert create_message.await_args.kwargs["content"] == "continue toward goal"
+        assert "synthetic" not in create_message.await_args.kwargs
         assert create_message.await_args.kwargs["part_metadata"]["goalContinuation"] is True
         event_names = [call.args[0] for call in event_callback.await_args_list]
         assert event_names == [
@@ -430,7 +431,7 @@ class TestTurnLifecycle:
         ]
         continued_payload = event_callback.await_args_list[1].args[1]
         assert continued_payload["continue_reason"] == "goal"
-        assert continued_payload["goalMessageID"] == synthetic.id
+        assert continued_payload["goalMessageID"] == goal_user.id
 
     @pytest.mark.asyncio
     async def test_run_loop_waits_for_user_input_after_goal_clarification(self):
@@ -485,6 +486,67 @@ class TestTurnLifecycle:
 
         assert result.action == "stop"
         create_message.assert_not_awaited()
+        event_names = [call.args[0] for call in event_callback.await_args_list]
+        assert event_names == ["turn.started", "turn.stopped"]
+
+    @pytest.mark.asyncio
+    async def test_run_loop_passes_pending_question_to_goal_judge(self):
+        session = SimpleNamespace(
+            id="turn_goal_pending_question_session",
+            agent="rex",
+            directory="/tmp",
+            memory_enabled=False,
+        )
+        ctx = LoopContext(
+            session=session,
+            provider_id="test-provider",
+            model_id="test-model",
+            agent_name="rex",
+        )
+        user = self._make_msg("msg_001", "user")
+        assistant = self._make_msg("msg_002", "assistant", finish="stop")
+        ctx.session_ctx = SimpleNamespace(
+            get_messages=AsyncMock(side_effect=[
+                [user],
+                [user, assistant],
+            ])
+        )
+        event_callback = AsyncMock()
+        callbacks = LoopCallbacks(event_publish_callback=event_callback)
+        evaluate_goal = AsyncMock(return_value=GoalDecision(
+            status="active",
+            verdict="waiting",
+            should_continue=False,
+            reason="session has a pending user question",
+        ))
+
+        with patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ), patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ), patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            MagicMock(return_value="Please provide the input."),
+        ), patch(
+            "flocks.server.routes.question.has_pending_questions",
+            MagicMock(return_value=True),
+        ), patch(
+            "flocks.session.session_loop.Message.create",
+            AsyncMock(),
+        ) as create_message, patch(
+            "flocks.session.session_loop.GoalManager.evaluate_after_turn",
+            evaluate_goal,
+        ), patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(return_value=StepResult(action="stop")),
+        ):
+            result = await SessionLoop._run_loop(ctx, callbacks)
+
+        assert result.action == "stop"
+        create_message.assert_not_awaited()
+        assert evaluate_goal.await_args.kwargs["pending_user_input"] is True
         event_names = [call.args[0] for call in event_callback.await_args_list]
         assert event_names == ["turn.started", "turn.stopped"]
 

--- a/tests/session/test_session_abort_inject.py
+++ b/tests/session/test_session_abort_inject.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from flocks.session.message import ToolPart, ToolStateCompleted
+from flocks.session.goal import GoalDecision
 from flocks.session.session_loop import SessionLoop, LoopCallbacks, LoopContext, LoopResult
 from flocks.session.runner import SessionRunner, StepResult
 from flocks.session.session import SessionInfo
@@ -355,6 +356,139 @@ class TestTurnLifecycle:
         msg.tokens = tokens
         msg.summary = summary
         return msg
+
+    @pytest.mark.asyncio
+    async def test_run_loop_continues_for_active_goal_after_stop(self):
+        session = SimpleNamespace(
+            id="turn_goal_session",
+            agent="rex",
+            directory="/tmp",
+            memory_enabled=False,
+        )
+        ctx = LoopContext(
+            session=session,
+            provider_id="test-provider",
+            model_id="test-model",
+            agent_name="rex",
+        )
+        user = self._make_msg("msg_001", "user")
+        assistant = self._make_msg("msg_002", "assistant", finish="stop")
+        synthetic = self._make_msg("msg_003", "user")
+        assistant_after_goal = self._make_msg("msg_004", "assistant", finish="stop")
+        ctx.session_ctx = SimpleNamespace(
+            get_messages=AsyncMock(side_effect=[
+                [user],
+                [user, assistant],
+                [user, assistant, synthetic],
+                [user, assistant, synthetic, assistant_after_goal],
+            ])
+        )
+        event_callback = AsyncMock()
+        callbacks = LoopCallbacks(event_publish_callback=event_callback)
+        goal_decisions = [
+            GoalDecision(
+                status="active",
+                verdict="continue",
+                should_continue=True,
+                continuation_prompt="continue toward goal",
+                reason="not done",
+            ),
+            GoalDecision(status="completed", verdict="inactive"),
+        ]
+
+        with patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ), patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ), patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            MagicMock(return_value="still working"),
+        ), patch(
+            "flocks.session.session_loop.Message.create",
+            AsyncMock(return_value=synthetic),
+        ) as create_message, patch(
+            "flocks.session.session_loop.GoalManager.evaluate_after_turn",
+            AsyncMock(side_effect=goal_decisions),
+        ), patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(side_effect=[StepResult(action="stop"), StepResult(action="stop")]),
+        ):
+            result = await SessionLoop._run_loop(ctx, callbacks)
+
+        assert result.action == "stop"
+        create_message.assert_awaited_once()
+        assert create_message.await_args.kwargs["content"] == "continue toward goal"
+        assert create_message.await_args.kwargs["part_metadata"]["goalContinuation"] is True
+        event_names = [call.args[0] for call in event_callback.await_args_list]
+        assert event_names == [
+            "turn.started",
+            "turn.continued",
+            "turn.started",
+            "turn.stopped",
+        ]
+        continued_payload = event_callback.await_args_list[1].args[1]
+        assert continued_payload["continue_reason"] == "goal"
+        assert continued_payload["goalMessageID"] == synthetic.id
+
+    @pytest.mark.asyncio
+    async def test_run_loop_publishes_goal_terminal_status(self):
+        session = SimpleNamespace(
+            id="turn_goal_done_session",
+            agent="rex",
+            directory="/tmp",
+            memory_enabled=False,
+        )
+        ctx = LoopContext(
+            session=session,
+            provider_id="test-provider",
+            model_id="test-model",
+            agent_name="rex",
+        )
+        messages = [
+            self._make_msg("msg_001", "user"),
+            self._make_msg("msg_002", "assistant", finish="stop"),
+        ]
+        ctx.session_ctx = SimpleNamespace(
+            get_messages=AsyncMock(side_effect=[[messages[0]], messages])
+        )
+        event_callback = AsyncMock()
+        callbacks = LoopCallbacks(event_publish_callback=event_callback)
+
+        with patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ), patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ), patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            MagicMock(return_value="Goal complete: done"),
+        ), patch(
+            "flocks.session.session_loop.GoalManager.evaluate_after_turn",
+            AsyncMock(return_value=GoalDecision(
+                status="completed",
+                verdict="complete",
+                reason="Goal complete: done",
+                objective="finish work",
+            )),
+        ), patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(return_value=StepResult(action="stop")),
+        ):
+            result = await SessionLoop._run_loop(ctx, callbacks)
+
+        assert result.action == "stop"
+        event_names = [call.args[0] for call in event_callback.await_args_list]
+        assert event_names == ["turn.started", "session.goal.updated", "turn.stopped"]
+        goal_payload = event_callback.await_args_list[1].args[1]
+        assert goal_payload == {
+            "sessionID": session.id,
+            "status": "completed",
+            "objective": "finish work",
+            "reason": "Goal complete: done",
+        }
 
     @pytest.mark.asyncio
     async def test_pre_compact_cleanup_emits_turn_continued_before_next_iteration(self):

--- a/tests/tool/test_question_channel.py
+++ b/tests/tool/test_question_channel.py
@@ -37,20 +37,65 @@ async def test_question_tool_falls_back_to_text_when_choice_has_no_valid_options
     monkeypatch.setattr(question_module, "_question_handler", fake_handler)
     monkeypatch.setattr(question_module, "_send_channel_question_if_applicable", AsyncMock(return_value=None))
 
-    result = await question_module.question_tool(
-        ToolContext(session_id="ses_question_fallback", message_id="msg_1"),
-        questions=[
-            {
-                "question": "漏洞数据源用什么?",
-                "type": "choice",
-                "options": [{"label": ""}],
-            }
-        ],
-    )
+    with patch(
+        "flocks.session.goal.GoalManager.record_initial_clarification",
+        AsyncMock(),
+    ) as record_clarification:
+        result = await question_module.question_tool(
+            ToolContext(session_id="ses_question_fallback", message_id="msg_1", call_id="call_1"),
+            questions=[
+                {
+                    "question": "漏洞数据源用什么?",
+                    "type": "choice",
+                    "options": [{"label": ""}],
+                }
+            ],
+        )
 
     assert result.success is True
     assert captured_questions[0]["type"] == "text"
     assert captured_questions[0]["options"] == []
+    record_clarification.assert_awaited_once_with(
+        "ses_question_fallback",
+        captured_questions,
+        [["manual answer"]],
+        message_id="msg_1",
+        call_id="call_1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_question_tool_preserves_custom_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_questions: list[dict] = []
+
+    async def fake_handler(_session_id: str, questions: list[dict]) -> list[list[str]]:
+        captured_questions.extend(questions)
+        return [["NVD"]]
+
+    monkeypatch.setattr(question_module, "_question_handler", fake_handler)
+    monkeypatch.setattr(question_module, "_send_channel_question_if_applicable", AsyncMock(return_value=None))
+
+    with patch(
+        "flocks.session.goal.GoalManager.record_initial_clarification",
+        AsyncMock(),
+    ):
+        result = await question_module.question_tool(
+            ToolContext(session_id="ses_question_custom", message_id="msg_1", call_id="call_1"),
+            questions=[
+                {
+                    "question": "漏洞数据源用什么?",
+                    "type": "choice",
+                    "custom": False,
+                    "options": [{"label": "NVD"}],
+                }
+            ],
+        )
+
+    assert result.success is True
+    assert captured_questions[0]["type"] == "choice"
+    assert captured_questions[0]["custom"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/tool/test_question_channel.py
+++ b/tests/tool/test_question_channel.py
@@ -4,7 +4,53 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from flocks.tool.registry import ToolContext
-from flocks.tool.system.question import question_tool
+from flocks.tool.system import question as question_module
+from flocks.tool.system.question import normalize_question_option, question_tool
+
+
+def test_normalize_question_option_accepts_common_llm_shapes() -> None:
+    assert normalize_question_option({"value": "NVD", "desc": "Public CVE feed"}) == {
+        "label": "NVD",
+        "description": "Public CVE feed",
+    }
+    assert normalize_question_option({"text": "Internal scanner"}) == {
+        "label": "Internal scanner",
+        "description": "",
+    }
+    assert normalize_question_option({"description": "Only descriptive text"}) == {
+        "label": "Only descriptive text",
+        "description": "",
+    }
+    assert normalize_question_option({"label": ""}) is None
+
+
+@pytest.mark.asyncio
+async def test_question_tool_falls_back_to_text_when_choice_has_no_valid_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_questions: list[dict] = []
+
+    async def fake_handler(_session_id: str, questions: list[dict]) -> list[list[str]]:
+        captured_questions.extend(questions)
+        return [["manual answer"]]
+
+    monkeypatch.setattr(question_module, "_question_handler", fake_handler)
+    monkeypatch.setattr(question_module, "_send_channel_question_if_applicable", AsyncMock(return_value=None))
+
+    result = await question_module.question_tool(
+        ToolContext(session_id="ses_question_fallback", message_id="msg_1"),
+        questions=[
+            {
+                "question": "漏洞数据源用什么?",
+                "type": "choice",
+                "options": [{"label": ""}],
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert captured_questions[0]["type"] == "text"
+    assert captured_questions[0]["options"] == []
 
 
 @pytest.mark.asyncio

--- a/webui/src/api/session.ts
+++ b/webui/src/api/session.ts
@@ -56,6 +56,18 @@ export interface ContextUsageSnapshot {
   excludedSegments: ContextUsageSegment[];
 }
 
+export interface SessionGoalState {
+  status: 'active' | 'completed' | 'blocked' | 'paused';
+  objective: string;
+  reason?: string | null;
+}
+
+export interface SessionResponse {
+  id: string;
+  goal?: SessionGoalState | null;
+  [key: string]: unknown;
+}
+
 export interface SessionListParams {
   limit?: number;
   offset?: number;
@@ -86,7 +98,7 @@ export const sessionApi = {
   /**
    * 获取单个会话
    */
-  get: async (sessionId: string) => {
+  get: async (sessionId: string): Promise<SessionResponse> => {
     const response = await client.get(`/api/session/${sessionId}`);
     return response.data;
   },

--- a/webui/src/components/common/QuestionTool.test.tsx
+++ b/webui/src/components/common/QuestionTool.test.tsx
@@ -87,4 +87,55 @@ describe('QuestionTool', () => {
 
     expect(onAnswer).toHaveBeenCalledWith([['Syslog 实时流'], ['none']]);
   });
+
+  it('renders choice options that use common non-label fields', async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <QuestionTool
+        questions={[{
+          header: '数据源',
+          question: '漏洞数据源用什么?',
+          type: 'choice',
+          options: [
+            { value: 'NVD', desc: 'Public CVE feed' },
+            { text: '内部扫描器' },
+            { label: '' },
+          ],
+        }]}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /NVD/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /内部扫描器/ })).toBeInTheDocument();
+    expect(screen.queryAllByRole('button')).toHaveLength(3);
+
+    await user.click(screen.getByRole('button', { name: /NVD/ }));
+    await user.click(screen.getByRole('button', { name: /确认/ }));
+
+    expect(onAnswer).toHaveBeenCalledWith([['NVD']]);
+  });
+
+  it('falls back to text input when a choice question has no visible options', async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <QuestionTool
+        questions={[{
+          question: '漏洞数据源用什么?',
+          type: 'choice',
+          options: [{ label: '' }],
+        }]}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    await user.type(screen.getByRole('textbox'), 'NVD');
+    await user.click(screen.getByRole('button', { name: /确认/ }));
+
+    expect(onAnswer).toHaveBeenCalledWith([['NVD']]);
+  });
 });

--- a/webui/src/components/common/QuestionTool.test.tsx
+++ b/webui/src/components/common/QuestionTool.test.tsx
@@ -98,6 +98,7 @@ describe('QuestionTool', () => {
           header: '数据源',
           question: '漏洞数据源用什么?',
           type: 'choice',
+          custom: false,
           options: [
             { value: 'NVD', desc: 'Public CVE feed' },
             { text: '内部扫描器' },
@@ -116,6 +117,79 @@ describe('QuestionTool', () => {
     await user.click(screen.getByRole('button', { name: /确认/ }));
 
     expect(onAnswer).toHaveBeenCalledWith([['NVD']]);
+  });
+
+  it('uses typed text as the answer when a provided Other option is selected', async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <QuestionTool
+        questions={[{
+          header: '测试范围',
+          question: '「做一个测试」具体指什么?',
+          type: 'choice',
+          options: [
+            '代码单元测试',
+            {
+              label: '其他(请补充)',
+              description: '描述具体测试内容和目标',
+            },
+          ],
+        }]}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /其他/ }));
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /确认/ })).toBeDisabled();
+
+    await user.type(screen.getByRole('textbox'), '验证登录失败提示');
+    await user.click(screen.getByRole('button', { name: /确认/ }));
+
+    expect(onAnswer).toHaveBeenCalledWith([['验证登录失败提示']]);
+  });
+
+  it('auto-appends an Other option by default and submits typed text', async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <QuestionTool
+        questions={[{
+          question: '选择测试范围',
+          type: 'choice',
+          options: ['代码单元测试', '环境/连通性测试'],
+        }]}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /自定义 \/ 补充说明/ }));
+    await user.type(screen.getByRole('textbox'), '测试登录接口的 401 返回');
+    await user.click(screen.getByRole('button', { name: /确认/ }));
+
+    expect(onAnswer).toHaveBeenCalledWith([['测试登录接口的 401 返回']]);
+  });
+
+  it('does not auto-append Other when custom is disabled', () => {
+    const onAnswer = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <QuestionTool
+        questions={[{
+          question: '选择测试范围',
+          type: 'choice',
+          custom: false,
+          options: ['代码单元测试', '环境/连通性测试'],
+        }]}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /自定义 \/ 补充说明/ })).not.toBeInTheDocument();
   });
 
   it('falls back to text input when a choice question has no visible options', async () => {

--- a/webui/src/components/common/QuestionTool.tsx
+++ b/webui/src/components/common/QuestionTool.tsx
@@ -21,8 +21,9 @@ import { useTranslation } from 'react-i18next';
 export type QuestionType = 'choice' | 'text' | 'number' | 'file' | 'confirm' | 'password';
 
 export interface QuestionOption {
-  label: string;
+  label?: string;
   description?: string;
+  [key: string]: unknown;
 }
 
 export interface QuestionItem {
@@ -61,17 +62,35 @@ export interface QuestionToolProps {
 // ============================================================================
 
 function resolveType(q: QuestionItem): QuestionType {
+  const hasOptions = (q.options ?? []).some(opt => optionLabel(opt));
+  if (q.type === 'choice' && !hasOptions) return 'text';
   if (q.type) return q.type;
-  if (q.options && q.options.length > 0) return 'choice';
+  if (hasOptions) return 'choice';
   return 'text';
 }
 
 function optionLabel(opt: QuestionOption | string): string {
-  return typeof opt === 'string' ? opt : opt.label;
+  if (typeof opt === 'string') return opt;
+  for (const key of ['label', 'text', 'title', 'name', 'value', 'id', 'key']) {
+    const value = opt[key];
+    if (value !== undefined && value !== null) {
+      const text = String(value).trim();
+      if (text) return text;
+    }
+  }
+  return '';
 }
 
 function optionDescription(opt: QuestionOption | string): string {
-  return typeof opt === 'string' ? '' : (opt.description ?? '');
+  if (typeof opt === 'string') return '';
+  for (const key of ['description', 'desc', 'subtitle', 'detail', 'details']) {
+    const value = opt[key];
+    if (value !== undefined && value !== null) {
+      const text = String(value).trim();
+      if (text) return text;
+    }
+  }
+  return '';
 }
 
 function isQuestionAnswered(q: QuestionItem, answer: string[], allowBlankAsNone = false): boolean {
@@ -142,6 +161,7 @@ function ChoiceInput({
       <div className="space-y-1.5">
         {(q.options ?? []).map(opt => {
           const label = optionLabel(opt);
+          if (!label) return null;
           const desc = optionDescription(opt);
           const selected = answer.includes(label);
           return (

--- a/webui/src/components/common/QuestionTool.tsx
+++ b/webui/src/components/common/QuestionTool.tsx
@@ -35,6 +35,8 @@ export interface QuestionItem {
   options?: (QuestionOption | string)[];
   /** For choice: allow selecting multiple options */
   multiple?: boolean;
+  /** For choice: allow a custom "Other" free-form answer. Defaults to true. */
+  custom?: boolean;
   /** Placeholder/hint text */
   placeholder?: string;
   /** For text: use textarea (multi-line) */
@@ -93,9 +95,39 @@ function optionDescription(opt: QuestionOption | string): string {
   return '';
 }
 
+const CUSTOM_CHOICE_PREFIX = '__flocks_custom_choice__:';
+
+function isCustomChoiceLabel(label: string): boolean {
+  return /^(其他|其它|自定义|补充)|\b(other|custom)\b|请补充|补充说明|type your answer/i.test(label.trim());
+}
+
+function customChoiceValue(text: string): string {
+  return `${CUSTOM_CHOICE_PREFIX}${text}`;
+}
+
+function isCustomChoiceValue(value: string): boolean {
+  return value.startsWith(CUSTOM_CHOICE_PREFIX);
+}
+
+function customChoiceText(answer: string[]): string {
+  const value = answer.find(isCustomChoiceValue) ?? '';
+  return value.slice(CUSTOM_CHOICE_PREFIX.length);
+}
+
+function hasCustomChoice(answer: string[]): boolean {
+  return answer.some(isCustomChoiceValue);
+}
+
+function shouldOfferCustomChoice(q: QuestionItem): boolean {
+  return resolveType(q) === 'choice' && q.custom !== false;
+}
+
 function isQuestionAnswered(q: QuestionItem, answer: string[], allowBlankAsNone = false): boolean {
   const type = resolveType(q);
-  if (type === 'choice') return answer.length > 0;
+  if (type === 'choice') {
+    if (hasCustomChoice(answer)) return customChoiceText(answer).trim().length > 0;
+    return answer.length > 0;
+  }
   if (type === 'confirm') return answer.length > 0;
   if (type === 'text' || type === 'password' || type === 'number') {
     return allowBlankAsNone || (answer[0] ?? '').trim().length > 0;
@@ -106,6 +138,13 @@ function isQuestionAnswered(q: QuestionItem, answer: string[], allowBlankAsNone 
 
 function normalizeAnswerForSubmit(q: QuestionItem, answer: string[], allowBlankAsNone = false): string[] {
   const type = resolveType(q);
+  if (type === 'choice') {
+    return answer.flatMap(value => {
+      if (!isCustomChoiceValue(value)) return [value];
+      const text = value.slice(CUSTOM_CHOICE_PREFIX.length).trim();
+      return text ? [text] : [];
+    });
+  }
   if (allowBlankAsNone && type === 'text') {
     const value = (answer[0] ?? '').trim();
     return [value || 'none'];
@@ -144,12 +183,55 @@ function ChoiceInput({
 }) {
   const { t } = useTranslation('common');
   const multiple = q.multiple ?? false;
+  const visibleOptions = (q.options ?? [])
+    .map(opt => ({
+      label: optionLabel(opt),
+      description: optionDescription(opt),
+      custom: false,
+    }))
+    .filter(opt => opt.label);
+  const hasProvidedCustomOption = visibleOptions.some(opt => isCustomChoiceLabel(opt.label));
+  const options = shouldOfferCustomChoice(q) && !hasProvidedCustomOption
+    ? [
+        ...visibleOptions,
+        {
+          label: t('question.customAnswer'),
+          description: t('question.textPlaceholder'),
+          custom: true,
+        },
+      ]
+    : visibleOptions.map(opt => ({
+        ...opt,
+        custom: isCustomChoiceLabel(opt.label),
+      }));
+  const customSelected = hasCustomChoice(answer);
+  const customText = customChoiceText(answer);
   const toggle = (label: string) => {
     if (multiple) {
       onChange(answer.includes(label) ? answer.filter(l => l !== label) : [...answer, label]);
     } else {
       onChange([label]);
     }
+  };
+  const toggleCustom = () => {
+    if (multiple) {
+      if (customSelected) {
+        onChange(answer.filter(value => !isCustomChoiceValue(value)));
+      } else {
+        onChange([...answer, customChoiceValue(customText)]);
+      }
+      return;
+    }
+    onChange(customSelected ? [] : [customChoiceValue(customText)]);
+  };
+  const setCustomText = (text: string) => {
+    const nextCustom = customChoiceValue(text);
+    if (multiple) {
+      const withoutCustom = answer.filter(value => !isCustomChoiceValue(value));
+      onChange([...withoutCustom, nextCustom]);
+      return;
+    }
+    onChange([nextCustom]);
   };
 
   return (
@@ -159,48 +241,59 @@ function ChoiceInput({
         {multiple ? `☑ ${t('question.multiSelect')}` : `○ ${t('question.singleSelect')}`}
       </div>
       <div className="space-y-1.5">
-        {(q.options ?? []).map(opt => {
-          const label = optionLabel(opt);
-          if (!label) return null;
-          const desc = optionDescription(opt);
-          const selected = answer.includes(label);
+        {options.map(opt => {
+          const label = opt.label;
+          const desc = opt.description;
+          const selected = opt.custom ? customSelected : answer.includes(label);
           return (
-            <button
-              key={label}
-              onClick={() => toggle(label)}
-              disabled={disabled}
-              className={`w-full text-left rounded-lg border px-3 py-2 text-sm transition-all flex items-start gap-2.5 ${
-                selected
-                  ? 'border-purple-500 bg-purple-500 text-white shadow-sm'
-                  : 'border-gray-200 bg-white text-gray-700 hover:border-purple-300 hover:bg-purple-50'
-              }`}
-            >
-              {multiple ? (
-                <span
-                  className={`mt-0.5 flex-shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center ${
-                    selected ? 'border-white bg-white' : 'border-gray-400 bg-transparent'
-                  }`}
-                >
-                  {selected && <Check className="w-2.5 h-2.5 text-purple-500" strokeWidth={3} />}
-                </span>
-              ) : (
-                <span
-                  className={`mt-0.5 flex-shrink-0 w-4 h-4 rounded-full border-2 flex items-center justify-center ${
-                    selected ? 'border-white' : 'border-gray-400'
-                  }`}
-                >
-                  {selected && <span className="w-2 h-2 rounded-full bg-white block" />}
-                </span>
-              )}
-              <span>
-                <span className={`font-medium ${compact ? 'text-xs' : 'text-sm'}`}>{label}</span>
-                {desc && (
-                  <span className={`block mt-0.5 ${compact ? 'text-[11px]' : 'text-xs'} ${selected ? 'text-purple-100' : 'text-gray-400'}`}>
-                    {desc}
+            <div key={label}>
+              <button
+                onClick={() => (opt.custom ? toggleCustom() : toggle(label))}
+                disabled={disabled}
+                className={`w-full text-left rounded-lg border px-3 py-2 text-sm transition-all flex items-start gap-2.5 ${
+                  selected
+                    ? 'border-purple-500 bg-purple-500 text-white shadow-sm'
+                    : 'border-gray-200 bg-white text-gray-700 hover:border-purple-300 hover:bg-purple-50'
+                }`}
+              >
+                {multiple ? (
+                  <span
+                    className={`mt-0.5 flex-shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center ${
+                      selected ? 'border-white bg-white' : 'border-gray-400 bg-transparent'
+                    }`}
+                  >
+                    {selected && <Check className="w-2.5 h-2.5 text-purple-500" strokeWidth={3} />}
+                  </span>
+                ) : (
+                  <span
+                    className={`mt-0.5 flex-shrink-0 w-4 h-4 rounded-full border-2 flex items-center justify-center ${
+                      selected ? 'border-white' : 'border-gray-400'
+                    }`}
+                  >
+                    {selected && <span className="w-2 h-2 rounded-full bg-white block" />}
                   </span>
                 )}
-              </span>
-            </button>
+                <span>
+                  <span className={`font-medium ${compact ? 'text-xs' : 'text-sm'}`}>{label}</span>
+                  {desc && (
+                    <span className={`block mt-0.5 ${compact ? 'text-[11px]' : 'text-xs'} ${selected ? 'text-purple-100' : 'text-gray-400'}`}>
+                      {desc}
+                    </span>
+                  )}
+                </span>
+              </button>
+              {opt.custom && selected && (
+                <div className="mt-1.5 rounded-lg border border-purple-100 bg-white px-3 py-2">
+                  <TextInput
+                    q={{ ...q, type: 'text', placeholder: q.placeholder || t('question.textPlaceholder'), multiline: q.multiline ?? true }}
+                    answer={[customText]}
+                    onChange={(value) => setCustomText(value[0] ?? '')}
+                    disabled={disabled}
+                    compact={compact}
+                  />
+                </div>
+              )}
+            </div>
           );
         })}
       </div>
@@ -479,10 +572,11 @@ export function QuestionTool({ questions, onAnswer, onReject, compact = false }:
 
           const type = resolveType(q);
           const answer = answers[qIdx] ?? [];
-          const inputProps = { q, answer, onChange: (v: string[]) => setAnswer(qIdx, v), disabled: submitting, compact };
           const inlineFollowUp = type === 'choice' && isInlineTextFollowUp(q, questions[qIdx + 1])
             ? questions[qIdx + 1]
             : undefined;
+          const inputQuestion = inlineFollowUp && q.custom === undefined ? { ...q, custom: false } : q;
+          const inputProps = { q: inputQuestion, answer, onChange: (v: string[]) => setAnswer(qIdx, v), disabled: submitting, compact };
           const inlineFollowUpIdx = inlineFollowUp ? qIdx + 1 : -1;
           const inlineFollowUpAnswer = inlineFollowUp ? (answers[inlineFollowUpIdx] ?? []) : [];
 

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -71,6 +71,11 @@ const tMock = (key: string, options?: Record<string, unknown>) => {
   'chat.contextUsage.breakdown.reasoning': 'Reasoning',
   'chat.contextUsage.breakdown.draft': 'Current draft',
   'chat.contextUsage.breakdown.compactedHistory': 'Compacted history',
+  'chat.goal.dismiss': 'Dismiss goal notice',
+  'chat.goal.status.active': 'Goal',
+  'chat.goal.status.completed': 'Completed',
+  'chat.goal.status.blocked': 'Blocked',
+  'chat.goal.status.paused': 'Paused',
   'chat.mention.title': '选择 Agent',
   'chat.mention.navigate': '导航',
   'chat.mention.select': '选择',
@@ -1202,6 +1207,47 @@ describe('SessionChat context usage popover', () => {
     });
 
     expect(sessionApiGetContextUsageMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SessionChat goal banner', () => {
+  it('shows goal status updates and lets the user dismiss the current notice', async () => {
+    const user = userEvent.setup();
+    render(React.createElement(SessionChat, { sessionId: 'sess-1', live: true }));
+
+    act(() => {
+      useSSEOptionsRef.current.onEvent({
+        type: 'session.goal.updated',
+        properties: {
+          sessionID: 'sess-1',
+          status: 'active',
+          objective: 'List built-in tools',
+        },
+      });
+    });
+
+    expect(await screen.findByText('Goal')).toBeInTheDocument();
+    expect(screen.getByText('List built-in tools')).toBeInTheDocument();
+
+    act(() => {
+      useSSEOptionsRef.current.onEvent({
+        type: 'session.goal.updated',
+        properties: {
+          sessionID: 'sess-1',
+          status: 'completed',
+          objective: 'List built-in tools',
+          reason: 'Goal complete: tools listed',
+        },
+      });
+    });
+
+    expect(await screen.findByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText('List built-in tools')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss goal notice' }));
+
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+    expect(screen.queryByText('List built-in tools')).not.toBeInTheDocument();
   });
 });
 

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -42,6 +42,7 @@ const sessionApiUpdateMessagePartMock = vi.fn();
 const sessionApiResendMessageMock = vi.fn();
 const sessionApiRegenerateMessageMock = vi.fn();
 const sessionApiGetContextUsageMock = vi.fn();
+const sessionApiGetMock = vi.fn();
 const useSessionMessagesMock = vi.fn();
 const useSSEOptionsRef = vi.hoisted(() => ({ current: null as any }));
 const tMock = (key: string, options?: Record<string, unknown>) => {
@@ -158,6 +159,7 @@ vi.mock('@/api/client', () => ({
 
 vi.mock('@/api/session', () => ({
   sessionApi: {
+    get: (...args: unknown[]) => sessionApiGetMock(...args),
     listPromptQueue: (...args: unknown[]) => sessionApiListPromptQueueMock(...args),
     enqueuePrompt: (...args: unknown[]) => sessionApiEnqueuePromptMock(...args),
     updateQueuedPrompt: (...args: unknown[]) => sessionApiUpdateQueuedPromptMock(...args),
@@ -172,17 +174,20 @@ vi.mock('@/api/session', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  if (typeof window.localStorage?.clear !== 'function') {
-    Object.defineProperty(window, 'localStorage', {
-      configurable: true,
-      value: {
-        clear: vi.fn(),
-        getItem: vi.fn(),
-        setItem: vi.fn(),
-        removeItem: vi.fn(),
-      },
-    });
-  }
+  const localStorageData = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: vi.fn(() => localStorageData.clear()),
+      getItem: vi.fn((key: string) => localStorageData.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        localStorageData.set(key, String(value));
+      }),
+      removeItem: vi.fn((key: string) => {
+        localStorageData.delete(key);
+      }),
+    },
+  });
   window.localStorage.clear();
   Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
     configurable: true,
@@ -198,6 +203,7 @@ beforeEach(() => {
   sessionApiUpdateMessagePartMock.mockResolvedValue({});
   sessionApiResendMessageMock.mockResolvedValue({});
   sessionApiRegenerateMessageMock.mockResolvedValue({});
+  sessionApiGetMock.mockResolvedValue({});
   sessionApiGetContextUsageMock.mockResolvedValue({
     sessionID: 'sess-1',
     usedTokens: 0,
@@ -1211,6 +1217,22 @@ describe('SessionChat context usage popover', () => {
 });
 
 describe('SessionChat goal banner', () => {
+  it('hydrates a persisted goal banner when the session loads', async () => {
+    sessionApiGetMock.mockResolvedValue({
+      id: 'sess-1',
+      goal: {
+        status: 'active',
+        objective: 'List built-in tools',
+      },
+    });
+
+    render(React.createElement(SessionChat, { sessionId: 'sess-1', live: true }));
+
+    expect(await screen.findByText('Goal')).toBeInTheDocument();
+    expect(screen.getByText('List built-in tools')).toBeInTheDocument();
+    expect(sessionApiGetMock).toHaveBeenCalledWith('sess-1');
+  });
+
   it('shows goal status updates and lets the user dismiss the current notice', async () => {
     const user = userEvent.setup();
     render(React.createElement(SessionChat, { sessionId: 'sess-1', live: true }));
@@ -1248,6 +1270,68 @@ describe('SessionChat goal banner', () => {
 
     expect(screen.queryByText('Completed')).not.toBeInTheDocument();
     expect(screen.queryByText('List built-in tools')).not.toBeInTheDocument();
+  });
+
+  it('keeps a dismissed persisted goal hidden after remount', async () => {
+    const user = userEvent.setup();
+    sessionApiGetMock.mockResolvedValue({
+      id: 'sess-1',
+      goal: {
+        status: 'completed',
+        objective: 'List built-in tools',
+        reason: 'Goal complete: tools listed',
+      },
+    });
+
+    const view = render(React.createElement(SessionChat, { sessionId: 'sess-1', live: true }));
+
+    expect(await screen.findByText('Completed')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Dismiss goal notice' }));
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('flocks:session:sess-1:dismissedGoal')).toBe(
+      'completed:List built-in tools',
+    );
+
+    view.unmount();
+    render(React.createElement(SessionChat, { sessionId: 'sess-1', live: true }));
+
+    await waitFor(() => {
+      expect(sessionApiGetMock).toHaveBeenCalledTimes(2);
+      expect(screen.queryByText('Completed')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('List built-in tools')).not.toBeInTheDocument();
+  });
+
+  it('shows a new goal even when a previous goal was dismissed', async () => {
+    const user = userEvent.setup();
+    render(React.createElement(SessionChat, { sessionId: 'sess-1', live: true }));
+
+    act(() => {
+      useSSEOptionsRef.current.onEvent({
+        type: 'session.goal.updated',
+        properties: {
+          sessionID: 'sess-1',
+          status: 'completed',
+          objective: 'List built-in tools',
+        },
+      });
+    });
+    expect(await screen.findByText('Completed')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Dismiss goal notice' }));
+
+    act(() => {
+      useSSEOptionsRef.current.onEvent({
+        type: 'session.goal.updated',
+        properties: {
+          sessionID: 'sess-1',
+          status: 'active',
+          objective: 'Calculate 4+87',
+        },
+      });
+    });
+
+    expect(await screen.findByText('Goal')).toBeInTheDocument();
+    expect(screen.getByText('Calculate 4+87')).toBeInTheDocument();
   });
 });
 

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -48,7 +48,7 @@ import {
   readFileAsDataUrl,
   type ImagePartData,
 } from '@/utils/imageUpload';
-import type { Message, MessagePart, ToolState } from '@/types';
+import type { Message, MessagePart, SessionGoalState, ToolState } from '@/types';
 
 export { formatSmartTime };
 export type { SSEConnectionStatus };
@@ -1094,6 +1094,47 @@ function getGoalBannerKey(goal: GoalBannerState | null): string {
   return goal ? `${goal.status}:${goal.objective}` : '';
 }
 
+function getDismissedGoalStorageKey(sessionId?: string | null): string | null {
+  return sessionId ? `flocks:session:${sessionId}:dismissedGoal` : null;
+}
+
+function readDismissedGoalKey(sessionId?: string | null): string {
+  const storageKey = getDismissedGoalStorageKey(sessionId);
+  if (!storageKey || typeof window === 'undefined') return '';
+  try {
+    return window.localStorage.getItem(storageKey) || '';
+  } catch {
+    return '';
+  }
+}
+
+function writeDismissedGoalKey(sessionId: string | null | undefined, goalKey: string): void {
+  const storageKey = getDismissedGoalStorageKey(sessionId);
+  if (!storageKey || typeof window === 'undefined') return;
+  try {
+    if (goalKey) {
+      window.localStorage.setItem(storageKey, goalKey);
+    } else {
+      window.localStorage.removeItem(storageKey);
+    }
+  } catch {
+    // Ignore unavailable storage; dismissal still works for the current mount.
+  }
+}
+
+function toGoalBannerState(goal: SessionGoalState | null | undefined): GoalBannerState | null {
+  const objective = typeof goal?.objective === 'string' ? goal.objective.trim() : '';
+  const status = typeof goal?.status === 'string' ? goal.status : '';
+  if (!objective || !['active', 'completed', 'blocked', 'paused'].includes(status)) {
+    return null;
+  }
+  return {
+    objective,
+    status: status as GoalBannerStatus,
+    reason: typeof goal?.reason === 'string' ? goal.reason : undefined,
+  };
+}
+
 function getGoalStatusLabel(t: ReturnType<typeof useTranslation>['t'], status: GoalBannerStatus): string {
   const fallback: Record<GoalBannerStatus, string> = {
     active: 'Goal',
@@ -1395,7 +1436,7 @@ export default function SessionChat({
   const [isCompacting, setIsCompacting] = useState(false);
   const [compactingMessage, setCompactingMessage] = useState('');
   const [goalBanner, setGoalBanner] = useState<GoalBannerState | null>(null);
-  const [dismissedGoalKey, setDismissedGoalKey] = useState('');
+  const [dismissedGoalKey, setDismissedGoalKey] = useState(() => readDismissedGoalKey(sessionId));
   const [queuedPrompts, setQueuedPrompts] = useState<QueuedPrompt[]>([]);
   const [queueExpanded, setQueueExpanded] = useState(true);
   const [editingQueueId, setEditingQueueId] = useState<string | null>(null);
@@ -1472,6 +1513,7 @@ export default function SessionChat({
   const initialMessageSentRef = useRef('');
   const abortingRef = useRef(false);
   const sessionBusyRef = useRef(false);
+  const goalHydrationVersionRef = useRef(0);
   // ID of the assistant message that was aborted; used to ignore its finish event
   const abortedMessageIdRef = useRef<string | null>(null);
   const statusCheckedRef = useRef<string | null>(null);
@@ -1654,6 +1696,31 @@ export default function SessionChat({
     void refreshContextUsage({ clear: true });
   }, [refreshContextUsage]);
 
+  useEffect(() => {
+    goalHydrationVersionRef.current += 1;
+    const hydrationVersion = goalHydrationVersionRef.current;
+
+    if (!sessionId) {
+      setGoalBanner(null);
+      setDismissedGoalKey('');
+      return;
+    }
+
+    setGoalBanner(null);
+    setDismissedGoalKey(readDismissedGoalKey(sessionId));
+
+    sessionApi.get(sessionId).then((session) => {
+      if (goalHydrationVersionRef.current !== hydrationVersion) return;
+      setGoalBanner(toGoalBannerState(session.goal));
+      setDismissedGoalKey(readDismissedGoalKey(sessionId));
+    }).catch((err) => {
+      if (goalHydrationVersionRef.current !== hydrationVersion) return;
+      setGoalBanner(null);
+      setDismissedGoalKey(readDismissedGoalKey(sessionId));
+      console.warn('[SessionChat] Failed to fetch session goal:', err);
+    });
+  }, [sessionId]);
+
   const handleSSEEvent = useCallback(
     (event: SSEChatEvent) => {
       const { type, properties } = event;
@@ -1788,18 +1855,11 @@ export default function SessionChat({
         setQueuedPrompts(items as QueuedPrompt[]);
         if (items.length > 0) setQueueExpanded(true);
       } else if (type === 'session.goal.updated' && properties.sessionID === sessionId) {
-        const objective = typeof properties.objective === 'string' ? properties.objective.trim() : '';
-        const status = typeof properties.status === 'string' ? properties.status : '';
-        if (
-          objective &&
-          (status === 'active' || status === 'completed' || status === 'blocked' || status === 'paused')
-        ) {
-          setGoalBanner({
-            objective,
-            status,
-            reason: typeof properties.reason === 'string' ? properties.reason : undefined,
-          });
-          setDismissedGoalKey('');
+        const nextGoal = toGoalBannerState(properties as SessionGoalState);
+        if (nextGoal) {
+          goalHydrationVersionRef.current += 1;
+          setGoalBanner(nextGoal);
+          setDismissedGoalKey(readDismissedGoalKey(sessionId));
         }
       } else if (type === 'context.compacted' && properties.sessionID === sessionId) {
         void refreshContextUsage({ skipIfFreshMs: 500 });
@@ -2312,6 +2372,8 @@ export default function SessionChat({
         agent: agentName,
       });
       if (command === 'goal' && args.trim()) {
+        goalHydrationVersionRef.current += 1;
+        writeDismissedGoalKey(sessionId, '');
         setGoalBanner({ objective: args.trim(), status: 'active' });
         setDismissedGoalKey('');
       }
@@ -2926,6 +2988,11 @@ export default function SessionChat({
   const visibleGoalBanner = goalBanner && getGoalBannerKey(goalBanner) !== dismissedGoalKey
     ? goalBanner
     : null;
+  const handleDismissGoalBanner = useCallback(() => {
+    const goalKey = getGoalBannerKey(visibleGoalBanner);
+    writeDismissedGoalKey(sessionId, goalKey);
+    setDismissedGoalKey(goalKey);
+  }, [sessionId, visibleGoalBanner]);
 
   return (
     <div className={`flex flex-col min-h-0 ${className}`}>
@@ -3129,7 +3196,7 @@ export default function SessionChat({
               <GoalBanner
                 goal={visibleGoalBanner}
                 t={t}
-                onDismiss={() => setDismissedGoalKey(getGoalBannerKey(visibleGoalBanner))}
+                onDismiss={handleDismissGoalBanner}
               />
             )}
             <QueuedPromptPanel

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -4272,10 +4272,10 @@ export function ChatToolPart({ part, pendingQuestion, onAnswer, onReject }: Chat
   const state: Partial<ToolState> = part.state || {};
   const status = state.status || 'pending';
 
-  // Some tools block on an internal `question` call (for example safety
-  // confirmation inside `ssh_host_cmd`), so render the question UI whenever
-  // this running tool part has a pending question attached to it.
-  const isWaitingForAnswer = status === 'running' && !!pendingQuestion;
+  // Pending question state is the source of truth. Tool status can briefly
+  // arrive as completed after reconnects or transport races, but the user
+  // still needs the answer UI while the question request exists.
+  const isWaitingForAnswer = !!pendingQuestion;
 
   type StatusCfg = {
     icon: React.ReactNode;

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -71,6 +71,14 @@ export interface NodeRef {
   description?: string;
 }
 
+type GoalBannerStatus = 'active' | 'completed' | 'blocked' | 'paused';
+
+interface GoalBannerState {
+  objective: string;
+  status: GoalBannerStatus;
+  reason?: string;
+}
+
 export interface ConversationBottomSlotActions {
   sendPrompt: (text: string, options?: PromptDisplayOptions) => void;
   setInput: (text: string) => void;
@@ -1082,6 +1090,90 @@ function getQueuedPromptText(item: QueuedPrompt): string {
   return typeof textPart?.text === 'string' ? textPart.text : '';
 }
 
+function getGoalBannerKey(goal: GoalBannerState | null): string {
+  return goal ? `${goal.status}:${goal.objective}` : '';
+}
+
+function getGoalStatusLabel(t: ReturnType<typeof useTranslation>['t'], status: GoalBannerStatus): string {
+  const fallback: Record<GoalBannerStatus, string> = {
+    active: 'Goal',
+    completed: 'Completed',
+    blocked: 'Blocked',
+    paused: 'Paused',
+  };
+  const key = `chat.goal.status.${status}`;
+  const label = t(key);
+  return label === key ? fallback[status] : label;
+}
+
+function getGoalBannerTone(status: GoalBannerStatus): {
+  root: string;
+  dot: string;
+  icon: React.ReactNode;
+} {
+  if (status === 'completed') {
+    return {
+      root: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+      dot: 'bg-emerald-500',
+      icon: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />,
+    };
+  }
+  if (status === 'blocked') {
+    return {
+      root: 'border-red-200 bg-red-50 text-red-900',
+      dot: 'bg-red-500',
+      icon: <AlertCircle className="h-3.5 w-3.5 text-red-600" />,
+    };
+  }
+  if (status === 'paused') {
+    return {
+      root: 'border-amber-200 bg-amber-50 text-amber-900',
+      dot: 'bg-amber-500',
+      icon: <Clock className="h-3.5 w-3.5 text-amber-600" />,
+    };
+  }
+  return {
+    root: 'border-sky-200 bg-sky-50 text-sky-950',
+    dot: 'bg-sky-500',
+    icon: <ListTree className="h-3.5 w-3.5 text-sky-600" />,
+  };
+}
+
+function GoalBanner({
+  goal,
+  t,
+  onDismiss,
+}: {
+  goal: GoalBannerState;
+  t: ReturnType<typeof useTranslation>['t'];
+  onDismiss: () => void;
+}) {
+  const tone = getGoalBannerTone(goal.status);
+  const statusLabel = getGoalStatusLabel(t, goal.status);
+  return (
+    <div className={`mb-2 flex min-w-0 items-center gap-2 rounded-lg border px-3 py-2 text-xs shadow-sm ${tone.root}`}>
+      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${tone.dot}`} />
+      <span className="shrink-0">{tone.icon}</span>
+      <span className="shrink-0 font-semibold">{statusLabel}</span>
+      <span className="min-w-0 flex-1 truncate font-medium">{goal.objective}</span>
+      {goal.reason && goal.status !== 'active' && (
+        <span className="hidden min-w-0 max-w-[35%] truncate text-[11px] opacity-70 sm:inline">
+          {goal.reason}
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="ml-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-current opacity-60 transition hover:bg-black/5 hover:opacity-100"
+        title={t('chat.goal.dismiss')}
+        aria-label={t('chat.goal.dismiss')}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
 interface QueuedPromptPanelProps {
   items: QueuedPrompt[];
   expanded: boolean;
@@ -1302,6 +1394,8 @@ export default function SessionChat({
   const [composerPreview, setComposerPreview] = useState<{ url: string; alt?: string } | null>(null);
   const [isCompacting, setIsCompacting] = useState(false);
   const [compactingMessage, setCompactingMessage] = useState('');
+  const [goalBanner, setGoalBanner] = useState<GoalBannerState | null>(null);
+  const [dismissedGoalKey, setDismissedGoalKey] = useState('');
   const [queuedPrompts, setQueuedPrompts] = useState<QueuedPrompt[]>([]);
   const [queueExpanded, setQueueExpanded] = useState(true);
   const [editingQueueId, setEditingQueueId] = useState<string | null>(null);
@@ -1579,6 +1673,8 @@ export default function SessionChat({
         setContextUsageRefreshing(true);
         setContextUsageWindowTokens(0);
         setIsStreaming(false);
+        setGoalBanner(null);
+        setDismissedGoalKey('');
         refetch();
         void refreshContextUsage({ clear: true });
       } else if (
@@ -1691,6 +1787,20 @@ export default function SessionChat({
         const items = Array.isArray(properties.items) ? properties.items : [];
         setQueuedPrompts(items as QueuedPrompt[]);
         if (items.length > 0) setQueueExpanded(true);
+      } else if (type === 'session.goal.updated' && properties.sessionID === sessionId) {
+        const objective = typeof properties.objective === 'string' ? properties.objective.trim() : '';
+        const status = typeof properties.status === 'string' ? properties.status : '';
+        if (
+          objective &&
+          (status === 'active' || status === 'completed' || status === 'blocked' || status === 'paused')
+        ) {
+          setGoalBanner({
+            objective,
+            status,
+            reason: typeof properties.reason === 'string' ? properties.reason : undefined,
+          });
+          setDismissedGoalKey('');
+        }
       } else if (type === 'context.compacted' && properties.sessionID === sessionId) {
         void refreshContextUsage({ skipIfFreshMs: 500 });
       } else if (type === 'context.usage.updated' && properties.sessionID === sessionId) {
@@ -1815,6 +1925,8 @@ export default function SessionChat({
     setIsCompacting(false);
     setCompactingMessage('');
     setCompactionStages([]);
+    setGoalBanner(null);
+    setDismissedGoalKey('');
     setQueuedPrompts([]);
     setEditingQueueId(null);
     setEditingQueueText('');
@@ -2199,6 +2311,10 @@ export default function SessionChat({
         arguments: args,
         agent: agentName,
       });
+      if (command === 'goal' && args.trim()) {
+        setGoalBanner({ objective: args.trim(), status: 'active' });
+        setDismissedGoalKey('');
+      }
     } catch (err: unknown) {
       setIsStreaming(false);
       const axiosErr = err as any;
@@ -2807,6 +2923,9 @@ export default function SessionChat({
   const msgListClass = compact
     ? fullWidth ? 'space-y-3 w-full px-4' : 'space-y-3'
     : fullWidth ? 'space-y-5 w-full px-5' : 'space-y-5 w-[min(76%,64rem)] mx-auto pl-4 pr-8';
+  const visibleGoalBanner = goalBanner && getGoalBannerKey(goalBanner) !== dismissedGoalKey
+    ? goalBanner
+    : null;
 
   return (
     <div className={`flex flex-col min-h-0 ${className}`}>
@@ -3005,6 +3124,13 @@ export default function SessionChat({
                   })
                   : conversationBottomSlot}
               </div>
+            )}
+            {visibleGoalBanner && (
+              <GoalBanner
+                goal={visibleGoalBanner}
+                t={t}
+                onDismiss={() => setDismissedGoalKey(getGoalBannerKey(visibleGoalBanner))}
+              />
             )}
             <QueuedPromptPanel
               items={queuedPrompts}

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -104,6 +104,15 @@
         "compactedHistory": "Compacted history"
       }
     },
+    "goal": {
+      "dismiss": "Dismiss goal notice",
+      "status": {
+        "active": "Goal",
+        "completed": "Completed",
+        "blocked": "Blocked",
+        "paused": "Paused"
+      }
+    },
     "edit": "Edit",
     "editRawHint": "You are editing the original unrendered content. Saving updates the raw message text directly.",
     "editRawTitle": "Edit raw content",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -104,6 +104,15 @@
         "compactedHistory": "已压缩历史"
       }
     },
+    "goal": {
+      "dismiss": "关闭目标提示",
+      "status": {
+        "active": "目标",
+        "completed": "已完成",
+        "blocked": "已阻塞",
+        "paused": "已暂停"
+      }
+    },
     "edit": "编辑",
     "editRawHint": "当前显示的是原始未渲染内容，保存后会直接更新这条消息文本。",
     "editRawTitle": "编辑原始内容",

--- a/webui/src/types/index.ts
+++ b/webui/src/types/index.ts
@@ -25,6 +25,13 @@ export interface Session {
   canWrite?: boolean;
   canDelete?: boolean;
   isShared?: boolean;
+  goal?: SessionGoalState | null;
+}
+
+export interface SessionGoalState {
+  status: 'active' | 'completed' | 'blocked' | 'paused';
+  objective: string;
+  reason?: string | null;
 }
 
 export interface SessionTime {


### PR DESCRIPTION
## Summary
- Add `/goal <objective>` persistent goal mode with automatic continuation across turns.
- Persist goal state and expose it to the session API/UI banner.
- Add Hermes-style model judge using the active provider/model, provider-specific options, strict JSON verdicts, and safe waiting behavior on judge failures.
- Normalize question tool options so ambiguous goals can ask clarifying questions and stop continuation while user input is pending.

## Root Cause / Rationale
Flocks did not have a persistent goal loop. The implementation follows the simpler Hermes-agent pattern: set a goal, evaluate the latest assistant final response after each turn, continue only when the judge says the goal is not done, and stop when pending user input or judge failure prevents safe autonomous continuation.

## Validation
- `uv run pytest tests/session/test_goal.py tests/session/test_session_abort_inject.py -k 'goal or pending_question'`
- `uv run ruff check flocks/session/goal.py tests/session/test_goal.py`
- Earlier focused UI/question checks were also run during implementation: QuestionTool tests, webui typecheck, and targeted session/question tests.