### PR TITLE
Fix device page draft testing and load performance

### DIFF
--- a/flocks/hub/installer.py
+++ b/flocks/hub/installer.py
@@ -131,10 +131,12 @@ async def _refresh_runtime(plugin_type: PluginType) -> None:
         # the Device Access wizard (the latter consumes
         # ``api_services[storage_key]`` shaped by ``discover_api_service_descriptors``).
         from flocks.config.api_versioning import discover_api_service_descriptors
+        from flocks.tool.device.plugin_index import clear_device_template_cache
         from flocks.tool.registry import ToolRegistry
 
         ToolRegistry.init()
         ToolRegistry.refresh_plugin_tools()
+        clear_device_template_cache()
         # Drop the descriptor cache so freshly installed/uninstalled
         # API plugins surface in ``_load_provider_yaml_metadata`` (and
         # therefore in the Tool API summary metadata) without waiting

--- a/flocks/server/routes/device.py
+++ b/flocks/server/routes/device.py
@@ -176,7 +176,6 @@ async def route_delete_group(group_id: str):
 
 @router.get("", response_model=List[DeviceIntegration])
 async def route_list_devices(group_id: Optional[str] = None, refresh: bool = False):
-    await ensure_user_device_instances(refresh_templates=refresh)
     return await list_devices(group_id)
 
 

--- a/flocks/tool/device/intake.py
+++ b/flocks/tool/device/intake.py
@@ -23,7 +23,12 @@ from flocks.tool.device.models import (
     DeviceTestRequest,
     DeviceTestResult,
 )
