### PR TITLE
fix: clean Windows installs

### DIFF
--- a/flocks/tool/agent/delegate_task.py
+++ b/flocks/tool/agent/delegate_task.py
@@ -37,12 +37,6 @@ async def _subagent_session_permissions(agent_name: str) -> list:
     from flocks.agent.registry import Agent
     from flocks.session.session import PermissionRule as SessionPermissionRule
 
-    def deny_nested_delegation() -> list:
-        return [
-            SessionPermissionRule(permission="delegate_task", action="deny", pattern="*"),
-            SessionPermissionRule(permission="task", action="deny", pattern="*"),
-        ]
-
     try:
         agent = await Agent.get(agent_name)
     except Exception as exc:
@@ -67,7 +61,6 @@ async def _subagent_session_permissions(agent_name: str) -> list:
                     pattern=getattr(rule, "pattern", None) or "*",
                 )
             )
-        rules.extend(deny_nested_delegation())
         return rules
 
     if agent_name == "prometheus":
@@ -78,7 +71,6 @@ async def _subagent_session_permissions(agent_name: str) -> list:
         ])
     elif not rules:
         rules.append(SessionPermissionRule(permission="question", action="deny", pattern="*"))
-    rules.extend(deny_nested_delegation())
     return rules
 
 

--- a/install.ps1
+++ b/install.ps1
@@ -157,6 +157,22 @@ function Unblock-InstallFiles {
     }
 }
 
