### PR TITLE
fix(session): support clipboard fallback for remote deployments

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -482,6 +482,52 @@ describe('getMessageGroupClassName', () => {
   });
 });
 
+describe('SessionChat copy action', () => {
+  it('falls back when async clipboard is unavailable', async () => {
+    const user = userEvent.setup();
+    const execCommand = vi.fn().mockReturnValue(true);
+
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'assistant-copy',
+          role: 'assistant',
+          parts: [{ id: 'text-1', type: 'text', text: 'copy this result' }],
+        }),
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      display: { compact: false, showActions: true },
+    }));
+
+    await user.click(screen.getByRole('button', { name: 'chat.copy' }));
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+});
+
 describe('getCompactionDividerClassName', () => {
   it('insets the divider into the assistant content column in full layout', () => {
     const className = getCompactionDividerClassName(false);

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -38,6 +38,7 @@ import { buildRunWorkflowHeaderSummary } from './toolStageSummary';
 import { workspaceAPI } from '@/api/workspace';
 import { formatSmartTime } from '@/utils/time';
 import { getAgentDisplayDescription } from '@/utils/agentDisplay';
+import { copyText } from '@/utils/clipboard';
 import {
   FILE_INPUT_ACCEPT_IMAGES,
   batchCompressOptions,
@@ -2890,7 +2891,7 @@ export default function SessionChat({
 
   // Copy text to clipboard
   const handleCopy = useCallback((text: string) => {
-    navigator.clipboard.writeText(text).catch(() => {});
+    void copyText(text).catch(() => {});
   }, []);
 
   const resetEditingState = useCallback(() => {


### PR DESCRIPTION
## Summary

- Route SessionChat copy actions through the shared clipboard helper.
- Preserve copy support when async Clipboard API is unavailable or blocked.
- Add a regression test for the fallback copy path.

## Root Cause

SessionChat called `navigator.clipboard.writeText()` directly and ignored failures. Remote deployments can run outside a browser secure context or under stricter clipboard permissions, so the async Clipboard API may be unavailable even though localhost works.

## Validation

- `npm run test:run -- SessionChat.test.ts`
- `npm run test:run -- clipboard.test.ts`
- `./node_modules/.bin/eslint src/components/common/SessionChat.tsx src/components/common/SessionChat.test.ts`
- `git diff --check`