-from flocks.tool.device.secrets import delete_secrets, persist_fields, resolve_for_runtime
+from flocks.tool.device.secrets import (
+    delete_secrets,
+    mask_for_display,
+    persist_fields,
+    resolve_for_runtime,
+)
 from flocks.tool.device.store import (
     delete_device_row,
     ensure_default_group,
@@ -261,7 +266,7 @@ async def test_device(
         raise DeviceNotFoundError("Device not found")
 
     db_fields: dict = json.loads(row["fields"] or "{}")
-    resolved = resolve_for_runtime(db_fields)
+    resolved = _resolve_test_fields(db_fields, body)
     persisted_base_url = (resolved.get("base_url") or "").strip()
 
     override_base_url = (body.base_url.strip() if body and body.base_url else "")
@@ -293,6 +298,29 @@ async def test_device(
         latency_ms=result.latency_ms,
     )
     return result
+
+
+def _resolve_test_fields(
+    db_fields: dict,
+    body: Optional[DeviceTestRequest],
+) -> dict[str, str]:
+    """Resolve persisted fields and apply unsaved form values for one probe."""
+    resolved = resolve_for_runtime(db_fields)
+    draft_fields = body.fields if body and body.fields else None
+    if not draft_fields:
+        return resolved
+
+    display_fields, _ = mask_for_display(db_fields)
+    merged = dict(resolved)
+    for key, value in draft_fields.items():
+        draft_value = value if isinstance(value, str) else ""
+        persisted_value = resolved.get(key, "")
+        display_value = display_fields.get(key, "")
+        is_masked_secret = bool(persisted_value) and display_value != persisted_value
+        if is_masked_secret and draft_value in {"", display_value}:
+            continue
+        merged[key] = draft_value
+    return merged
 
 
 async def _probe(base_url: str, *, verify_ssl: bool) -> DeviceTestResult:

--- a/flocks/tool/device/models.py
+++ b/flocks/tool/device/models.py
@@ -164,6 +164,10 @@ class DeviceTestResult(BaseModel):
 class DeviceTestRequest(BaseModel):
     """Optional body for ``POST /devices/{id}/test``."""
 
+    fields: Optional[Dict[str, str]] = Field(
+        None,
+        description="Unsaved form fields to use for this probe only",
+    )
     base_url: Optional[str] = Field(
         None,
         description="Override the persisted base_url for this probe only",

--- a/flocks/tool/device/plugin_index.py
+++ b/flocks/tool/device/plugin_index.py
@@ -29,14 +29,26 @@ log = Log.create(service="device.plugin-index")
 
 _SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 _SAFE_SERVICE_ID = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_template_cache: Optional[list[DeviceTemplate]] = None
+
+
+def clear_device_template_cache() -> None:
+    """Clear the in-process device template cache after plugin changes."""
+    global _template_cache
+    _template_cache = None
 
 
 def list_device_templates(*, refresh: bool = False) -> list[DeviceTemplate]:
     """Return device templates from Hub catalog plus local descriptor discovery."""
+    global _template_cache
+    if _template_cache is not None and not refresh:
+        return list(_template_cache)
+
     if refresh:
         _refresh_device_plugin_runtime()
 
     by_key: dict[str, DeviceTemplate] = {}
+    tool_counts = _device_tool_counts()
     for entry in hub_catalog.list_catalog(plugin_type="device"):
         root = _catalog_entry_root(entry)
         if root is None:
@@ -66,6 +78,7 @@ def list_device_templates(*, refresh: bool = False) -> list[DeviceTemplate]:
             fallback_description=entry.description,
             fallback_description_cn=entry.descriptionCn,
             fallback_version=entry.installedVersion or entry.version,
+            tool_counts=tool_counts,
         )
         if template is not None:
             by_key[template.storage_key] = template
@@ -89,9 +102,12 @@ def list_device_templates(*, refresh: bool = False) -> list[DeviceTemplate]:
             state="localOnly",
             installed=True,
             source=source,
+            tool_counts=tool_counts,
         )
 
-    return sorted(by_key.values(), key=_sort_key)
+    templates = sorted(by_key.values(), key=_sort_key)
+    _template_cache = templates
+    return list(templates)
 
 
 def create_custom_device_template(body: CustomDeviceTemplateCreate) -> DeviceTemplate:
@@ -145,6 +161,7 @@ def create_custom_device_template(body: CustomDeviceTemplateCreate) -> DeviceTem
 
 def _refresh_device_plugin_runtime() -> None:
     """Refresh both device descriptors and runtime tool registrations."""
+    clear_device_template_cache()
     discover_api_service_descriptors(refresh=True)
     try:
         ToolRegistry.refresh_plugin_tools()
@@ -163,6 +180,7 @@ def _template_from_plugin_root(
     fallback_description: Optional[str] = None,
     fallback_description_cn: Optional[str] = None,
     fallback_version: Optional[str] = None,
+    tool_counts: Optional[dict[str, int]] = None,
 ) -> Optional[DeviceTemplate]:
     provider = _read_provider_yaml(root)
     if _integration_type(provider) != "device":
@@ -187,6 +205,7 @@ def _template_from_plugin_root(
         fallback_name=fallback_name,
         fallback_description=fallback_description,
         fallback_description_cn=fallback_description_cn,
+        tool_counts=tool_counts,
     )
 
 
@@ -201,6 +220,7 @@ def _template_from_descriptor(
     fallback_name: Optional[str] = None,
     fallback_description: Optional[str] = None,
     fallback_description_cn: Optional[str] = None,
+    tool_counts: Optional[dict[str, int]] = None,
 ) -> DeviceTemplate:
     name = _template_name(provider, descriptor, fallback_name, plugin_id)
     description = _optional_str(provider.get("description")) or fallback_description
@@ -218,7 +238,7 @@ def _template_from_descriptor(
             field.model_dump(mode="json")
             for field in _build_api_service_credential_schema(descriptor.storage_key, provider)
         ],
-        tool_count=_tool_count(descriptor.storage_key, descriptor.provider_yaml.parent),
+        tool_count=_tool_count(descriptor.storage_key, descriptor.provider_yaml.parent, tool_counts),
         installed=installed,
         state=state,  # type: ignore[arg-type]
         source=source,  # type: ignore[arg-type]
@@ -303,17 +323,29 @@ def _source_from_path(path: Optional[Path]) -> str:
     return "bundled"
 
 
-def _tool_count(storage_key: str, root: Path) -> int:
+def _device_tool_counts() -> Optional[dict[str, int]]:
     try:
         ToolRegistry.init()
-        count = len([
-            tool for tool in ToolRegistry.list_tools()
-            if tool.source == "device" and tool.provider == storage_key
-        ])
-        if count:
-            return count
     except Exception as exc:
         log.debug("device.templates.tool_registry_unavailable", {"error": str(exc)})
+        return None
+
+    counts: dict[str, int] = {}
+    for tool in ToolRegistry.list_tools():
+        if tool.source != "device" or not tool.provider:
+            continue
+        counts[tool.provider] = counts.get(tool.provider, 0) + 1
+    return counts
+
+
+def _tool_count(
+    storage_key: str,
+    root: Path,
+    tool_counts: Optional[dict[str, int]] = None,
+) -> int:
+    count = tool_counts.get(storage_key, 0) if tool_counts is not None else 0
+    if count:
+        return count
 
     return len([
         path for path in _tool_yaml_files(root)

--- a/tests/hub/test_bundled_tools.py
+++ b/tests/hub/test_bundled_tools.py
@@ -22,7 +22,12 @@ import pytest
 import yaml
 
 from flocks.hub import catalog, local
-from flocks.hub.installer import _resolve_install_destination, install_plugin, uninstall_plugin
+from flocks.hub.installer import (
+    _refresh_runtime,
+    _resolve_install_destination,
+    install_plugin,
+    uninstall_plugin,
+)
 from flocks.hub.models import HubPluginManifest
 from flocks.hub.security import SKIP_NAMES, validate_package
 
@@ -128,6 +133,33 @@ def _write_bundled_tool(
 # ---------------------------------------------------------------------------
 # _bundled_tool_roots
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_runtime_refresh_clears_device_template_cache(monkeypatch):
+    from flocks.config import api_versioning
+    from flocks.tool.device import plugin_index
+    from flocks.tool.registry import ToolRegistry
+
+    calls: list[str] = []
+    monkeypatch.setattr(ToolRegistry, "init", classmethod(lambda cls: calls.append("init")))
+    monkeypatch.setattr(
+        ToolRegistry,
+        "refresh_plugin_tools",
+        classmethod(lambda cls: calls.append("refresh")),
+    )
+    monkeypatch.setattr(
+        api_versioning,
+        "discover_api_service_descriptors",
+        lambda *, refresh=False: calls.append(f"discover:{refresh}") or [],
+    )
+    plugin_index._template_cache = []
+
+    await _refresh_runtime("device")
+
+    assert plugin_index._template_cache is None
+    assert calls == ["init", "refresh", "discover:True"]
+
 
 class TestBundledToolRoots:
     def test_discovers_api_subdir_plugins(self, isolated_hub):

--- a/tests/server/routes/test_device_routes.py
+++ b/tests/server/routes/test_device_routes.py
@@ -157,6 +157,81 @@ class TestDeviceTestEndpoint:
         assert captured["probed_base_url"] == "https://staging.example.com"
 
     @pytest.mark.asyncio
+    async def test_draft_fields_win_over_persisted_fields_for_probe(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        captured: dict = {}
+        _install_route_stubs(
+            monkeypatch,
+            row=_fake_row(fields={"base_url": "https://persisted.example.com"}),
+            probe_result=DeviceTestResult(success=True, message="ok"),
+            captured=captured,
+        )
+
+        resp = await client.post(
+            "/api/devices/dev-test/test",
+            json={"fields": {"base_url": "https://draft.example.com"}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert captured["probed_base_url"] == "https://draft.example.com"
+        assert captured["record_calls"] == [
+            {"device_id": "dev-test", "success": True, "message": "ok"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_masked_draft_secret_keeps_persisted_secret(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        captured: dict = {}
+        _install_route_stubs(
+            monkeypatch,
+            row=_fake_row(
+                fields={
+                    "base_url": "https://persisted.example.com",
+                    "password": "{secret:device_dev-test_password}",
+                }
+            ),
+            probe_result=DeviceTestResult(success=True, message="ok"),
+            captured=captured,
+        )
+        monkeypatch.setattr(
+            device_intake,
+            "resolve_for_runtime",
+            lambda db_fields: {
+                **db_fields,
+                "password": "real-password",
+            },
+        )
+        monkeypatch.setattr(
+            device_intake,
+            "mask_for_display",
+            lambda db_fields: (
+                {
+                    "base_url": "https://persisted.example.com",
+                    "password": "r***word",
+                },
+                {"base_url": True, "password": True},
+            ),
+        )
+
+        resolved = device_intake._resolve_test_fields(
+            {
+                "base_url": "https://persisted.example.com",
+                "password": "{secret:device_dev-test_password}",
+            },
+            device_intake.DeviceTestRequest(fields={"password": "r***word"}),
+        )
+        resp = await client.post(
+            "/api/devices/dev-test/test",
+            json={"fields": {"password": "r***word"}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resolved["password"] == "real-password"
+        assert captured["probed_base_url"] == "https://persisted.example.com"
+
+    @pytest.mark.asyncio
     async def test_error_message_mentions_both_base_url_and_host(
         self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
     ):
@@ -261,6 +336,28 @@ class TestDeviceCredentialEndpoint:
 
 
 class TestDeviceSyncEndpoint:
+    @pytest.mark.asyncio
+    async def test_list_devices_does_not_invoke_auto_instance_creation(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        async def fail_ensure_user_device_instances(*, refresh_templates: bool):
+            raise AssertionError("GET /api/devices must stay read-only")
+
+        monkeypatch.setattr(
+            device_routes,
+            "ensure_user_device_instances",
+            fail_ensure_user_device_instances,
+        )
+        async def fake_list_devices(group_id=None):
+            return []
+
+        monkeypatch.setattr(device_routes, "list_devices", fake_list_devices)
+
+        resp = await client.get("/api/devices?refresh=true")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
     @pytest.mark.asyncio
     async def test_sync_invokes_auto_instance_creation_with_refresh_flag(
         self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch

--- a/tests/tool/test_device_plugin_index.py
+++ b/tests/tool/test_device_plugin_index.py
@@ -339,8 +339,8 @@ async def test_device_list_auto_creates_user_device_plugin_instance(monkeypatch,
     app.include_router(device_routes.router, prefix="/api/devices")
     client = TestClient(app)
 
-    response = client.get("/api/devices?refresh=true")
-    repeated = client.get("/api/devices?refresh=true")
+    response = client.post("/api/devices/sync?refresh=true")
+    repeated = client.post("/api/devices/sync?refresh=true")
     devices = await list_devices()
 
     assert response.status_code == 200
@@ -352,10 +352,12 @@ async def test_device_list_auto_creates_user_device_plugin_instance(monkeypatch,
     assert devices[0].enabled is True
 
     delete_response = client.delete(f"/api/devices/{devices[0].id}")
-    after_delete = client.get("/api/devices?refresh=true")
+    sync_after_delete = client.post("/api/devices/sync?refresh=true")
+    after_delete = client.get("/api/devices")
     devices_after_delete = await list_devices()
 
     assert delete_response.status_code == 204
+    assert sync_after_delete.status_code == 200
     assert after_delete.status_code == 200
     assert after_delete.json() == []
     assert devices_after_delete == []
@@ -369,7 +371,7 @@ async def test_device_list_auto_creates_user_device_plugin_instance(monkeypatch,
             "fields": {},
         },
     )
-    after_manual_create = client.get("/api/devices?refresh=true")
+    after_manual_create = client.get("/api/devices")
 
     assert manual_create.status_code == 201
     assert len(after_manual_create.json()) == 1

--- a/webui/src/api/device.ts
+++ b/webui/src/api/device.ts
@@ -91,6 +91,8 @@ export interface DeviceTestResult {
 }
 
 export interface DeviceTestRequest {
+  /** Unsaved form fields used only for this probe. */
+  fields?: Record<string, string>;
   /** Override the persisted base_url for this probe only (typically the
    *  current value in the form, before it has been saved). */
   base_url?: string;

--- a/webui/src/pages/DeviceIntegration/index.test.tsx
+++ b/webui/src/pages/DeviceIntegration/index.test.tsx
@@ -53,6 +53,7 @@ vi.mock('react-i18next', () => ({
         'config.roomLabel': '所属机房',
         'config.saveBtn': '保存配置',
         'config.addBtn': '添加设备',
+        'config.testBtn': '连通测试',
         'config.showSecretAction': '显示',
         'config.hideSecretAction': '隐藏',
         'wizard.selectVendorTitle': `选择 ${String(params?.vendor ?? '')} 设备`,
@@ -230,6 +231,9 @@ describe('DeviceIntegrationPage', () => {
         updated_at: 0,
       },
     });
+    mocks.testDevice.mockResolvedValue({
+      data: { success: true, message: 'HTTP 200, 163ms', latency_ms: 163 },
+    });
     mocks.listGroups.mockResolvedValue({
       data: [{ id: 'default', name: '默认机房', sort_order: 0, created_at: 0, updated_at: 0 }],
     });
@@ -243,7 +247,7 @@ describe('DeviceIntegrationPage', () => {
     mocks.refreshTools.mockResolvedValue({ data: { ok: true } });
   });
 
-  it('refreshes devices and templates when the window regains focus', async () => {
+  it('refreshes devices and templates without syncing when the window regains focus', async () => {
     render(<DeviceIntegrationPage />);
 
     await screen.findByText('设备接入');
@@ -257,13 +261,11 @@ describe('DeviceIntegrationPage', () => {
     window.dispatchEvent(new Event('focus'));
 
     await waitFor(() => {
-      expect(mocks.syncDevices).toHaveBeenCalledWith({ refresh: true });
-    });
-    await waitFor(() => {
       expect(mocks.listDevices).toHaveBeenCalledWith();
-      expect(mocks.listTemplates).toHaveBeenCalledWith({ refresh: true });
+      expect(mocks.listTemplates).toHaveBeenCalledWith();
       expect(mocks.listGroups).toHaveBeenCalled();
     });
+    expect(mocks.syncDevices).not.toHaveBeenCalled();
   });
 
   it('shows custom device option and access modes', async () => {
@@ -568,6 +570,109 @@ describe('DeviceIntegrationPage', () => {
         expect.objectContaining({ group_id: 'group-2' }),
       );
     });
+  });
+
+  it('tests connectivity with draft fields without replacing the form', async () => {
+    const user = userEvent.setup();
+    const initialDevice = {
+      id: 'device-1',
+      group_id: 'group-1',
+      name: 'onesig-02',
+      storage_key: 'onesig_api_v2_5_3',
+      service_id: 'onesig_api',
+      enabled: true,
+      verify_ssl: false,
+      fields: {
+        base_url: 'https://persisted.example.com',
+        api_prefix: '/api',
+        username: 'admin',
+        password: 'p***word',
+      },
+      fields_set: { base_url: true, api_prefix: true, username: true, password: true },
+      status: 'connected',
+      created_at: 0,
+      updated_at: 0,
+    };
+    mocks.listDevices.mockResolvedValue({ data: [initialDevice] });
+    mocks.listTemplates.mockResolvedValue({
+      data: [
+        buildTemplate({
+          plugin_id: 'onesig_v2_5_3',
+          storage_key: 'onesig_api_v2_5_3',
+          service_id: 'onesig_api',
+          name: 'OneSIG',
+          vendor: 'threatbook',
+        }),
+      ],
+    });
+    mocks.getServiceMetadata.mockResolvedValueOnce({
+      data: {
+        name: 'OneSIG',
+        credential_schema: [
+          {
+            key: 'base_url',
+            label: 'Base URL',
+            storage: 'config',
+            sensitive: false,
+            required: true,
+            input_type: 'url',
+            config_key: 'base_url',
+          },
+          {
+            key: 'api_prefix',
+            label: 'API Prefix',
+            storage: 'config',
+            sensitive: false,
+            required: false,
+            input_type: 'text',
+            config_key: 'api_prefix',
+          },
+          {
+            key: 'username',
+            label: 'Username',
+            storage: 'config',
+            sensitive: false,
+            required: true,
+            input_type: 'text',
+            config_key: 'username',
+          },
+          {
+            key: 'password',
+            label: 'Password',
+            storage: 'secret',
+            sensitive: true,
+            required: true,
+            input_type: 'password',
+            config_key: 'password',
+          },
+        ],
+      },
+    });
+
+    render(<DeviceIntegrationPage />);
+
+    await user.click(await screen.findByText('onesig-02'));
+    const baseUrl = await screen.findByDisplayValue('https://persisted.example.com');
+    await user.clear(baseUrl);
+    await user.type(baseUrl, 'https://draft.example.com');
+    await user.click(screen.getByRole('button', { name: /连通测试/ }));
+
+    await waitFor(() => {
+      expect(mocks.testDevice).toHaveBeenCalledWith('device-1', {
+        fields: expect.objectContaining({
+          base_url: 'https://draft.example.com',
+          api_prefix: '/api',
+          username: 'admin',
+          password: 'p***word',
+        }),
+        verify_ssl: false,
+        base_url: 'https://draft.example.com',
+      });
+    });
+    expect(mocks.getDevice).not.toHaveBeenCalled();
+    expect(mocks.listDevices).toHaveBeenCalledTimes(1);
+    expect(screen.getByDisplayValue('https://draft.example.com')).toBeInTheDocument();
+    expect(await screen.findByText('HTTP 200, 163ms')).toBeInTheDocument();
   });
 
   it('reveals the full persisted secret when clicking show', async () => {

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -451,7 +451,7 @@ function Toggle({ on, onToggle }: { on: boolean; onToggle: () => void }) {
 
 function DeviceConfigPanel({
   device, template, vendorKey, initialGroupId, groups, groupLocked,
-  onSave, onDelete, onClose, onTest, onToggleVerifySsl, onToggleEnabled, onBack,
+  onSave, onDelete, onClose, onTest, onBack,
 }: {
   device?: DeviceIntegration;
   template?: DeviceTemplate;
@@ -469,9 +469,7 @@ function DeviceConfigPanel({
   }) => Promise<void>;
   onDelete?: () => Promise<void>;
   onClose: () => void;
-  onTest?: (overrides: { verify_ssl: boolean; base_url?: string }) => Promise<{ success: boolean; message: string }>;
-  onToggleVerifySsl?: (next: boolean) => Promise<void>;
-  onToggleEnabled?: (next: boolean) => Promise<void>;
+  onTest?: (overrides: { fields: Record<string, string>; verify_ssl: boolean; base_url?: string }) => Promise<{ success: boolean; message: string }>;
   onBack?: () => void;
 }) {
   const toast = useToast();
@@ -495,6 +493,7 @@ function DeviceConfigPanel({
   const [metadata, setMetadata] = useState<{ name?: string; version?: string; description?: string; description_cn?: string; docs_url?: string } | null>(null);
   const [toolEnabled, setToolEnabled] = useState<Record<string, boolean>>({});
   const originalMasked = useRef<Record<string, string>>({});
+  const dirtyRef = useRef(false);
 
   const serviceId = device?.service_id ?? template?.service_id ?? '';
   const storageKey = device?.storage_key ?? template?.storage_key ?? '';
@@ -530,7 +529,9 @@ function DeviceConfigPanel({
             }
           });
           originalMasked.current = masked;
-          setFields({ ...device.fields });
+          if (!dirtyRef.current) {
+            setFields({ ...device.fields });
+          }
         } else {
           const defaults: Record<string, string> = {};
           schema.forEach((f) => { if (f.default_value) defaults[f.key] = f.default_value; });
@@ -570,6 +571,7 @@ function DeviceConfigPanel({
         if (payload[k] === masked) payload[k] = '';
       });
       await onSave({ name: name.trim(), fields: payload, enabled, verify_ssl: verifySsl, group_id: groupId });
+      dirtyRef.current = false;
       toast.success(device ? t('toast.saveDone') : t('toast.addDone'));
     } catch {
       toast.error(t('toast.saveFailed'));
@@ -594,6 +596,7 @@ function DeviceConfigPanel({
         }
       }
       setTestResult(await onTest({
+        fields,
         verify_ssl: verifySsl,
         base_url: candidateBaseUrl || undefined,
       }));
@@ -602,30 +605,16 @@ function DeviceConfigPanel({
     }
   };
 
-  const handleToggleSsl = async () => {
+  const handleToggleSsl = () => {
     const next = !verifySsl;
+    dirtyRef.current = true;
     setVerifySsl(next);
-    if (!device || !onToggleVerifySsl) return;
-    try {
-      await onToggleVerifySsl(next);
-      toast.success(next ? t('toast.sslOn') : t('toast.sslOff'));
-    } catch {
-      setVerifySsl(!next);
-      toast.error(t('toast.rollback'));
-    }
   };
 
-  const handleToggleEnabled = async () => {
+  const handleToggleEnabled = () => {
     const next = !enabled;
+    dirtyRef.current = true;
     setEnabled(next);
-    if (!device || !onToggleEnabled) return;
-    try {
-      await onToggleEnabled(next);
-      toast.success(next ? t('toast.enabledOn') : t('toast.enabledOff'));
-    } catch {
-      setEnabled(!next);
-      toast.error(t('toast.rollback'));
-    }
   };
 
   const handleToggleFieldVisibility = async (field: APIServiceCredentialField, hasExisting: boolean) => {
@@ -759,7 +748,10 @@ function DeviceConfigPanel({
                   <input
                     type="text"
                     value={name}
-                    onChange={(e) => setName(e.target.value)}
+                    onChange={(e) => {
+                      dirtyRef.current = true;
+                      setName(e.target.value);
+                    }}
                     placeholder={t('config.namePlaceholder')}
                     className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
                   />
@@ -779,7 +771,10 @@ function DeviceConfigPanel({
                   ) : (
                     <select
                       value={groupId}
-                      onChange={(e) => setGroupId(e.target.value)}
+                      onChange={(e) => {
+                        dirtyRef.current = true;
+                        setGroupId(e.target.value);
+                      }}
                       className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
                     >
                       {groups.map((g) => (
@@ -807,7 +802,10 @@ function DeviceConfigPanel({
                             <input
                               type={isSecret && !show ? 'password' : 'text'}
                               value={fields[f.key] ?? ''}
-                              onChange={(e) => setFields((p) => ({ ...p, [f.key]: e.target.value }))}
+                              onChange={(e) => {
+                                dirtyRef.current = true;
+                                setFields((p) => ({ ...p, [f.key]: e.target.value }));
+                              }}
                               placeholder={f.default_value ?? ''}
                               className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100 pr-10"
                             />
@@ -1338,7 +1336,7 @@ export default function DeviceIntegrationPage() {
       }
       const [devRes, tplRes, grpRes] = await Promise.all([
         deviceAPI.list(),
-        deviceAPI.listTemplates(refreshTemplates ? { refresh: true } : undefined),
+        deviceAPI.listTemplates(),
         deviceAPI.listGroups(),
       ]);
       const nextTemplates = tplRes.data || [];
@@ -1361,7 +1359,7 @@ export default function DeviceIntegrationPage() {
     const now = Date.now();
     if (now - lastRefreshRef.current < 1000) return;
     lastRefreshRef.current = now;
-    void fetchData(true, true);
+    void fetchData(true);
   }, [fetchData]);
 
   useEffect(() => {
@@ -1497,31 +1495,21 @@ export default function DeviceIntegrationPage() {
     await fetchData(true);
   };
 
-  const handleTest = async (overrides: { verify_ssl: boolean; base_url?: string }) => {
+  const handleTest = async (overrides: { fields: Record<string, string>; verify_ssl: boolean; base_url?: string }) => {
     if (panel?.kind !== 'edit') return { success: false, message: '' };
     const res = await deviceAPI.test(panel.device.id, overrides);
-    await fetchData(true);
-    if (panel?.kind === 'edit') {
-      const updated = await deviceAPI.get(panel.device.id);
-      setPanel({ kind: 'edit', device: updated.data });
-    }
+    setDevices((current) => current.map((device) => (
+      device.id === panel.device.id
+        ? {
+            ...device,
+            status: res.data.success ? 'ok' : 'error',
+            message: res.data.message,
+            latency_ms: res.data.latency_ms ?? null,
+            checked_at: Date.now(),
+          }
+        : device
+    )));
     return res.data;
-  };
-
-  const handleToggleVerifySsl = async (next: boolean) => {
-    if (panel?.kind !== 'edit') return;
-    await deviceAPI.update(panel.device.id, { verify_ssl: next });
-    const updated = await deviceAPI.get(panel.device.id);
-    setPanel({ kind: 'edit', device: updated.data });
-    await fetchData(true);
-  };
-
-  const handleToggleEnabled = async (next: boolean) => {
-    if (panel?.kind !== 'edit') return;
-    await deviceAPI.update(panel.device.id, { enabled: next });
-    const updated = await deviceAPI.get(panel.device.id);
-    setPanel({ kind: 'edit', device: updated.data });
-    await fetchData(true);
   };
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -1847,8 +1835,6 @@ export default function DeviceIntegrationPage() {
             onDelete={panel.kind === 'edit' ? handleDelete : undefined}
             onClose={() => setPanel(null)}
             onTest={panel.kind === 'edit' ? handleTest : undefined}
-            onToggleVerifySsl={panel.kind === 'edit' ? handleToggleVerifySsl : undefined}
-            onToggleEnabled={panel.kind === 'edit' ? handleToggleEnabled : undefined}
             onBack={panel.kind === 'add'
               ? () => setPanel({
                   kind: 'wizard',


### PR DESCRIPTION
## Summary
- Preserve unsaved device configuration drafts during connectivity tests and toggles
- Use draft fields for connectivity probes without persisting them
- Make device list reads pure reads and keep auto-sync behind the explicit sync endpoint
- Cache device template indexing and invalidate it when plugin runtime refreshes

## Tests
- /Users/zgy/workspace/flocks/.venv/bin/python -m pytest tests/server/routes/test_device_routes.py tests/tool/test_device_plugin_index.py tests/hub/test_bundled_tools.py::test_tool_runtime_refresh_clears_device_template_cache
- npm run test:run -- src/pages/DeviceIntegration/index.test.tsx