+function Remove-ExistingInstallDirectory {
+    param([string]$TargetDir)
+
+    if ([string]::IsNullOrWhiteSpace($TargetDir) -or -not (Test-Path -LiteralPath $TargetDir)) {
+        return
+    }
+
+    Write-Info "Removing previous Flocks installation: $TargetDir"
+    try {
+        Remove-Item -LiteralPath $TargetDir -Recurse -Force -ErrorAction Stop
+    }
+    catch {
+        Fail "Failed to remove previous Flocks installation directory '$TargetDir'. Close any running Flocks process and retry. Error: $($_.Exception.Message)"
+    }
+}
+
 function Invoke-WorkspaceInstaller {
     param(
         [string]$InstallerPath,
@@ -252,9 +268,7 @@ function Main {
         if ((-not [string]::IsNullOrWhiteSpace($installParent)) -and -not (Test-Path -LiteralPath $installParent)) {
             New-Item -ItemType Directory -Path $installParent -Force | Out-Null
         }
-        if (Test-Path $InstallDir) {
-            Remove-Item -Path $InstallDir -Recurse -Force
-        }
+        Remove-ExistingInstallDirectory -TargetDir $InstallDir
         Copy-Item -Path $projectRoot -Destination $InstallDir -Recurse -Force
         Unblock-InstallFiles -TargetDir $InstallDir
 

--- a/install_zh.ps1
+++ b/install_zh.ps1
@@ -163,6 +163,22 @@ function Unblock-InstallFiles {
     }
 }
 
+function Remove-ExistingInstallDirectory {
+    param([string]$TargetDir)
+
+    if ([string]::IsNullOrWhiteSpace($TargetDir) -or -not (Test-Path -LiteralPath $TargetDir)) {
+        return
+    }
+
+    Write-Info "正在删除历史 Flocks 安装目录: $TargetDir"
+    try {
+        Remove-Item -LiteralPath $TargetDir -Recurse -Force -ErrorAction Stop
+    }
+    catch {
+        Fail "无法删除历史 Flocks 安装目录 '$TargetDir'。请关闭正在运行的 Flocks 进程后重试。错误: $($_.Exception.Message)"
+    }
+}
+
 function Invoke-WorkspaceInstaller {
     param(
         [string]$InstallerPath,
@@ -291,9 +307,7 @@ function Main {
         if ((-not [string]::IsNullOrWhiteSpace($installParent)) -and -not (Test-Path -LiteralPath $installParent)) {
             New-Item -ItemType Directory -Path $installParent -Force | Out-Null
         }
-        if (Test-Path $InstallDir) {
-            Remove-Item -Path $InstallDir -Recurse -Force
-        }
+        Remove-ExistingInstallDirectory -TargetDir $InstallDir
         Copy-Item -Path $projectRoot -Destination $InstallDir -Recurse -Force
         Unblock-InstallFiles -TargetDir $InstallDir
 

--- a/packaging/windows/flocks-setup.iss
+++ b/packaging/windows/flocks-setup.iss
@@ -76,6 +76,31 @@ Type: filesandordirs; Name: "{app}\*"
 Type: dirifempty; Name: "{app}"
 
 [Code]
+procedure RemoveExistingFlocksRepoDir;
+var
+  ExistingRepoDir: string;
+begin
+  ExistingRepoDir := ExpandConstant('{app}\flocks');
+  if not DirExists(ExistingRepoDir) then
+    exit;
+
+  WizardForm.StatusLabel.Caption := 'Removing previous Flocks installation...';
+  if not DelTree(ExistingRepoDir, True, True, True) then
+  begin
+    RaiseException(
+      'Failed to remove previous Flocks installation directory:' + #13#10 +
+      ExistingRepoDir + #13#10 + #13#10 +
+      'Please close any running Flocks process and retry.'
+    );
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssInstall then
+    RemoveExistingFlocksRepoDir;
+end;
+
 function IsUnderBaseDir(const CandidateDir, BaseDir: string): Boolean;
 var
   NormalizedCandidate: string;

--- a/tests/scripts/test_install_script_sources.py
+++ b/tests/scripts/test_install_script_sources.py
@@ -238,6 +238,20 @@ def test_windows_bootstrap_installers_only_create_missing_parent_directories() -
         assert "Test-Path -LiteralPath $installParent" in script
 
 
+def test_windows_bootstrap_installers_remove_existing_install_directory_before_copy() -> None:
+    for path in (
+        REPO_ROOT / "install.ps1",
+        REPO_ROOT / "install_zh.ps1",
+    ):
+        script = path.read_text(encoding="utf-8-sig")
+        assert "function Remove-ExistingInstallDirectory" in script
+        assert "Remove-Item -LiteralPath $TargetDir -Recurse -Force -ErrorAction Stop" in script
+        assert "Remove-ExistingInstallDirectory -TargetDir $InstallDir" in script
+        assert script.index("Remove-ExistingInstallDirectory -TargetDir $InstallDir") < script.index(
+            "Copy-Item -Path $projectRoot -Destination $InstallDir -Recurse -Force"
+        )
+
+
 def test_main_bash_installer_falls_back_to_nvm_when_brew_is_missing_on_macos() -> None:
     script = (SCRIPT_DIR / "install.sh").read_text(encoding="utf-8")
     script_without_main = re.sub(r'\nmain "\$@"\s*$', "\n", script)

--- a/tests/tool/test_delegate_task_compat.py
+++ b/tests/tool/test_delegate_task_compat.py
@@ -37,7 +37,7 @@ class TestDelegateTaskTolerance:
             patch("flocks.tool.agent.delegate_task.is_delegatable", return_value=True),
             patch("flocks.tool.agent.delegate_task.Skill.get", AsyncMock()) as skill_get,
             patch("flocks.tool.agent.delegate_task.Session.get_by_id", AsyncMock(return_value=parent_session)),
-            patch("flocks.tool.agent.delegate_task.Session.create", AsyncMock(return_value=child_session)),
+            patch("flocks.tool.agent.delegate_task.Session.create", AsyncMock(return_value=child_session)) as create_session,
             patch("flocks.tool.agent.delegate_task.Message.create", AsyncMock()),
             patch("flocks.tool.agent.delegate_task.SessionLoop.run", AsyncMock(return_value=SimpleNamespace(
                 action="stop",
@@ -57,6 +57,10 @@ class TestDelegateTaskTolerance:
         assert result.title == "Investigate threatbook.cn assets"
         assert result.metadata["sessionId"] == "ses-child"
         skill_get.assert_not_awaited()
+        permissions = create_session.await_args.kwargs["permission"]
+        denied_permissions = {rule.permission for rule in permissions if rule.action == "deny"}
+        assert "delegate_task" not in denied_permissions
+        assert "task" not in denied_permissions
 
     @pytest.mark.asyncio
     async def test_delegate_task_category_model_uses_runtime_override_without_pinning(self):


### PR DESCRIPTION
## Summary
- clean previous Windows source and EXE install directories before copying new Flocks files
- add regression coverage for nested delegation permissions and Windows bootstrap cleanup