### PR TITLE
docs: refresh README header badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Flocks
 
+AI-Native SecOps Platform
+
 <p align="center">
   <a href="https://agentflocks.github.io/flocks-docs/"><img alt="Docs" src="https://img.shields.io/badge/docs-agentflocks.github.io-555555?style=for-the-badge"></a>
   <a href="https://github.com/AgentFlocks/flocks/releases"><img alt="Release" src="https://img.shields.io/badge/release-v2026.6.18-f06f2f?style=for-the-badge"></a>
@@ -10,8 +12,6 @@
   <a href="README.md"><img alt="English" src="https://img.shields.io/badge/lang-English-e33f44?style=for-the-badge"></a>
   <a href="README_zh.md"><img alt="Chinese" src="https://img.shields.io/badge/lang-%E4%B8%AD%E6%96%87-e33f44?style=for-the-badge"></a>
 </p>
-
-AI-Native SecOps Platform
 
 ![Flocks WebUI](assets/flocks.webp)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Flocks
+<h1 align="center">Flocks</h1>
 
-AI-Native SecOps Platform
+<p align="center">
+  AI-Native SecOps Platform
+</p>
 
 <p align="center">
   <a href="https://agentflocks.github.io/flocks-docs/"><img alt="Docs" src="https://img.shields.io/badge/docs-agentflocks.github.io-555555?style=for-the-badge"></a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Flocks
 
-**English** | [简体中文](README_zh.md)
+<p align="center">
+  <a href="https://agentflocks.github.io/flocks-docs/"><img alt="Docs" src="https://img.shields.io/badge/docs-agentflocks.github.io-555555?style=for-the-badge"></a>
+  <a href="https://github.com/AgentFlocks/flocks/releases"><img alt="Release" src="https://img.shields.io/badge/release-v2026.6.18-f06f2f?style=for-the-badge"></a>
+</p>
+
+<p align="center">
+  <a href="LICENSE.txt"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-52b100?style=for-the-badge"></a>
+  <a href="README.md"><img alt="English" src="https://img.shields.io/badge/lang-English-e33f44?style=for-the-badge"></a>
+  <a href="README_zh.md"><img alt="Chinese" src="https://img.shields.io/badge/lang-%E4%B8%AD%E6%96%87-e33f44?style=for-the-badge"></a>
+</p>
 
 AI-Native SecOps Platform
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,5 +1,7 @@
 # Flocks
 
+AI 原生 SecOps 平台
+
 <p align="center">
   <a href="https://agentflocks.github.io/flocks-docs/"><img alt="文档" src="https://img.shields.io/badge/docs-agentflocks.github.io-555555?style=for-the-badge"></a>
   <a href="https://github.com/AgentFlocks/flocks/releases"><img alt="Release" src="https://img.shields.io/badge/release-v2026.6.18-f06f2f?style=for-the-badge"></a>
@@ -10,8 +12,6 @@
   <a href="README.md"><img alt="English" src="https://img.shields.io/badge/lang-English-e33f44?style=for-the-badge"></a>
   <a href="README_zh.md"><img alt="中文" src="https://img.shields.io/badge/lang-%E4%B8%AD%E6%96%87-e33f44?style=for-the-badge"></a>
 </p>
-
-AI 原生 SecOps 平台
 
 ![Flocks Web](assets/flocks.webp)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,15 @@
 # Flocks
 
-[English](README.md) | **简体中文**
+<p align="center">
+  <a href="https://agentflocks.github.io/flocks-docs/"><img alt="文档" src="https://img.shields.io/badge/docs-agentflocks.github.io-555555?style=for-the-badge"></a>
+  <a href="https://github.com/AgentFlocks/flocks/releases"><img alt="Release" src="https://img.shields.io/badge/release-v2026.6.18-f06f2f?style=for-the-badge"></a>
+</p>
+
+<p align="center">
+  <a href="LICENSE.txt"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-52b100?style=for-the-badge"></a>
+  <a href="README.md"><img alt="English" src="https://img.shields.io/badge/lang-English-e33f44?style=for-the-badge"></a>
+  <a href="README_zh.md"><img alt="中文" src="https://img.shields.io/badge/lang-%E4%B8%AD%E6%96%87-e33f44?style=for-the-badge"></a>
+</p>
 
 AI 原生 SecOps 平台
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,8 @@
-# Flocks
+<h1 align="center">Flocks</h1>
 
-AI 原生 SecOps 平台
+<p align="center">
+  AI 原生 SecOps 平台
+</p>
 
 <p align="center">
   <a href="https://agentflocks.github.io/flocks-docs/"><img alt="文档" src="https://img.shields.io/badge/docs-agentflocks.github.io-555555?style=for-the-badge"></a>


### PR DESCRIPTION
## Summary
- Replace the README language switcher with Docs, Release, License, and language badges.
- Apply the same header badge layout to the English and Chinese README files.
- Link Docs to the published Flocks documentation site and show the Apache-2.0 license badge.

## Validation
- git diff --check