### PR TITLE
[codex] Fix Pro install receipt release attribution

### DIFF
--- a/flocks/server/routes/console_upgrade.py
+++ b/flocks/server/routes/console_upgrade.py
@@ -316,6 +316,7 @@ def _enrich_record_from_install_marker(record: dict[str, Any]) -> dict[str, Any]
     details = record.setdefault("details", {})
     marker = _read_pro_bundle_install_marker()
     if marker:
+        details.setdefault("auto_install_release_id", marker.get("release_id") or marker.get("bundle_release_id"))
         details.setdefault("auto_install_version", marker.get("installed_version"))
         details.setdefault("auto_install_pro_version", marker.get("flockspro_component_version"))
         details.setdefault("flockspro_component_version", marker.get("flockspro_component_version"))
@@ -418,13 +419,91 @@ async def _maybe_refresh_pro_license(record: dict[str, Any]) -> None:
         details["license_refresh_error"] = str(exc)
 
 
+def _clean_bundle_value(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _clean_version_value(value: Any) -> str:
+    return _clean_bundle_value(value).removeprefix("v")
+
+
+def _record_target_bundle(record: dict[str, Any]) -> dict[str, str]:
+    details = record.get("details") if isinstance(record.get("details"), dict) else {}
+    latest_bundle = details.get("latest_pro_bundle") if isinstance(details.get("latest_pro_bundle"), dict) else {}
+    release_id = _clean_bundle_value(
+        record.get("approved_bundle_release_id")
+        or details.get("approved_bundle_release_id")
+        or details.get("bundle_release_id")
+        or latest_bundle.get("release_id")
+    )
+    target = {
+        "release_id": release_id,
+        "bundle_release_id": _clean_bundle_value(details.get("bundle_release_id") or release_id),
+        "build_id": _clean_bundle_value(details.get("target_build_id") or latest_bundle.get("build_id")),
+        "display_version": _clean_bundle_value(
+            details.get("target_display_version")
+            or details.get("auto_install_target")
+            or latest_bundle.get("display_version")
+        ),
+        "oss_version": _clean_bundle_value(details.get("target_oss_version") or latest_bundle.get("oss_version")),
+        "flockspro_component_version": _clean_bundle_value(
+            details.get("target_flockspro_component_version")
+            or latest_bundle.get("flockspro_component_version")
+        ),
+    }
+    return {key: value for key, value in target.items() if value}
+
+
+def _target_bundle_fingerprint_matches(target: dict[str, str], marker: dict[str, Any]) -> bool | None:
+    build_id = target.get("build_id")
+    marker_build_id = _clean_bundle_value(marker.get("build_id"))
+    if build_id and marker_build_id:
+        return marker_build_id == build_id
+
+    pro_version = target.get("flockspro_component_version")
+    marker_pro_version = _clean_bundle_value(marker.get("flockspro_component_version"))
+    if pro_version and marker_pro_version:
+        return marker_pro_version == pro_version
+
+    display_version = target.get("display_version")
+    marker_display_version = _clean_bundle_value(marker.get("installed_version") or marker.get("display_version"))
+    if display_version and marker_display_version:
+        return _clean_version_value(marker_display_version) == _clean_version_value(display_version)
+
+    oss_version = target.get("oss_version")
+    marker_oss_version = _clean_bundle_value(marker.get("oss_version"))
+    if oss_version and marker_oss_version:
+        return _clean_version_value(marker_oss_version) == _clean_version_value(oss_version)
+
+    return None
+
+
+def _marker_matches_target_bundle(marker: dict[str, Any], record: dict[str, Any]) -> bool:
+    if not marker:
+        return False
+    target = _record_target_bundle(record)
+    target_release_id = _clean_bundle_value(target.get("release_id") or target.get("bundle_release_id"))
+    marker_release_id = _clean_bundle_value(marker.get("release_id") or marker.get("bundle_release_id"))
+    if target_release_id:
+        if marker_release_id:
+            return marker_release_id == target_release_id
+        fingerprint_match = _target_bundle_fingerprint_matches(target, marker)
+        return fingerprint_match is True
+
+    fingerprint_match = _target_bundle_fingerprint_matches(target, marker)
+    if fingerprint_match is not None:
+        return fingerprint_match
+    return True
+
+
 async def _run_auto_upgrade_install(record: dict[str, Any]) -> dict[str, Any]:
     details = record.setdefault("details", {})
     details["auto_install_result"] = "running"
     details["auto_install_started_at"] = datetime.now(UTC).isoformat()
     marker = _read_pro_bundle_install_marker()
-    if _is_pro_component_installed() and marker:
+    if _is_pro_component_installed() and _marker_matches_target_bundle(marker, record):
         details["auto_install_result"] = "already_latest"
+        details["auto_install_release_id"] = marker.get("release_id") or marker.get("bundle_release_id")
         details["auto_install_version"] = marker.get("installed_version")
         details["auto_install_completed_at"] = datetime.now(UTC).isoformat()
         _record_pro_capability(details)
@@ -446,6 +525,7 @@ async def _run_auto_upgrade_install(record: dict[str, Any]) -> dict[str, Any]:
     details["auto_install_result"] = (
         "done" if final_stage == "done" and capability.get("pro_enabled") else "license_inactive"
     )
+    details["auto_install_release_id"] = marker.get("release_id") or marker.get("bundle_release_id")
     details["auto_install_version"] = marker.get("installed_version")
     details["auto_install_pro_version"] = marker.get("flockspro_component_version")
     details["auto_install_completed_at"] = datetime.now(UTC).isoformat()
@@ -477,14 +557,28 @@ async def _report_pro_bundle_installation(
         details["install_receipt_error"] = str(exc)
         return
     marker = _read_pro_bundle_install_marker()
+    target = _record_target_bundle(record)
+    release_id = _clean_bundle_value(
+        marker.get("release_id")
+        or marker.get("bundle_release_id")
+        or target.get("release_id")
+        or target.get("bundle_release_id")
+    )
+    bundle_release_id = _clean_bundle_value(marker.get("bundle_release_id") or marker.get("release_id") or release_id)
     payload = {
+        "release_id": release_id or None,
+        "bundle_release_id": bundle_release_id or None,
         "license_id": _record_license_id(record),
         "fingerprint": console_session.get("fingerprint"),
         "install_id": console_session.get("install_id"),
-        "installed_version": marker.get("installed_version") or details.get("auto_install_target") or details.get("auto_install_version") or "",
-        "oss_version": marker.get("oss_version"),
-        "flockspro_component_version": marker.get("flockspro_component_version"),
-        "build_id": marker.get("build_id"),
+        "installed_version": marker.get("installed_version")
+        or target.get("display_version")
+        or details.get("auto_install_target")
+        or details.get("auto_install_version")
+        or "",
+        "oss_version": marker.get("oss_version") or target.get("oss_version"),
+        "flockspro_component_version": marker.get("flockspro_component_version") or target.get("flockspro_component_version"),
+        "build_id": marker.get("build_id") or target.get("build_id"),
         "install_result": install_result,
         "error_message": error_message,
         "reported_at": datetime.now(UTC).isoformat(),
@@ -529,7 +623,10 @@ async def _maybe_auto_activate_upgrade(record: dict[str, Any]) -> dict[str, Any]
     if not _is_approved(record):
         return record
     details = record.setdefault("details", {})
-    if details.get("auto_install_result") in {"done", "already_latest"}:
+    if details.get("auto_install_result") in {"done", "already_latest"} and _marker_matches_target_bundle(
+        _read_pro_bundle_install_marker(),
+        record,
+    ):
         return record
     try:
         await _maybe_activate_pro_license(record)
@@ -566,7 +663,12 @@ def _schedule_auto_activate_upgrade(request_id: str, record: dict[str, Any]) -> 
     if not _is_approved(record):
         return
     details = record.setdefault("details", {})
-    if details.get("auto_install_result") in {"running", "done", "already_latest"}:
+    if details.get("auto_install_result") == "running":
+        return
+    if details.get("auto_install_result") in {"done", "already_latest"} and _marker_matches_target_bundle(
+        _read_pro_bundle_install_marker(),
+        record,
+    ):
         return
     if request_id in _AUTO_UPGRADE_REQUEST_IDS:
         return

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -80,6 +80,8 @@ class ConsoleManifestRelease:
     bundle_format: str
     manifest: dict[str, Any]
     console_session_token: str | None = None
+    release_id: str | None = None
+    bundle_release_id: str | None = None
 
 
 def _record_update_journal(message: str) -> None:
@@ -1252,6 +1254,8 @@ async def _fetch_console_manifest_release_info(console_session_token: str | None
     if not bundle_url:
         raise ValueError("manifest 响应缺少 bundle_url")
     bundle_format = _archive_format_for_url(bundle_url, str(data.get("bundle_format") or data.get("archive_format") or ""))
+    release_id = str(data.get("release_id") or data.get("bundle_release_id") or "").strip() or None
+    bundle_release_id = str(data.get("bundle_release_id") or data.get("release_id") or "").strip() or None
     return ConsoleManifestRelease(
         version=latest,
         release_notes=data.get("release_notes") or data.get("notes"),
@@ -1261,6 +1265,8 @@ async def _fetch_console_manifest_release_info(console_session_token: str | None
         bundle_format=bundle_format,
         manifest=data,
         console_session_token=token,
+        release_id=release_id,
+        bundle_release_id=bundle_release_id,
     )
 
 
@@ -1773,10 +1779,33 @@ async def run_handoff_upgrade_tasks(
     return None
 
 
+def _merge_console_manifest_release_identity(
+    bundle_manifest: dict[str, Any],
+    console_manifest: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not console_manifest:
+        return bundle_manifest
+    merged = dict(bundle_manifest)
+    release_id = str(console_manifest.get("release_id") or console_manifest.get("bundle_release_id") or "").strip()
+    bundle_release_id = str(console_manifest.get("bundle_release_id") or console_manifest.get("release_id") or "").strip()
+    if release_id and not merged.get("release_id"):
+        merged["release_id"] = release_id
+    if bundle_release_id and not merged.get("bundle_release_id"):
+        merged["bundle_release_id"] = bundle_release_id
+    for key in ("display_version", "oss_version", "flockspro_component_version", "build_id"):
+        if not merged.get(key) and console_manifest.get(key):
+            merged[key] = console_manifest.get(key)
+    return merged
+
+
 def _write_pro_bundle_install_marker(manifest: dict[str, Any], *, bundle_sha256: str | None = None) -> None:
     marker = _flocks_root() / "run" / "pro-bundle-installed.json"
     marker.parent.mkdir(parents=True, exist_ok=True)
+    release_id = manifest.get("release_id") or manifest.get("bundle_release_id")
+    bundle_release_id = manifest.get("bundle_release_id") or manifest.get("release_id")
     payload = {
+        "release_id": release_id,
+        "bundle_release_id": bundle_release_id,
         "display_version": manifest.get("display_version"),
         "installed_version": manifest.get("display_version"),
         "oss_version": manifest.get("oss_version"),
@@ -2697,6 +2726,7 @@ async def perform_pro_bundle_install(
         bundle_sha256=manifest_info.bundle_sha256,
         bundle_format=manifest_info.bundle_format,
         console_session_token=manifest_info.console_session_token,
+        console_manifest_payload=manifest_info.manifest,
         restart=restart,
         force_console_manifest=True,
     ):
@@ -2711,6 +2741,7 @@ async def perform_update(
     bundle_sha256: str | None = None,
     bundle_format: str | None = None,
     console_session_token: str | None = None,
+    console_manifest_payload: dict[str, Any] | None = None,
     restart: bool = True,
     locale: str | None = None,
     region: str | None = None,
@@ -2738,6 +2769,7 @@ async def perform_update(
     current_version = get_current_version()
     handover_active = False
     console_manifest_info: ConsoleManifestRelease | None = None
+    console_manifest_payload = console_manifest_payload if isinstance(console_manifest_payload, dict) else None
     fmt = _choose_archive_format(ucfg.archive_format)
     if profile.sources == ["console-manifest"]:
         if not (zipball_url or tarball_url) or console_session_token is None:
@@ -2765,6 +2797,7 @@ async def perform_update(
             bundle_sha256 = console_manifest_info.bundle_sha256
             bundle_format = console_manifest_info.bundle_format
             console_session_token = console_manifest_info.console_session_token
+            console_manifest_payload = console_manifest_info.manifest
         primary_bundle_url = zipball_url or tarball_url or ""
         fmt = _archive_format_for_url(primary_bundle_url, bundle_format)
 
@@ -2873,6 +2906,11 @@ async def perform_update(
             extract_dir,
         )
         content_root, pro_wheel_path, pro_bundle_manifest = _resolve_pro_bundle_content(content_root)
+        if profile.sources == ["console-manifest"]:
+            pro_bundle_manifest = _merge_console_manifest_release_identity(
+                pro_bundle_manifest,
+                console_manifest_payload,
+            )
         if profile.sources == ["console-manifest"] and pro_wheel_path is None:
             raise ValueError("Pro bundle 中未找到 flockspro wheel")
     except Exception as exc:

--- a/tests/server/routes/test_console_upgrade_routes.py
+++ b/tests/server/routes/test_console_upgrade_routes.py
@@ -1154,6 +1154,76 @@ async def test_auto_activate_reports_already_latest_install(
     assert reported == [("success", None)]
 
 
+async def test_auto_activate_reinstalls_when_existing_pro_marker_is_not_target_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from flocks.server.routes import console_upgrade as console_routes
+    from flocks.updater.models import UpdateProgress
+
+    marker_state = {
+        "payload": {
+            "release_id": "rel_20260601",
+            "bundle_release_id": "rel_20260601",
+            "installed_version": "v2026.6.1",
+            "flockspro_component_version": "pro-v2026-6-1",
+            "build_id": "job_20260601",
+        }
+    }
+    reported: list[tuple[str, str | None]] = []
+
+    async def _fake_perform_pro_bundle_install(*args, **kwargs):
+        assert args == ()
+        assert kwargs["restart"] is False
+        marker_state["payload"] = {
+            "release_id": "rel_20260605",
+            "bundle_release_id": "rel_20260605",
+            "installed_version": "v2026.6.5",
+            "flockspro_component_version": "pro-v2026-6-5",
+            "build_id": "job_20260605",
+        }
+        yield UpdateProgress(stage="done", message="Flocks Pro component installed.", success=True)
+
+    async def _fake_report(record: dict, *, install_result: str, error_message: str | None = None):
+        reported.append((install_result, error_message))
+
+    async def _noop(_record: dict):
+        return None
+
+    monkeypatch.setattr(console_routes, "perform_pro_bundle_install", _fake_perform_pro_bundle_install)
+    monkeypatch.setattr(console_routes, "_maybe_activate_pro_license", _noop)
+    monkeypatch.setattr(console_routes, "_maybe_refresh_pro_license", _noop)
+    monkeypatch.setattr(console_routes, "_report_pro_bundle_installation", _fake_report)
+    monkeypatch.setattr(console_routes, "_is_pro_component_installed", lambda: True)
+    monkeypatch.setattr(console_routes, "_get_pro_capability_status", lambda: {"pro_enabled": True, "active": True})
+    monkeypatch.setattr(console_routes, "_read_pro_bundle_install_marker", lambda: marker_state["payload"])
+
+    record = {
+        "request_id": "req_auto_reinstall_target_bundle",
+        "status": "approved",
+        "activate_key": "key_auto",
+        "details": {
+            "auto_install_result": "already_latest",
+            "approved_bundle_release_id": "rel_20260605",
+            "latest_pro_bundle": {
+                "release_id": "rel_20260605",
+                "display_version": "v2026.6.5",
+                "flockspro_component_version": "pro-v2026-6-5",
+                "build_id": "job_20260605",
+            },
+        },
+        "created_at": "2026-06-05T08:00:00+00:00",
+        "updated_at": "2026-06-05T08:00:00+00:00",
+    }
+
+    payload = await console_routes._maybe_auto_activate_upgrade(record)
+
+    assert payload["status"] == "activated"
+    assert payload["details"]["auto_install_result"] == "done"
+    assert payload["details"]["auto_install_release_id"] == "rel_20260605"
+    assert payload["details"]["auto_install_version"] == "v2026.6.5"
+    assert reported == [("success", None)]
+
+
 async def test_auto_activate_does_not_mark_activated_when_license_inactive(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -1270,7 +1340,10 @@ async def test_report_pro_bundle_installation_uses_license_id(
     monkeypatch.setattr(
         console_routes,
         "_read_pro_bundle_install_marker",
-        lambda: {"installed_version": "v2026.5.9"},
+        lambda: {
+            "installed_version": "v2026.6.5",
+            "flockspro_component_version": "pro-v2026-6-5",
+        },
     )
 
     record = {
@@ -1278,9 +1351,21 @@ async def test_report_pro_bundle_installation_uses_license_id(
         "status": "approved",
         "activate_key": "activation_token",
         "license_id": "lic_receipt",
-        "details": {"license_id": "lic_receipt"},
+        "details": {
+            "license_id": "lic_receipt",
+            "approved_bundle_release_id": "rel_receipt",
+            "latest_pro_bundle": {
+                "release_id": "rel_receipt",
+                "display_version": "v2026.6.5",
+                "flockspro_component_version": "pro-v2026-6-5",
+                "build_id": "job_receipt",
+            },
+        },
     }
 
     await console_routes._report_pro_bundle_installation(record, install_result="success")
 
     assert posted_payloads[0]["license_id"] == "lic_receipt"
+    assert posted_payloads[0]["release_id"] == "rel_receipt"
+    assert posted_payloads[0]["bundle_release_id"] == "rel_receipt"
+    assert posted_payloads[0]["build_id"] == "job_receipt"

--- a/tests/updater/test_updater_console_manifest_bundle.py
+++ b/tests/updater/test_updater_console_manifest_bundle.py
@@ -24,6 +24,8 @@ async def test_fetch_console_manifest_release_uses_bundle_url(monkeypatch: pytes
             return {
                 "display_version": "v2026.5.10",
                 "compare_version": "2026.5.10",
+                "release_id": "rel_20260510",
+                "bundle_release_id": "rel_20260510",
                 "bundle_url": "https://cdn.example.com/flockspro-bundle-v2026.5.10.tar.gz",
                 "bundle_sha256": "abc123",
                 "oss_version": "v2026.5.10",
@@ -54,6 +56,8 @@ async def test_fetch_console_manifest_release_uses_bundle_url(monkeypatch: pytes
         "https://cdn.example.com/flockspro-bundle-v2026.5.10.tar.gz",
     )
     info = await updater._fetch_console_manifest_release_info()
+    assert info.release_id == "rel_20260510"
+    assert info.bundle_release_id == "rel_20260510"
     assert info.bundle_sha256 == "abc123"
     assert info.bundle_format == "tar.gz"
 
@@ -470,6 +474,8 @@ async def test_perform_pro_bundle_install_replaces_core_and_installs_wheel(
     marker = tmp_path / "flocks-root" / "run" / "pro-bundle-installed.json"
     assert marker.is_file()
     marker_payload = __import__("json").loads(marker.read_text(encoding="utf-8"))
+    assert marker_payload["release_id"] == "rel_test"
+    assert marker_payload["bundle_release_id"] == "rel_test"
     assert marker_payload["display_version"] == "v2026.5.10"
     assert marker_payload["oss_version"] == "v2026.5.10"
 
@@ -540,6 +546,8 @@ async def _async_manifest_info(bundle):
         bundle_sha256=None,
         bundle_format="zip",
         manifest={
+            "release_id": "rel_test",
+            "bundle_release_id": "rel_test",
             "display_version": "v2026.5.10",
             "oss_version": "v2026.5.10",
             "flockspro_component_version": "pro-v2026-5-10",
@@ -550,4 +558,3 @@ async def _async_manifest_info(bundle):
 
 async def _async_path(path):
     return path
-


### PR DESCRIPTION
## Summary
- Persist Console release identifiers into the local pro-bundle-installed marker.
- Only skip Pro bundle installation as already_latest when the marker matches the current target bundle.
- Report release_id/bundle_release_id with install receipts, falling back to approved target bundle metadata.

## Why
A machine with Pro 6.1 installed must still install and report Pro 6.5 when Console approves the 6.5 bundle; stale markers should not suppress installation or misattribute the receipt.

## Validation
- .venv/bin/pytest tests/server/routes/test_console_upgrade_routes.py tests/updater/test_updater_console_manifest_bundle.py -q
