### PR TITLE
fix(task): tolerate legacy task text encoding

### DIFF
--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -54,6 +54,7 @@ class TaskStore:
             Storage._db_path,
             timeout=Storage._sqlite_timeout_s,
         )
+        cls._conn.text_factory = cls._decode_legacy_text
         await Storage.configure_connection(cls._conn)
         await cls._conn.executescript(_TASKS_DDL)
         for stmt in _INDEX_STMTS:
@@ -89,6 +90,13 @@ class TaskStore:
     @classmethod
     async def raw_db(cls) -> aiosqlite.Connection:
         return await cls._db()
+
+    @staticmethod
+    def _decode_legacy_text(value: bytes) -> str:
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.decode("gb18030", errors="replace")
 
     # ------------------------------------------------------------------
     # Scheduler CRUD

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -95,6 +95,39 @@ async def test_immediate_scheduler_creates_single_queued_execution(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_list_executions_tolerates_legacy_non_utf8_description(
+    tmp_path: Path,
+):
+    legacy_description = "扫描 Windows 主机 192.168.254.1"
+    scheduler = await TaskManager.create_scheduler(
+        title="legacy encoding",
+        description="placeholder",
+        mode=SchedulerMode.ONCE,
+        priority=TaskPriority.NORMAL,
+        trigger=TaskTrigger(run_immediately=True),
+        workspace_directory=str(tmp_path / "workspace"),
+    )
+    executions, _ = await TaskManager.list_scheduler_executions(scheduler.id)
+    execution_id = executions[0].id
+
+    db = await TaskStore.raw_db()
+    await db.execute(
+        """
+        UPDATE task_executions
+        SET description = CAST(? AS TEXT)
+        WHERE id = ?
+        """,
+        (legacy_description.encode("gbk"), execution_id),
+    )
+    await db.commit()
+
+    executions, total = await TaskManager.list_executions(limit=20)
+
+    assert total == 1
+    assert executions[0].description == legacy_description
+
+
+@pytest.mark.asyncio
 async def test_once_scheduler_tick_creates_execution_and_disables_scheduler(tmp_path: Path):
     scheduler = await TaskManager.create_scheduler(
         title="单次定时",


### PR DESCRIPTION
## Summary
- add TaskStore-level fallback decoding for legacy non-UTF-8 task text
- keep existing task database data unchanged while preventing task execution listing from returning 500
- add regression coverage for GBK-encoded task execution descriptions

## Root Cause
Existing task execution rows can contain legacy Windows-encoded bytes in SQLite TEXT columns. The default sqlite3 UTF-8 decoder raises OperationalError while fetching /api/task-executions, causing the route to return 500.

## Validation
- .venv/bin/python -m pytest tests/task/test_task.py::test_list_executions_tolerates_legacy_non_utf8_description -q
- .venv/bin/python -m pytest tests/task/test_task.py -q
- .venv/bin/python -m ruff check flocks/task/store.py tests/task/test_task.py
- git diff --check