### PR TITLE
fix(webui): default to light theme

### DIFF
--- a/webui/src/contexts/ThemeContext.test.tsx
+++ b/webui/src/contexts/ThemeContext.test.tsx
@@ -45,7 +45,7 @@ describe('ThemeProvider', () => {
     mockPreferredScheme(false);
   });
 
-  it('uses system dark preference when no stored theme exists', async () => {
+  it('defaults to light when no stored theme exists', async () => {
     mockPreferredScheme(true);
 
     render(
@@ -54,10 +54,10 @@ describe('ThemeProvider', () => {
       </ThemeProvider>,
     );
 
-    expect(screen.getByTestId('theme-value')).toHaveTextContent('dark');
-    expect(document.documentElement).toHaveClass('dark');
-    expect(document.documentElement.style.colorScheme).toBe('dark');
-    await waitFor(() => expect(localStorage.getItem('flocks_theme')).toBe('dark'));
+    expect(screen.getByTestId('theme-value')).toHaveTextContent('light');
+    expect(document.documentElement).not.toHaveClass('dark');
+    expect(document.documentElement.style.colorScheme).toBe('light');
+    await waitFor(() => expect(localStorage.getItem('flocks_theme')).toBe('light'));
   });
 
   it('prefers the stored theme over system preference', async () => {

--- a/webui/src/contexts/ThemeContext.tsx
+++ b/webui/src/contexts/ThemeContext.tsx
@@ -23,9 +23,7 @@ function getInitialTheme(): Theme {
   const stored = typeof storage?.getItem === 'function' ? storage.getItem(THEME_STORAGE_KEY) : null;
   if (stored === 'light' || stored === 'dark') return stored;
 
-  if (typeof window.matchMedia !== 'function') return 'light';
-
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  return 'light';
 }
 
 function applyTheme(theme: Theme) {


### PR DESCRIPTION
## Summary
- Default the Web UI theme to light when no stored theme preference exists.
- Keep persisted light/dark preferences respected across sessions.
- Update ThemeProvider tests for the new default behavior.

## Validation
- npm test -- ThemeContext.test.tsx