### PR TITLE
fix: prevent DingTalk stream from blocking event loop

### DIFF
--- a/flocks/channel/builtin/dingtalk/channel.py
+++ b/flocks/channel/builtin/dingtalk/channel.py
@@ -73,6 +73,13 @@ class DingTalkChannel(ChannelPlugin):
                 "Missing required config: appKey/appSecret (also accepted as "
                 "clientId/clientSecret), at top-level or under accounts.<name>"
             )
+        for account in accounts:
+            app_key = str(account.get("appKey") or account.get("clientId") or "")
+            if app_key.startswith("dingtalk_"):
+                return (
+                    "Invalid DingTalk Client ID: use the app AppKey, for example "
+                    "'dingxxxxxxxxxxxxxxxx', not a value prefixed with 'dingtalk_'."
+                )
         return None
 
     # ------------------------------------------------------------------

--- a/flocks/channel/builtin/dingtalk/stream.py
+++ b/flocks/channel/builtin/dingtalk/stream.py
@@ -34,6 +34,8 @@ import json
 import platform
 import re
 import time
+from types import MethodType
+from urllib.parse import quote_plus
 import uuid
 from typing import Any, Awaitable, Callable, Optional
 
@@ -72,6 +74,7 @@ _CONVERSATION_TYPE_GROUP = "2"
 # us distinguish "wrong key/secret" from "transient network blip".
 _GATEWAY_OPEN_URL = "https://api.dingtalk.com/v1.0/gateway/connections/open"
 _GATEWAY_PREFLIGHT_TIMEOUT = 10.0
+_SDK_OPEN_CONNECTION_TIMEOUT = 10.0
 
 # DingTalk error codes that mean "the credentials / app are not valid"
 # — retrying with the same secret will never succeed.  Codes are
@@ -230,6 +233,81 @@ async def _preflight_open_connection(
         request=resp.request,
         response=resp,
     )
+
+
+def _safe_get_host_ip(client: Any) -> str:
+    """Best-effort host IP for the SDK gateway payload."""
+    getter = getattr(client, "get_host_ip", None)
+    if getter is None:
+        return ""
+    try:
+        return str(getter() or "")
+    except Exception:
+        return ""
+
+
+def _install_bounded_open_connection(client: Any) -> None:
+    """Patch the SDK's blocking gateway open call with a finite timeout.
+
+    dingtalk-stream 0.24.x exposes an async ``start()``, but it calls a
+    synchronous ``requests.post`` without a timeout inside
+    ``open_connection``.  Keeping the patch on the client instance avoids
+    changing global SDK behavior while guaranteeing this runner cannot
+    park forever on a gateway TCP read.
+    """
+
+    def _open_connection_with_timeout(self: Any) -> Optional[dict]:
+        import requests
+
+        api = getattr(type(self), "OPEN_CONNECTION_API", _GATEWAY_OPEN_URL)
+        logger = getattr(self, "logger", None)
+        if logger is not None:
+            logger.info("open connection, url=%s", api)
+
+        request_headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": (
+                f"FlocksDingTalkStream/1.0 Python/{platform.python_version()}"
+            ),
+        }
+        topics = []
+        if getattr(self, "_is_event_required", False):
+            topics.append({"type": "EVENT", "topic": "*"})
+        callback_map = getattr(self, "callback_handler_map", {}) or {}
+        for topic in callback_map.keys():
+            topics.append({"type": "CALLBACK", "topic": topic})
+
+        credential = getattr(self, "credential", None)
+        request_body = json.dumps({
+            "clientId": getattr(credential, "client_id", ""),
+            "clientSecret": getattr(credential, "client_secret", ""),
+            "subscriptions": topics,
+            "ua": "flocks-dingtalk-stream/1.0",
+            "localIp": _safe_get_host_ip(self),
+        }).encode("utf-8")
+
+        response_text = ""
+        try:
+            response = requests.post(
+                api,
+                headers=request_headers,
+                data=request_body,
+                timeout=_SDK_OPEN_CONNECTION_TIMEOUT,
+            )
+            response_text = response.text
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            if logger is not None:
+                logger.error(
+                    "open connection failed, error=%s, response.text=%s",
+                    exc,
+                    response_text,
+                )
+            return None
+
+    client.open_connection = MethodType(_open_connection_with_timeout, client)
 
 
 # ---------------------------------------------------------------------------
