### PR TITLE
fix(session): enforce disabled agent availability

### DIFF
--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -174,6 +174,39 @@ def _require_session_write_access(session: SessionModel, user) -> None:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅会话所有者可写，受邀用户为只读")
 
 
+async def _require_agent_usable_for_chat(agent_name: Optional[str]) -> None:
+    """Validate an explicitly requested chat agent.
+
+    The Agent page "enabled" toggle is stored as ``delegatable`` for backward
+    compatibility, but product semantics treat disabled subagents as unusable
+    from both delegation and direct chat selection.
+    """
+    if not agent_name:
+        return
+
+    from flocks.agent.registry import Agent
+
+    agent = await Agent.get(agent_name)
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Agent "{agent_name}" is not available',
+        )
+
+    tags = getattr(agent, "tags", None) or []
+    if getattr(agent, "hidden", False) or "system" in tags:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Agent "{agent_name}" is not available for chat',
+        )
+
+    if getattr(agent, "mode", None) != "primary" and getattr(agent, "delegatable", True) is False:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Agent "{agent_name}" is disabled',
+        )
+
+
 def _is_hidden_from_session_manager(session: SessionModel) -> bool:
     """Return whether a session should be excluded from manager listings."""
     metadata = session.metadata if isinstance(session.metadata, dict) else {}
