### PR TITLE
Split storage into task and workflow databases

### DIFF
--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -448,22 +448,28 @@ async def _cleanup_workflow_storage(workflow_id: str) -> None:
     await _remove_storage_key_if_exists(f"{_WORKFLOW_CENTER_RUNTIME_PREFIX}{workflow_id}")
     await _remove_storage_key_if_exists(f"{_WORKFLOW_CENTER_LOCAL_PID_PREFIX}{workflow_id}")
     await _remove_storage_prefix(f"{_WORKFLOW_CENTER_RELEASE_PREFIX}{workflow_id}/")
+    await _remove_storage_prefix(f"workflow_execution_index/{workflow_id}/")
 
     try:
-        exec_keys = await Storage.list("workflow_execution/")
+        exec_keys = await Storage.list_keys("workflow_execution/")
         for key in exec_keys:
             try:
                 exec_data = await Storage.read(key)
                 if isinstance(exec_data, dict) and exec_data.get("workflowId") == workflow_id:
-                    await Storage.remove(key)
                     exec_id = key.rsplit("/", 1)[-1]
-                    step_rows = await Storage.list_raw(_workflow_execution_step_prefix(exec_id))
-                    for step_key, _value in step_rows:
-                        await Storage.remove(step_key)
-            except Exception:
-                pass
-    except Exception:
-        pass
+                    await Storage.clear(_workflow_execution_step_prefix(exec_id))
+                    await Storage.remove(key)
+            except Exception as exc:
+                log.warning("workflow.delete.execution_cleanup_failed", {
+                    "workflow_id": workflow_id,
+                    "key": key,
+                    "error": str(exc),
+                })
+    except Exception as exc:
+        log.warning("workflow.delete.execution_scan_failed", {
+            "workflow_id": workflow_id,
+            "error": str(exc),
+        })
 
     service_dir = Config.get_data_path() / "workflow-services" / "workflows" / workflow_id
     if service_dir.is_dir():

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -98,6 +98,7 @@ class Storage:
     _workflow_key_prefixes = (
         "workflow/",
         "workflow_execution/",
+        "workflow_execution_index/",
         "workflow_execution_step/",
         "workflow_registry/",
         "workflow_release/",

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -94,6 +94,7 @@ class Storage:
     _sqlite_write_retry_attempts = 6
     _sqlite_write_retry_base_delay_s = 0.05
     _multi_db_migration_marker_key = "storage.migration.multi_db.v1"
+    _multi_db_migration_batch_size = 500
     _workflow_key_prefixes = (
         "workflow/",
         "workflow_execution/",
@@ -469,6 +470,38 @@ class Storage:
         return key
 
     @classmethod
+    def _like_prefix_pattern(cls, prefix: str) -> str:
+        """Return a SQLite LIKE pattern that treats prefix chars literally."""
+        return (
+            prefix.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+            + "%"
+        )
+
+    @classmethod
+    def _like_prefix_clause(cls, column: str = "key") -> str:
+        return f"{column} LIKE ? ESCAPE '\\'"
+
+    @classmethod
+    def _workflow_prefix_filter(cls) -> tuple[str, tuple[str, ...]]:
+        clause = " OR ".join(
+            cls._like_prefix_clause("key") for _ in cls._workflow_key_prefixes
+        )
+        params = tuple(
+            cls._like_prefix_pattern(prefix)
+            for prefix in cls._workflow_key_prefixes
+        )
+        return clause, params
+
+    @staticmethod
+    def _marker_row_count(marker: Dict[str, Any], key: str) -> int:
+        try:
+            return int(marker.get(key) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @classmethod
     async def _ensure_storage_table(cls, db_path: Path) -> None:
         """Ensure the generic KV storage table exists in *db_path*."""
         db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -543,43 +576,102 @@ class Storage:
             conn.close()
 
     @classmethod
-    def _copy_workflow_kv_to_workflow_db_sync(cls) -> int:
+    def _copy_workflow_kv_to_workflow_db_sync(cls) -> tuple[int, int]:
         if cls._db_path is None:
             raise StorageError("Storage DB path is not initialized")
         workflow_db_path = cls.get_workflow_db_path()
         source = cls.connect_sync(cls._db_path)
         target = cls.connect_sync(workflow_db_path)
         try:
-            clauses = " OR ".join("key LIKE ?" for _ in cls._workflow_key_prefixes)
-            rows = source.execute(
-                f"SELECT key, value, type, created_at, updated_at FROM storage WHERE {clauses}",
-                tuple(f"{prefix}%" for prefix in cls._workflow_key_prefixes),
-            ).fetchall()
-            for row in rows:
-                target.execute(
+            clauses, params = cls._workflow_prefix_filter()
+            total_migrated = 0
+            total_deleted = 0
+            last_key = ""
+            while True:
+                rows = source.execute(
+                    f"""
+                    SELECT key, value, type, created_at, updated_at
+                    FROM storage
+                    WHERE ({clauses}) AND key > ?
+                    ORDER BY key
+                    LIMIT ?
+                    """,
+                    (*params, last_key, cls._multi_db_migration_batch_size),
+                ).fetchall()
+                if not rows:
+                    break
+
+                target.executemany(
                     """
                     INSERT OR REPLACE INTO storage (key, value, type, created_at, updated_at)
                     VALUES (?, ?, ?, ?, ?)
                     """,
-                    (
-                        row["key"],
-                        row["value"],
-                        row["type"],
-                        row["created_at"],
-                        row["updated_at"],
-                    ),
+                    [
+                        (
+                            row["key"],
+                            row["value"],
+                            row["type"],
+                            row["created_at"],
+                            row["updated_at"],
+                        )
+                        for row in rows
+                    ],
                 )
-            target.commit()
-            return len(rows)
+                target.commit()
+
+                keys = [row["key"] for row in rows]
+                placeholders = ", ".join("?" for _ in keys)
+                copied = target.execute(
+                    f"SELECT COUNT(*) FROM storage WHERE key IN ({placeholders})",
+                    keys,
+                ).fetchone()[0]
+                if copied != len(keys):
+                    raise StorageError(
+                        "Workflow storage migration verification failed: "
+                        f"expected {len(keys)} copied rows, got {copied}"
+                    )
+
+                deleted = 0
+                for key in keys:
+                    cursor = source.execute(
+                        "DELETE FROM storage WHERE key = ?",
+                        (key,),
+                    )
+                    if cursor.rowcount > 0:
+                        deleted += cursor.rowcount
+                source.commit()
+
+                total_migrated += len(rows)
+                total_deleted += deleted
+                last_key = keys[-1]
+
+            return total_migrated, total_deleted
+        except Exception:
+            if source.in_transaction:
+                source.rollback()
+            if target.in_transaction:
+                target.rollback()
+            raise
         finally:
             source.close()
             target.close()
 
     @classmethod
-    async def _migrate_workflow_storage_to_workflow_db(cls) -> None:
+    async def _migrate_workflow_storage_to_workflow_db(
+        cls,
+        *,
+        workflow_db_existed_before_init: bool,
+    ) -> None:
         """Copy legacy workflow-domain KV rows from flocks.db to workflow.db."""
         marker = await asyncio.to_thread(cls._read_multi_db_migration_marker_sync)
         if marker.get("workflow_migrated") is True:
+            if (
+                not workflow_db_existed_before_init
+                and cls._marker_row_count(marker, "workflow_rows") > 0
+            ):
+                raise StorageError(
+                    "workflow.db is missing after a completed multi-db migration"
+                )
             return
 
         from datetime import UTC
@@ -589,14 +681,18 @@ class Storage:
         marker["source_db"] = str(cls.get_db_path())
         marker["workflow_db"] = str(cls.get_workflow_db_path())
         try:
-            migrated = await asyncio.to_thread(cls._copy_workflow_kv_to_workflow_db_sync)
+            migrated, deleted = await asyncio.to_thread(
+                cls._copy_workflow_kv_to_workflow_db_sync
+            )
             marker["workflow_migrated"] = True
             marker["workflow_migrated_at"] = datetime.now(UTC).isoformat()
             marker["workflow_rows"] = migrated
+            marker["workflow_source_rows_deleted"] = deleted
             marker.pop("workflow_error", None)
             await asyncio.to_thread(cls._write_multi_db_migration_marker_sync, marker)
             cls._log.info("storage.multi_db.workflow_migrated", {
                 "rows": migrated,
+                "source_rows_deleted": deleted,
                 "source_db": marker["source_db"],
                 "workflow_db": marker["workflow_db"],
             })
@@ -693,8 +789,12 @@ class Storage:
         # public Storage API unchanged by routing workflow key prefixes at
         # the KV-operation seam, while initialising the sibling DB here so
         # startup fails early if that database is unusable.
-        await cls._ensure_storage_table(cls.get_workflow_db_path())
-        await cls._migrate_workflow_storage_to_workflow_db()
+        workflow_db_path = cls.get_workflow_db_path()
+        workflow_db_existed_before_init = workflow_db_path.exists()
+        await cls._ensure_storage_table(workflow_db_path)
+        await cls._migrate_workflow_storage_to_workflow_db(
+            workflow_db_existed_before_init=workflow_db_existed_before_init,
+        )
 
         # Drain any residual WAL frames left by the previous process so the
         # next ``SIGKILL`` does not have to truncate a 4 MB-class WAL during
@@ -1110,22 +1210,60 @@ class Storage:
             List of matching keys
         """
         await cls._ensure_init()
-        db_path = cls.route_db_path_for_prefix(prefix)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
+        if prefix is None:
+            db_paths = (cls.get_db_path(), cls.get_workflow_db_path())
+        else:
+            db_paths = (cls.route_db_path_for_prefix(prefix),)
+        for db_path in db_paths:
+            if db_path != cls.get_db_path():
+                await cls._ensure_storage_table(db_path)
         
-        async with cls.connect(db_path) as db:
-            if prefix:
-                query = "SELECT key FROM storage WHERE key LIKE ?"
-                params = (f"{prefix}%",)
-            else:
-                query = "SELECT key FROM storage"
-                params = ()
-            
-            async with db.execute(query, params) as cursor:
-                rows = await cursor.fetchall()
+        keys: set[str] = set()
+        for db_path in db_paths:
+            async with cls.connect(db_path) as db:
+                if prefix:
+                    query = f"SELECT key FROM storage WHERE {cls._like_prefix_clause()}"
+                    params = (cls._like_prefix_pattern(prefix),)
+                else:
+                    query = "SELECT key FROM storage"
+                    params = ()
+
+                async with db.execute(query, params) as cursor:
+                    rows = await cursor.fetchall()
+            keys.update(row[0] for row in rows)
         
-        return [row[0] for row in rows]
+        return sorted(keys)
+
+    @classmethod
+    async def _list_entry_rows(
+        cls,
+        *,
+        prefix: Optional[str],
+    ) -> List[Tuple[str, str]]:
+        if prefix is None:
+            db_paths = (cls.get_db_path(), cls.get_workflow_db_path())
+        else:
+            db_paths = (cls.route_db_path_for_prefix(prefix),)
+        for db_path in db_paths:
+            if db_path != cls.get_db_path():
+                await cls._ensure_storage_table(db_path)
+
+        rows_by_key: dict[str, str] = {}
+        for db_path in db_paths:
+            async with cls.connect(db_path) as db:
+                if prefix:
+                    query = f"SELECT key, value FROM storage WHERE {cls._like_prefix_clause()}"
+                    params = (cls._like_prefix_pattern(prefix),)
+                else:
+                    query = "SELECT key, value FROM storage"
+                    params = ()
+
+                async with db.execute(query, params) as cursor:
+                    rows = await cursor.fetchall()
+            for key, value in rows:
+                rows_by_key[key] = value
+
+        return sorted(rows_by_key.items(), key=lambda item: item[0])
 
     @classmethod
     async def list_entries(
@@ -1147,20 +1285,7 @@ class Storage:
             List of ``(key, value)`` tuples
         """
         await cls._ensure_init()
-        db_path = cls.route_db_path_for_prefix(prefix)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
-
-        async with cls.connect(db_path) as db:
-            if prefix:
-                query = "SELECT key, value FROM storage WHERE key LIKE ?"
-                params = (f"{prefix}%",)
-            else:
-                query = "SELECT key, value FROM storage"
-                params = ()
-
-            async with db.execute(query, params) as cursor:
-                rows = await cursor.fetchall()
+        rows = await cls._list_entry_rows(prefix=prefix)
 
         entries: List[Tuple[str, T | Any]] = []
         for key, value_str in rows:
@@ -1188,11 +1313,11 @@ class Storage:
 
         safe_offset = max(int(offset), 0)
         safe_limit = max(int(limit), 0)
-        params = (f"{prefix}%",)
+        params = (cls._like_prefix_pattern(prefix),)
 
         async with cls.connect(db_path) as db:
             async with db.execute(
-                "SELECT COUNT(*) FROM storage WHERE key LIKE ?",
+                f"SELECT COUNT(*) FROM storage WHERE {cls._like_prefix_clause()}",
                 params,
             ) as cursor:
                 row = await cursor.fetchone()
@@ -1202,13 +1327,13 @@ class Storage:
                 return [], total
 
             async with db.execute(
-                """
+                f"""
                 SELECT key, value FROM storage
-                WHERE key LIKE ?
+                WHERE {cls._like_prefix_clause()}
                 ORDER BY key
                 LIMIT ? OFFSET ?
                 """,
-                (f"{prefix}%", safe_limit, safe_offset),
+                (cls._like_prefix_pattern(prefix), safe_limit, safe_offset),
             ) as cursor:
                 rows = await cursor.fetchall()
 
@@ -1235,22 +1360,7 @@ class Storage:
         Compatible with all SQLite versions (no ``json_extract`` required).
         """
         await cls._ensure_init()
-        db_path = cls.route_db_path_for_prefix(prefix)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
-
-        if prefix:
-            query = "SELECT key, value FROM storage WHERE key LIKE ?"
-            params: tuple = (f"{prefix}%",)
-        else:
-            query = "SELECT key, value FROM storage"
-            params = ()
-
-        async with cls.connect(db_path) as db:
-            async with db.execute(query, params) as cursor:
-                rows = await cursor.fetchall()
-
-        return [(row[0], row[1]) for row in rows]
+        return await cls._list_entry_rows(prefix=prefix)
 
     @classmethod
     async def exists(cls, key: str) -> bool:
@@ -1299,8 +1409,8 @@ class Storage:
         async def _clear_db(db_path: Path) -> int:
             async with cls.connect(db_path) as db:
                 if prefix:
-                    query = "DELETE FROM storage WHERE key LIKE ?"
-                    params = (f"{prefix}%",)
+                    query = f"DELETE FROM storage WHERE {cls._like_prefix_clause()}"
+                    params = (cls._like_prefix_pattern(prefix),)
                     cursor = await db.execute(query, params)
                 else:
                     query = "DELETE FROM storage WHERE key != ?"

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -162,7 +162,7 @@ class Storage:
         """Return the storage DB path for a prefix-scoped KV operation."""
         if prefix and (
             cls._is_workflow_key(prefix)
-            or any(workflow_prefix.startswith(prefix) for workflow_prefix in cls._workflow_key_prefixes)
+            or f"{prefix}/" in cls._workflow_key_prefixes
         ):
             return cls.get_workflow_db_path()
         return cls.get_db_path()
@@ -1288,11 +1288,15 @@ class Storage:
             Number of deleted entries
         """
         await cls._ensure_init()
-        db_path = cls.route_db_path_for_prefix(prefix)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
+        if prefix is None:
+            db_paths = (cls.get_db_path(), cls.get_workflow_db_path())
+        else:
+            db_paths = (cls.route_db_path_for_prefix(prefix),)
+        for db_path in db_paths:
+            if db_path != cls.get_db_path():
+                await cls._ensure_storage_table(db_path)
         
-        async def _clear() -> int:
+        async def _clear_db(db_path: Path) -> int:
             async with cls.connect(db_path) as db:
                 if prefix:
                     query = "DELETE FROM storage WHERE key LIKE ?"
@@ -1310,11 +1314,13 @@ class Storage:
                 await db.commit()
                 return cursor.rowcount
 
-        deleted = await cls._run_write_with_retry(
-            _clear,
-            action="clear",
-            target=prefix or "<all>",
-        )
+        deleted = 0
+        for db_path in db_paths:
+            deleted += await cls._run_write_with_retry(
+                lambda db_path=db_path: _clear_db(db_path),
+                action="clear",
+                target=f"{prefix or '<all>'}@{db_path}",
+            )
         
         cls._log.info("storage.clear", {"prefix": prefix, "deleted": deleted})
         cls._invalidate_runtime_caches()

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -93,6 +93,21 @@ class Storage:
     _sqlite_synchronous = "NORMAL"
     _sqlite_write_retry_attempts = 6
     _sqlite_write_retry_base_delay_s = 0.05
+    _multi_db_migration_marker_key = "storage.migration.multi_db.v1"
+    _workflow_key_prefixes = (
+        "workflow/",
+        "workflow_execution/",
+        "workflow_execution_step/",
+        "workflow_registry/",
+        "workflow_release/",
+        "workflow_runtime/",
+        "workflow_local_pid/",
+        "workflow_api_service/",
+        "workflow_integration_config/",
+        "workflow_kafka_config/",
+        "workflow_poller_config/",
+        "workflow_syslog_config/",
+    )
 
     # Substrings that mark an SQLite file as unrecoverably damaged at open
     # time.  We deliberately keep this list short and English-only because
@@ -129,6 +144,32 @@ class Storage:
             return cls._db_path
         data_dir = Config.get_data_path()
         return data_dir / "flocks.db"
+
+    @classmethod
+    def get_workflow_db_path(cls) -> Path:
+        """Return the SQLite database path for workflow-domain KV data."""
+        return cls.get_db_path().with_name("workflow.db")
+
+    @classmethod
+    def route_db_path_for_key(cls, key: str) -> Path:
+        """Return the storage DB path that owns *key*."""
+        if cls._is_workflow_key(key):
+            return cls.get_workflow_db_path()
+        return cls.get_db_path()
+
+    @classmethod
+    def route_db_path_for_prefix(cls, prefix: Optional[str]) -> Path:
+        """Return the storage DB path for a prefix-scoped KV operation."""
+        if prefix and (
+            cls._is_workflow_key(prefix)
+            or any(workflow_prefix.startswith(prefix) for workflow_prefix in cls._workflow_key_prefixes)
+        ):
+            return cls.get_workflow_db_path()
+        return cls.get_db_path()
+
+    @classmethod
+    def _is_workflow_key(cls, key: str) -> bool:
+        return any(key.startswith(prefix) for prefix in cls._workflow_key_prefixes)
 
     @classmethod
     async def configure_connection(
@@ -426,6 +467,153 @@ class Storage:
         if isinstance(key, list):
             return "/".join(key)
         return key
+
+    @classmethod
+    async def _ensure_storage_table(cls, db_path: Path) -> None:
+        """Ensure the generic KV storage table exists in *db_path*."""
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        async def _create_storage_table() -> None:
+            async with cls.connect(db_path) as db:
+                await db.execute("""
+                    CREATE TABLE IF NOT EXISTS storage (
+                        key TEXT PRIMARY KEY,
+                        value TEXT NOT NULL,
+                        type TEXT NOT NULL,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    )
+                """)
+                await db.commit()
+
+        await cls._run_write_with_retry(
+            _create_storage_table,
+            action="init.create_storage_table",
+            target=str(db_path),
+        )
+
+    @classmethod
+    def _read_multi_db_migration_marker_sync(cls) -> Dict[str, Any]:
+        if cls._db_path is None or not cls._db_path.exists():
+            return {}
+        try:
+            conn = cls.connect_sync(cls._db_path)
+            try:
+                row = conn.execute(
+                    "SELECT value FROM storage WHERE key = ?",
+                    (cls._multi_db_migration_marker_key,),
+                ).fetchone()
+            finally:
+                conn.close()
+            if row is None:
+                return {}
+            value = json.loads(row["value"])
+            return value if isinstance(value, dict) else {}
+        except Exception:
+            return {}
+
+    @classmethod
+    def _write_multi_db_migration_marker_sync(cls, marker: Dict[str, Any]) -> None:
+        if cls._db_path is None:
+            raise StorageError("Storage DB path is not initialized")
+        from datetime import UTC
+
+        now = datetime.now(UTC).isoformat()
+        serialized = json.dumps(marker)
+        conn = cls.connect_sync(cls._db_path)
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO storage (key, value, type, created_at, updated_at)
+                VALUES (?, ?, ?,
+                    COALESCE((SELECT created_at FROM storage WHERE key = ?), ?),
+                    ?)
+                """,
+                (
+                    cls._multi_db_migration_marker_key,
+                    serialized,
+                    "json",
+                    cls._multi_db_migration_marker_key,
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @classmethod
+    def _copy_workflow_kv_to_workflow_db_sync(cls) -> int:
+        if cls._db_path is None:
+            raise StorageError("Storage DB path is not initialized")
+        workflow_db_path = cls.get_workflow_db_path()
+        source = cls.connect_sync(cls._db_path)
+        target = cls.connect_sync(workflow_db_path)
+        try:
+            clauses = " OR ".join("key LIKE ?" for _ in cls._workflow_key_prefixes)
+            rows = source.execute(
+                f"SELECT key, value, type, created_at, updated_at FROM storage WHERE {clauses}",
+                tuple(f"{prefix}%" for prefix in cls._workflow_key_prefixes),
+            ).fetchall()
+            for row in rows:
+                target.execute(
+                    """
+                    INSERT OR REPLACE INTO storage (key, value, type, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        row["key"],
+                        row["value"],
+                        row["type"],
+                        row["created_at"],
+                        row["updated_at"],
+                    ),
+                )
+            target.commit()
+            return len(rows)
+        finally:
+            source.close()
+            target.close()
+
+    @classmethod
+    async def _migrate_workflow_storage_to_workflow_db(cls) -> None:
+        """Copy legacy workflow-domain KV rows from flocks.db to workflow.db."""
+        marker = await asyncio.to_thread(cls._read_multi_db_migration_marker_sync)
+        if marker.get("workflow_migrated") is True:
+            return
+
+        from datetime import UTC
+
+        marker.setdefault("version", 1)
+        marker.setdefault("started_at", datetime.now(UTC).isoformat())
+        marker["source_db"] = str(cls.get_db_path())
+        marker["workflow_db"] = str(cls.get_workflow_db_path())
+        try:
+            migrated = await asyncio.to_thread(cls._copy_workflow_kv_to_workflow_db_sync)
+            marker["workflow_migrated"] = True
+            marker["workflow_migrated_at"] = datetime.now(UTC).isoformat()
+            marker["workflow_rows"] = migrated
+            marker.pop("workflow_error", None)
+            await asyncio.to_thread(cls._write_multi_db_migration_marker_sync, marker)
+            cls._log.info("storage.multi_db.workflow_migrated", {
+                "rows": migrated,
+                "source_db": marker["source_db"],
+                "workflow_db": marker["workflow_db"],
+            })
+        except Exception as exc:
+            marker["workflow_migrated"] = False
+            marker["workflow_error"] = str(exc)
+            marker["workflow_failed_at"] = datetime.now(UTC).isoformat()
+            try:
+                await asyncio.to_thread(cls._write_multi_db_migration_marker_sync, marker)
+            except Exception:
+                pass
+            cls._log.error("storage.multi_db.workflow_migration_failed", {
+                "source_db": marker.get("source_db"),
+                "workflow_db": marker.get("workflow_db"),
+                "error": str(exc),
+            })
+            raise
     
     @classmethod
     async def init(cls, db_path: Optional[Path] = None) -> None:
@@ -500,6 +688,13 @@ class Storage:
             if quarantined is None:
                 raise
             await cls._bootstrap_schema()
+
+        # Workflow-domain KV rows live in a sibling workflow.db.  Keep the
+        # public Storage API unchanged by routing workflow key prefixes at
+        # the KV-operation seam, while initialising the sibling DB here so
+        # startup fails early if that database is unusable.
+        await cls._ensure_storage_table(cls.get_workflow_db_path())
+        await cls._migrate_workflow_storage_to_workflow_db()
 
         # Drain any residual WAL frames left by the previous process so the
         # next ``SIGKILL`` does not have to truncate a 4 MB-class WAL during
@@ -666,24 +861,7 @@ class Storage:
         first call surfaces the corruption, and the second call (after the
         rename) bootstraps a fresh database in its place.
         """
-        async def _create_storage_table() -> None:
-            async with cls.connect(cls._db_path) as db:
-                await db.execute("""
-                    CREATE TABLE IF NOT EXISTS storage (
-                        key TEXT PRIMARY KEY,
-                        value TEXT NOT NULL,
-                        type TEXT NOT NULL,
-                        created_at TEXT NOT NULL,
-                        updated_at TEXT NOT NULL
-                    )
-                """)
-                await db.commit()
-
-        await cls._run_write_with_retry(
-            _create_storage_table,
-            action="init.create_storage_table",
-            target=str(cls._db_path),
-        )
+        await cls._ensure_storage_table(cls._db_path)
 
         # Initialize vector storage tables (for memory system)
         try:
@@ -830,6 +1008,9 @@ class Storage:
             value_type: Type identifier for the value
         """
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_key(key)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
         
         if isinstance(value, BaseModel):
             serialized = value.model_dump_json()
@@ -840,7 +1021,7 @@ class Storage:
         now = datetime.now(UTC).isoformat()
         
         async def _write() -> None:
-            async with cls.connect(cls._db_path) as db:
+            async with cls.connect(db_path) as db:
                 await db.execute("""
                     INSERT OR REPLACE INTO storage (key, value, type, created_at, updated_at)
                     VALUES (?, ?, ?, 
@@ -866,8 +1047,11 @@ class Storage:
             Stored value or None if not found
         """
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_key(key)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
         
-        async with cls.connect(cls._db_path) as db:
+        async with cls.connect(db_path) as db:
             async with db.execute(
                 "SELECT value, type FROM storage WHERE key = ?", (key,)
             ) as cursor:
@@ -897,9 +1081,12 @@ class Storage:
             True if deleted, False if not found
         """
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_key(key)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
         
         async def _delete() -> bool:
-            async with cls.connect(cls._db_path) as db:
+            async with cls.connect(db_path) as db:
                 cursor = await db.execute("DELETE FROM storage WHERE key = ?", (key,))
                 await db.commit()
                 return cursor.rowcount > 0
@@ -923,8 +1110,11 @@ class Storage:
             List of matching keys
         """
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_prefix(prefix)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
         
-        async with cls.connect(cls._db_path) as db:
+        async with cls.connect(db_path) as db:
             if prefix:
                 query = "SELECT key FROM storage WHERE key LIKE ?"
                 params = (f"{prefix}%",)
@@ -957,8 +1147,11 @@ class Storage:
             List of ``(key, value)`` tuples
         """
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_prefix(prefix)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
 
-        async with cls.connect(cls._db_path) as db:
+        async with cls.connect(db_path) as db:
             if prefix:
                 query = "SELECT key, value FROM storage WHERE key LIKE ?"
                 params = (f"{prefix}%",)
@@ -989,12 +1182,15 @@ class Storage:
     ) -> tuple[List[Tuple[str, T | Any]], int]:
         """List one page of entries for a prefix, plus total matching rows."""
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_prefix(prefix)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
 
         safe_offset = max(int(offset), 0)
         safe_limit = max(int(limit), 0)
         params = (f"{prefix}%",)
 
-        async with cls.connect(cls._db_path) as db:
+        async with cls.connect(db_path) as db:
             async with db.execute(
                 "SELECT COUNT(*) FROM storage WHERE key LIKE ?",
                 params,
@@ -1039,6 +1235,9 @@ class Storage:
         Compatible with all SQLite versions (no ``json_extract`` required).
         """
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_prefix(prefix)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
 
         if prefix:
             query = "SELECT key, value FROM storage WHERE key LIKE ?"
@@ -1047,7 +1246,7 @@ class Storage:
             query = "SELECT key, value FROM storage"
             params = ()
 
-        async with cls.connect(cls._db_path) as db:
+        async with cls.connect(db_path) as db:
             async with db.execute(query, params) as cursor:
                 rows = await cursor.fetchall()
 
@@ -1065,8 +1264,11 @@ class Storage:
             True if exists, False otherwise
         """
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_key(key)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
         
-        async with cls.connect(cls._db_path) as db:
+        async with cls.connect(db_path) as db:
             async with db.execute(
                 "SELECT 1 FROM storage WHERE key = ?", (key,)
             ) as cursor:
@@ -1086,17 +1288,25 @@ class Storage:
             Number of deleted entries
         """
         await cls._ensure_init()
+        db_path = cls.route_db_path_for_prefix(prefix)
+        if db_path != cls.get_db_path():
+            await cls._ensure_storage_table(db_path)
         
         async def _clear() -> int:
-            async with cls.connect(cls._db_path) as db:
+            async with cls.connect(db_path) as db:
                 if prefix:
                     query = "DELETE FROM storage WHERE key LIKE ?"
                     params = (f"{prefix}%",)
+                    cursor = await db.execute(query, params)
                 else:
-                    query = "DELETE FROM storage"
-                    params = ()
+                    query = "DELETE FROM storage WHERE key != ?"
+                    params = (cls._multi_db_migration_marker_key,)
+                    cursor = await db.execute(query, params)
+                    await db.execute(
+                        "DELETE FROM storage WHERE key = ?",
+                        (cls._multi_db_migration_marker_key,),
+                    )
 
-                cursor = await db.execute(query, params)
                 await db.commit()
                 return cursor.rowcount
 

--- a/flocks/task/manager.py
+++ b/flocks/task/manager.py
@@ -820,29 +820,44 @@ class TaskManager:
     def _with_db_connection() -> sqlite3.Connection:
         return Storage.connect_sync()
 
+    @staticmethod
+    def _legacy_table_db_paths() -> list[Path]:
+        paths = [Storage.get_db_path(), TaskStore.get_db_path()]
+        unique: list[Path] = []
+        for path in paths:
+            if path not in unique:
+                unique.append(path)
+        return unique
+
     @classmethod
     def _legacy_tables_exist(cls) -> bool:
-        with cls._with_db_connection() as conn:
-            for table_name in ("tasks", "task_execution_records", "task_queue_refs"):
-                row = conn.execute(
-                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?",
-                    (table_name,),
-                ).fetchone()
-                if row is not None:
-                    return True
+        for db_path in cls._legacy_table_db_paths():
+            if not db_path.exists():
+                continue
+            with Storage.connect_sync(db_path) as conn:
+                for table_name in ("tasks", "task_execution_records", "task_queue_refs"):
+                    row = conn.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?",
+                        (table_name,),
+                    ).fetchone()
+                    if row is not None:
+                        return True
         return False
 
     @classmethod
     def _drop_legacy_tables(cls) -> None:
-        with cls._with_db_connection() as conn:
-            conn.executescript(
-                """
-                DROP TABLE IF EXISTS task_queue_refs;
-                DROP TABLE IF EXISTS task_execution_records;
-                DROP TABLE IF EXISTS tasks;
-                """
-            )
-            conn.commit()
+        for db_path in cls._legacy_table_db_paths():
+            if not db_path.exists():
+                continue
+            with Storage.connect_sync(db_path) as conn:
+                conn.executescript(
+                    """
+                    DROP TABLE IF EXISTS task_queue_refs;
+                    DROP TABLE IF EXISTS task_execution_records;
+                    DROP TABLE IF EXISTS tasks;
+                    """
+                )
+                conn.commit()
 
     @classmethod
     async def _enqueue_execution(cls, execution: TaskExecution) -> TaskExecution:

--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -1,8 +1,11 @@
 """Task Store — SQLite persistence for scheduler/execution domain."""
 
+import asyncio
 import json
 import os
+import sqlite3
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import aiosqlite
@@ -34,6 +37,11 @@ class TaskStore:
     _init_pid: Optional[int] = None
 
     @classmethod
+    def get_db_path(cls) -> Path:
+        """Return the SQLite database path for task-center tables."""
+        return Storage.get_db_path().with_name("tasks.db")
+
+    @classmethod
     async def init(cls) -> None:
         current_pid = os.getpid()
         if cls._initialized and cls._init_pid == current_pid:
@@ -50,8 +58,10 @@ class TaskStore:
             cls._initialized = False
             cls._init_pid = None
         await Storage._ensure_init()
+        db_path = cls.get_db_path()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
         cls._conn = await aiosqlite.connect(
-            Storage._db_path,
+            db_path,
             timeout=Storage._sqlite_timeout_s,
         )
         await Storage.configure_connection(cls._conn)
@@ -59,6 +69,7 @@ class TaskStore:
         for stmt in _INDEX_STMTS:
             await cls._conn.execute(stmt)
         await cls._conn.commit()
+        await cls._migrate_task_tables_to_tasks_db()
         await cls._normalize_legacy_paused_executions()
         cls._initialized = True
         cls._init_pid = current_pid
@@ -89,6 +100,134 @@ class TaskStore:
     @classmethod
     async def raw_db(cls) -> aiosqlite.Connection:
         return await cls._db()
+
+    @staticmethod
+    def _quote_identifier(identifier: str) -> str:
+        return '"' + identifier.replace('"', '""') + '"'
+
+    @staticmethod
+    def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?",
+            (table_name,),
+        ).fetchone()
+        return row is not None
+
+    @staticmethod
+    def _table_columns(conn: sqlite3.Connection, table_name: str) -> list[str]:
+        rows = conn.execute(f"PRAGMA table_info({TaskStore._quote_identifier(table_name)})").fetchall()
+        return [str(row["name"]) for row in rows]
+
+    @classmethod
+    def _copy_task_table_sync(
+        cls,
+        source: sqlite3.Connection,
+        target: sqlite3.Connection,
+        table_name: str,
+    ) -> int:
+        if not cls._table_exists(source, table_name):
+            return 0
+        source_columns = cls._table_columns(source, table_name)
+        target_columns = set(cls._table_columns(target, table_name))
+        copy_columns = [column for column in source_columns if column in target_columns]
+        if not copy_columns:
+            return 0
+        quoted_columns = ", ".join(cls._quote_identifier(column) for column in copy_columns)
+        table_sql = cls._quote_identifier(table_name)
+        rows = source.execute(f"SELECT {quoted_columns} FROM {table_sql}").fetchall()
+        if not rows:
+            return 0
+        placeholders = ", ".join("?" for _ in copy_columns)
+        insert_sql = (
+            f"INSERT OR REPLACE INTO {table_sql} ({quoted_columns}) "
+            f"VALUES ({placeholders})"
+        )
+        target.executemany(
+            insert_sql,
+            [tuple(row[column] for column in copy_columns) for row in rows],
+        )
+        return len(rows)
+
+    @classmethod
+    def _copy_task_tables_to_tasks_db_sync(cls) -> tuple[int, int]:
+        source_path = Storage.get_db_path()
+        target_path = cls.get_db_path()
+        if not source_path.exists():
+            return 0, 0
+        source = Storage.connect_sync(source_path)
+        target = Storage.connect_sync(target_path)
+        try:
+            original_foreign_keys = target.execute("PRAGMA foreign_keys").fetchone()[0]
+            target.execute("PRAGMA foreign_keys = OFF")
+            total = 0
+            for table_name in (
+                "task_schedulers",
+                "task_executions",
+                "task_execution_queue_refs",
+            ):
+                total += cls._copy_task_table_sync(source, target, table_name)
+            target.commit()
+            foreign_key_violations = len(target.execute("PRAGMA foreign_key_check").fetchall())
+            target.execute(f"PRAGMA foreign_keys = {original_foreign_keys}")
+            return total, foreign_key_violations
+        except Exception:
+            if target.in_transaction:
+                target.rollback()
+            try:
+                target.execute("PRAGMA foreign_keys = ON")
+            except Exception:
+                pass
+            raise
+        finally:
+            source.close()
+            target.close()
+
+    @classmethod
+    async def _migrate_task_tables_to_tasks_db(cls) -> None:
+        marker = await asyncio.to_thread(Storage._read_multi_db_migration_marker_sync)
+        if marker.get("tasks_migrated") is True:
+            return
+
+        marker.setdefault("version", 1)
+        marker.setdefault("started_at", datetime.now(timezone.utc).isoformat())
+        marker["source_db"] = str(Storage.get_db_path())
+        marker["tasks_db"] = str(cls.get_db_path())
+        try:
+            migrated, foreign_key_violations = await asyncio.to_thread(
+                cls._copy_task_tables_to_tasks_db_sync
+            )
+            marker["tasks_migrated"] = True
+            marker["tasks_migrated_at"] = datetime.now(timezone.utc).isoformat()
+            marker["task_rows"] = migrated
+            marker["task_foreign_key_violations"] = foreign_key_violations
+            marker.pop("tasks_error", None)
+            await asyncio.to_thread(Storage._write_multi_db_migration_marker_sync, marker)
+            log.info("task.store.multi_db_migrated", {
+                "rows": migrated,
+                "foreign_key_violations": foreign_key_violations,
+                "source_db": marker["source_db"],
+                "tasks_db": marker["tasks_db"],
+            })
+            if foreign_key_violations:
+                log.warn("task.store.multi_db_migrated_with_legacy_fk_violations", {
+                    "foreign_key_violations": foreign_key_violations,
+                    "source_db": marker["source_db"],
+                    "tasks_db": marker["tasks_db"],
+                })
+        except Exception as exc:
+            marker["tasks_migrated"] = False
+            marker["tasks_error"] = str(exc)
+            marker["tasks_failed_at"] = datetime.now(timezone.utc).isoformat()
+            try:
+                await asyncio.to_thread(Storage._write_multi_db_migration_marker_sync, marker)
+            except Exception:
+                pass
+            log.error("task.store.multi_db_migration_failed", {
+                "source_db": marker.get("source_db"),
+                "tasks_db": marker.get("tasks_db"),
+                "error": str(exc),
+            })
+            raise
 
     # ------------------------------------------------------------------
     # Scheduler CRUD

--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -165,6 +165,8 @@ class TaskStore:
         source = Storage.connect_sync(source_path)
         target = Storage.connect_sync(target_path)
         try:
+            source.text_factory = cls._decode_legacy_text
+            target.text_factory = cls._decode_legacy_text
             original_foreign_keys = target.execute("PRAGMA foreign_keys").fetchone()[0]
             target.execute("PRAGMA foreign_keys = OFF")
             total = 0

--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -59,22 +59,33 @@ class TaskStore:
             cls._init_pid = None
         await Storage._ensure_init()
         db_path = cls.get_db_path()
+        db_existed_before_init = db_path.exists()
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        cls._conn = await aiosqlite.connect(
-            db_path,
-            timeout=Storage._sqlite_timeout_s,
-        )
-        cls._conn.text_factory = cls._decode_legacy_text
-        await Storage.configure_connection(cls._conn)
-        await cls._conn.executescript(_TASKS_DDL)
-        for stmt in _INDEX_STMTS:
-            await cls._conn.execute(stmt)
-        await cls._conn.commit()
-        await cls._migrate_task_tables_to_tasks_db()
-        await cls._normalize_legacy_paused_executions()
-        cls._initialized = True
-        cls._init_pid = current_pid
-        log.info("task.store.initialized")
+        try:
+            cls._conn = await aiosqlite.connect(
+                db_path,
+                timeout=Storage._sqlite_timeout_s,
+            )
+            cls._conn.text_factory = cls._decode_legacy_text
+            await Storage.configure_connection(cls._conn)
+            await cls._conn.executescript(_TASKS_DDL)
+            for stmt in _INDEX_STMTS:
+                await cls._conn.execute(stmt)
+            await cls._conn.commit()
+            await cls._migrate_task_tables_to_tasks_db(
+                tasks_db_existed_before_init=db_existed_before_init,
+            )
+            cls._initialized = True
+            cls._init_pid = current_pid
+            await cls._normalize_legacy_paused_executions()
+            log.info("task.store.initialized")
+        except Exception:
+            if cls._conn:
+                await cls._conn.close()
+            cls._conn = None
+            cls._initialized = False
+            cls._init_pid = None
+            raise
 
     @classmethod
     async def close(cls) -> None:
@@ -94,7 +105,7 @@ class TaskStore:
             and cls._init_pid != os.getpid()
         ):
             await cls.init()
-        if not cls._conn:
+        if not cls._conn or not cls._initialized:
             await cls.init()
         return cls._conn  # type: ignore[return-value]
 
@@ -132,58 +143,111 @@ class TaskStore:
         source: sqlite3.Connection,
         target: sqlite3.Connection,
         table_name: str,
-    ) -> int:
+    ) -> tuple[int, list[str]]:
         if not cls._table_exists(source, table_name):
-            return 0
+            return 0, []
         source_columns = cls._table_columns(source, table_name)
         target_columns = set(cls._table_columns(target, table_name))
         copy_columns = [column for column in source_columns if column in target_columns]
-        if not copy_columns:
-            return 0
+        if not copy_columns or "id" not in copy_columns:
+            return 0, []
         quoted_columns = ", ".join(cls._quote_identifier(column) for column in copy_columns)
         table_sql = cls._quote_identifier(table_name)
-        rows = source.execute(f"SELECT {quoted_columns} FROM {table_sql}").fetchall()
-        if not rows:
-            return 0
         placeholders = ", ".join("?" for _ in copy_columns)
         insert_sql = (
             f"INSERT OR REPLACE INTO {table_sql} ({quoted_columns}) "
             f"VALUES ({placeholders})"
         )
-        target.executemany(
-            insert_sql,
-            [tuple(row[column] for column in copy_columns) for row in rows],
-        )
-        return len(rows)
+        copied = 0
+        copied_ids: list[str] = []
+        last_rowid = 0
+        while True:
+            rows = source.execute(
+                f"""
+                SELECT rowid AS __rowid, {quoted_columns}
+                FROM {table_sql}
+                WHERE rowid > ?
+                ORDER BY rowid
+                LIMIT ?
+                """,
+                (last_rowid, Storage._multi_db_migration_batch_size),
+            ).fetchall()
+            if not rows:
+                break
+
+            target.executemany(
+                insert_sql,
+                [tuple(row[column] for column in copy_columns) for row in rows],
+            )
+            ids = [str(row["id"]) for row in rows]
+            placeholders = ", ".join("?" for _ in ids)
+            verified = target.execute(
+                f"SELECT COUNT(*) FROM {table_sql} WHERE id IN ({placeholders})",
+                ids,
+            ).fetchone()[0]
+            if verified != len(ids):
+                raise RuntimeError(
+                    f"Task table migration verification failed for {table_name}: "
+                    f"expected {len(ids)} copied rows, got {verified}"
+                )
+
+            copied += len(rows)
+            copied_ids.extend(ids)
+            last_rowid = int(rows[-1]["__rowid"])
+
+        return copied, copied_ids
 
     @classmethod
-    def _copy_task_tables_to_tasks_db_sync(cls) -> tuple[int, int]:
+    def _copy_task_tables_to_tasks_db_sync(cls) -> tuple[int, int, int]:
         source_path = Storage.get_db_path()
         target_path = cls.get_db_path()
         if not source_path.exists():
-            return 0, 0
+            return 0, 0, 0
         source = Storage.connect_sync(source_path)
         target = Storage.connect_sync(target_path)
         try:
             source.text_factory = cls._decode_legacy_text
             target.text_factory = cls._decode_legacy_text
+            source.execute("PRAGMA foreign_keys = OFF")
             original_foreign_keys = target.execute("PRAGMA foreign_keys").fetchone()[0]
             target.execute("PRAGMA foreign_keys = OFF")
             total = 0
+            copied_ids_by_table: dict[str, list[str]] = {}
             for table_name in (
                 "task_schedulers",
                 "task_executions",
                 "task_execution_queue_refs",
             ):
-                total += cls._copy_task_table_sync(source, target, table_name)
+                copied, copied_ids = cls._copy_task_table_sync(source, target, table_name)
+                total += copied
+                copied_ids_by_table[table_name] = copied_ids
             target.commit()
             foreign_key_violations = len(target.execute("PRAGMA foreign_key_check").fetchall())
             target.execute(f"PRAGMA foreign_keys = {original_foreign_keys}")
-            return total, foreign_key_violations
+
+            deleted = 0
+            for table_name in (
+                "task_execution_queue_refs",
+                "task_executions",
+                "task_schedulers",
+            ):
+                table_sql = cls._quote_identifier(table_name)
+                for row_id in copied_ids_by_table.get(table_name, []):
+                    cursor = source.execute(
+                        f"DELETE FROM {table_sql} WHERE id = ?",
+                        (row_id,),
+                    )
+                    if cursor.rowcount > 0:
+                        deleted += cursor.rowcount
+            source.commit()
+            return total, foreign_key_violations, deleted
         except Exception:
+            if source.in_transaction:
+                source.rollback()
             if target.in_transaction:
                 target.rollback()
             try:
+                source.execute("PRAGMA foreign_keys = ON")
                 target.execute("PRAGMA foreign_keys = ON")
             except Exception:
                 pass
@@ -193,9 +257,20 @@ class TaskStore:
             target.close()
 
     @classmethod
-    async def _migrate_task_tables_to_tasks_db(cls) -> None:
+    async def _migrate_task_tables_to_tasks_db(
+        cls,
+        *,
+        tasks_db_existed_before_init: bool,
+    ) -> None:
         marker = await asyncio.to_thread(Storage._read_multi_db_migration_marker_sync)
         if marker.get("tasks_migrated") is True:
+            if (
+                not tasks_db_existed_before_init
+                and Storage._marker_row_count(marker, "task_rows") > 0
+            ):
+                raise RuntimeError(
+                    "tasks.db is missing after a completed multi-db migration"
+                )
             return
 
         marker.setdefault("version", 1)
@@ -203,17 +278,19 @@ class TaskStore:
         marker["source_db"] = str(Storage.get_db_path())
         marker["tasks_db"] = str(cls.get_db_path())
         try:
-            migrated, foreign_key_violations = await asyncio.to_thread(
+            migrated, foreign_key_violations, deleted = await asyncio.to_thread(
                 cls._copy_task_tables_to_tasks_db_sync
             )
             marker["tasks_migrated"] = True
             marker["tasks_migrated_at"] = datetime.now(timezone.utc).isoformat()
             marker["task_rows"] = migrated
             marker["task_foreign_key_violations"] = foreign_key_violations
+            marker["task_source_rows_deleted"] = deleted
             marker.pop("tasks_error", None)
             await asyncio.to_thread(Storage._write_multi_db_migration_marker_sync, marker)
             log.info("task.store.multi_db_migrated", {
                 "rows": migrated,
+                "source_rows_deleted": deleted,
                 "foreign_key_violations": foreign_key_violations,
                 "source_db": marker["source_db"],
                 "tasks_db": marker["tasks_db"],

--- a/flocks/workflow/execution_store.py
+++ b/flocks/workflow/execution_store.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import re
 import time
 import uuid
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 from flocks.session.recorder import Recorder
 from flocks.storage.storage import Storage
@@ -203,16 +202,10 @@ def derive_loop_progress(
 # Keep this intentionally small so high-frequency workflows do not keep
 # inflating the SQLite row set and matching JSONL audit files indefinitely.
 _MAX_EXECUTION_HISTORY_PER_WORKFLOW = 30
-# Trim is an O(N) scan over all workflow_execution rows; only run it every Nth
-# call per workflow to amortise the cost under high syslog throughput.
-_TRIM_CHECK_INTERVAL = 5
-_trim_counters: Dict[str, int] = {}
-# Workflows with an in-flight trim task.  Because trims run as fire-and-forget
-# ``asyncio.create_task`` background jobs, a slow trim under high syslog load
-# could otherwise spawn many overlapping scans that each materialise table
-# state simultaneously — the exact pattern that drove RSS to 20 GB.  This
-# guard ensures at most one trim per workflow is ever running.
-_trim_in_flight: Set[str] = set()
+# Per-workflow trim lock.  Trims are awaited by the writer so the retention cap
+# is enforced before ``record_execution_result`` returns, while concurrent runs
+# for the same workflow serialize instead of skipping cleanup.
+_trim_locks: Dict[str, asyncio.Lock] = {}
 
 # Per-workflow lock to serialize read-modify-write of stats. Concurrent
 # executions of the same workflow (e.g. syslog-triggered runs with
@@ -231,6 +224,14 @@ def _get_stats_lock(workflow_id: str) -> asyncio.Lock:
 
 def _workflow_stats_key(workflow_id: str) -> str:
     return f"workflow/{workflow_id}/stats"
+
+
+def _get_trim_lock(workflow_id: str) -> asyncio.Lock:
+    lock = _trim_locks.get(workflow_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _trim_locks[workflow_id] = lock
+    return lock
 
 
 _DEFAULT_STATS: Dict[str, Any] = {
@@ -278,6 +279,20 @@ async def _update_workflow_stats(workflow_id: str, success: bool, duration: floa
 def workflow_execution_key(exec_id: str) -> str:
     """Return the storage key for one workflow execution."""
     return f"workflow_execution/{exec_id}"
+
+
+def workflow_execution_index_prefix(workflow_id: str) -> str:
+    """Return the storage prefix for one workflow's execution index."""
+    return f"workflow_execution_index/{workflow_id}/"
+
+
+def workflow_execution_index_key(
+    workflow_id: str,
+    started_at: int,
+    exec_id: str,
+) -> str:
+    """Return the index key used to trim one workflow without full-table scans."""
+    return f"{workflow_execution_index_prefix(workflow_id)}{started_at:020d}/{exec_id}"
 
 
 def workflow_execution_step_key(exec_id: str, step_index: int) -> str:
@@ -495,7 +510,14 @@ async def create_execution_record(
         input_params=compacted_params,
         exec_id=exec_id,
     )
-    await Storage.write(workflow_execution_key(exec_data["id"]), compact_execution_summary(exec_data))
+    exec_key = workflow_execution_key(exec_data["id"])
+    await Storage.write(exec_key, compact_execution_summary(exec_data))
+    await _write_execution_index(
+        workflow_id=workflow_id,
+        exec_id=str(exec_data["id"]),
+        execution_key=exec_key,
+        started_at=int(exec_data.get("startedAt") or 0),
+    )
     return exec_data
 
 
@@ -512,6 +534,12 @@ async def record_execution_result(
         summary_data["stepCount"] = backfilled_steps
 
     await Storage.write(workflow_execution_key(exec_id), compact_execution_summary(summary_data))
+    await _write_execution_index(
+        workflow_id=workflow_id,
+        exec_id=exec_id,
+        execution_key=workflow_execution_key(exec_id),
+        started_at=int(summary_data.get("startedAt") or 0),
+    )
 
     # Update call/success/error counters so all trigger paths (HTTP, syslog, etc.)
     # are reflected in the UI stats panel.
@@ -554,78 +582,113 @@ async def record_execution_result(
             pass
 
     # Prune old execution records when the per-workflow limit is exceeded.
-    # Throttled by a per-workflow counter to amortise the O(N) storage scan.
+    # This is awaited so a successful completion does not silently leave the
+    # workflow above its retention cap.
     try:
-        counter = _trim_counters.get(workflow_id, 0) + 1
-        _trim_counters[workflow_id] = counter
-        if counter >= _TRIM_CHECK_INTERVAL:
-            _trim_counters[workflow_id] = 0
-            # Run trim in the background as well; it scans all execution rows
-            # and we don't want to delay the caller.
-            try:
-                asyncio.create_task(
-                    _trim_execution_history(workflow_id),
-                    name=f"trim-{workflow_id}",
-                )
-            except RuntimeError:
-                await _trim_execution_history(workflow_id)
-    except Exception:
-        pass
+        await _trim_execution_history(workflow_id)
+    except Exception as exc:
+        log.error("workflow.history.trim_failed", {
+            "workflow_id": workflow_id,
+            "exec_id": exec_id,
+            "error": str(exc),
+        })
 
 
-# Regex patterns to extract scalar fields from raw JSON strings without
-# calling json.loads.  workflowId/startedAt are always serialised near the
-# start of the record (set in build_initial_execution_record), so we only
-# scan a small prefix of each value string — O(prefix) instead of O(value).
-_RE_WORKFLOW_ID = re.compile(r'"workflowId"\s*:\s*"([^"]+)"')
-_RE_STARTED_AT = re.compile(r'"startedAt"\s*:\s*(\d+)')
+async def _write_execution_index(
+    *,
+    workflow_id: str,
+    exec_id: str,
+    execution_key: str,
+    started_at: int,
+) -> str:
+    index_key = workflow_execution_index_key(workflow_id, started_at, exec_id)
+    await Storage.write(
+        index_key,
+        {
+            "workflowId": workflow_id,
+            "execId": exec_id,
+            "executionKey": execution_key,
+            "startedAt": started_at,
+        },
+    )
+    return index_key
+
+
+async def _list_workflow_execution_entries(
+    workflow_id: str,
+) -> List[Tuple[str, int, Optional[str]]]:
+    """Return indexed ``(execution_key, started_at, index_key)`` rows for one workflow."""
+    indexed_rows = await Storage.list_entries(workflow_execution_index_prefix(workflow_id))
+    entries: List[Tuple[str, int, Optional[str]]] = []
+    for index_key, value in indexed_rows:
+        if not isinstance(value, dict):
+            continue
+        exec_key = value.get("executionKey")
+        exec_id = value.get("execId")
+        if not isinstance(exec_key, str) and isinstance(exec_id, str):
+            exec_key = workflow_execution_key(exec_id)
+        if not isinstance(exec_key, str):
+            continue
+        started_at = _as_positive_int(value.get("startedAt")) or 0
+        entries.append((exec_key, started_at, index_key))
+    return entries
+
+
+async def _delete_execution_history_record(
+    execution_key: str,
+    *,
+    index_key: Optional[str] = None,
+) -> None:
+    exec_id = execution_key.rsplit("/", 1)[-1]
+    deleted_steps = await Storage.clear(workflow_execution_step_prefix(exec_id))
+    removed_execution = await Storage.remove(execution_key)
+    if index_key:
+        await Storage.remove(index_key)
+    record_path = Recorder.paths().workflow_dir / f"{exec_id}.jsonl"
+    await asyncio.to_thread(record_path.unlink, missing_ok=True)
+    log.debug("workflow.history.trim_deleted", {
+        "exec_id": exec_id,
+        "execution_key": execution_key,
+        "steps": deleted_steps,
+        "removed_execution": removed_execution,
+    })
 
 
 async def _trim_execution_history(workflow_id: str) -> None:
     """Delete the oldest execution records once the per-workflow cap is exceeded.
 
-    Uses ``Storage.list_raw`` + regex instead of ``list_entries`` + ``json.loads``
-    so that scanning the execution-history table never materialises large JSON
-    blobs as Python objects.  The previous approach caused 100% single-core CPU
-    usage (``json.raw_decode``) and drove RSS to 20 GB under syslog load.
+    New records carry a per-workflow ``workflow_execution_index`` key, so hot
+    trims avoid scanning unrelated workflows.  This path is intentionally
+    index-only: if an old execution has no index key, it is outside the hot
+    retention path and should be handled by a separate migration/GC task.
 
-    Also guards against overlapping trim tasks via ``_trim_in_flight``: because
-    trims run as fire-and-forget background tasks, without the guard a slow trim
-    would spawn multiple concurrent scans that each load the full table
-    simultaneously, multiplying the memory spike.
+    A per-workflow lock serializes concurrent trims.  Cleanup is awaited by
+    ``record_execution_result`` so the retention cap is enforced synchronously
+    instead of being an opportunistic background task.
     """
-    # Coalesce overlapping trims: only one scan per workflow at a time.
-    if workflow_id in _trim_in_flight:
-        return
-    _trim_in_flight.add(workflow_id)
-    try:
-        raw_rows = await Storage.list_raw("workflow_execution/")
-        wf_entries: List[tuple] = []
-        for key, value_str in raw_rows:
-            # Scan only the first 400 chars — enough for workflowId + startedAt.
-            head = value_str[:400]
-            m_wf = _RE_WORKFLOW_ID.search(head)
-            if not m_wf or m_wf.group(1) != workflow_id:
-                continue
-            m_ts = _RE_STARTED_AT.search(head)
-            started_at = int(m_ts.group(1)) if m_ts else 0
-            wf_entries.append((key, started_at))
-
+    lock = _get_trim_lock(workflow_id)
+    async with lock:
+        wf_entries = await _list_workflow_execution_entries(workflow_id)
         if len(wf_entries) <= _MAX_EXECUTION_HISTORY_PER_WORKFLOW:
             return
+
         # Sort ascending by startedAt and remove the oldest excess records.
         wf_entries.sort(key=lambda kd: kd[1])
         excess = len(wf_entries) - _MAX_EXECUTION_HISTORY_PER_WORKFLOW
-        for key, _ in wf_entries[:excess]:
+        failures: List[str] = []
+        for key, _started_at, index_key in wf_entries[:excess]:
             try:
-                exec_id = key.rsplit("/", 1)[-1]
-                await Storage.remove(key)
-                step_rows = await Storage.list_raw(workflow_execution_step_prefix(exec_id))
-                for step_key, _value in step_rows:
-                    await Storage.remove(step_key)
-                record_path = Recorder.paths().workflow_dir / f"{exec_id}.jsonl"
-                await asyncio.to_thread(record_path.unlink, missing_ok=True)
-            except Exception:
-                pass
-    finally:
-        _trim_in_flight.discard(workflow_id)
+                await _delete_execution_history_record(key, index_key=index_key)
+            except Exception as exc:
+                failures.append(f"{key}: {exc}")
+                log.warning("workflow.history.trim_delete_failed", {
+                    "workflow_id": workflow_id,
+                    "key": key,
+                    "error": str(exc),
+                })
+
+        if failures:
+            raise RuntimeError(
+                "Failed to trim workflow execution history: "
+                + "; ".join(failures[:3])
+            )

--- a/tests/server/routes/test_workflow_trigger_routes.py
+++ b/tests/server/routes/test_workflow_trigger_routes.py
@@ -519,6 +519,8 @@ async def test_delete_workflow_cleans_directory_and_storage(
         f"workflow_release/{workflow_id}/active",
         f"workflow_release/{workflow_id}/rel-1",
         workflow_routes._workflow_execution_key("exec-delete"),
+        "workflow_execution_step/exec-delete/00000001",
+        f"workflow_execution_index/{workflow_id}/00000000000000000001/exec-delete",
     ]
     for key in storage_keys:
         payload = {"workflowId": workflow_id}

--- a/tests/storage/test_multi_db_routing.py
+++ b/tests/storage/test_multi_db_routing.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from flocks.config.config import Config
+from flocks.storage.storage import Storage
+from flocks.task.models import TaskExecution, TaskScheduler
+from flocks.task.store import TaskStore, _TASKS_DDL
+
+
+def _reset_state() -> None:
+    Config._global_config = None
+    Config._cached_config = None
+    Storage._db_path = None
+    Storage._initialized = False
+    Storage._init_pid = None
+    TaskStore._initialized = False
+    TaskStore._conn = None
+    TaskStore._init_pid = None
+
+
+def _fetch_storage_value(db_path: Path, key: str):
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT value FROM storage WHERE key = ?",
+            (key,),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+async def isolated_multi_db_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    data_dir = tmp_path / "flocks_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("FLOCKS_DATA_DIR", str(data_dir))
+    _reset_state()
+    yield
+    await TaskStore.close()
+    _reset_state()
+
+
+@pytest.mark.asyncio
+async def test_workflow_keys_route_to_workflow_db() -> None:
+    await Storage.init()
+
+    await Storage.write("workflow/wf-1", {"name": "workflow"})
+    await Storage.write("project/proj-1", {"name": "project"})
+
+    flocks_db = Storage.get_db_path()
+    workflow_db = Storage.get_workflow_db_path()
+
+    assert _fetch_storage_value(workflow_db, "workflow/wf-1") is not None
+    assert _fetch_storage_value(flocks_db, "workflow/wf-1") is None
+    assert _fetch_storage_value(flocks_db, "project/proj-1") is not None
+    assert _fetch_storage_value(workflow_db, "project/proj-1") is None
+    assert await Storage.read("workflow/wf-1") == {"name": "workflow"}
+    assert await Storage.list_keys("workflow") == ["workflow/wf-1"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_kv_migrates_from_legacy_flocks_db() -> None:
+    flocks_db = Config.get_data_path() / "flocks.db"
+    flocks_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(flocks_db)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE storage (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                type TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+            ("workflow_registry/wf-legacy", '{"ok": true}', "json", "old", "old"),
+        )
+        conn.execute(
+            "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+            ("session:legacy", '{"ok": false}', "json", "old", "old"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    await Storage.init()
+
+    workflow_db = Storage.get_workflow_db_path()
+    assert _fetch_storage_value(workflow_db, "workflow_registry/wf-legacy") == '{"ok": true}'
+    assert _fetch_storage_value(flocks_db, "workflow_registry/wf-legacy") == '{"ok": true}'
+    assert _fetch_storage_value(workflow_db, "session:legacy") is None
+    marker = await Storage.get(Storage._multi_db_migration_marker_key)
+    assert marker["workflow_migrated"] is True
+    assert marker["workflow_rows"] == 1
+
+
+@pytest.mark.asyncio
+async def test_task_store_uses_tasks_db_and_migrates_existing_task_tables() -> None:
+    await Storage.init()
+    flocks_db = Storage.get_db_path()
+    conn = sqlite3.connect(flocks_db)
+    try:
+        conn.executescript(_TASKS_DDL)
+        legacy_scheduler = TaskScheduler(title="legacy task")
+        conn.execute(
+            """
+            INSERT INTO task_schedulers
+            (id, title, description, mode, status, priority, source, trigger,
+             execution_mode, agent_name, workflow_id, skills, category, context,
+             workspace_directory, retry, tags, created_at, updated_at, created_by, dedup_key)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            TaskStore._scheduler_to_row(legacy_scheduler),
+        )
+        legacy_orphan_execution = TaskExecution(
+            schedulerID="missing-legacy-scheduler",
+            title="legacy orphan execution",
+        )
+        conn.execute(
+            """
+            INSERT INTO task_executions
+            (id, scheduler_id, title, description, priority, source, trigger_type,
+             status, delivery_status, queued_at, started_at, completed_at, duration_ms,
+             session_id, result_summary, error, execution_input_snapshot,
+             workspace_directory, retry, execution_mode, agent_name, workflow_id,
+             created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            TaskStore._execution_to_row(legacy_orphan_execution),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    await TaskStore.init()
+
+    tasks_db = TaskStore.get_db_path()
+    conn = sqlite3.connect(tasks_db)
+    try:
+        row = conn.execute(
+            "SELECT title FROM task_schedulers WHERE id = ?",
+            (legacy_scheduler.id,),
+        ).fetchone()
+        orphan_row = conn.execute(
+            "SELECT title FROM task_executions WHERE id = ?",
+            (legacy_orphan_execution.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "legacy task"
+    assert orphan_row[0] == "legacy orphan execution"
+
+    new_scheduler = TaskScheduler(title="new task")
+    await TaskStore.create_scheduler(new_scheduler)
+    assert await TaskStore.get_scheduler(new_scheduler.id) is not None
+
+    conn = sqlite3.connect(flocks_db)
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM task_schedulers WHERE id = ?",
+            (new_scheduler.id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is None
+
+    marker = await Storage.get(Storage._multi_db_migration_marker_key)
+    assert marker["tasks_migrated"] is True
+    assert marker["task_rows"] == 2
+    assert marker["task_foreign_key_violations"] == 1
+
+    await TaskStore.close()
+    TaskStore._initialized = False
+    await TaskStore.init()
+    conn = sqlite3.connect(tasks_db)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM task_schedulers").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 2

--- a/tests/storage/test_multi_db_routing.py
+++ b/tests/storage/test_multi_db_routing.py
@@ -64,6 +64,28 @@ async def test_workflow_keys_route_to_workflow_db() -> None:
 
 
 @pytest.mark.asyncio
+async def test_short_non_workflow_prefix_stays_on_flocks_db() -> None:
+    await Storage.init()
+
+    await Storage.write("workspace/item-1", {"name": "workspace"})
+    await Storage.write("workflow/item-1", {"name": "workflow"})
+
+    assert await Storage.list_keys("work") == ["workspace/item-1"]
+
+
+@pytest.mark.asyncio
+async def test_clear_without_prefix_clears_flocks_and_workflow_dbs() -> None:
+    await Storage.init()
+
+    await Storage.write("project/proj-1", {"name": "project"})
+    await Storage.write("workflow/wf-1", {"name": "workflow"})
+
+    assert await Storage.clear() == 2
+    assert await Storage.read("project/proj-1") is None
+    assert await Storage.read("workflow/wf-1") is None
+
+
+@pytest.mark.asyncio
 async def test_workflow_kv_migrates_from_legacy_flocks_db() -> None:
     flocks_db = Config.get_data_path() / "flocks.db"
     flocks_db.parent.mkdir(parents=True, exist_ok=True)
@@ -125,6 +147,10 @@ async def test_task_store_uses_tasks_db_and_migrates_existing_task_tables() -> N
             schedulerID="missing-legacy-scheduler",
             title="legacy orphan execution",
         )
+        legacy_non_utf8_execution = TaskExecution(
+            schedulerID=legacy_scheduler.id,
+            title="legacy non-utf8 execution",
+        )
         conn.execute(
             """
             INSERT INTO task_executions
@@ -136,6 +162,22 @@ async def test_task_store_uses_tasks_db_and_migrates_existing_task_tables() -> N
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             TaskStore._execution_to_row(legacy_orphan_execution),
+        )
+        conn.execute(
+            """
+            INSERT INTO task_executions
+            (id, scheduler_id, title, description, priority, source, trigger_type,
+             status, delivery_status, queued_at, started_at, completed_at, duration_ms,
+             session_id, result_summary, error, execution_input_snapshot,
+             workspace_directory, retry, execution_mode, agent_name, workflow_id,
+             created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            TaskStore._execution_to_row(legacy_non_utf8_execution),
+        )
+        conn.execute(
+            "UPDATE task_executions SET description = CAST(? AS TEXT) WHERE id = ?",
+            ("扫描 Windows 主机 192.168.254.1".encode("gbk"), legacy_non_utf8_execution.id),
         )
         conn.commit()
     finally:
@@ -154,10 +196,15 @@ async def test_task_store_uses_tasks_db_and_migrates_existing_task_tables() -> N
             "SELECT title FROM task_executions WHERE id = ?",
             (legacy_orphan_execution.id,),
         ).fetchone()
+        non_utf8_row = conn.execute(
+            "SELECT description FROM task_executions WHERE id = ?",
+            (legacy_non_utf8_execution.id,),
+        ).fetchone()
     finally:
         conn.close()
     assert row[0] == "legacy task"
     assert orphan_row[0] == "legacy orphan execution"
+    assert non_utf8_row[0] == "扫描 Windows 主机 192.168.254.1"
 
     new_scheduler = TaskScheduler(title="new task")
     await TaskStore.create_scheduler(new_scheduler)
@@ -175,7 +222,7 @@ async def test_task_store_uses_tasks_db_and_migrates_existing_task_tables() -> N
 
     marker = await Storage.get(Storage._multi_db_migration_marker_key)
     assert marker["tasks_migrated"] is True
-    assert marker["task_rows"] == 2
+    assert marker["task_rows"] == 3
     assert marker["task_foreign_key_violations"] == 1
 
     await TaskStore.close()

--- a/tests/storage/test_multi_db_routing.py
+++ b/tests/storage/test_multi_db_routing.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from flocks.config.config import Config
-from flocks.storage.storage import Storage
+from flocks.storage.storage import Storage, StorageError
 from flocks.task.models import TaskExecution, TaskScheduler
 from flocks.task.store import TaskStore, _TASKS_DDL
 
@@ -30,6 +30,14 @@ def _fetch_storage_value(db_path: Path, key: str):
             (key,),
         ).fetchone()
         return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _fetch_table_count(db_path: Path, table_name: str) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]
     finally:
         conn.close()
 
@@ -86,6 +94,24 @@ async def test_clear_without_prefix_clears_flocks_and_workflow_dbs() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_without_prefix_merges_flocks_and_workflow_dbs() -> None:
+    await Storage.init()
+
+    await Storage.write("project/proj-1", {"name": "project"})
+    await Storage.write("workflow/wf-1", {"name": "workflow"})
+
+    keys = await Storage.list_keys()
+    entries = dict(await Storage.list_entries())
+    raw_entries = dict(await Storage.list_raw())
+
+    assert {"project/proj-1", "workflow/wf-1"}.issubset(set(keys))
+    assert entries["project/proj-1"] == {"name": "project"}
+    assert entries["workflow/wf-1"] == {"name": "workflow"}
+    assert raw_entries["project/proj-1"] == '{"name": "project"}'
+    assert raw_entries["workflow/wf-1"] == '{"name": "workflow"}'
+
+
+@pytest.mark.asyncio
 async def test_workflow_kv_migrates_from_legacy_flocks_db() -> None:
     flocks_db = Config.get_data_path() / "flocks.db"
     flocks_db.parent.mkdir(parents=True, exist_ok=True)
@@ -118,11 +144,85 @@ async def test_workflow_kv_migrates_from_legacy_flocks_db() -> None:
 
     workflow_db = Storage.get_workflow_db_path()
     assert _fetch_storage_value(workflow_db, "workflow_registry/wf-legacy") == '{"ok": true}'
-    assert _fetch_storage_value(flocks_db, "workflow_registry/wf-legacy") == '{"ok": true}'
+    assert _fetch_storage_value(flocks_db, "workflow_registry/wf-legacy") is None
     assert _fetch_storage_value(workflow_db, "session:legacy") is None
     marker = await Storage.get(Storage._multi_db_migration_marker_key)
     assert marker["workflow_migrated"] is True
     assert marker["workflow_rows"] == 1
+    assert marker["workflow_source_rows_deleted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_workflow_prefix_migration_treats_underscore_literally() -> None:
+    flocks_db = Config.get_data_path() / "flocks.db"
+    flocks_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(flocks_db)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE storage (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                type TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+            ("workflow_registry/wf-ok", '{"ok": true}', "json", "old", "old"),
+        )
+        conn.execute(
+            "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+            ("workflowXregistry/wf-bad", '{"bad": true}', "json", "old", "old"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    await Storage.init()
+
+    workflow_db = Storage.get_workflow_db_path()
+    assert _fetch_storage_value(workflow_db, "workflow_registry/wf-ok") == '{"ok": true}'
+    assert _fetch_storage_value(workflow_db, "workflowXregistry/wf-bad") is None
+    assert _fetch_storage_value(flocks_db, "workflowXregistry/wf-bad") == '{"bad": true}'
+    assert await Storage.list_keys("workflow_registry/") == ["workflow_registry/wf-ok"]
+
+
+@pytest.mark.asyncio
+async def test_completed_workflow_migration_fails_if_workflow_db_disappears() -> None:
+    flocks_db = Config.get_data_path() / "flocks.db"
+    flocks_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(flocks_db)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE storage (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                type TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+            ("workflow/wf-legacy", '{"ok": true}', "json", "old", "old"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    await Storage.init()
+    workflow_db = Storage.get_workflow_db_path()
+    assert workflow_db.exists()
+    workflow_db.unlink()
+    _reset_state()
+
+    with pytest.raises(StorageError, match="workflow.db is missing"):
+        await Storage.init()
 
 
 @pytest.mark.asyncio
@@ -224,6 +324,9 @@ async def test_task_store_uses_tasks_db_and_migrates_existing_task_tables() -> N
     assert marker["tasks_migrated"] is True
     assert marker["task_rows"] == 3
     assert marker["task_foreign_key_violations"] == 1
+    assert marker["task_source_rows_deleted"] == 3
+    assert _fetch_table_count(flocks_db, "task_schedulers") == 0
+    assert _fetch_table_count(flocks_db, "task_executions") == 0
 
     await TaskStore.close()
     TaskStore._initialized = False
@@ -234,3 +337,58 @@ async def test_task_store_uses_tasks_db_and_migrates_existing_task_tables() -> N
     finally:
         conn.close()
     assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_completed_task_migration_fails_if_tasks_db_disappears() -> None:
+    await Storage.init()
+    flocks_db = Storage.get_db_path()
+    conn = sqlite3.connect(flocks_db)
+    try:
+        conn.executescript(_TASKS_DDL)
+        legacy_scheduler = TaskScheduler(title="legacy task")
+        conn.execute(
+            """
+            INSERT INTO task_schedulers
+            (id, title, description, mode, status, priority, source, trigger,
+             execution_mode, agent_name, workflow_id, skills, category, context,
+             workspace_directory, retry, tags, created_at, updated_at, created_by, dedup_key)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            TaskStore._scheduler_to_row(legacy_scheduler),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    await TaskStore.init()
+    tasks_db = TaskStore.get_db_path()
+    assert tasks_db.exists()
+    await TaskStore.close()
+    tasks_db.unlink()
+    _reset_state()
+
+    with pytest.raises(RuntimeError, match="tasks.db is missing"):
+        await TaskStore.init()
+
+
+@pytest.mark.asyncio
+async def test_task_store_init_failure_clears_half_open_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await Storage.init()
+
+    async def fail_migration(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        TaskStore,
+        "_migrate_task_tables_to_tasks_db",
+        classmethod(fail_migration),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await TaskStore.init()
+
+    assert TaskStore._conn is None
+    assert TaskStore._initialized is False

--- a/tests/workflow/test_execution_store_compact.py
+++ b/tests/workflow/test_execution_store_compact.py
@@ -16,8 +16,6 @@ stripping legitimately small metadata lists.
 """
 
 from __future__ import annotations
-
-import json
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, patch
 
@@ -31,6 +29,8 @@ from flocks.workflow.execution_store import (
     compact_outputs_for_storage,
     compact_step_for_storage,
     record_execution_result,
+    workflow_execution_index_key,
+    workflow_execution_step_prefix,
     workflow_execution_step_key,
 )
 from flocks.storage.storage import Storage
@@ -307,6 +307,7 @@ async def test_record_execution_result_backfills_execution_log_steps() -> None:
     assert write_calls[2].args[0] == "workflow_execution/exec-1"
     assert write_calls[2].args[1]["executionLog"] == []
     assert write_calls[2].args[1]["stepCount"] == 2
+    assert write_calls[3].args[0].startswith("workflow_execution_index/wf/")
 
 
 def test_compact_history_compacts_each_step_inputs() -> None:
@@ -397,14 +398,16 @@ async def test_trim_execution_history_keeps_only_30_and_deletes_matching_jsonl(
     tmp_path,
 ) -> None:
     workflow_id = "wf-trim"
-    entries = []
+    indexed_rows = []
     for idx in range(32):
         exec_id = f"exec-{idx:02d}"
-        entries.append((
-            f"workflow_execution/{exec_id}",
+        index_key = workflow_execution_index_key(workflow_id, idx, exec_id)
+        indexed_rows.append((
+            index_key,
             {
-                "id": exec_id,
                 "workflowId": workflow_id,
+                "execId": exec_id,
+                "executionKey": f"workflow_execution/{exec_id}",
                 "startedAt": idx,
             },
         ))
@@ -412,34 +415,101 @@ async def test_trim_execution_history_keeps_only_30_and_deletes_matching_jsonl(
         workflow_record.parent.mkdir(parents=True, exist_ok=True)
         workflow_record.write_text('{"type":"workflow.summary"}\n', encoding="utf-8")
 
-    # Another workflow's record should be ignored entirely.
-    entries.append((
-        "workflow_execution/other-exec",
-        {"id": "other-exec", "workflowId": "wf-other", "startedAt": 0},
-    ))
+    # Another workflow's record should be ignored entirely because the trim
+    # only reads workflow_execution_index/<workflow_id>/.
     other_record = tmp_path / "workflow" / "other-exec.jsonl"
     other_record.parent.mkdir(parents=True, exist_ok=True)
     other_record.write_text('{"type":"workflow.summary"}\n', encoding="utf-8")
 
     remove_mock = AsyncMock(return_value=None)
-    raw_entries = [(key, json.dumps(value)) for key, value in entries]
+    clear_mock = AsyncMock(return_value=2)
+    list_raw_mock = AsyncMock(return_value=[])
 
-    async def list_raw_side_effect(prefix: str):
-        if prefix == "workflow_execution/":
-            return raw_entries
-        return []
-
-    with patch.object(Storage, "list_raw", AsyncMock(side_effect=list_raw_side_effect)), \
+    with patch.object(Storage, "list_entries", AsyncMock(return_value=indexed_rows)), \
+         patch.object(Storage, "list_raw", list_raw_mock), \
+         patch.object(Storage, "clear", clear_mock), \
          patch.object(Storage, "remove", remove_mock), \
          patch("flocks.session.recorder._record_dir", return_value=tmp_path):
         await _trim_execution_history(workflow_id)
 
+    list_raw_mock.assert_not_awaited()
     removed_keys = [call.args[0] for call in remove_mock.await_args_list]
-    assert removed_keys == [
-        "workflow_execution/exec-00",
-        "workflow_execution/exec-01",
+    assert "workflow_execution/exec-00" in removed_keys
+    assert "workflow_execution/exec-01" in removed_keys
+    assert workflow_execution_index_key(workflow_id, 0, "exec-00") in removed_keys
+    assert workflow_execution_index_key(workflow_id, 1, "exec-01") in removed_keys
+    cleared_prefixes = [call.args[0] for call in clear_mock.await_args_list]
+    assert cleared_prefixes == [
+        workflow_execution_step_prefix("exec-00"),
+        workflow_execution_step_prefix("exec-01"),
     ]
     assert not (tmp_path / "workflow" / "exec-00.jsonl").exists()
     assert not (tmp_path / "workflow" / "exec-01.jsonl").exists()
     assert (tmp_path / "workflow" / "exec-02.jsonl").exists()
     assert other_record.exists()
+
+
+@pytest.mark.asyncio
+async def test_trim_execution_history_uses_index_without_full_scan(tmp_path) -> None:
+    workflow_id = "wf-indexed"
+    indexed_rows = []
+    for idx in range(32):
+        exec_id = f"exec-{idx:02d}"
+        index_key = workflow_execution_index_key(workflow_id, idx, exec_id)
+        indexed_rows.append((
+            index_key,
+            {
+                "workflowId": workflow_id,
+                "execId": exec_id,
+                "executionKey": f"workflow_execution/{exec_id}",
+                "startedAt": idx,
+            },
+        ))
+        workflow_record = tmp_path / "workflow" / f"{exec_id}.jsonl"
+        workflow_record.parent.mkdir(parents=True, exist_ok=True)
+        workflow_record.write_text('{"type":"workflow.summary"}\n', encoding="utf-8")
+
+    list_raw_mock = AsyncMock(return_value=[])
+    clear_mock = AsyncMock(return_value=1)
+    remove_mock = AsyncMock(return_value=True)
+
+    with patch.object(Storage, "list_entries", AsyncMock(return_value=indexed_rows)), \
+         patch.object(Storage, "list_raw", list_raw_mock), \
+         patch.object(Storage, "clear", clear_mock), \
+         patch.object(Storage, "remove", remove_mock), \
+         patch("flocks.session.recorder._record_dir", return_value=tmp_path):
+        await _trim_execution_history(workflow_id)
+
+    list_raw_mock.assert_not_awaited()
+    assert [call.args[0] for call in clear_mock.await_args_list] == [
+        workflow_execution_step_prefix("exec-00"),
+        workflow_execution_step_prefix("exec-01"),
+    ]
+    removed = [call.args[0] for call in remove_mock.await_args_list]
+    assert "workflow_execution/exec-00" in removed
+    assert workflow_execution_index_key(workflow_id, 0, "exec-00") in removed
+
+
+@pytest.mark.asyncio
+async def test_trim_execution_history_surfaces_delete_failures() -> None:
+    workflow_id = "wf-trim-fail"
+    indexed_rows = [
+        (
+            workflow_execution_index_key(workflow_id, idx, f"exec-{idx:02d}"),
+            {
+                "workflowId": workflow_id,
+                "execId": f"exec-{idx:02d}",
+                "executionKey": f"workflow_execution/exec-{idx:02d}",
+                "startedAt": idx,
+            },
+        )
+        for idx in range(31)
+    ]
+    list_raw_mock = AsyncMock(return_value=[])
+
+    with patch.object(Storage, "list_entries", AsyncMock(return_value=indexed_rows)), \
+         patch.object(Storage, "list_raw", list_raw_mock), \
+         patch.object(Storage, "clear", AsyncMock(side_effect=RuntimeError("locked"))):
+        with pytest.raises(RuntimeError, match="Failed to trim workflow execution history"):
+            await _trim_execution_history(workflow_id)
+    list_raw_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary
- route workflow-domain Storage KV keys into workflow.db while keeping the existing Storage API
- move task-center tables into tasks.db and migrate legacy task tables automatically
- keep flocks.db as the core database and record multi-db migration status in storage.migration.multi_db.v1
- preserve legacy rows during migration, including historical task rows with FK inconsistencies

## Validation
- .venv/bin/python -m pytest tests/storage/test_multi_db_routing.py tests/storage/test_storage.py tests/task/test_task.py tests/workflow/test_execution_store_compact.py tests/server/routes/test_workflow_trigger_routes.py -q
- .venv/bin/python -m ruff check flocks/storage/storage.py flocks/task/store.py flocks/task/manager.py tests/storage/test_multi_db_routing.py
- git diff --check
- validated migration and routing against a copied real flocks.db snapshot with constructed workflow/task edge cases