### PR TITLE
ci: dispatch autotest Windows upgrade

### DIFF
--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -152,3 +152,192 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             --data-binary "@${RUNNER_TEMP}/flocks-autotest-dispatch.json" \
             "https://api.github.com/repos/AgentFlocks/flocks_autotest/dispatches"
+
+      - name: Wait for flocks_autotest result
+        id: autotest
+        timeout-minutes: 210
+        env:
+          GH_TOKEN: ${{ secrets.AUTOTEST_DISPATCH_TOKEN }}
+          RELEASE_TAG: ${{ steps.payload.outputs.release_tag }}
+          SOURCE_RUN_ID: ${{ github.run_id }}
+          AUTOTEST_REPOSITORY: AgentFlocks/flocks_autotest
+          AUTOTEST_WORKFLOW_FILE: flocks-release-dispatch.yml
+          AUTOTEST_POLL_INTERVAL_SECONDS: "30"
+          AUTOTEST_WAIT_TIMEOUT_SECONDS: "10800"
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          api_root = "https://api.github.com"
+          token = os.environ["GH_TOKEN"]
+          release_tag = os.environ["RELEASE_TAG"]
+          source_run_id = os.environ["SOURCE_RUN_ID"]
+          autotest_repo = os.environ["AUTOTEST_REPOSITORY"]
+          workflow_file = os.environ["AUTOTEST_WORKFLOW_FILE"]
+          poll_interval = int(os.environ["AUTOTEST_POLL_INTERVAL_SECONDS"])
+          wait_timeout = int(os.environ["AUTOTEST_WAIT_TIMEOUT_SECONDS"])
+          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+          output_path = os.environ["GITHUB_OUTPUT"]
+          runner_temp = os.environ["RUNNER_TEMP"]
+
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def api_json(url):
+              request = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.loads(response.read().decode("utf-8"))
+
+          def download(url, destination):
+              request = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(request, timeout=300) as response:
+                  with open(destination, "wb") as f:
+                      f.write(response.read())
+
+          def write_summary(lines):
+              with open(summary_path, "a", encoding="utf-8") as f:
+                  f.write("\n".join(lines))
+                  f.write("\n")
+
+          def write_outputs(values):
+              with open(output_path, "a", encoding="utf-8") as f:
+                  for key, value in values.items():
+                      f.write(f"{key}={value}\n")
+
+          workflow_ref = urllib.parse.quote(workflow_file, safe="")
+          runs_url = (
+              f"{api_root}/repos/{autotest_repo}/actions/workflows/"
+              f"{workflow_ref}/runs?event=repository_dispatch&per_page=30"
+          )
+          artifact_prefix = f"flocks-windows-upgrade-{release_tag}-time"
+          deadline = time.time() + wait_timeout
+          matched_run = None
+
+          while time.time() < deadline:
+              runs = api_json(runs_url).get("workflow_runs", [])
+              for run in runs:
+                  title = run.get("display_title") or run.get("name") or ""
+                  if f"#{source_run_id}" in title:
+                      matched_run = run
+                      break
+              if matched_run:
+                  break
+              print(
+                  f"Waiting for flocks_autotest workflow run with source_run_id={source_run_id}...",
+                  flush=True,
+              )
+              time.sleep(poll_interval)
+
+          if not matched_run:
+              write_summary(
+                  [
+                      "### flocks_autotest result",
+                      "",
+                      f"- Status: timed out waiting for workflow run",
+                      f"- Source run id: {source_run_id}",
+                      f"- Expected artifact prefix: {artifact_prefix}",
+                  ]
+              )
+              raise SystemExit("Timed out waiting for flocks_autotest workflow run")
+
+          run_id = matched_run["id"]
+          run_api_url = matched_run["url"]
+          run_html_url = matched_run["html_url"]
+          print(f"Matched flocks_autotest run: {run_html_url}", flush=True)
+
+          while time.time() < deadline:
+              matched_run = api_json(run_api_url)
+              status = matched_run.get("status")
+              conclusion = matched_run.get("conclusion") or ""
+              print(
+                  f"flocks_autotest run {run_id}: status={status} conclusion={conclusion}",
+                  flush=True,
+              )
+              if status == "completed":
+                  break
+              time.sleep(poll_interval)
+
+          if matched_run.get("status") != "completed":
+              write_summary(
+                  [
+                      "### flocks_autotest result",
+                      "",
+                      f"- Status: timed out waiting for completion",
+                      f"- Run: {run_html_url}",
+                      f"- Expected artifact prefix: {artifact_prefix}",
+                  ]
+              )
+              raise SystemExit("Timed out waiting for flocks_autotest completion")
+
+          conclusion = matched_run.get("conclusion") or "unknown"
+          artifacts_url = f"{api_root}/repos/{autotest_repo}/actions/runs/{run_id}/artifacts?per_page=100"
+          artifacts = api_json(artifacts_url).get("artifacts", [])
+          matching_artifacts = [
+              artifact
+              for artifact in artifacts
+              if not artifact.get("expired") and (artifact.get("name") or "").startswith(artifact_prefix)
+          ]
+          matching_artifacts.sort(key=lambda artifact: artifact.get("created_at") or "", reverse=True)
+
+          artifact_name = ""
+          artifact_html_url = ""
+          artifact_path = ""
+          if matching_artifacts:
+              artifact = matching_artifacts[0]
+              artifact_name = artifact["name"]
+              artifact_html_url = (
+                  f"https://github.com/{autotest_repo}/actions/runs/{run_id}/artifacts/{artifact['id']}"
+              )
+              artifact_path = os.path.join(runner_temp, f"{artifact_name}.zip")
+              download(artifact["archive_download_url"], artifact_path)
+              print(f"Downloaded flocks_autotest artifact: {artifact_path}", flush=True)
+
+          write_outputs(
+              {
+                  "run_id": str(run_id),
+                  "run_url": run_html_url,
+                  "conclusion": conclusion,
+                  "artifact_name": artifact_name,
+                  "artifact_url": artifact_html_url,
+                  "artifact_path": artifact_path,
+              }
+          )
+
+          summary_lines = [
+              "### flocks_autotest result",
+              "",
+              f"- Run: {run_html_url}",
+              f"- Conclusion: {conclusion}",
+              f"- Expected artifact prefix: {artifact_prefix}",
+          ]
+          if artifact_name:
+              summary_lines.append(f"- Artifact: [{artifact_name}]({artifact_html_url})")
+              summary_lines.append("- Artifact copy: uploaded to this flocks workflow run")
+          else:
+              summary_lines.append("- Artifact: not found")
+          write_summary(summary_lines)
+
+          if conclusion != "success":
+              raise SystemExit(f"flocks_autotest concluded with {conclusion}")
+          if not artifact_name:
+              raise SystemExit("flocks_autotest artifact was not found")
+          PY
+
+      - name: Upload flocks_autotest artifact copy
+        if: ${{ always() && steps.autotest.outputs.artifact_path != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.autotest.outputs.artifact_name }}
+          path: ${{ steps.autotest.outputs.artifact_path }}
+          if-no-files-found: error