@@ -2382,6 +2415,7 @@ async def _process_session_message(
     # ------------------------------------------------------------------
     # 2. Resolve agent and model (5-level priority)
     # ------------------------------------------------------------------
+    await _require_agent_usable_for_chat(request.agent)
     agent_name = request.agent or await Agent.default_agent()
     agent = await Agent.get(agent_name) or await Agent.get(DEFAULT_AGENT)
     
@@ -3350,6 +3384,7 @@ async def _enqueue_prompt_request(
 ):
     from flocks.session.interaction_queue import InteractionQueue
 
+    await _require_agent_usable_for_chat(request.agent)
     model = request.model.model_dump(by_alias=True) if request.model else None
     parts = _materialize_queued_parts(session_id, [dict(part) for part in request.parts])
     return await InteractionQueue.enqueue(
@@ -3400,6 +3435,7 @@ async def enqueue_prompt(sessionID: str, request: PromptRequest) -> Dict[str, An
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {sessionID} not found",
         )
+    await _require_agent_usable_for_chat(request.agent)
     try:
         item = await _enqueue_prompt_request(sessionID, request)
     except QueueFullError as exc:
@@ -3511,6 +3547,7 @@ async def send_session_message_async(
         _require_session_write_access(session, current_user)
     
     working_directory = session.directory or os.getcwd()
+    await _require_agent_usable_for_chat(request.agent)
     
     log.info("session.prompt_async.accepted", {
         "sessionID": sessionID,
@@ -3607,6 +3644,7 @@ async def send_session_command(sessionID: str, request: CommandRequest, http_req
         _require_session_write_access(session, current_user)
 
     working_directory = session.directory or os.getcwd()
+    await _require_agent_usable_for_chat(request.agent)
     raw_arguments = request.arguments
     if not raw_arguments and request.arguments_json is not None:
         raw_arguments = json.dumps(request.arguments_json, ensure_ascii=False)

--- a/tests/server/routes/test_session_routes.py
+++ b/tests/server/routes/test_session_routes.py
@@ -368,6 +368,42 @@ class TestSessionLocalSharing:
 
 class TestSessionMessagesRemaining:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("path_suffix", "payload"),
+        [
+            ("/message", {"parts": [{"type": "text", "text": "blocked"}], "agent": "disabled-agent"}),
+            ("/prompt_async", {"parts": [{"type": "text", "text": "blocked"}], "agent": "disabled-agent"}),
+            ("/prompt_queue", {"parts": [{"type": "text", "text": "blocked"}], "agent": "disabled-agent"}),
+            ("/command", {"command": "help", "agent": "disabled-agent"}),
+        ],
+    )
+    async def test_input_routes_reject_disabled_agents(
+        self,
+        client: AsyncClient,
+        session_id: str,
+        monkeypatch: pytest.MonkeyPatch,
+        path_suffix: str,
+        payload: dict,
+    ):
+        """Disabled subagents cannot be used through direct session input APIs."""
+        monkeypatch.setattr(
+            "flocks.agent.registry.Agent.get",
+            AsyncMock(return_value=SimpleNamespace(
+                name="disabled-agent",
+                mode="subagent",
+                delegatable=False,
+                hidden=False,
+                tags=[],
+                model=None,
+            )),
+        )
+
+        resp = await client.post(f"/api/session/{session_id}{path_suffix}", json=payload)
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert resp.json()["message"] == 'Agent "disabled-agent" is disabled'
+
+    @pytest.mark.asyncio
     async def test_send_message_empty_parts_returns_success(
         self, client: AsyncClient, session_id: str
     ):

--- a/webui/src/components/common/ChatPromptSelectors.tsx
+++ b/webui/src/components/common/ChatPromptSelectors.tsx
@@ -6,7 +6,7 @@ import type { Agent } from '@/api/agent';
 import { defaultModelAPI, modelV2API } from '@/api/provider';
 import { useAgents } from '@/hooks/useAgents';
 import { useProviders } from '@/hooks/useProviders';
-import { getAgentDisplayDescription, getAgentDisplayName } from '@/utils/agentDisplay';
+import { getAgentDisplayDescription, getAgentDisplayName, isAgentUsableInChat } from '@/utils/agentDisplay';
 import type { ModelDefinitionV2 } from '@/types';
 
 export type AgentSourceFilter = 'all' | 'builtin' | 'custom';
@@ -47,11 +47,11 @@ export function useChatAgentOptions(options: { allowedAgentNames?: string[] } = 
   ), [options.allowedAgentNames]);
 
   const primaryAgents = useMemo(
-    () => agents.filter((agent) => agent.mode === 'primary'),
+    () => agents.filter((agent) => agent.mode === 'primary' && isAgentUsableInChat(agent)),
     [agents],
   );
   const subAgents = useMemo(
-    () => agents.filter((agent) => agent.mode !== 'primary' && !(agent.tags ?? []).includes('system')),
+    () => agents.filter((agent) => agent.mode !== 'primary' && isAgentUsableInChat(agent)),
     [agents],
   );
   const chatAgents = useMemo(

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -1110,6 +1110,28 @@ describe('SessionChat agent mentions', () => {
     });
   });
 
+  it('uses the selected agent when creating a session from the first message', async () => {
+    const user = userEvent.setup();
+    const onCreateAndSend = vi.fn().mockResolvedValue('sess-created');
+    render(React.createElement(SessionChat, {
+      sessionId: null,
+      agentName: 'explore',
+      mentionAgents,
+      onCreateAndSend,
+    }));
+
+    await user.type(screen.getByPlaceholderText('请输入消息'), 'summarize this file{enter}');
+
+    await waitFor(() => {
+      expect(onCreateAndSend).toHaveBeenCalledWith(
+        'summarize this file',
+        [],
+        'explore',
+        undefined,
+      );
+    });
+  });
+
   it('queues streaming messages to the mentioned agent', async () => {
     const user = userEvent.setup();
     render(React.createElement(SessionChat, {

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -2409,8 +2409,9 @@ export default function SessionChat({
       if (onCreateAndSend) {
         setSending(true);
         try {
-          setPendingAgentName(mentionedAgent || 'rex');
-          await onCreateAndSend(text, imageParts, mentionedAgent || undefined, model);
+          const effectiveAgent = mentionedAgent || agentName;
+          setPendingAgentName(effectiveAgent || 'rex');
+          await onCreateAndSend(text, imageParts, effectiveAgent || undefined, model);
           setAttachments([]);
         } catch {
           // Restore both the text and the attachment list so the user can

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -93,10 +93,12 @@ vi.mock('@/components/common/SessionChat', () => ({
     toolbarSlot,
     centerToolbarSlot,
     onCreateAndSend,
+    agentName,
     model,
     display,
   }: {
     sessionId?: string | null;
+    agentName?: string;
     mentionAgents?: Array<{ name: string }>;
     toolbarSlot?: React.ReactNode;
     centerToolbarSlot?: React.ReactNode;
@@ -112,6 +114,7 @@ vi.mock('@/components/common/SessionChat', () => ({
   }) => (
     <div
       data-testid="session-chat"
+      data-agent-name={agentName ?? ''}
       data-mention-agents={(mentionAgents ?? []).map((a) => a.name).join(',')}
       data-model={model ? `${model.providerID}/${model.modelID}` : ''}
       data-collapse-intermediate={String(Boolean(display?.collapseIntermediateSteps))}
@@ -120,7 +123,7 @@ vi.mock('@/components/common/SessionChat', () => ({
       {sessionId ?? 'no-session'}
       {toolbarSlot}
       {centerToolbarSlot}
-      <button type="button" onClick={() => void onCreateAndSend?.('hello from empty session')}>
+      <button type="button" onClick={() => void onCreateAndSend?.('hello from empty session', [], agentName)}>
         mock-create-and-send
       </button>
     </div>
@@ -130,6 +133,12 @@ vi.mock('@/components/common/SessionChat', () => ({
 vi.mock('@/utils/agentDisplay', () => ({
   getAgentDisplayDescription: () => 'agent-description',
   getAgentDisplayName: (agent: { name: string }) => agent.name.charAt(0).toUpperCase() + agent.name.slice(1),
+  isAgentUsableInChat: (agent: { mode?: string; hidden?: boolean; delegatable?: boolean; tags?: string[] }) => (
+    Boolean(agent)
+    && !agent.hidden
+    && !(agent.tags ?? []).includes('system')
+    && (agent.mode === 'primary' || agent.delegatable !== false)
+  ),
 }));
 
 vi.mock('@/utils/time', () => ({
@@ -464,6 +473,17 @@ describe('SessionPage session actions menu', () => {
           skills: [],
           tools: [],
         },
+        {
+          name: 'oracle',
+          description: 'Oracle',
+          mode: 'subagent',
+          native: true,
+          delegatable: false,
+          permission: [],
+          options: {},
+          skills: [],
+          tools: [],
+        },
       ],
       loading: false,
       error: null,
@@ -478,6 +498,7 @@ describe('SessionPage session actions menu', () => {
 
     expect(screen.getByRole('button', { name: /Explore/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /hidden-system/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Oracle/i })).not.toBeInTheDocument();
   });
 
   it('resets the chat agent to Rex when creating a new session', async () => {
@@ -648,7 +669,7 @@ describe('SessionPage session actions menu', () => {
     });
   });
 
-  it('uses Rex for the first message when an empty session is created by sending', async () => {
+  it('uses the selected agent for the first message when an empty session is created by sending', async () => {
     const user = userEvent.setup();
     useAgents.mockReturnValue({
       agents: [
@@ -687,9 +708,9 @@ describe('SessionPage session actions menu', () => {
     await waitFor(() => {
       expect(client.post).toHaveBeenCalledWith(
         '/api/session/session-2/prompt_async',
-        expect.objectContaining({ agent: 'rex' }),
+        expect.objectContaining({ agent: 'explore' }),
       );
     });
-    expect(screen.getByRole('button', { name: /Rex/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Explore/i })).toBeInTheDocument();
   });
 });

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -21,7 +21,7 @@ import client from '@/api/client';
 import { defaultModelAPI, modelV2API } from '@/api/provider';
 import { useDefaultModelVision } from '@/hooks/useDefaultModelVision';
 import { buildPromptParts, type ImagePartData } from '@/utils/imageUpload';
-import { getAgentDisplayDescription, getAgentDisplayName } from '@/utils/agentDisplay';
+import { getAgentDisplayDescription, getAgentDisplayName, isAgentUsableInChat } from '@/utils/agentDisplay';
 import { formatSessionDate } from '@/utils/time';
 import type { ModelDefinitionV2 } from '@/types';
 
@@ -122,9 +122,9 @@ export default function SessionPage() {
   const { sessions, loading: loadingSessions, refetch: refetchSessions, updateSessionTitle, removeSession, removeSessions, addSession } = useSessions();
   const { agents, loading: loadingAgents } = useAgents();
   const { providers, loading: loadingProviders } = useProviders();
-  const primaryAgents = useMemo(() => agents.filter((a) => a.mode === 'primary'), [agents]);
+  const primaryAgents = useMemo(() => agents.filter((a) => a.mode === 'primary' && isAgentUsableInChat(a)), [agents]);
   const subAgents = useMemo(
-    () => agents.filter((a) => a.mode !== 'primary' && !(a.tags ?? []).includes('system')),
+    () => agents.filter((a) => a.mode !== 'primary' && isAgentUsableInChat(a)),
     [agents],
   );
   const chatAgents = useMemo(() => [...primaryAgents, ...subAgents], [primaryAgents, subAgents]);
@@ -497,14 +497,13 @@ export default function SessionPage() {
       const newSessionId = response.data.id;
 
       addSession(response.data);
-      setSelectedAgent('rex');
       setSelectedModelKey(null);
       setSelectedSessionId(newSessionId);
 
       const payload: Record<string, unknown> = {
         parts: buildPromptParts(text, imageParts),
       };
-      const effectiveAgent = agentOverride || 'rex';
+      const effectiveAgent = agentOverride || selectedAgent || 'rex';
       if (effectiveAgent) payload.agent = effectiveAgent;
       if (modelOverride) payload.model = modelOverride;
       client.post(`/api/session/${newSessionId}/prompt_async`, payload).catch((err: any) => {
@@ -513,7 +512,7 @@ export default function SessionPage() {
     } catch (err: any) {
       toast.error(t('createFailed'), err.message);
     }
-  }, [addSession, toast, t]);
+  }, [addSession, selectedAgent, toast, t]);
 
   const showSelectorTooltip = useCallback((target: HTMLElement, title: string, lines: string[]) => {
     const rect = target.getBoundingClientRect();

--- a/webui/src/utils/agentDisplay.ts
+++ b/webui/src/utils/agentDisplay.ts
@@ -30,3 +30,12 @@ export function getAgentDisplayName(
   const cn = (agent.nameCn ?? '').trim();
   return isChineseLocale(language) ? (cn || en) : en;
 }
+
+export function isAgentUsableInChat(
+  agent: { mode?: string; hidden?: boolean; delegatable?: boolean; tags?: string[] } | null | undefined,
+): boolean {
+  if (!agent || agent.hidden) return false;
+  if ((agent.tags ?? []).includes('system')) return false;
+  if (agent.mode === 'primary') return true;
+  return agent.delegatable !== false;
+}


### PR DESCRIPTION
## Summary
- Hide disabled sub-agents from chat agent selectors and @mention routing
- Use the selected chat agent when creating a session from the first message
- Reject explicit disabled agent usage across session message, async prompt, queue, and command routes

## Tests
- npm test -- --run src/pages/Session/index.test.tsx src/components/common/SessionChat.test.ts
- .venv/bin/python -m pytest tests/server/routes/test_session_routes.py -q
- .venv/bin/python -m ruff check flocks/server/routes/session.py tests/server/routes/test_session_routes.py
- git diff --check