### PR TITLE
fix: tolerate Windows start build runtime failures

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -43,6 +43,11 @@ MISSING_PORT_OWNER_TOOLS_WARNING = (
     "未检测到 lsof 或 fuser，无法解析端口占用 PID；将退回到 bind 检查。"
     "可尝试安装：apt/yum install lsof -y"
 )
+WINDOWS_FRONTEND_BUILD_ASSERTION_MARKERS = (
+    "UV_HANDLE_CLOSING",
+    "src\\win\\async.c",
+    "src/win/async.c",
+)
 
 
 class ServiceError(RuntimeError):
@@ -559,10 +564,12 @@ def _windows_process_snapshot(pid: int) -> dict[str, str] | None:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         if completed.returncode == 0:
             with contextlib.suppress(json.JSONDecodeError):
-                payload = json.loads(completed.stdout.strip() or "{}")
+                payload = json.loads((completed.stdout or "").strip() or "{}")
                 if isinstance(payload, dict):
                     return {
                         "name": str(payload.get("Name") or ""),
@@ -1038,14 +1045,20 @@ def start_frontend(config: ServiceConfig, console) -> None:
     frontend_env = build_frontend_env(config)
     if not config.skip_frontend_build:
         console.print("[flocks] 构建 WebUI...")
-        completed = subprocess.run(
-            [npm, "run", "build"],
-            cwd=webui_dir,
-            check=False,
-            env=frontend_env,
-        )
+        run_kwargs: dict[str, object] = {"cwd": webui_dir, "check": False, "env": frontend_env}
+        if sys.platform == "win32":
+            run_kwargs.update({"capture_output": True, "text": True, "encoding": "utf-8", "errors": "replace"})
+        completed = subprocess.run([npm, "run", "build"], **run_kwargs)
         if completed.returncode != 0:
-            raise ServiceError("WebUI 构建失败。")
+            output = "\n".join(
+                value for value in (getattr(completed, "stdout", None), getattr(completed, "stderr", None)) if value
+            )
+            if windows_frontend_build_assertion_is_recoverable(webui_dir, output):
+                console.print("[flocks] WebUI 构建产物已生成，忽略 Windows Node.js 退出断言。")
+            else:
+                if output:
+                    console.print(output)
+                raise ServiceError("WebUI 构建失败。")
 
     command = [
         npm,
@@ -1612,6 +1625,15 @@ def backend_access_base_url(config: ServiceConfig) -> str:
 def websocket_access_base_url(config: ServiceConfig) -> str:
     """Return the websocket base URL matching ``backend_access_base_url()``."""
     return _http_to_ws_url(backend_access_base_url(config))
+
+
+def windows_frontend_build_assertion_is_recoverable(webui_dir: Path, output: str) -> bool:
+    """Return True when Windows npm crashed after producing a usable build."""
+    if sys.platform != "win32":
+        return False
+    if not (webui_dir / "dist" / "index.html").exists():
+        return False
+    return any(marker in output for marker in WINDOWS_FRONTEND_BUILD_ASSERTION_MARKERS)
 
 
 def build_frontend_env(config: ServiceConfig) -> dict[str, str]:

--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -443,7 +443,7 @@ async def _build_frontend_workspace(
             continue
 
         try:
-            code, _, err = await _run_async(
+            code, out, err = await _run_async(
                 [candidate.npm, "run", "build"],
                 cwd=webui_dir,
                 timeout=_FRONTEND_BUILD_TIMEOUT_SECONDS,
@@ -464,6 +464,12 @@ async def _build_frontend_workspace(
             continue
 
         if code != 0:
+            from flocks.cli import service_manager
+
+            build_output = "\n".join(value for value in (out, err) if value)
+            if service_manager.windows_frontend_build_assertion_is_recoverable(webui_dir, build_output):
+                final_frontend_error = None
+                break
             final_frontend_error = f"Frontend build failed: {err}"
             if is_last_attempt:
                 break

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -179,6 +179,24 @@ def test_pid_is_running_uses_windows_probe(monkeypatch) -> None:
     assert service_manager.pid_is_running(456) is False
 
 
+def test_windows_process_snapshot_handles_empty_stdout(monkeypatch) -> None:
+    monkeypatch.setattr(service_manager.sys, "platform", "win32")
+    monkeypatch.setattr(service_manager, "which", lambda name: "powershell.exe" if name == "powershell" else None)
+
+    def fake_run(*_args, **kwargs):
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
+        return SimpleNamespace(returncode=0, stdout=None)
+
+    monkeypatch.setattr(service_manager.subprocess, "run", fake_run)
+
+    assert service_manager._windows_process_snapshot(123) == {
+        "name": "",
+        "command_line": "",
+        "executable_path": "",
+    }
+
+
 def test_process_group_is_running_ignores_permission_error_without_live_members(monkeypatch) -> None:
     monkeypatch.setattr(service_manager.sys, "platform", "darwin")
     monkeypatch.setattr(
@@ -1189,6 +1207,53 @@ def test_start_frontend_passes_backend_urls_to_build_and_preview(monkeypatch, tm
     assert record is not None
     assert record.host == "0.0.0.0"
     assert record.port == 5174
+
+
+def test_start_frontend_tolerates_windows_node_assertion_after_build(monkeypatch, tmp_path: Path) -> None:
+    paths = service_manager.RuntimePaths(
+        root=tmp_path,
+        run_dir=tmp_path / "run",
+        log_dir=tmp_path / "logs",
+        backend_pid=tmp_path / "run" / "backend.pid",
+        frontend_pid=tmp_path / "run" / "webui.pid",
+        backend_log=tmp_path / "logs" / "backend.log",
+        frontend_log=tmp_path / "logs" / "webui.log",
+    )
+    paths.run_dir.mkdir(parents=True)
+    paths.log_dir.mkdir(parents=True)
+    webui_dir = tmp_path / "webui"
+    webui_dist = webui_dir / "dist"
+    webui_dist.mkdir(parents=True)
+    console = DummyConsole()
+    preview_calls: list[list[str]] = []
+
+    def fake_run(_command, **_kwargs):
+        (webui_dist / "index.html").write_text("<html></html>", encoding="utf-8")
+        return SimpleNamespace(
+            returncode=3221226505,
+            stdout="built in 6.83s",
+            stderr="Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\\win\\async.c, line 76",
+        )
+
+    def fake_spawn(command, **_kwargs):
+        preview_calls.append(list(command))
+        return SimpleNamespace(pid=2468)
+
+    monkeypatch.setattr(service_manager.sys, "platform", "win32")
+    monkeypatch.setattr(service_manager, "ensure_install_layout", lambda: tmp_path)
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "cleanup_stale_pid_file", lambda _path: None)
+    monkeypatch.setattr(service_manager, "port_owner_pids", lambda _port: [])
+    monkeypatch.setattr(service_manager, "wait_for_http", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(service_manager, "resolve_npm_executable", lambda: "npm.cmd")
+    monkeypatch.setattr(service_manager, "node_version_satisfies_requirement", lambda: True)
+    monkeypatch.setattr(service_manager.subprocess, "run", fake_run)
+    monkeypatch.setattr(service_manager, "_spawn_process", fake_spawn)
+
+    service_manager.start_frontend(service_manager.ServiceConfig(), console)
+
+    assert preview_calls[0][:3] == ["npm.cmd", "run", "preview"]
+    assert "[flocks] WebUI 构建产物已生成，忽略 Windows Node.js 退出断言。" in console.messages
 
 
 def test_start_frontend_passes_direct_backend_urls_when_opted_in(monkeypatch, tmp_path: Path) -> None:

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -2110,6 +2110,46 @@ async def test_build_frontend_workspace_retries_npm_ci_before_switching_candidat
 
 
 @pytest.mark.asyncio
+async def test_build_frontend_workspace_tolerates_windows_node_assertion_after_build(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    webui_dir = tmp_path / "webui"
+    webui_dir.mkdir()
+    (webui_dir / "package.json").write_text("{}", encoding="utf-8")
+    bundled_npm = str(tmp_path / "npm.cmd")
+    run_calls: list[list[str]] = []
+
+    async def fake_run_async(cmd, cwd=None, timeout=None, env=None):
+        run_calls.append(list(cmd))
+        if cmd == [bundled_npm, "install"]:
+            return 0, "", ""
+        if cmd == [bundled_npm, "run", "build"]:
+            dist_dir = webui_dir / "dist"
+            dist_dir.mkdir()
+            (dist_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+            return (
+                3221226505,
+                "built in 6.83s",
+                "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\\win\\async.c, line 76",
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(updater.sys, "platform", "win32")
+    monkeypatch.setattr(
+        updater,
+        "_resolve_frontend_npm_candidates",
+        lambda *, npm_registry=None: [
+            updater._FrontendNpmCandidate(npm=bundled_npm, env=None, source="bundled"),
+        ],
+    )
+    monkeypatch.setattr(updater, "_run_async", fake_run_async)
+
+    assert await updater._build_frontend_workspace(webui_dir) is None
+    assert run_calls == [[bundled_npm, "install"], [bundled_npm, "run", "build"]]
+
+
+@pytest.mark.asyncio
 async def test_perform_update_retries_windows_frontend_with_full_timeout_after_bundled_install_and_ci_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- tolerate Windows Node/libuv build-exit assertions when WebUI build output already exists
- use UTF-8 replacement decoding and guard empty PowerShell stdout while checking stale Windows runtime records
- add focused regressions for start/update Windows build and runtime cleanup paths

## Tests
- .venv/bin/ruff check flocks/cli/service_manager.py flocks/updater/updater.py tests/cli/test_service_manager.py tests/updater/test_updater.py
- .venv/bin/python -m pytest tests/cli/test_service_manager.py::test_windows_process_snapshot_handles_empty_stdout tests/cli/test_service_manager.py::test_start_frontend_tolerates_windows_node_assertion_after_build tests/updater/test_updater.py::test_build_frontend_workspace_tolerates_windows_node_assertion_after_build