@@ -579,6 +657,7 @@ class DingTalkStreamRunner:
         self._stream_client: Any = None
         self._stream_task: Optional[asyncio.Task] = None
         self._running = False
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
         # ── R3: bounded inbound dispatch queue + worker pool ─────────
         # Both knobs are tunable per-account so noisy tenants can lift
@@ -636,6 +715,7 @@ class DingTalkStreamRunner:
 
         credential = dingtalk_stream.Credential(self.client_id, self.client_secret)
         self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
+        _install_bounded_open_connection(self._stream_client)
 
         handler = _IncomingHandler(self)
         self._stream_client.register_callback_handler(
@@ -660,6 +740,7 @@ class DingTalkStreamRunner:
         })
 
         self._running = True
+        self._loop = asyncio.get_running_loop()
         self._stream_task = asyncio.create_task(self._run_with_reconnect())
         try:
             if abort_event is None:
@@ -686,6 +767,52 @@ class DingTalkStreamRunner:
             task.cancel()
         await asyncio.gather(*pending, return_exceptions=True)
 
+    async def _start_stream_client_session(self) -> None:
+        """Open one DingTalk websocket session under Flocks cancellation rules.
+
+        The official SDK's ``start()`` has its own forever loop and performs a
+        synchronous no-timeout gateway request on the caller's event loop.  We
+        keep using the SDK's credential, callback, keepalive, and message
+        background-task helpers, but drive one connection attempt ourselves so
+        a slow DingTalk gateway cannot block FastAPI and shutdown can cancel
+        promptly.
+        """
+        import websockets
+
+        client = self._stream_client
+        if client is None:
+            raise RuntimeError("DingTalk stream client is not initialised")
+
+        client.pre_start()
+        connection = await asyncio.to_thread(client.open_connection)
+        if not self._running:
+            return
+        if not connection:
+            raise RuntimeError("DingTalk SDK open_connection failed")
+
+        endpoint = connection.get("endpoint")
+        ticket = connection.get("ticket")
+        if not endpoint or not ticket:
+            raise RuntimeError("DingTalk SDK open_connection returned no endpoint")
+
+        uri = f"{endpoint}?ticket={quote_plus(str(ticket))}"
+        keepalive_task: Optional[asyncio.Task] = None
+        async with websockets.connect(uri) as websocket:
+            client.websocket = websocket
+            keepalive_task = asyncio.create_task(client.keepalive(websocket))
+            try:
+                async for raw_message in websocket:
+                    if not self._running:
+                        return
+                    json_message = json.loads(raw_message)
+                    asyncio.create_task(client.background_task(json_message))
+            finally:
+                if keepalive_task is not None:
+                    keepalive_task.cancel()
+                    await asyncio.gather(keepalive_task, return_exceptions=True)
+                if getattr(client, "websocket", None) is websocket:
+                    client.websocket = None
+
     async def _run_with_reconnect(self) -> None:
         backoff_idx = 0
         while self._running:
@@ -711,15 +838,15 @@ class DingTalkStreamRunner:
                 return
             except Exception as exc:
                 # Transient pre-flight failure (network blip, 5xx, …) —
-                # log and fall through to the SDK, which will re-attempt
-                # ``open_connection`` with its own loop.
+                # log and still attempt one bounded SDK gateway open; the
+                # outer reconnect loop applies normal backoff afterwards.
                 log.warning("dingtalk.stream.preflight_transient_error", {
                     "account": self.account_id, "error": str(exc),
                 })
 
             # ── R1: stall accounting ─────────────────────────────────
-            # Snapshot inbound counters around the SDK's ``start()`` so
-            # we can later tell apart:
+            # Snapshot inbound counters around one stream session so we
+            # can later tell apart:
             #   (a) healthy long-lived connection (duration ≫ threshold)
             #   (b) connection torn down by an exception → backoff path
             #   (c) silent gateway rejection (clean return, < threshold,
@@ -734,7 +861,7 @@ class DingTalkStreamRunner:
             # tried to open a websocket.
             try:
                 log.info("dingtalk.stream.starting", {"account": self.account_id})
-                await self._stream_client.start()
+                await self._start_stream_client_session()
                 clean_return = True
             except asyncio.CancelledError:
                 return
@@ -875,6 +1002,7 @@ class DingTalkStreamRunner:
         self._dispatch_queue = None
 
         self._stream_client = None
+        self._loop = None
 
     # -- inbound dispatch ------------------------------------------------
 
