### PR TITLE
fix(storage): keep source rows during multi-db migration

### DIFF
--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -586,7 +586,6 @@ class Storage:
         try:
             clauses, params = cls._workflow_prefix_filter()
             total_migrated = 0
-            total_deleted = 0
             last_key = ""
             while True:
                 rows = source.execute(
@@ -632,21 +631,10 @@ class Storage:
                         f"expected {len(keys)} copied rows, got {copied}"
                     )
 
-                deleted = 0
-                for key in keys:
-                    cursor = source.execute(
-                        "DELETE FROM storage WHERE key = ?",
-                        (key,),
-                    )
-                    if cursor.rowcount > 0:
-                        deleted += cursor.rowcount
-                source.commit()
-
                 total_migrated += len(rows)
-                total_deleted += deleted
                 last_key = keys[-1]
 
-            return total_migrated, total_deleted
+            return total_migrated, 0
         except Exception:
             if source.in_transaction:
                 source.rollback()

--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -143,14 +143,14 @@ class TaskStore:
         source: sqlite3.Connection,
         target: sqlite3.Connection,
         table_name: str,
-    ) -> tuple[int, list[str]]:
+    ) -> int:
         if not cls._table_exists(source, table_name):
-            return 0, []
+            return 0
         source_columns = cls._table_columns(source, table_name)
         target_columns = set(cls._table_columns(target, table_name))
         copy_columns = [column for column in source_columns if column in target_columns]
         if not copy_columns or "id" not in copy_columns:
-            return 0, []
+            return 0
         quoted_columns = ", ".join(cls._quote_identifier(column) for column in copy_columns)
         table_sql = cls._quote_identifier(table_name)
         placeholders = ", ".join("?" for _ in copy_columns)
@@ -159,7 +159,6 @@ class TaskStore:
             f"VALUES ({placeholders})"
         )
         copied = 0
-        copied_ids: list[str] = []
         last_rowid = 0
         while True:
             rows = source.execute(
@@ -192,10 +191,9 @@ class TaskStore:
                 )
 
             copied += len(rows)
-            copied_ids.extend(ids)
             last_rowid = int(rows[-1]["__rowid"])
 
-        return copied, copied_ids
+        return copied
 
     @classmethod
     def _copy_task_tables_to_tasks_db_sync(cls) -> tuple[int, int, int]:
@@ -212,35 +210,18 @@ class TaskStore:
             original_foreign_keys = target.execute("PRAGMA foreign_keys").fetchone()[0]
             target.execute("PRAGMA foreign_keys = OFF")
             total = 0
-            copied_ids_by_table: dict[str, list[str]] = {}
             for table_name in (
                 "task_schedulers",
                 "task_executions",
                 "task_execution_queue_refs",
             ):
-                copied, copied_ids = cls._copy_task_table_sync(source, target, table_name)
+                copied = cls._copy_task_table_sync(source, target, table_name)
                 total += copied
-                copied_ids_by_table[table_name] = copied_ids
             target.commit()
             foreign_key_violations = len(target.execute("PRAGMA foreign_key_check").fetchall())
             target.execute(f"PRAGMA foreign_keys = {original_foreign_keys}")
 
-            deleted = 0
-            for table_name in (
-                "task_execution_queue_refs",
-                "task_executions",
-                "task_schedulers",
-            ):
-                table_sql = cls._quote_identifier(table_name)
-                for row_id in copied_ids_by_table.get(table_name, []):
-                    cursor = source.execute(
-                        f"DELETE FROM {table_sql} WHERE id = ?",
-                        (row_id,),
-                    )
-                    if cursor.rowcount > 0:
-                        deleted += cursor.rowcount
-            source.commit()
-            return total, foreign_key_violations, deleted
+            return total, foreign_key_violations, 0
         except Exception:
             if source.in_transaction:
                 source.rollback()

--- a/tests/storage/test_multi_db_routing.py
+++ b/tests/storage/test_multi_db_routing.py
@@ -144,12 +144,12 @@ async def test_workflow_kv_migrates_from_legacy_flocks_db() -> None:
 
     workflow_db = Storage.get_workflow_db_path()
     assert _fetch_storage_value(workflow_db, "workflow_registry/wf-legacy") == '{"ok": true}'
-    assert _fetch_storage_value(flocks_db, "workflow_registry/wf-legacy") is None
+    assert _fetch_storage_value(flocks_db, "workflow_registry/wf-legacy") == '{"ok": true}'
     assert _fetch_storage_value(workflow_db, "session:legacy") is None
     marker = await Storage.get(Storage._multi_db_migration_marker_key)
     assert marker["workflow_migrated"] is True
     assert marker["workflow_rows"] == 1
-    assert marker["workflow_source_rows_deleted"] == 1
+    assert marker["workflow_source_rows_deleted"] == 0
 
 
 @pytest.mark.asyncio
@@ -186,6 +186,7 @@ async def test_workflow_prefix_migration_treats_underscore_literally() -> None:
     workflow_db = Storage.get_workflow_db_path()
     assert _fetch_storage_value(workflow_db, "workflow_registry/wf-ok") == '{"ok": true}'
     assert _fetch_storage_value(workflow_db, "workflowXregistry/wf-bad") is None
+    assert _fetch_storage_value(flocks_db, "workflow_registry/wf-ok") == '{"ok": true}'
     assert _fetch_storage_value(flocks_db, "workflowXregistry/wf-bad") == '{"bad": true}'
     assert await Storage.list_keys("workflow_registry/") == ["workflow_registry/wf-ok"]
 
@@ -324,9 +325,9 @@ async def test_task_store_uses_tasks_db_and_migrates_existing_task_tables() -> N
     assert marker["tasks_migrated"] is True
     assert marker["task_rows"] == 3
     assert marker["task_foreign_key_violations"] == 1
-    assert marker["task_source_rows_deleted"] == 3
-    assert _fetch_table_count(flocks_db, "task_schedulers") == 0
-    assert _fetch_table_count(flocks_db, "task_executions") == 0
+    assert marker["task_source_rows_deleted"] == 0
+    assert _fetch_table_count(flocks_db, "task_schedulers") == 1
+    assert _fetch_table_count(flocks_db, "task_executions") == 2
 
     await TaskStore.close()
     TaskStore._initialized = False


### PR DESCRIPTION
## Summary
- make workflow KV multi-db migration copy-only by preserving source rows in flocks.db
- make task table migration copy-only by preserving legacy task rows in flocks.db
- update multi-db routing tests to assert source rows are retained after migration

## Validation
- uv run pytest tests/storage/test_multi_db_routing.py
- uv run ruff check flocks/storage/storage.py flocks/task/store.py tests/storage/test_multi_db_routing.py
- git diff --check