--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       release_tag:
@@ -47,8 +44,6 @@ jobs:
         id: payload
         env:
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
-          EVENT_RELEASE_URL: ${{ github.event.release.html_url }}
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
           INPUT_RELEASE_URL: ${{ inputs.release_url }}
           INPUT_ROLLBACK_VERSION: ${{ inputs.rollback_version }}
@@ -70,13 +65,6 @@ jobs:
 
           release_tag="${INPUT_RELEASE_TAG:-}"
           release_url="${INPUT_RELEASE_URL:-}"
-
-          if [ -z "$release_tag" ] && [ "$EVENT_NAME" = "release" ]; then
-            release_tag="${EVENT_RELEASE_TAG:-}"
-          fi
-          if [ -z "$release_url" ] && [ "$EVENT_NAME" = "release" ]; then
-            release_url="${EVENT_RELEASE_URL:-}"
-          fi
 
           if [ -z "$release_tag" ]; then
             release_tag="$pyproject_version"
@@ -127,7 +115,7 @@ jobs:
           import os
 
           payload = {
-              "event_type": "flocks_release_published",
+              "event_type": "flocks_main_updated",
               "client_payload": {
                   "release_tag": os.environ["RELEASE_TAG"],
                   "release_url": os.environ["RELEASE_URL"],

--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -95,7 +95,7 @@ jobs:
             echo "- Source sha: ${GITHUB_SHA_VALUE}"
             echo "- Rollback version: ${INPUT_ROLLBACK_VERSION:-}"
             echo "- Run force fallback: ${INPUT_RUN_FORCE_FALLBACK:-false}"
-            echo "- Expected autotest artifact prefix: flocks-windows-upgrade-${release_tag}-run-"
+            echo "- Expected autotest artifact prefix: flocks-windows-upgrade-${release_tag}-time"
             echo "- Autotest workflow: https://github.com/AgentFlocks/flocks_autotest/actions/workflows/flocks-release-dispatch.yml"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -1,0 +1,164 @@
+name: Dispatch autotest Windows upgrade
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Optional Flocks version tag. Defaults to pyproject.toml version."
+        required: false
+        type: string
+      release_url:
+        description: "Optional source URL. Defaults to the release or commit URL."
+        required: false
+        type: string
+      rollback_version:
+        description: "Optional old version for flocks_autotest to prepare an upgradeable baseline."
+        required: false
+        type: string
+      run_force_fallback:
+        description: "Also ask flocks_autotest to run the force fallback reinstall case."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dispatch-autotest-windows-upgrade-${{ github.event_name }}-${{ github.ref_name || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch flocks_autotest Windows upgrade
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve dispatch payload
+        id: payload
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_RELEASE_URL: ${{ github.event.release.html_url }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_RELEASE_URL: ${{ inputs.release_url }}
+          INPUT_ROLLBACK_VERSION: ${{ inputs.rollback_version }}
+          INPUT_RUN_FORCE_FALLBACK: ${{ inputs.run_force_fallback }}
+          GITHUB_SERVER_URL_VALUE: ${{ github.server_url }}
+          GITHUB_REPOSITORY_VALUE: ${{ github.repository }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+          GITHUB_REF_NAME_VALUE: ${{ github.ref_name }}
+          GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          pyproject_version="$(python3 - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )"
+
+          release_tag="${INPUT_RELEASE_TAG:-}"
+          release_url="${INPUT_RELEASE_URL:-}"
+
+          if [ -z "$release_tag" ] && [ "$EVENT_NAME" = "release" ]; then
+            release_tag="${EVENT_RELEASE_TAG:-}"
+          fi
+          if [ -z "$release_url" ] && [ "$EVENT_NAME" = "release" ]; then
+            release_url="${EVENT_RELEASE_URL:-}"
+          fi
+
+          if [ -z "$release_tag" ]; then
+            release_tag="$pyproject_version"
+          fi
+          if [ -z "$release_url" ]; then
+            release_url="${GITHUB_SERVER_URL_VALUE}/${GITHUB_REPOSITORY_VALUE}/commit/${GITHUB_SHA_VALUE}"
+          fi
+
+          if [ -z "$release_tag" ]; then
+            echo "release_tag is empty" >&2
+            exit 1
+          fi
+
+          {
+            echo "release_tag=$release_tag"
+            echo "release_url=$release_url"
+            echo "rollback_version=${INPUT_ROLLBACK_VERSION:-}"
+            echo "run_force_fallback=${INPUT_RUN_FORCE_FALLBACK:-false}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### flocks_autotest dispatch payload"
+            echo ""
+            echo "- Event: ${EVENT_NAME}"
+            echo "- Release tag: ${release_tag}"
+            echo "- Release URL: ${release_url}"
+            echo "- Source ref: ${GITHUB_REF_NAME_VALUE}"
+            echo "- Source sha: ${GITHUB_SHA_VALUE}"
+            echo "- Rollback version: ${INPUT_ROLLBACK_VERSION:-}"
+            echo "- Run force fallback: ${INPUT_RUN_FORCE_FALLBACK:-false}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create repository_dispatch payload
+        env:
+          RELEASE_TAG: ${{ steps.payload.outputs.release_tag }}
+          RELEASE_URL: ${{ steps.payload.outputs.release_url }}
+          ROLLBACK_VERSION: ${{ steps.payload.outputs.rollback_version }}
+          RUN_FORCE_FALLBACK: ${{ steps.payload.outputs.run_force_fallback }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ github.run_id }}
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY' > "$RUNNER_TEMP/flocks-autotest-dispatch.json"
+          import json
+          import os
+
+          payload = {
+              "event_type": "flocks_release_published",
+              "client_payload": {
+                  "release_tag": os.environ["RELEASE_TAG"],
+                  "release_url": os.environ["RELEASE_URL"],
+                  "installer_asset_name": "",
+                  "source_repository": os.environ["SOURCE_REPOSITORY"],
+                  "source_run_id": os.environ["SOURCE_RUN_ID"],
+                  "source_sha": os.environ["SOURCE_SHA"],
+                  "source_ref": os.environ["SOURCE_REF"],
+                  "rollback_version": os.environ.get("ROLLBACK_VERSION", ""),
+                  "run_force_fallback": os.environ.get("RUN_FORCE_FALLBACK", "false"),
+              },
+          }
+          print(json.dumps(payload, ensure_ascii=False))
+          PY
+
+          cat "$RUNNER_TEMP/flocks-autotest-dispatch.json"
+
+      - name: Dispatch flocks_autotest
+        env:
+          GH_TOKEN: ${{ secrets.AUTOTEST_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Missing AUTOTEST_DISPATCH_TOKEN secret" >&2
+            exit 1
+          fi
+
+          curl --fail-with-body -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data-binary "@${RUNNER_TEMP}/flocks-autotest-dispatch.json" \
+            "https://api.github.com/repos/AgentFlocks/flocks_autotest/dispatches"

--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -95,6 +95,8 @@ jobs:
             echo "- Source sha: ${GITHUB_SHA_VALUE}"
             echo "- Rollback version: ${INPUT_ROLLBACK_VERSION:-}"
             echo "- Run force fallback: ${INPUT_RUN_FORCE_FALLBACK:-false}"
+            echo "- Expected autotest artifact prefix: flocks-windows-upgrade-${release_tag}-run-"
+            echo "- Autotest workflow: https://github.com/AgentFlocks/flocks_autotest/actions/workflows/flocks-release-dispatch.yml"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create repository_dispatch payload


### PR DESCRIPTION
## Summary
- add a workflow that dispatches flocks_autotest Windows upgrade regression on main push, release publish, or manual trigger
- resolve release payload from release metadata, workflow inputs, or pyproject version
- send repository_dispatch event_type=flocks_release_published to AgentFlocks/flocks_autotest using AUTOTEST_DISPATCH_TOKEN

## Verification
- ruby YAML parse for .github/workflows/dispatch-autotest-windows-upgrade.yml
- local shell simulation for main-push release_tag/release_url resolution