@@ -955,6 +1083,28 @@ class DingTalkStreamRunner:
         path.  Burst load (group floods) sheds gracefully instead of
         spinning unbounded background tasks (R3).
         """
+        owner_loop = self._loop
+        if owner_loop is not None:
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            if running_loop is not owner_loop:
+                try:
+                    owner_loop.call_soon_threadsafe(
+                        self._enqueue_dispatch_on_owner_loop,
+                        chatbot_msg,
+                    )
+                except RuntimeError:
+                    log.warning("dingtalk.stream.dispatch_loop_unavailable", {
+                        "account": self.account_id,
+                    })
+                return
+
+        self._enqueue_dispatch_on_owner_loop(chatbot_msg)
+
+    def _enqueue_dispatch_on_owner_loop(self, chatbot_msg: Any) -> None:
+        """Enqueue on the loop that owns the asyncio.Queue."""
         # ``_messages_received`` powers the stall-detection counter
         # (R1); count what the SDK actually delivered, even if we end
         # up shedding the message due to back-pressure.

--- a/tests/channel/test_dingtalk.py
+++ b/tests/channel/test_dingtalk.py
@@ -13,6 +13,8 @@ import asyncio
 import contextlib
 import importlib.util
 import json
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -368,6 +370,16 @@ class TestBuiltinChannelPlugin:
         error = plugin.validate_config({})
         assert error is not None
         assert "appKey" in error or "credentials" in error.lower()
+
+    def test_validate_config_rejects_dingtalk_prefixed_client_id(self):
+        from flocks.channel.builtin.dingtalk import DingTalkChannel
+        plugin = DingTalkChannel()
+        error = plugin.validate_config({
+            "clientId": "dingtalk_dingecjrxh34nr6aqbit",
+            "clientSecret": "s",
+        })
+        assert error is not None
+        assert "dingtalk_" in error
 
     def test_meta_aliases(self):
         from flocks.channel.builtin.dingtalk import DingTalkChannel
@@ -1016,25 +1028,31 @@ class TestStreamRunnerResilience:
 
         runner = self._make_runner()
 
-        # Fake stream client whose ``start()`` returns immediately every
-        # time — the exact pathology we want to detect.
-        class _ImmediateStartClient:
+        # Fake stream client; the runner's own session method is patched below
+        # to return immediately every time, which is the pathology we want to
+        # detect.
+        class _ImmediateClient:
             def __init__(self, *_a, **_kw):
-                self.start_calls = 0
                 self.websocket = None
 
             def register_callback_handler(self, *_a, **_kw):
                 pass
-
-            async def start(self):
-                self.start_calls += 1
 
             def close(self):
                 pass
 
         monkeypatch.setattr(
             stream_mod.dingtalk_stream, "DingTalkStreamClient",
-            _ImmediateStartClient,
+            _ImmediateClient,
+        )
+
+        async def _immediate_session(_runner):
+            return None
+
+        monkeypatch.setattr(
+            stream_mod.DingTalkStreamRunner,
+            "_start_stream_client_session",
+            _immediate_session,
         )
 
         with pytest.raises(stream_mod.DingTalkStreamStallError) as exc_info:
@@ -1078,19 +1096,6 @@ class TestStreamRunnerResilience:
             def register_callback_handler(self, *_a, **_kw):
                 pass
 
-            async def start(self):
-                call_count["n"] += 1
-                if call_count["n"] == 1:
-                    # Simulate a healthy run: deliver one message,
-                    # then return cleanly.  The runner counts
-                    # ``_messages_received`` directly, so we bump it
-                    # before returning to mimic an inbound frame.
-                    runner._messages_received += 1
-                    return
-                # On the 2nd call, stop the runner so the loop exits
-                # without further iterations.
-                runner._running = False
-
             def close(self):
                 pass
 
@@ -1099,9 +1104,68 @@ class TestStreamRunnerResilience:
             _MixedClient,
         )
 
+        async def _mixed_session(_runner):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # Simulate a healthy run: deliver one message, then return
+                # cleanly.  The runner counts ``_messages_received`` directly,
+                # so we bump it before returning to mimic an inbound frame.
+                runner._messages_received += 1
+                return
+            # On the 2nd call, stop the runner so the loop exits without
+            # further iterations.
+            runner._running = False
+
+        monkeypatch.setattr(
+            stream_mod.DingTalkStreamRunner,
+            "_start_stream_client_session",
+            _mixed_session,
+        )
+
         await asyncio.wait_for(runner.run(), timeout=2.0)
         # Counter MUST have reset after the run that delivered a message.
         assert runner._consecutive_short_runs == 0
+
+    @pytest.mark.asyncio
+    async def test_blocking_open_connection_does_not_block_event_loop(self):
+        """Regression for the production freeze: SDK open_connection is sync.
+
+        The runner must push that call into a worker thread so a slow gateway
+        request cannot block FastAPI's main event loop.
+        """
+        runner = self._make_runner()
+        entered = threading.Event()
+
+        class _BlockingClient:
+            websocket = None
+
+            def pre_start(self):
+                pass
+
+            def open_connection(self):
+                entered.set()
+                time.sleep(0.2)
+                return None
+
+        runner._stream_client = _BlockingClient()
+        runner._running = True
+
+        started_at = time.monotonic()
+        task = asyncio.create_task(runner._start_stream_client_session())
+        try:
+            while not entered.is_set():
+                await asyncio.sleep(0)
+
+            await asyncio.sleep(0.02)
+            assert time.monotonic() - started_at < 0.1
+            assert not task.done()
+
+            with pytest.raises(RuntimeError):
+                await asyncio.wait_for(task, timeout=1.0)
+        finally:
+            if not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
 
     @pytest.mark.asyncio
     async def test_dispatch_queue_drops_overflow_without_blocking(
@@ -1207,6 +1271,35 @@ class TestStreamRunnerResilience:
         # signal in case a frame slips through during shutdown.
         assert runner._messages_received == 1
         assert runner._dropped_messages == 0  # no QueueFull, just no queue
+
+    @pytest.mark.asyncio
+    async def test_enqueue_from_thread_hops_to_owner_loop(self):
+        """SDK callbacks from a non-owner thread must not touch asyncio.Queue."""
+        runner = self._make_runner(account_overrides={
+            "dispatchWorkers": 1,
+            "dispatchQueueSize": 2,
+        })
+        runner._loop = asyncio.get_running_loop()
+        runner._dispatch_queue = asyncio.Queue(
+            maxsize=runner._dispatch_queue_size,
+        )
+        message = SimpleNamespace(text="from-thread")
+
+        thread = threading.Thread(
+            target=runner._enqueue_dispatch,
+            args=(message,),
+        )
+        thread.start()
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+
+        for _ in range(20):
+            if runner._messages_received == 1:
+                break
+            await asyncio.sleep(0.01)
+
+        assert runner._messages_received == 1
+        assert runner._dispatch_queue.get_nowait() is message
 
     def test_permanent_error_hierarchy(self):
         """``DingTalkStreamStallError`` MUST inherit from

