### PR TITLE
Fix workflow API service recovery and dependency mirrors

### DIFF
--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -322,11 +322,16 @@ async def lifespan(app: FastAPI):
 
     # Sync workflows from .flocks/workflow/ filesystem into Storage
     try:
-        from flocks.server.routes.workflow import sync_workflows_from_filesystem
+        from flocks.server.routes.workflow import (
+            reconcile_published_workflow_api_services,
+            sync_workflows_from_filesystem,
+        )
 
         async def _sync_workflows_phase() -> None:
             imported = await sync_workflows_from_filesystem()
             log.info("workflow.sync.done", {"imported": imported})
+            api_services = await reconcile_published_workflow_api_services()
+            log.info("workflow.api_services.reconciled", api_services)
 
         _schedule_startup_phase(app, log, "workflow.sync_filesystem", _sync_workflows_phase)
     except Exception as e:

--- a/flocks/server/routes/health.py
+++ b/flocks/server/routes/health.py
@@ -19,15 +19,6 @@ class HealthResponse(BaseModel):
     timestamp: str
     config_dir: str
     data_dir: str
-    task_manager_started: bool
-    task_scheduler_running: bool
-    task_scheduler_available: bool
-    task_manager_error: str | None = None
-    task_queue_paused: bool = False
-    task_queue_running: int = 0
-    task_queue_queued: int = 0
-    task_stale_running: int = 0
-    task_oldest_running_seconds: int | None = None
 
 
 @router.get(
@@ -45,9 +36,6 @@ async def health_check() -> HealthResponse:
     """
     from datetime import UTC
     config = Config.get_global()
-    from flocks.task.manager import TaskManager
-    task_status = TaskManager.runtime_status()
-    queue_status = await TaskManager.queue_status()
     
     from flocks.updater import get_current_version
     return HealthResponse(
@@ -56,12 +44,6 @@ async def health_check() -> HealthResponse:
         timestamp=datetime.now(UTC).isoformat(),
         config_dir=str(config.config_dir),
         data_dir=str(config.data_dir),
-        **task_status,
-        task_queue_paused=queue_status["paused"],
-        task_queue_running=queue_status["running"],
-        task_queue_queued=queue_status["queued"],
-        task_stale_running=queue_status["stale_running"],
-        task_oldest_running_seconds=queue_status["oldest_running_seconds"],
     )
 
 

--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -2067,8 +2067,126 @@ def _api_service_key(workflow_id: str) -> str:
     return f"{_API_SERVICE_PREFIX}{workflow_id}"
 
 
+def _workflow_id_from_api_service_key(key: Any) -> str:
+    return str(key).removeprefix(_API_SERVICE_PREFIX)
+
+
 def _kafka_config_key(workflow_id: str) -> str:
     return f"{_KAFKA_CONFIG_PREFIX}{workflow_id}"
+
+
+async def _prepare_workflow_api_registry(workflow_id: str) -> tuple[Dict[str, Any], int]:
+    """Write the current workflow snapshot to the workflow center registry."""
+    data = _read_workflow_from_fs(workflow_id)
+    if not data:
+        raise WorkflowNotFoundError(f"Workflow not found: {workflow_id}")
+
+    workflow_json = data["workflowJson"]
+    service_dir = Config.get_data_path() / "workflow-services" / "workflows" / workflow_id
+    service_dir.mkdir(parents=True, exist_ok=True)
+    workflow_path = service_dir / "workflow.json"
+    workflow_path.write_text(json.dumps(workflow_json), encoding="utf-8")
+
+    fp = hashlib.sha256(workflow_path.read_bytes()).hexdigest()
+    now_ms = int(time.time() * 1000)
+
+    existing_registry = await Storage.read(f"{_REGISTRY_PREFIX_MAIN}{workflow_id}") or {}
+    registry_entry = {
+        "workflowId": workflow_id,
+        "name": data["name"],
+        "sourceType": "main_storage",
+        "workflowPath": str(workflow_path),
+        "fingerprint": fp,
+        "publishStatus": "unpublished",
+        "registeredAt": existing_registry.get("registeredAt", now_ms),
+        "updatedAt": now_ms,
+    }
+    await Storage.write(f"{_REGISTRY_PREFIX_MAIN}{workflow_id}", registry_entry)
+    return data, now_ms
+
+
+def _workflow_api_autostart_enabled() -> bool:
+    raw = os.getenv("FLOCKS_WORKFLOW_API_AUTOSTART", "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def _service_driver_from_record(service: Dict[str, Any]) -> Optional[Literal["local", "docker"]]:
+    driver = str(service.get("driver") or "").strip().lower()
+    if driver in {"local", "docker"}:
+        return driver  # type: ignore[return-value]
+    return None
+
+
+def _is_manually_stopped_service(service: Dict[str, Any]) -> bool:
+    return str(service.get("status") or "").strip().lower() == "stopped" and bool(service.get("stoppedAt"))
+
+
+async def reconcile_published_workflow_api_services() -> Dict[str, int]:
+    """Restart persisted workflow API services after the main server restarts."""
+    stats = {"checked": 0, "healthy": 0, "restarted": 0, "failed": 0, "skipped": 0}
+    if not _workflow_api_autostart_enabled():
+        return stats
+
+    keys = await Storage.list_keys(_API_SERVICE_PREFIX)
+    for key in keys:
+        service = await Storage.read(key)
+        if not isinstance(service, dict):
+            continue
+
+        workflow_id = str(service.get("workflowId") or _workflow_id_from_api_service_key(key))
+        if _is_manually_stopped_service(service):
+            stats["skipped"] += 1
+            continue
+
+        stats["checked"] += 1
+        try:
+            health = await get_workflow_health(workflow_id)
+        except Exception as exc:
+            health = {"ok": False, "error": str(exc)}
+
+        if health.get("ok"):
+            service["status"] = "running"
+            service["health"] = health
+            await Storage.write(_api_service_key(workflow_id), service)
+            stats["healthy"] += 1
+            continue
+
+        now_ms = int(time.time() * 1000)
+        service["lastStartAttemptAt"] = now_ms
+        try:
+            data, _ = await _prepare_workflow_api_registry(workflow_id)
+            active_record = await publish_workflow(
+                workflow_id,
+                image=service.get("image") or None,
+                driver=_service_driver_from_record(service),
+                api_key=service.get("apiKey") or None,
+            )
+
+            service_url = active_record.get("serviceUrl", "")
+            service.update({
+                "workflowId": workflow_id,
+                "workflowName": service.get("workflowName") or data["name"],
+                "serviceUrl": service_url,
+                "invokeUrl": f"{service_url}/invoke",
+                "apiKey": service.get("apiKey") or active_record.get("apiKey"),
+                "status": "running",
+                "containerName": active_record.get("containerName", ""),
+                "driver": active_record.get("driver") or service.get("driver"),
+                "image": active_record.get("image") or service.get("image"),
+                "restartedAt": int(time.time() * 1000),
+            })
+            service.pop("lastStartError", None)
+            service["health"] = {"ok": True, "restarted": True}
+            await Storage.write(_api_service_key(workflow_id), service)
+            stats["restarted"] += 1
+        except Exception as exc:
+            service["status"] = "error"
+            service["health"] = health
+            service["lastStartError"] = str(exc)
+            await Storage.write(_api_service_key(workflow_id), service)
+            log.warning("workflow.api.autostart_failed", {"id": workflow_id, "error": str(exc)})
+            stats["failed"] += 1
+    return stats
 
 
 class WorkflowServiceResponse(BaseModel):
@@ -2081,6 +2199,7 @@ class WorkflowServiceResponse(BaseModel):
     publishedAt: int
     containerName: Optional[str] = None
     driver: Optional[Literal["local", "docker"]] = None
+    image: Optional[str] = None
 
 
 class KafkaConfigRequest(BaseModel):
@@ -2175,33 +2294,7 @@ async def publish_workflow_as_api(
     starts the selected runtime, and returns the service URL and generated API key.
     """
     try:
-        data = _read_workflow_from_fs(workflow_id)
-        if not data:
-            raise HTTPException(status_code=404, detail=f"Workflow not found: {workflow_id}")
-
-        workflow_json = data["workflowJson"]
-
-        # Write workflow JSON to a stable path that center.py can read
-        service_dir = Config.get_data_path() / "workflow-services" / "workflows" / workflow_id
-        service_dir.mkdir(parents=True, exist_ok=True)
-        workflow_path = service_dir / "workflow.json"
-        workflow_path.write_text(json.dumps(workflow_json), encoding="utf-8")
-
-        fp = hashlib.sha256(workflow_path.read_bytes()).hexdigest()
-        now_ms = int(time.time() * 1000)
-
-        existing_registry = await Storage.read(f"{_REGISTRY_PREFIX_MAIN}{workflow_id}") or {}
-        registry_entry = {
-            "workflowId": workflow_id,
-            "name": data["name"],
-            "sourceType": "main_storage",
-            "workflowPath": str(workflow_path),
-            "fingerprint": fp,
-            "publishStatus": "unpublished",
-            "registeredAt": existing_registry.get("registeredAt", now_ms),
-            "updatedAt": now_ms,
-        }
-        await Storage.write(f"{_REGISTRY_PREFIX_MAIN}{workflow_id}", registry_entry)
+        data, now_ms = await _prepare_workflow_api_registry(workflow_id)
 
         # Preserve existing API key across re-publishes so callers don't break.
         # The runtime must receive the same key before it starts so /invoke can
@@ -2221,6 +2314,7 @@ async def publish_workflow_as_api(
         invoke_url = f"{service_url}/invoke"
         container_name = active_record.get("containerName", "")
         driver = active_record.get("driver") or (req.driver if req else None)
+        image = active_record.get("image") or (req.image if req else None)
 
         service_info = {
             "workflowId": workflow_id,
@@ -2232,11 +2326,14 @@ async def publish_workflow_as_api(
             "publishedAt": now_ms,
             "containerName": container_name,
             "driver": driver,
+            "image": image,
         }
         await Storage.write(_api_service_key(workflow_id), service_info)
 
         log.info("workflow.api.published", {"id": workflow_id, "url": service_url})
         return service_info
+    except WorkflowNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
     except HTTPException:
         raise
     except WorkflowCenterError as e:
@@ -2282,17 +2379,7 @@ async def get_workflow_service(workflow_id: str):
     Returns null if not published.
     """
     try:
-        service = await Storage.read(_api_service_key(workflow_id))
-        if isinstance(service, dict) and service.get("status") == "running":
-            try:
-                health = await get_workflow_health(workflow_id)
-            except Exception:
-                health = {}
-            if health and not health.get("ok"):
-                service["status"] = "error" if health.get("published") else "stopped"
-                service["health"] = health
-                await Storage.write(_api_service_key(workflow_id), service)
-        return service  # None / null if not found
+        return await Storage.read(_api_service_key(workflow_id))  # None / null if not found
     except Exception as e:
         log.error("workflow.service.get.error", {"id": workflow_id, "error": str(e)})
         raise HTTPException(status_code=500, detail=f"Failed to get service info: {str(e)}")

--- a/flocks/workflow/center.py
+++ b/flocks/workflow/center.py
@@ -28,6 +28,7 @@ from flocks.sandbox.docker import docker_container_state, exec_docker
 from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 from flocks.workflow.models import Workflow
+from flocks.workflow.requirements import resolve_python_package_index_url
 from flocks.workflow.visibility import is_hidden_workflow
 
 log = Log.create(service="workflow.center")
@@ -835,6 +836,14 @@ async def _publish_workflow_docker(
             proxy_injections.extend(["-e", f"{env_name}={env_value}"])
     if proxy_injections:
         cmd[cmd.index(image_name):cmd.index(image_name)] = proxy_injections
+    python_index_url = resolve_python_package_index_url()
+    if python_index_url:
+        cmd[cmd.index(image_name):cmd.index(image_name)] = [
+            "-e",
+            f"PIP_INDEX_URL={python_index_url}",
+            "-e",
+            f"UV_DEFAULT_INDEX={python_index_url}",
+        ]
     if runtime_install:
         if has_requirements_snapshot:
             # Pre-install all pinned deps from requirements.txt (no resolver = fast),

--- a/flocks/workflow/requirements.py
+++ b/flocks/workflow/requirements.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
+_CN_PYPI_INDEX_URL = "https://mirrors.aliyun.com/pypi/simple"
+
 
 def _default_cache_dir() -> Path:
     raw = os.getenv("FLOCKS_WORKFLOW_REQUIREMENTS_CACHE_DIR")
@@ -28,6 +30,40 @@ def _normalize_requirements(reqs: Iterable[str]) -> List[str]:
             continue
         out.append(s)
     return sorted(out)
+
+
+def _is_cn_region(value: Optional[str]) -> bool:
+    normalized = (value or "").strip().lower().replace("_", "-")
+    return normalized in {"cn", "china", "zh", "zh-cn"}
+
+
+def _is_zh_locale(value: Optional[str]) -> bool:
+    normalized = (value or "").strip().lower().replace("_", "-")
+    return normalized.startswith("zh")
+
+
+def resolve_python_package_index_url() -> Optional[str]:
+    """Return the preferred Python package index for workflow installs."""
+    for env_name in (
+        "FLOCKS_WORKFLOW_SERVICE_PIP_INDEX_URL",
+        "FLOCKS_WORKFLOW_REQUIREMENTS_PIP_INDEX_URL",
+        "PIP_INDEX_URL",
+        "UV_INDEX_URL",
+        "UV_DEFAULT_INDEX",
+        "FLOCKS_UV_DEFAULT_INDEX",
+    ):
+        value = os.getenv(env_name)
+        if value and value.strip():
+            return value.strip()
+
+    if _is_cn_region(os.getenv("FLOCKS_UPDATE_REGION")):
+        return _CN_PYPI_INDEX_URL
+    if _is_cn_region(os.getenv("FLOCKS_INSTALL_LANGUAGE")):
+        return _CN_PYPI_INDEX_URL
+    for env_name in ("LANGUAGE", "LC_ALL", "LANG"):
+        if _is_zh_locale(os.getenv(env_name)):
+            return _CN_PYPI_INDEX_URL
+    return None
 
 
 def requirements_cache_key(requirements: Sequence[str], *, python_executable: Optional[str] = None) -> str:
@@ -56,6 +92,7 @@ def requirements_from_workflow_metadata(metadata: Optional[Dict[str, Any]]) -> L
 class RequirementsInstaller:
     installer: str = "auto"
     cache_dir: Path = None  # type: ignore[assignment]
+    index_url: Optional[str] = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "cache_dir", self.cache_dir or _default_cache_dir())
@@ -79,10 +116,13 @@ class RequirementsInstaller:
         if marker.exists():
             return False
         which = self._select_installer()
+        index_url = self.index_url or resolve_python_package_index_url()
+        index_args = ["--default-index", index_url] if index_url else []
         if which == "uv":
-            cmd = ["uv", "pip", "install", "--python", sys.executable, *reqs]
+            cmd = ["uv", "pip", "install", "--python", sys.executable, *index_args, *reqs]
         else:
-            cmd = [sys.executable, "-m", "pip", "install", *reqs]
+            pip_index_args = ["--index-url", index_url] if index_url else []
+            cmd = [sys.executable, "-m", "pip", "install", *pip_index_args, *reqs]
         subprocess.run(cmd, check=True)
         marker.write_text("\n".join(reqs) + "\n", encoding="utf-8")
         return True
@@ -96,6 +136,7 @@ class SandboxRequirementsInstaller:
     python_executable: str = "python3"
     marker_root: str = "/workspace/.flocks/workflow/requirements"
     site_packages_dir: str = "/workspace/.flocks/workflow/site-packages"
+    index_url: Optional[str] = None
 
     def _select_installer(self) -> str:
         v = (self.installer or "auto").strip().lower()
@@ -165,7 +206,9 @@ class SandboxRequirementsInstaller:
         subprocess.run(mkdir_cmd, check=True)
 
         which = self._select_installer()
+        index_url = self.index_url or resolve_python_package_index_url()
         if which == "uv":
+            index_args = ["--default-index", index_url] if index_url else []
             install_cmd = [
                 *base_cmd,
                 "uv",
@@ -175,9 +218,11 @@ class SandboxRequirementsInstaller:
                 py,
                 "--target",
                 self.site_packages_dir,
+                *index_args,
                 *reqs,
             ]
         else:
+            index_args = ["--index-url", index_url] if index_url else []
             install_cmd = [
                 *base_cmd,
                 py,
@@ -188,6 +233,7 @@ class SandboxRequirementsInstaller:
                 "--no-cache-dir",
                 "--target",
                 self.site_packages_dir,
+                *index_args,
                 *reqs,
             ]
         subprocess.run(install_cmd, check=True)

--- a/tests/server/routes/test_workflow_publish_api.py
+++ b/tests/server/routes/test_workflow_publish_api.py
@@ -77,3 +77,221 @@ async def test_publish_workflow_as_api_reuses_key_for_runtime(
     }]
     assert result["apiKey"] == existing_key
     assert writes[workflow_routes._api_service_key(workflow_id)]["apiKey"] == existing_key
+
+
+@pytest.mark.asyncio
+async def test_reconcile_published_workflow_api_services_restarts_unhealthy_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_id = "wf-1"
+    existing_key = "existing-api-key"
+    service_key = workflow_routes._api_service_key(workflow_id)
+    store: dict[str, Any] = {
+        service_key: {
+            "workflowId": workflow_id,
+            "workflowName": "Demo Workflow",
+            "serviceUrl": "http://127.0.0.1:19000",
+            "invokeUrl": "http://127.0.0.1:19000/invoke",
+            "apiKey": existing_key,
+            "status": "running",
+            "driver": "docker",
+            "image": "custom-image:latest",
+        }
+    }
+    publish_calls: list[dict[str, Any]] = []
+
+    async def fake_list_keys(prefix: str) -> list[str]:
+        assert prefix == workflow_routes._API_SERVICE_PREFIX
+        return list(store.keys())
+
+    async def fake_read(key: Any, *_args: Any, **_kwargs: Any) -> Any:
+        return store.get(str(key))
+
+    async def fake_write(key: Any, value: Any) -> None:
+        store[str(key)] = value
+
+    async def fake_health(requested_id: str) -> dict[str, Any]:
+        assert requested_id == workflow_id
+        return {"ok": False, "published": True, "endpointOk": False}
+
+    async def fake_prepare_registry(requested_id: str) -> tuple[dict[str, Any], int]:
+        assert requested_id == workflow_id
+        return {"name": "Demo Workflow"}, 123
+
+    async def fake_publish_workflow(
+        requested_id: str,
+        image: str | None = None,
+        driver: str | None = None,
+        api_key: str | None = None,
+    ) -> dict[str, Any]:
+        publish_calls.append({
+            "workflow_id": requested_id,
+            "image": image,
+            "driver": driver,
+            "api_key": api_key,
+        })
+        return {
+            "serviceUrl": "http://127.0.0.1:19001",
+            "containerName": "flocks-wf-wf-1-rel-1",
+            "driver": driver,
+            "image": image,
+            "apiKey": api_key,
+        }
+
+    monkeypatch.setattr(workflow_routes.Storage, "list_keys", fake_list_keys)
+    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
+    monkeypatch.setattr(workflow_routes.Storage, "write", fake_write)
+    monkeypatch.setattr(workflow_routes, "get_workflow_health", fake_health)
+    monkeypatch.setattr(workflow_routes, "_prepare_workflow_api_registry", fake_prepare_registry)
+    monkeypatch.setattr(workflow_routes, "publish_workflow", fake_publish_workflow)
+
+    result = await workflow_routes.reconcile_published_workflow_api_services()
+
+    assert result["checked"] == 1
+    assert result["restarted"] == 1
+    assert publish_calls == [{
+        "workflow_id": workflow_id,
+        "image": "custom-image:latest",
+        "driver": "docker",
+        "api_key": existing_key,
+    }]
+    assert store[service_key]["status"] == "running"
+    assert store[service_key]["apiKey"] == existing_key
+    assert store[service_key]["serviceUrl"] == "http://127.0.0.1:19001"
+    assert store[service_key]["invokeUrl"] == "http://127.0.0.1:19001/invoke"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_published_workflow_api_services_restarts_health_marked_stopped_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_id = "wf-health-stopped"
+    service_key = workflow_routes._api_service_key(workflow_id)
+    store: dict[str, Any] = {
+        service_key: {
+            "workflowId": workflow_id,
+            "status": "stopped",
+            "apiKey": "existing-api-key",
+        }
+    }
+    publish_calls: list[str] = []
+
+    async def fake_list_keys(prefix: str) -> list[str]:
+        assert prefix == workflow_routes._API_SERVICE_PREFIX
+        return list(store.keys())
+
+    async def fake_read(key: Any, *_args: Any, **_kwargs: Any) -> Any:
+        return store.get(str(key))
+
+    async def fake_write(key: Any, value: Any) -> None:
+        store[str(key)] = value
+
+    async def fake_health(requested_id: str) -> dict[str, Any]:
+        assert requested_id == workflow_id
+        return {"ok": False, "published": False}
+
+    async def fake_prepare_registry(requested_id: str) -> tuple[dict[str, Any], int]:
+        assert requested_id == workflow_id
+        return {"name": "Demo Workflow"}, 123
+
+    async def fake_publish_workflow(
+        requested_id: str,
+        image: str | None = None,
+        driver: str | None = None,
+        api_key: str | None = None,
+    ) -> dict[str, Any]:
+        publish_calls.append(requested_id)
+        return {
+            "serviceUrl": "http://127.0.0.1:19002",
+            "containerName": "local-wf-health-stopped",
+            "driver": driver or "local",
+            "apiKey": api_key,
+        }
+
+    monkeypatch.setattr(workflow_routes.Storage, "list_keys", fake_list_keys)
+    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
+    monkeypatch.setattr(workflow_routes.Storage, "write", fake_write)
+    monkeypatch.setattr(workflow_routes, "get_workflow_health", fake_health)
+    monkeypatch.setattr(workflow_routes, "_prepare_workflow_api_registry", fake_prepare_registry)
+    monkeypatch.setattr(workflow_routes, "publish_workflow", fake_publish_workflow)
+
+    result = await workflow_routes.reconcile_published_workflow_api_services()
+
+    assert result["checked"] == 1
+    assert result["restarted"] == 1
+    assert result["skipped"] == 0
+    assert publish_calls == [workflow_id]
+    assert store[service_key]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_published_workflow_api_services_skips_manually_stopped_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_id = "wf-manual-stopped"
+    service_key = workflow_routes._api_service_key(workflow_id)
+    store: dict[str, Any] = {
+        service_key: {
+            "workflowId": workflow_id,
+            "status": "stopped",
+            "stoppedAt": 123,
+            "apiKey": "existing-api-key",
+        }
+    }
+    health_calls: list[str] = []
+
+    async def fake_list_keys(prefix: str) -> list[str]:
+        assert prefix == workflow_routes._API_SERVICE_PREFIX
+        return list(store.keys())
+
+    async def fake_read(key: Any, *_args: Any, **_kwargs: Any) -> Any:
+        return store.get(str(key))
+
+    async def fake_health(requested_id: str) -> dict[str, Any]:
+        health_calls.append(requested_id)
+        return {"ok": True}
+
+    monkeypatch.setattr(workflow_routes.Storage, "list_keys", fake_list_keys)
+    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
+    monkeypatch.setattr(workflow_routes, "get_workflow_health", fake_health)
+
+    result = await workflow_routes.reconcile_published_workflow_api_services()
+
+    assert result["skipped"] == 1
+    assert result["checked"] == 0
+    assert health_calls == []
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_service_does_not_probe_runtime_health(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_id = "wf-service-read"
+    service = {
+        "workflowId": workflow_id,
+        "status": "running",
+        "serviceUrl": "http://127.0.0.1:19000",
+    }
+    writes: list[Any] = []
+    health_calls: list[str] = []
+
+    async def fake_read(key: Any, *_args: Any, **_kwargs: Any) -> Any:
+        assert str(key) == workflow_routes._api_service_key(workflow_id)
+        return service
+
+    async def fake_write(key: Any, value: Any) -> None:
+        writes.append((key, value))
+
+    async def fake_health(requested_id: str) -> dict[str, Any]:
+        health_calls.append(requested_id)
+        return {"ok": False, "published": False}
+
+    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
+    monkeypatch.setattr(workflow_routes.Storage, "write", fake_write)
+    monkeypatch.setattr(workflow_routes, "get_workflow_health", fake_health)
+
+    result = await workflow_routes.get_workflow_service(workflow_id)
+
+    assert result is service
+    assert health_calls == []
+    assert writes == []

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -9,7 +9,6 @@ from httpx import AsyncClient, ASGITransport
 from fastapi import status
 
 from flocks.server.app import app
-from flocks.task.manager import TaskManager
 from flocks.task.store import TaskStore
 from flocks.task.models import (
     DeliveryStatus,
@@ -54,12 +53,17 @@ async def test_health_check(client):
     assert data["status"] == "healthy"
     assert isinstance(data["version"], str) and data["version"]
     assert "timestamp" in data
-    assert "task_manager_started" in data
-    assert "task_scheduler_running" in data
-    assert "task_scheduler_available" in data
-    assert "task_queue_running" in data
-    assert "task_queue_queued" in data
-    assert "task_stale_running" in data
+    assert "config_dir" in data
+    assert "data_dir" in data
+    assert "task_manager_started" not in data
+    assert "task_scheduler_running" not in data
+    assert "task_scheduler_available" not in data
+    assert "task_manager_error" not in data
+    assert "task_queue_paused" not in data
+    assert "task_queue_running" not in data
+    assert "task_queue_queued" not in data
+    assert "task_stale_running" not in data
+    assert "task_oldest_running_seconds" not in data
 
 
 @pytest.mark.asyncio
@@ -551,5 +555,4 @@ async def test_question_pending_route_lists_session_requests(client):
     finally:
         clear_request_state(req1["id"])
         clear_request_state(req2["id"])
-
 

--- a/tests/workflow/test_workflow_center.py
+++ b/tests/workflow/test_workflow_center.py
@@ -111,6 +111,7 @@ async def test_publish_invoke_stop_workflow_service(
     monkeypatch.setenv("FLOCKS_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setattr(Config, "_global_config", None)
     monkeypatch.setenv("FLOCKS_WORKFLOW_SERVICE_DRIVER", "docker")
+    monkeypatch.setenv("FLOCKS_WORKFLOW_SERVICE_PIP_INDEX_URL", "https://mirror.example/simple")
     scanned = await center.scan_skill_workflows()
     workflow_id = scanned[0]["workflowId"]
 
@@ -158,6 +159,8 @@ async def test_publish_invoke_stop_workflow_service(
     assert "/runtime" in run_call[0][run_call[0].index("-w") + 1]
     assert "-e" in run_call[0]
     assert f"FLOCKS_WORKFLOW_SERVICE_API_KEY={published['apiKey']}" in run_call[0]
+    assert "PIP_INDEX_URL=https://mirror.example/simple" in run_call[0]
+    assert "UV_DEFAULT_INDEX=https://mirror.example/simple" in run_call[0]
     assert json_post_calls
     assert json_post_calls[0][0][0] == "http://127.0.0.1:19123/invoke"
     assert json_post_calls[0][0][3] == {"x-api-key": published["apiKey"]}

--- a/tests/workflow/test_workflow_requirements_mirrors.py
+++ b/tests/workflow/test_workflow_requirements_mirrors.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from flocks.workflow.requirements import (
+    RequirementsInstaller,
+    SandboxRequirementsInstaller,
+    resolve_python_package_index_url,
+)
+
+
+def test_resolve_python_package_index_uses_chinese_locale(monkeypatch) -> None:
+    monkeypatch.delenv("FLOCKS_WORKFLOW_SERVICE_PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("FLOCKS_WORKFLOW_REQUIREMENTS_PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
+    monkeypatch.delenv("UV_DEFAULT_INDEX", raising=False)
+    monkeypatch.delenv("FLOCKS_UV_DEFAULT_INDEX", raising=False)
+    monkeypatch.delenv("FLOCKS_UPDATE_REGION", raising=False)
+    monkeypatch.setenv("FLOCKS_INSTALL_LANGUAGE", "zh-CN")
+
+    assert resolve_python_package_index_url() == "https://mirrors.aliyun.com/pypi/simple"
+
+
+def test_requirements_installer_passes_index_to_pip(monkeypatch, tmp_path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("flocks.workflow.requirements.subprocess.run", fake_run)
+
+    installed = RequirementsInstaller(
+        installer="pip",
+        cache_dir=tmp_path,
+        index_url="https://mirror.example/simple",
+    ).ensure_installed(["requests==2.32.0"])
+
+    assert installed is True
+    assert len(calls) == 1
+    assert calls[0][1:] == [
+        "-m",
+        "pip",
+        "install",
+        "--index-url",
+        "https://mirror.example/simple",
+        "requests==2.32.0",
+    ]
+
+
+def test_sandbox_requirements_installer_passes_index_to_pip(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], check: bool = True, **_kwargs: Any) -> SimpleNamespace:
+        calls.append(cmd)
+        if len(calls) == 1:
+            return SimpleNamespace(returncode=1)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("flocks.workflow.requirements.subprocess.run", fake_run)
+
+    installed = SandboxRequirementsInstaller(
+        installer="pip",
+        index_url="https://mirror.example/simple",
+    ).ensure_installed(
+        ["requests==2.32.0"],
+        sandbox={"container_name": "workflow-container", "container_workdir": "/workspace"},
+    )
+
+    assert installed is True
+    install_cmd = calls[2]
+    assert install_cmd[:5] == ["docker", "exec", "-i", "-w", "/workspace"]
+    assert install_cmd[5] == "workflow-container"
+    assert install_cmd[6:15] == [
+        "python3",
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-cache-dir",
+        "--target",
+        "/workspace/.flocks/workflow/site-packages",
+        "--index-url",
+    ]
+    assert install_cmd[15:17] == ["https://mirror.example/simple", "requests==2.32.0"]


### PR DESCRIPTION
## Summary
- Restart published workflow API services after server startup unless the user manually stopped them.
- Prefer configured or Chinese PyPI mirrors when installing workflow API Python dependencies in Docker.
- Simplify /api/health to basic server metadata only.

## Tests
- .venv/bin/python -m pytest tests/server/test_server.py::test_health_check tests/integration/test_live_intel_query.py::TestWebUIAPI::test_health_check tests/server/routes/test_workflow_publish_api.py tests/workflow/test_workflow_requirements_mirrors.py tests/workflow/test_workflow_center.py tests/workflow/test_workflow_center_lifecycle.py tests/workflow/test_workflow_service_runtime.py
- .venv/bin/ruff check --ignore E402 flocks/server/routes/health.py tests/server/test_server.py flocks/workflow/requirements.py flocks/workflow/center.py flocks/server/routes/workflow.py flocks/server/app.py tests/workflow/test_workflow_requirements_mirrors.py tests/workflow/test_workflow_center.py tests/server/routes/test_workflow_publish_api.py
- git diff --check