--- a/webui/src/pages/Channel/index.tsx
+++ b/webui/src/pages/Channel/index.tsx
@@ -1142,7 +1142,7 @@ function DingTalkPanel({ config, onChange }: DingTalkPanelProps) {
           <TextInput
             value={config.clientId ?? ''}
             onChange={(v) => set('clientId', v || undefined)}
-            placeholder="dingtalk_xxxxxxxxxxxxxxxxxx"
+            placeholder="dingxxxxxxxxxxxxxxxx"
           />
         </FieldRow>
         <FieldRow label="Client Secret" required hint={t('dingtalk.clientSecretHint')}>


### PR DESCRIPTION
## Summary

- bound DingTalk SDK gateway open_connection with a finite timeout
- drive DingTalk stream sessions from Flocks instead of awaiting the SDK forever loop directly
- make DingTalk dispatch queue handoff safe across event loops/threads
- reject dingtalk_-prefixed Client IDs and correct the UI placeholder to the real ding... AppKey shape

## Root Cause

The dingtalk-stream SDK exposes an async start(), but internally calls synchronous requests.post() without a timeout during gateway connection setup. When saving DingTalk config triggers a channel restart, that blocking call can park FastAPI's main event loop and make unrelated API requests time out.

The supplied logs also showed a separate credential issue: dingtalk_... was used as Client ID, while DingTalk expects the app AppKey format such as ding....

## Validation

- .venv/bin/python -m pytest tests/channel/test_dingtalk.py -q
- .venv/bin/ruff check flocks/channel/builtin/dingtalk/stream.py flocks/channel/builtin/dingtalk/channel.py tests/channel/test_dingtalk.py
- npm run lint -- --quiet
- git diff --check