### PR TITLE
Add workflow payload risk observability

### DIFF
--- a/flocks/ingest/kafka/manager.py
+++ b/flocks/ingest/kafka/manager.py
@@ -27,7 +27,6 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional
 
-from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 from flocks.workflow.execution_store import (
     DEFAULT_LARGE_LIST_KEYS,
@@ -40,11 +39,16 @@ from flocks.workflow.execution_store import (
 )
 from flocks.workflow.fs_store import read_workflow_from_fs
 from flocks.workflow.runner import run_workflow
+from flocks.workflow.store import WorkflowStore
 
 from flocks.ingest.kafka.constants import WORKFLOW_KAFKA_CONFIG_PREFIX
 from flocks.workflow.triggers.compat import legacy_kafka_trigger_from_config
 from flocks.workflow.triggers.dispatcher import EventDispatcher, TriggerDispatchError, build_trigger_event
-from flocks.workflow.triggers.models import TriggerDefinition, workflow_json_declares_triggers, workflow_trigger_definitions_from_json
+from flocks.workflow.triggers.models import (
+    TriggerDefinition,
+    workflow_json_declares_triggers,
+    workflow_trigger_definitions_from_json,
+)
 
 log = Log.create(service="kafka.manager")
 
@@ -176,9 +180,7 @@ def _compact_for_kafka_storage(outputs: Any) -> Dict[str, Any]:
         size_threshold=0,
     )
     for key, value in list(compacted.items()):
-        if key == "kafka_output" or (
-            isinstance(value, str) and len(value) > _STORAGE_PREVIEW_CHARS
-        ):
+        if key == "kafka_output" or (isinstance(value, str) and len(value) > _STORAGE_PREVIEW_CHARS):
             compacted[key] = _summarize_large_value(value)
     return compacted
 
@@ -203,8 +205,10 @@ def _compact_history_for_kafka_storage(
             if not isinstance(payload, dict):
                 continue
             for key, value in list(payload.items()):
-                if key in raw_input_keys or key == "kafka_output" or (
-                    isinstance(value, str) and len(value) > _STORAGE_PREVIEW_CHARS
+                if (
+                    key in raw_input_keys
+                    or key == "kafka_output"
+                    or (isinstance(value, str) and len(value) > _STORAGE_PREVIEW_CHARS)
                 ):
                     payload[key] = _summarize_large_value(value)
     return compacted
@@ -282,21 +286,13 @@ class KafkaManager:
 
     async def start_all(self) -> None:
         try:
-            keys = await Storage.list_keys(WORKFLOW_KAFKA_CONFIG_PREFIX)
+            configs = await WorkflowStore.list_configs(kind="workflow_kafka_config")
         except Exception as exc:
-            log.warning("kafka.list_keys_failed", {"error": str(exc)})
+            log.warning("kafka.list_configs_failed", {"error": str(exc)})
             return
 
-        for key in keys:
-            if not key.startswith(WORKFLOW_KAFKA_CONFIG_PREFIX):
-                continue
-            workflow_id = key[len(WORKFLOW_KAFKA_CONFIG_PREFIX):]
+        for workflow_id, data in configs:
             if not workflow_id:
-                continue
-            try:
-                data = await Storage.read(key)
-            except Exception as exc:
-                log.warning("kafka.config_read_failed", {"key": key, "error": str(exc)})
                 continue
             if isinstance(data, dict) and data.get("enabled"):
                 await self.restart_workflow(workflow_id)
@@ -370,9 +366,8 @@ class KafkaManager:
         surface connection errors to the user.
         """
         await self.stop_workflow(workflow_id)
-        key = self._config_key(workflow_id)
         try:
-            data = await Storage.read(key)
+            data = await WorkflowStore.get_config(workflow_id, kind="workflow_kafka_config")
         except Exception as exc:
             log.warning("kafka.restart_read_failed", {"workflow_id": workflow_id, "error": str(exc)})
             return {"state": "failed", "error": str(exc)}
@@ -404,9 +399,7 @@ class KafkaManager:
 
         trigger = self._resolve_active_trigger(workflow_json, data)
         group_id = str(data.get("inputGroupId") or "").strip() or f"flocks-consumer-{workflow_id}"
-        configured_inputs = _strip_execution_only_comments(
-            trigger.inputs if isinstance(trigger.inputs, dict) else {}
-        )
+        configured_inputs = _strip_execution_only_comments(trigger.inputs if isinstance(trigger.inputs, dict) else {})
 
         queue: asyncio.Queue = asyncio.Queue(maxsize=_MAX_QUEUE_SIZE)
         self._queues[workflow_id] = queue
@@ -432,7 +425,13 @@ class KafkaManager:
             workers.append(
                 asyncio.create_task(
                     self._worker_loop(
-                        workflow_id, workflow_json, trigger, configured_inputs, queue, abort, input_topic,
+                        workflow_id,
+                        workflow_json,
+                        trigger,
+                        configured_inputs,
+                        queue,
+                        abort,
+                        input_topic,
                     ),
                     name=f"kafka-worker-{workflow_id}-{i}",
                 )
@@ -441,9 +440,14 @@ class KafkaManager:
 
         task = asyncio.create_task(
             self._consumer_loop(
-                workflow_id, input_broker, input_topic, group_id,
+                workflow_id,
+                input_broker,
+                input_topic,
+                group_id,
                 str(data.get("autoOffsetReset") or "latest"),
-                queue, abort, ready,
+                queue,
+                abort,
+                ready,
             ),
             name=f"kafka-{workflow_id}",
         )
@@ -698,23 +702,25 @@ class KafkaManager:
                 duration = time.time() - start_time
                 step_count = step_recorder.step_count or result.steps
                 exec_data.update(step_recorder.summary)
-                exec_data.update({
-                    "status": status,
-                    "outputResults": _compact_for_kafka_storage(result.outputs),
-                    "finishedAt": int(time.time() * 1000),
-                    "duration": duration,
-                    "errorMessage": error_msg,
-                    "executionLog": [],
-                    "stepCount": step_count,
-                    "currentNodeId": result.last_node_id,
-                    "currentPhase": status,
-                    "currentStepIndex": step_count,
-                    "triggerId": trigger.id,
-                    "triggerType": trigger.type,
-                    "deliveryId": trigger_meta.get("deliveryId"),
-                    "attempt": trigger_meta.get("attempt"),
-                    "triggerSource": trigger_meta.get("source"),
-                })
+                exec_data.update(
+                    {
+                        "status": status,
+                        "outputResults": _compact_for_kafka_storage(result.outputs),
+                        "finishedAt": int(time.time() * 1000),
+                        "duration": duration,
+                        "errorMessage": error_msg,
+                        "executionLog": [],
+                        "stepCount": step_count,
+                        "currentNodeId": result.last_node_id,
+                        "currentPhase": status,
+                        "currentStepIndex": step_count,
+                        "triggerId": trigger.id,
+                        "triggerType": trigger.type,
+                        "deliveryId": trigger_meta.get("deliveryId"),
+                        "attempt": trigger_meta.get("attempt"),
+                        "triggerSource": trigger_meta.get("source"),
+                    }
+                )
             except Exception as exc:
                 duration = time.time() - start_time
                 log.error(
@@ -722,19 +728,21 @@ class KafkaManager:
                     {"workflow_id": workflow_id, "exec_id": exec_id, "error": str(exc)},
                 )
                 exec_data.update(step_recorder.summary)
-                exec_data.update({
-                    "status": "error",
-                    "errorMessage": str(exc),
-                    "finishedAt": int(time.time() * 1000),
-                    "duration": duration,
-                    "executionLog": [],
-                    "currentPhase": "error",
-                    "triggerId": trigger.id,
-                    "triggerType": trigger.type,
-                    "deliveryId": trigger_meta.get("deliveryId"),
-                    "attempt": trigger_meta.get("attempt"),
-                    "triggerSource": trigger_meta.get("source"),
-                })
+                exec_data.update(
+                    {
+                        "status": "error",
+                        "errorMessage": str(exc),
+                        "finishedAt": int(time.time() * 1000),
+                        "duration": duration,
+                        "executionLog": [],
+                        "currentPhase": "error",
+                        "triggerId": trigger.id,
+                        "triggerType": trigger.type,
+                        "deliveryId": trigger_meta.get("deliveryId"),
+                        "attempt": trigger_meta.get("attempt"),
+                        "triggerSource": trigger_meta.get("source"),
+                    }
+                )
             finally:
                 try:
                     await record_execution_result(workflow_id, exec_id, exec_data)

--- a/flocks/ingest/syslog/manager.py
+++ b/flocks/ingest/syslog/manager.py
@@ -7,7 +7,6 @@ import time
 import uuid
 from typing import Any, Dict, List
 
-from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 from flocks.workflow.execution_store import (
     compact_outputs_for_storage,
@@ -18,12 +17,17 @@ from flocks.workflow.execution_store import (
 )
 from flocks.workflow.fs_store import read_workflow_from_fs
 from flocks.workflow.runner import run_workflow
+from flocks.workflow.store import WorkflowStore
 
 from flocks.ingest.syslog.constants import WORKFLOW_SYSLOG_CONFIG_PREFIX
 from flocks.ingest.syslog.listener import run_tcp_syslog_server, run_udp_syslog_server
 from flocks.workflow.triggers.compat import legacy_syslog_trigger_from_config
 from flocks.workflow.triggers.dispatcher import EventDispatcher, TriggerDispatchError, build_trigger_event
-from flocks.workflow.triggers.models import TriggerDefinition, workflow_json_declares_triggers, workflow_trigger_definitions_from_json
+from flocks.workflow.triggers.models import (
+    TriggerDefinition,
+    workflow_json_declares_triggers,
+    workflow_trigger_definitions_from_json,
+)
 
 log = Log.create(service="syslog.manager")
 
@@ -88,13 +92,16 @@ class _DropWarningThrottle:
             self._flush(trigger=trigger)
 
     def _flush(self, *, trigger: str) -> None:
-        log.warning("syslog.queue_full_dropped", {
-            "workflow_id": self._workflow_id,
-            "queue_size": self._queue.qsize(),
-            "queue_capacity": self._queue.maxsize,
-            "dropped_in_window": int(self._count),
-            "trigger": trigger,
-        })
+        log.warning(
+            "syslog.queue_full_dropped",
+            {
+                "workflow_id": self._workflow_id,
+                "queue_size": self._queue.qsize(),
+                "queue_capacity": self._queue.maxsize,
+                "dropped_in_window": int(self._count),
+                "trigger": trigger,
+            },
+        )
         self._count = 0
         self._last_log = time.monotonic()
 
@@ -168,21 +175,13 @@ class SyslogManager:
 
     async def start_all(self) -> None:
         try:
-            keys = await Storage.list_keys(WORKFLOW_SYSLOG_CONFIG_PREFIX)
+            configs = await WorkflowStore.list_configs(kind="workflow_syslog_config")
         except Exception as exc:
-            log.warning("syslog.list_keys_failed", {"error": str(exc)})
+            log.warning("syslog.list_configs_failed", {"error": str(exc)})
             return
 
-        for key in keys:
-            if not key.startswith(WORKFLOW_SYSLOG_CONFIG_PREFIX):
-                continue
-            workflow_id = key[len(WORKFLOW_SYSLOG_CONFIG_PREFIX) :]
+        for workflow_id, data in configs:
             if not workflow_id:
-                continue
-            try:
-                data = await Storage.read(key)
-            except Exception as exc:
-                log.warning("syslog.config_read_failed", {"key": key, "error": str(exc)})
                 continue
             if isinstance(data, dict) and data.get("enabled"):
                 await self.restart_workflow(workflow_id)
@@ -254,9 +253,8 @@ class SyslogManager:
         user instead of silently leaving the listener in a failed state.
         """
         await self.stop_workflow(workflow_id)
-        key = self._config_key(workflow_id)
         try:
-            data = await Storage.read(key)
+            data = await WorkflowStore.get_config(workflow_id, kind="workflow_syslog_config")
         except Exception as exc:
             log.warning("syslog.restart_read_failed", {"workflow_id": workflow_id, "error": str(exc)})
             return {"state": "failed", "error": str(exc)}
@@ -543,23 +541,25 @@ class SyslogManager:
                 duration = time.time() - start_time
                 step_count = step_recorder.step_count or result.steps
                 exec_data.update(step_recorder.summary)
-                exec_data.update({
-                    "status": status,
-                    "outputResults": compact_outputs_for_storage(result.outputs),
-                    "finishedAt": int(time.time() * 1000),
-                    "duration": duration,
-                    "errorMessage": error_msg,
-                    "executionLog": [],
-                    "stepCount": step_count,
-                    "currentNodeId": result.last_node_id,
-                    "currentPhase": status,
-                    "currentStepIndex": step_count,
-                    "triggerId": trigger.id,
-                    "triggerType": trigger.type,
-                    "deliveryId": trigger_meta.get("deliveryId"),
-                    "attempt": trigger_meta.get("attempt"),
-                    "triggerSource": trigger_meta.get("source"),
-                })
+                exec_data.update(
+                    {
+                        "status": status,
+                        "outputResults": compact_outputs_for_storage(result.outputs),
+                        "finishedAt": int(time.time() * 1000),
+                        "duration": duration,
+                        "errorMessage": error_msg,
+                        "executionLog": [],
+                        "stepCount": step_count,
+                        "currentNodeId": result.last_node_id,
+                        "currentPhase": status,
+                        "currentStepIndex": step_count,
+                        "triggerId": trigger.id,
+                        "triggerType": trigger.type,
+                        "deliveryId": trigger_meta.get("deliveryId"),
+                        "attempt": trigger_meta.get("attempt"),
+                        "triggerSource": trigger_meta.get("source"),
+                    }
+                )
             except Exception as exc:
                 duration = time.time() - start_time
                 log.error(
@@ -567,19 +567,21 @@ class SyslogManager:
                     {"workflow_id": workflow_id, "exec_id": exec_id, "error": str(exc)},
                 )
                 exec_data.update(step_recorder.summary)
-                exec_data.update({
-                    "status": "error",
-                    "errorMessage": str(exc),
-                    "finishedAt": int(time.time() * 1000),
-                    "duration": duration,
-                    "executionLog": [],
-                    "currentPhase": "error",
-                    "triggerId": trigger.id,
-                    "triggerType": trigger.type,
-                    "deliveryId": trigger_meta.get("deliveryId"),
-                    "attempt": trigger_meta.get("attempt"),
-                    "triggerSource": trigger_meta.get("source"),
-                })
+                exec_data.update(
+                    {
+                        "status": "error",
+                        "errorMessage": str(exc),
+                        "finishedAt": int(time.time() * 1000),
+                        "duration": duration,
+                        "executionLog": [],
+                        "currentPhase": "error",
+                        "triggerId": trigger.id,
+                        "triggerType": trigger.type,
+                        "deliveryId": trigger_meta.get("deliveryId"),
+                        "attempt": trigger_meta.get("attempt"),
+                        "triggerSource": trigger_meta.get("source"),
+                    }
+                )
             finally:
                 try:
                     await record_execution_result(workflow_id, exec_id, exec_data)

--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -394,6 +394,27 @@ def _write_workflow_to_fs(
         legacy_edit_file.unlink()
 
 
+def _apply_new_workflow_runtime_defaults(workflow_json: Dict[str, Any]) -> Dict[str, Any]:
+    """Return workflow JSON with runtime defaults for newly created workflows."""
+    normalized = dict(workflow_json)
+    metadata = normalized.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    else:
+        metadata = dict(metadata)
+    runtime = metadata.get("runtime")
+    if not isinstance(runtime, dict):
+        runtime = {}
+    else:
+        runtime = dict(runtime)
+
+    runtime.setdefault("strict_edge_mapping", True)
+    runtime.setdefault("dataflow_mode", "vertex_cache")
+    metadata["runtime"] = runtime
+    normalized["metadata"] = metadata
+    return normalized
+
+
 def _delete_workflow_from_fs(workflow_id: str) -> bool:
     """Remove a workflow directory from all known locations (primary + legacy plugins).
 
@@ -1328,8 +1349,9 @@ async def create_workflow(req: WorkflowCreateRequest):
     of truth. Stats are initialised in Storage on first access.
     """
     try:
+        workflow_json = _apply_new_workflow_runtime_defaults(req.workflow_json)
         try:
-            Workflow.from_dict(req.workflow_json)
+            Workflow.from_dict(workflow_json)
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid workflow JSON: {str(e)}")
 
@@ -1349,12 +1371,12 @@ async def create_workflow(req: WorkflowCreateRequest):
             "updatedAt": now_ms,
         }
 
-        _write_workflow_to_fs(workflow_id, req.workflow_json, meta, global_store=(source == "global"))
+        _write_workflow_to_fs(workflow_id, workflow_json, meta, global_store=(source == "global"))
 
         stats = await _get_workflow_stats(workflow_id)
         data = {
             **meta,
-            "workflowJson": req.workflow_json,
+            "workflowJson": workflow_json,
             "markdownContent": None,
             "editMarkdownContent": None,
             "stats": stats,

--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -248,6 +248,7 @@ class WorkflowExecutionResponse(BaseModel):
     stepLogLimit: Optional[int] = Field(None, description="Returned step log limit")
     stepLogTotal: Optional[int] = Field(None, description="Total persisted step logs")
     loopProgress: Optional[Dict[str, Any]] = Field(None, description="Best-effort loop progress metadata")
+    payloadRiskSummary: Optional[Dict[str, Any]] = Field(None, description="Workflow payload memory risk summary")
 
 
 class WorkflowCenterPublishRequest(BaseModel):
@@ -1065,13 +1066,15 @@ async def _run_workflow_execution_task(
             outputs=None,
         )
         pending_step_index = step_index
-        pending_step = {
-            "node_id": node_id,
-            "node_type": node_type,
-            "inputs": _inputs if isinstance(_inputs, dict) else {},
-            "outputs": {},
-            "error": "Run cancelled before node completed",
-        }
+        pending_step = compact_step_for_storage(
+            {
+                "node_id": node_id,
+                "node_type": node_type,
+                "inputs": _inputs if isinstance(_inputs, dict) else {},
+                "outputs": {},
+                "error": "Run cancelled before node completed",
+            }
+        )
         _write_progress(
             {
                 "currentNodeId": node_id,
@@ -1183,6 +1186,7 @@ async def _run_workflow_execution_task(
                 "finishedAt": int(time.time() * 1000),
                 "duration": duration,
                 "executionLog": final_history,
+                "payloadRiskSummary": result.payload_risk_summary,
                 "stepCount": final_steps,
                 "errorMessage": error_message,
                 "currentNodeId": result.last_node_id,

--- a/flocks/server/routes/workflow.py
+++ b/flocks/server/routes/workflow.py
@@ -3,6 +3,7 @@ Workflow management routes
 
 Provides API endpoints for workflow CRUD, execution, history, and AI generation.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -21,7 +22,7 @@ from pydantic import BaseModel, Field, ConfigDict
 import uuid
 
 from flocks.workflow.models import Workflow, Node, Edge
-from flocks.workflow.runner import run_workflow, RunWorkflowResult
+from flocks.workflow.runner import RunWorkflowResult, run_workflow
 from flocks.workflow.center import (
     WorkflowCenterError,
     WorkflowNotFoundError,
@@ -61,6 +62,7 @@ from flocks.workflow.execution_store import (
     workflow_execution_step_prefix as _workflow_execution_step_prefix,
 )
 from flocks.workflow.io import load_workflow, dump_workflow
+from flocks.workflow.store import WorkflowStore
 from flocks.workflow.tool_context import build_workflow_tool_context
 from flocks.workflow.tools import get_tool_registry
 from flocks.workflow.visibility import is_hidden_workflow_data
@@ -105,21 +107,23 @@ _WORKFLOW_CENTER_RELEASE_PREFIX = "workflow_release/"
 _WORKFLOW_CENTER_RUNTIME_PREFIX = "workflow_runtime/"
 _WORKFLOW_CENTER_LOCAL_PID_PREFIX = "workflow_local_pid/"
 _WORKFLOW_POLLER_CONFIG_PREFIX = "workflow_poller_config/"
-_WORKFLOW_CONFIG_TRIGGER_TYPES = frozenset({
-    "manual",
-    "schedule",
-    "webhook",
-    "syslog",
-    "kafka",
-    "internal_event",
-    "custom_webhook",
-    "custom_adapter",
-    "plugin",
-    "api",
-    "publish",
-    "api_service",
-    "service",
-})
+_WORKFLOW_CONFIG_TRIGGER_TYPES = frozenset(
+    {
+        "manual",
+        "schedule",
+        "webhook",
+        "syslog",
+        "kafka",
+        "internal_event",
+        "custom_webhook",
+        "custom_adapter",
+        "plugin",
+        "api",
+        "publish",
+        "api_service",
+        "service",
+    }
+)
 _WORKFLOW_CONFIG_SECRET_KEYS = frozenset({"apikey", "password", "token", "secret"})
 _WORKFLOW_CONFIG_SECRET_REF_KEYS = frozenset({"secretref", "secretreference"})
 
@@ -127,6 +131,7 @@ _WORKFLOW_CONFIG_SECRET_REF_KEYS = frozenset({"secretref", "secretreference"})
 @dataclass
 class ActiveWorkflowExecution:
     """Tracks an in-flight workflow execution that can be cancelled."""
+
     workflow_id: str
     task: asyncio.Task[Any]
     cancel_event: threading.Event
@@ -139,10 +144,12 @@ _active_workflow_executions: Dict[str, ActiveWorkflowExecution] = {}
 # Request/Response Models
 # =============================================================================
 
+
 class WorkflowCreateRequest(BaseModel):
     """Request to create a workflow"""
+
     model_config = ConfigDict(populate_by_name=True)
-    
+
     name: str = Field(..., description="Workflow name")
     name_i18n: Optional[Dict[str, str]] = Field(None, alias="nameI18n", description="Localized workflow display names")
     description: Optional[str] = Field(None, description="Workflow description")
@@ -157,8 +164,9 @@ class WorkflowCreateRequest(BaseModel):
 
 class WorkflowUpdateRequest(BaseModel):
     """Request to update a workflow"""
+
     model_config = ConfigDict(populate_by_name=True)
-    
+
     name: Optional[str] = Field(None, description="Workflow name")
     name_i18n: Optional[Dict[str, str]] = Field(None, alias="nameI18n", description="Localized workflow display names")
     description: Optional[str] = Field(None, description="Workflow description")
@@ -179,8 +187,9 @@ class WorkflowUpdateRequest(BaseModel):
 
 class WorkflowResponse(BaseModel):
     """Workflow response"""
+
     model_config = ConfigDict(populate_by_name=True, by_alias=True)
-    
+
     id: str = Field(..., description="Workflow ID")
     name: str = Field(..., description="Workflow name")
     nameI18n: Optional[Dict[str, str]] = Field(None, description="Localized workflow display names")
@@ -199,8 +208,9 @@ class WorkflowResponse(BaseModel):
 
 class WorkflowRunRequest(BaseModel):
     """Request to run a workflow"""
+
     model_config = ConfigDict(populate_by_name=True)
-    
+
     inputs: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Input parameters")
     timeout_s: Optional[float] = Field(None, alias="timeoutS", description="Timeout in seconds")
     trace: bool = Field(False, description="Enable tracing")
@@ -211,8 +221,9 @@ class WorkflowRunRequest(BaseModel):
 
 class WorkflowExecutionResponse(BaseModel):
     """Workflow execution response"""
+
     model_config = ConfigDict(populate_by_name=True, by_alias=True)
-    
+
     id: str = Field(..., description="Execution ID")
     workflowId: str = Field(..., description="Workflow ID")
     inputParams: Dict[str, Any] = Field(default_factory=dict, description="Input parameters")
@@ -260,8 +271,9 @@ class WorkflowCenterInvokeRequest(BaseModel):
 
 class WorkflowStatsResponse(BaseModel):
     """Workflow statistics response"""
+
     model_config = ConfigDict(populate_by_name=True, by_alias=True)
-    
+
     workflowId: Optional[str] = Field(None, description="Workflow ID (null for aggregate)")
     callCount: int = Field(0, description="Total calls")
     successCount: int = Field(0, description="Successful calls")
@@ -438,38 +450,23 @@ async def _stop_workflow_runtime_resources(workflow_id: str) -> None:
 
 
 async def _cleanup_workflow_storage(workflow_id: str) -> None:
-    await _remove_storage_key_if_exists(_workflow_stats_key(workflow_id))
-    await _remove_storage_key_if_exists(_workflow_integration_config_key(workflow_id))
-    await _remove_storage_key_if_exists(_api_service_key(workflow_id))
-    await _remove_storage_key_if_exists(_syslog_config_key(workflow_id))
-    await _remove_storage_key_if_exists(_kafka_config_key(workflow_id))
-    await _remove_storage_key_if_exists(f"{_WORKFLOW_POLLER_CONFIG_PREFIX}{workflow_id}")
-    await _remove_storage_key_if_exists(f"{_WORKFLOW_CENTER_REGISTRY_PREFIX}{workflow_id}")
-    await _remove_storage_key_if_exists(f"{_WORKFLOW_CENTER_RUNTIME_PREFIX}{workflow_id}")
-    await _remove_storage_key_if_exists(f"{_WORKFLOW_CENTER_LOCAL_PID_PREFIX}{workflow_id}")
-    await _remove_storage_prefix(f"{_WORKFLOW_CENTER_RELEASE_PREFIX}{workflow_id}/")
-    await _remove_storage_prefix(f"workflow_execution_index/{workflow_id}/")
-
     try:
-        exec_keys = await Storage.list_keys("workflow_execution/")
-        for key in exec_keys:
-            try:
-                exec_data = await Storage.read(key)
-                if isinstance(exec_data, dict) and exec_data.get("workflowId") == workflow_id:
-                    exec_id = key.rsplit("/", 1)[-1]
-                    await Storage.clear(_workflow_execution_step_prefix(exec_id))
-                    await Storage.remove(key)
-            except Exception as exc:
-                log.warning("workflow.delete.execution_cleanup_failed", {
-                    "workflow_id": workflow_id,
-                    "key": key,
-                    "error": str(exc),
-                })
+        await WorkflowStore.delete_stats(workflow_id)
+        await WorkflowStore.delete_config(workflow_id)
+        await WorkflowStore.delete_executions_for_workflow(workflow_id)
+        await WorkflowStore.kv_remove(_api_service_key(workflow_id))
+        await WorkflowStore.kv_remove(f"{_WORKFLOW_CENTER_REGISTRY_PREFIX}{workflow_id}")
+        await WorkflowStore.kv_remove(f"{_WORKFLOW_CENTER_RUNTIME_PREFIX}{workflow_id}")
+        await WorkflowStore.kv_remove(f"{_WORKFLOW_CENTER_LOCAL_PID_PREFIX}{workflow_id}")
+        await WorkflowStore.kv_clear(f"{_WORKFLOW_CENTER_RELEASE_PREFIX}{workflow_id}/")
     except Exception as exc:
-        log.warning("workflow.delete.execution_scan_failed", {
-            "workflow_id": workflow_id,
-            "error": str(exc),
-        })
+        log.warning(
+            "workflow.delete.workflow_store_cleanup_failed",
+            {
+                "workflow_id": workflow_id,
+                "error": str(exc),
+            },
+        )
 
     service_dir = Config.get_data_path() / "workflow-services" / "workflows" / workflow_id
     if service_dir.is_dir():
@@ -583,6 +580,7 @@ async def _migrate_storage_to_filesystem() -> None:
 # Storage Helpers (Stats & Execution only)
 # =============================================================================
 
+
 def _workflow_stats_key(workflow_id: str) -> str:
     return f"workflow/{workflow_id}/stats"
 
@@ -593,13 +591,13 @@ def _syslog_config_key(workflow_id: str) -> str:
 
 async def _read_legacy_trigger_defs(workflow_id: str) -> List[TriggerDefinition]:
     triggers: List[TriggerDefinition] = []
-    for key, converter in (
-        (_kafka_config_key(workflow_id), legacy_kafka_trigger_from_config),
-        (f"workflow_poller_config/{workflow_id}", legacy_schedule_trigger_from_config),
-        (_syslog_config_key(workflow_id), legacy_syslog_trigger_from_config),
+    for kind, converter in (
+        ("workflow_kafka_config", legacy_kafka_trigger_from_config),
+        ("workflow_poller_config", legacy_schedule_trigger_from_config),
+        ("workflow_syslog_config", legacy_syslog_trigger_from_config),
     ):
         try:
-            config = await Storage.read(key)
+            config = await WorkflowStore.get_config(workflow_id, kind=kind)
         except Exception:
             config = None
         trigger = converter(config)
@@ -786,7 +784,7 @@ async def _build_workflow_integration_config(
     if trigger_defs is None:
         trigger_defs = await _get_workflow_trigger_defs(workflow_id, workflow_data)
     if service is None:
-        service = await Storage.read(_api_service_key(workflow_id))
+        service = await WorkflowStore.kv_get(_api_service_key(workflow_id))
     now_ms = int(time.time() * 1000)
     return {
         "version": _WORKFLOW_INTEGRATION_CONFIG_VERSION,
@@ -810,7 +808,7 @@ async def _build_workflow_integration_runtime(
     workflow_data: Dict[str, Any],
 ) -> Dict[str, Any]:
     triggers = await _get_workflow_trigger_defs(workflow_id, workflow_data)
-    service = await Storage.read(_api_service_key(workflow_id))
+    service = await WorkflowStore.kv_get(_api_service_key(workflow_id))
     statuses: Dict[str, Dict[str, Any]] = {}
     try:
         statuses = {
@@ -822,10 +820,13 @@ async def _build_workflow_integration_runtime(
             if item.get("triggerId")
         }
     except Exception as exc:
-        log.warning("workflow.config.runtime_status_failed", {
-            "id": workflow_id,
-            "error": str(exc),
-        })
+        log.warning(
+            "workflow.config.runtime_status_failed",
+            {
+                "id": workflow_id,
+                "error": str(exc),
+            },
+        )
 
     return {
         "publish": _publish_for_config(service),
@@ -863,7 +864,7 @@ async def _write_workflow_integration_config(
 
 
 async def _read_stored_workflow_integration_config(workflow_id: str) -> Optional[Dict[str, Any]]:
-    stored = await Storage.read(_workflow_integration_config_key(workflow_id))
+    stored = await WorkflowStore.get_config(workflow_id)
     return stored if isinstance(stored, dict) else None
 
 
@@ -892,12 +893,15 @@ async def _load_workflow_integration_config_template(
 
     file_config = await _read_file_workflow_integration_config(workflow_id, workflow_data, config_path)
     if file_config is not None:
-        await Storage.write(_workflow_integration_config_key(workflow_id), file_config)
-        log.info("workflow.config.migrated_from_file", {
-            "id": workflow_id,
-            "path": str(config_path),
-            "storage_key": _workflow_integration_config_key(workflow_id),
-        })
+        await WorkflowStore.put_config(workflow_id, file_config)
+        log.info(
+            "workflow.config.migrated_from_file",
+            {
+                "id": workflow_id,
+                "path": str(config_path),
+                "storage_key": _workflow_integration_config_key(workflow_id),
+            },
+        )
         return file_config, "file_migrated"
 
     return None, "missing"
@@ -938,19 +942,19 @@ def _disable_legacy_trigger_of_type(
 async def _sync_trigger_legacy_state(workflow_id: str, trigger: TriggerDefinition) -> Optional[Dict[str, Any]]:
     if trigger.type == "kafka":
         config = kafka_trigger_to_legacy_config(workflow_id, trigger)
-        await Storage.write(_kafka_config_key(workflow_id), config)
+        await WorkflowStore.put_config(workflow_id, config, kind="workflow_kafka_config")
         from flocks.ingest.kafka.manager import default_manager as _kafka_default_manager
 
         return await _kafka_default_manager.restart_workflow(workflow_id)
     if trigger.type == "schedule":
         config = schedule_trigger_to_legacy_config(workflow_id, trigger)
-        await Storage.write(f"workflow_poller_config/{workflow_id}", config)
+        await WorkflowStore.put_config(workflow_id, config, kind="workflow_poller_config")
         from flocks.workflow.poller_manager import default_manager as _poller_default_manager
 
         return await _poller_default_manager.restart_workflow(workflow_id)
     if trigger.type == "syslog":
         config = syslog_trigger_to_legacy_config(workflow_id, trigger)
-        await Storage.write(_syslog_config_key(workflow_id), config)
+        await WorkflowStore.put_config(workflow_id, config, kind="workflow_syslog_config")
         from flocks.ingest.syslog.manager import default_manager as _syslog_default_manager
 
         return await _syslog_default_manager.restart_workflow(workflow_id)
@@ -966,10 +970,7 @@ async def _remove_legacy_trigger_state(workflow_id: str, trigger: TriggerDefinit
             await _kafka_default_manager.stop_workflow(workflow_id)
         except Exception:
             pass
-        try:
-            await Storage.remove(_kafka_config_key(workflow_id))
-        except Storage.NotFoundError:
-            pass
+        await WorkflowStore.delete_config(workflow_id, kind="workflow_kafka_config")
         return
     if trigger.type == "schedule":
         try:
@@ -978,10 +979,7 @@ async def _remove_legacy_trigger_state(workflow_id: str, trigger: TriggerDefinit
             await _poller_default_manager.stop_workflow(workflow_id)
         except Exception:
             pass
-        try:
-            await Storage.remove(f"workflow_poller_config/{workflow_id}")
-        except Storage.NotFoundError:
-            pass
+        await WorkflowStore.delete_config(workflow_id, kind="workflow_poller_config")
         return
     if trigger.type == "syslog":
         try:
@@ -990,10 +988,7 @@ async def _remove_legacy_trigger_state(workflow_id: str, trigger: TriggerDefinit
             await _syslog_default_manager.stop_workflow(workflow_id)
         except Exception:
             pass
-        try:
-            await Storage.remove(_syslog_config_key(workflow_id))
-        except Storage.NotFoundError:
-            pass
+        await WorkflowStore.delete_config(workflow_id, kind="workflow_syslog_config")
 
 
 async def _persist_workflow_triggers(
@@ -1027,7 +1022,6 @@ async def _run_workflow_execution_task(
     tool_context: Optional[ToolContext] = None,
 ) -> None:
     """Execute a workflow in the background and keep the execution record updated."""
-    exec_key = _workflow_execution_key(exec_id)
     start_time = time.time()
     step_count = 0
     loop = asyncio.get_running_loop()
@@ -1049,13 +1043,16 @@ async def _run_workflow_execution_task(
         try:
             execution_summary.update(update_fields)
             asyncio.run_coroutine_threadsafe(
-                Storage.write(exec_key, compact_execution_summary(execution_summary)), loop
+                WorkflowStore.upsert_execution(compact_execution_summary(execution_summary)), loop
             ).result(timeout=5)
         except Exception as exc:
-            log.warning("workflow.step_progress.write_failed", {
-                "exec_id": exec_id,
-                "error": str(exc),
-            })
+            log.warning(
+                "workflow.step_progress.write_failed",
+                {
+                    "exec_id": exec_id,
+                    "error": str(exc),
+                },
+            )
 
     def _on_step_start(_run_id, step_index, node, _inputs):
         nonlocal pending_step_index, pending_step
@@ -1075,14 +1072,16 @@ async def _run_workflow_execution_task(
             "outputs": {},
             "error": "Run cancelled before node completed",
         }
-        execution_summary.update({
-            "currentNodeId": node_id,
-            "currentNodeType": node_type,
-            "currentPhase": "running",
-            "currentStepIndex": step_index,
-            "loopProgress": loop_progress,
-            "updatedAt": int(time.time() * 1000),
-        })
+        _write_progress(
+            {
+                "currentNodeId": node_id,
+                "currentNodeType": node_type,
+                "currentPhase": "running",
+                "currentStepIndex": step_index,
+                "loopProgress": loop_progress,
+                "updatedAt": int(time.time() * 1000),
+            }
+        )
         return step_index
 
     def _on_step_complete(step_result) -> None:
@@ -1097,28 +1096,8 @@ async def _run_workflow_execution_task(
             inputs=step_dict.get("inputs"),
             outputs=step_dict.get("outputs"),
         )
-        execution_summary.update({
-            "stepCount": step_count,
-            "currentNodeId": step_dict.get("node_id"),
-            "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
-            "currentPhase": "running",
-            "currentStepIndex": step_count,
-            "loopProgress": loop_progress,
-            "updatedAt": int(time.time() * 1000),
-        })
-        try:
-            asyncio.run_coroutine_threadsafe(
-                record_execution_step(exec_id, step_count, step_dict),
-                loop,
-            ).result(timeout=5)
-        except Exception as exc:
-            log.warning("workflow.execution_step.write_failed", {
-                "exec_id": exec_id,
-                "step_index": step_count,
-                "error": str(exc),
-            })
-        if step_count % _PROGRESS_FLUSH_EVERY_STEPS == 0:
-            _write_progress({
+        execution_summary.update(
+            {
                 "stepCount": step_count,
                 "currentNodeId": step_dict.get("node_id"),
                 "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
@@ -1126,7 +1105,34 @@ async def _run_workflow_execution_task(
                 "currentStepIndex": step_count,
                 "loopProgress": loop_progress,
                 "updatedAt": int(time.time() * 1000),
-            })
+            }
+        )
+        try:
+            asyncio.run_coroutine_threadsafe(
+                record_execution_step(exec_id, step_count, step_dict),
+                loop,
+            ).result(timeout=5)
+        except Exception as exc:
+            log.warning(
+                "workflow.execution_step.write_failed",
+                {
+                    "exec_id": exec_id,
+                    "step_index": step_count,
+                    "error": str(exc),
+                },
+            )
+        if step_count % _PROGRESS_FLUSH_EVERY_STEPS == 0:
+            _write_progress(
+                {
+                    "stepCount": step_count,
+                    "currentNodeId": step_dict.get("node_id"),
+                    "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
+                    "currentPhase": "running",
+                    "currentStepIndex": step_count,
+                    "loopProgress": loop_progress,
+                    "updatedAt": int(time.time() * 1000),
+                }
+            )
 
     async def _flush_pending_step() -> None:
         if pending_step_index is None or pending_step is None:
@@ -1134,11 +1140,14 @@ async def _run_workflow_execution_task(
         try:
             await record_execution_step(exec_id, pending_step_index, pending_step)
         except Exception as exc:
-            log.warning("workflow.pending_step.write_failed", {
-                "exec_id": exec_id,
-                "step_index": pending_step_index,
-                "error": str(exc),
-            })
+            log.warning(
+                "workflow.pending_step.write_failed",
+                {
+                    "exec_id": exec_id,
+                    "step_index": pending_step_index,
+                    "error": str(exc),
+                },
+            )
 
     try:
         result: RunWorkflowResult = await asyncio.to_thread(
@@ -1167,47 +1176,57 @@ async def _run_workflow_execution_task(
         final_steps = result.steps
         if pending_step_index is not None:
             final_steps = max(final_steps, pending_step_index)
-        current_data.update({
-            "outputResults": compact_outputs_for_storage(result.outputs),
-            "status": status_value,
-            "finishedAt": int(time.time() * 1000),
-            "duration": duration,
-            "executionLog": final_history,
-            "stepCount": final_steps,
-            "errorMessage": error_message,
-            "currentNodeId": result.last_node_id,
-            "currentNodeType": current_data.get("currentNodeType"),
-            "currentPhase": status_value,
-            "currentStepIndex": final_steps,
-            "updatedAt": int(time.time() * 1000),
-        })
+        current_data.update(
+            {
+                "outputResults": compact_outputs_for_storage(result.outputs),
+                "status": status_value,
+                "finishedAt": int(time.time() * 1000),
+                "duration": duration,
+                "executionLog": final_history,
+                "stepCount": final_steps,
+                "errorMessage": error_message,
+                "currentNodeId": result.last_node_id,
+                "currentNodeType": current_data.get("currentNodeType"),
+                "currentPhase": status_value,
+                "currentStepIndex": final_steps,
+                "updatedAt": int(time.time() * 1000),
+            }
+        )
 
         await _record_execution_result(workflow_id, exec_id, current_data)
-        log.info("workflow.executed", {
-            "id": workflow_id,
-            "exec_id": exec_id,
-            "status": status_value,
-            "duration": duration,
-        })
+        log.info(
+            "workflow.executed",
+            {
+                "id": workflow_id,
+                "exec_id": exec_id,
+                "status": status_value,
+                "duration": duration,
+            },
+        )
     except Exception as exc:
         duration = time.time() - start_time
         current_data = dict(execution_summary)
-        current_data.update({
-            "status": "cancelled" if cancel_event.is_set() else "error",
-            "finishedAt": int(time.time() * 1000),
-            "duration": duration,
-            "errorMessage": str(exc),
-            "executionLog": [],
-            "stepCount": step_count,
-            "currentPhase": "cancelled" if cancel_event.is_set() else "error",
-            "updatedAt": int(time.time() * 1000),
-        })
+        current_data.update(
+            {
+                "status": "cancelled" if cancel_event.is_set() else "error",
+                "finishedAt": int(time.time() * 1000),
+                "duration": duration,
+                "errorMessage": str(exc),
+                "executionLog": [],
+                "stepCount": step_count,
+                "currentPhase": "cancelled" if cancel_event.is_set() else "error",
+                "updatedAt": int(time.time() * 1000),
+            }
+        )
         await _record_execution_result(workflow_id, exec_id, current_data)
-        log.error("workflow.execute.error", {
-            "id": workflow_id,
-            "exec_id": exec_id,
-            "error": str(exc),
-        })
+        log.error(
+            "workflow.execute.error",
+            {
+                "id": workflow_id,
+                "exec_id": exec_id,
+                "error": str(exc),
+            },
+        )
     finally:
         _active_workflow_executions.pop(exec_id, None)
 
@@ -1234,7 +1253,7 @@ def _compute_avg_runtime(stats: Dict[str, Any]) -> Dict[str, Any]:
 async def _get_workflow_stats(workflow_id: str) -> Dict[str, Any]:
     """Get workflow statistics"""
     try:
-        data = await Storage.read(_workflow_stats_key(workflow_id))
+        data = await WorkflowStore.get_stats(workflow_id)
         if data is None:
             return dict(_DEFAULT_STATS)
         return _compute_avg_runtime(data)
@@ -1246,11 +1265,14 @@ async def _get_workflow_stats(workflow_id: str) -> Dict[str, Any]:
 # API Endpoints - Workflow CRUD
 # =============================================================================
 
+
 @router.get("/workflow", response_model=List[WorkflowResponse])
 async def list_workflows(
     category: Optional[str] = Query(None, description="Filter by category"),
     status: Optional[str] = Query(None, description="Filter by status"),
-    exclude_id: Optional[str] = Query(None, alias="excludeId", description="Exclude workflow by ID (e.g. exclude self when selecting sub-workflows)"),
+    exclude_id: Optional[str] = Query(
+        None, alias="excludeId", description="Exclude workflow by ID (e.g. exclude self when selecting sub-workflows)"
+    ),
 ):
     """
     Get workflow list
@@ -1284,7 +1306,9 @@ async def list_workflows(
 
         workflows.sort(key=lambda w: w.updatedAt, reverse=True)
 
-        log.info("workflow.list", {"count": len(workflows), "category": category, "status": status, "exclude_id": exclude_id})
+        log.info(
+            "workflow.list", {"count": len(workflows), "category": category, "status": status, "exclude_id": exclude_id}
+        )
         return workflows
     except Exception as e:
         log.error("workflow.list.error", {"error": str(e)})
@@ -1473,11 +1497,12 @@ async def delete_workflow(workflow_id: str):
 # API Endpoints - Workflow Operations
 # =============================================================================
 
+
 @router.post("/workflow/{workflow_id}/run", response_model=WorkflowExecutionResponse)
 async def run_workflow_endpoint(workflow_id: str, req: WorkflowRunRequest):
     """
     Execute workflow
-    
+
     Runs the workflow with provided inputs and returns execution results.
     """
     try:
@@ -1499,7 +1524,7 @@ async def run_workflow_endpoint(workflow_id: str, req: WorkflowRunRequest):
             input_params=req.inputs or {},
         )
         exec_id = str(exec_data["id"])
-        
+
         cancel_event = threading.Event()
         task = asyncio.create_task(
             _run_workflow_execution_task(
@@ -1517,18 +1542,23 @@ async def run_workflow_endpoint(workflow_id: str, req: WorkflowRunRequest):
             task=task,
             cancel_event=cancel_event,
         )
+
         # Guarantee cleanup of the registry entry even when the task is
         # cancelled or fails before reaching its own ``finally`` block (e.g.
         # if the event loop is shutting down).  This prevents the ``Active*``
         # map from growing forever when tasks are abandoned.
         def _cleanup_active(_t: asyncio.Task, _eid: str = exec_id) -> None:
             _active_workflow_executions.pop(_eid, None)
+
         task.add_done_callback(_cleanup_active)
 
-        log.info("workflow.execution.started", {
-            "id": workflow_id,
-            "exec_id": exec_id,
-        })
+        log.info(
+            "workflow.execution.started",
+            {
+                "id": workflow_id,
+                "exec_id": exec_id,
+            },
+        )
         return WorkflowExecutionResponse(**exec_data)
     except HTTPException:
         raise
@@ -1541,7 +1571,9 @@ async def run_workflow_endpoint(workflow_id: str, req: WorkflowRunRequest):
 async def cancel_workflow_execution(workflow_id: str, exec_id: str):
     """Request cooperative cancellation of a running workflow execution."""
     try:
-        exec_data = await Storage.read(_workflow_execution_key(exec_id))
+        exec_data = await WorkflowStore.get_execution(exec_id)
+        if not exec_data:
+            raise HTTPException(status_code=404, detail=f"Execution not found: {exec_id}")
         if exec_data.get("workflowId") != workflow_id:
             raise HTTPException(status_code=404, detail="Execution not found for this workflow")
 
@@ -1557,30 +1589,36 @@ async def cancel_workflow_execution(workflow_id: str, exec_id: str):
             raise HTTPException(status_code=404, detail="Execution not found for this workflow")
 
         active.cancel_event.set()
-        exec_data.update({
-            "currentPhase": "cancelling",
-            "errorMessage": exec_data.get("errorMessage") or "Cancellation requested",
-        })
-        await Storage.write(_workflow_execution_key(exec_id), exec_data)
-        log.info("workflow.execution.cancel_requested", {
-            "id": workflow_id,
-            "exec_id": exec_id,
-        })
+        exec_data.update(
+            {
+                "currentPhase": "cancelling",
+                "errorMessage": exec_data.get("errorMessage") or "Cancellation requested",
+            }
+        )
+        await WorkflowStore.upsert_execution(exec_data)
+        log.info(
+            "workflow.execution.cancel_requested",
+            {
+                "id": workflow_id,
+                "exec_id": exec_id,
+            },
+        )
         return {
             "status": "accepted",
             "message": f"Cancellation requested for execution {exec_id}",
             "executionId": exec_id,
         }
-    except Storage.NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Execution not found: {exec_id}")
     except HTTPException:
         raise
     except Exception as e:
-        log.error("workflow.execution.cancel.error", {
-            "id": workflow_id,
-            "exec_id": exec_id,
-            "error": str(e),
-        })
+        log.error(
+            "workflow.execution.cancel.error",
+            {
+                "id": workflow_id,
+                "exec_id": exec_id,
+                "error": str(e),
+            },
+        )
         raise HTTPException(status_code=500, detail=f"Failed to cancel execution: {str(e)}")
 
 
@@ -1588,7 +1626,7 @@ async def cancel_workflow_execution(workflow_id: str, exec_id: str):
 async def validate_workflow(workflow_id: str):
     """
     Validate workflow
-    
+
     Lints the workflow and returns validation errors/warnings.
     """
     try:
@@ -1621,11 +1659,10 @@ async def validate_workflow(workflow_id: str):
         raise HTTPException(status_code=500, detail=f"Failed to validate workflow: {str(e)}")
 
 
-
-
 # =============================================================================
 # API Endpoints - Workflow Center (Skill -> Register -> Publish Service)
 # =============================================================================
+
 
 @router.post("/workflow-center/scan-workflows")
 async def workflow_center_scan_workflows():
@@ -1718,34 +1755,39 @@ async def workflow_center_invoke(workflow_id: str, req: WorkflowCenterInvokeRequ
         # step callbacks run locally so executionLog stays as the empty list
         # set by create_execution_record.  We still run compact_history here
         # as a forward-compatible guard in case a future code path populates it.
-        exec_data.update({
-            "outputResults": compact_outputs_for_storage(
-                result.get("outputs", {}) if isinstance(result, dict) else {}
-            ),
-            "executionLog": compact_history_for_storage(exec_data.get("executionLog")),
-            "status": status_value,
-            "finishedAt": int(time.time() * 1000),
-            "duration": duration,
-            "currentPhase": status_value,
-        })
+        exec_data.update(
+            {
+                "outputResults": compact_outputs_for_storage(
+                    result.get("outputs", {}) if isinstance(result, dict) else {}
+                ),
+                "executionLog": compact_history_for_storage(exec_data.get("executionLog")),
+                "status": status_value,
+                "finishedAt": int(time.time() * 1000),
+                "duration": duration,
+                "currentPhase": status_value,
+            }
+        )
         await _record_execution_result(workflow_id, exec_id, exec_data)
         return result
     except (WorkflowNotFoundError, WorkflowNotPublishedError) as e:
         duration = time.time() - started
-        exec_data.update({"status": "error", "finishedAt": int(time.time() * 1000),
-                          "duration": duration, "errorMessage": str(e)})
+        exec_data.update(
+            {"status": "error", "finishedAt": int(time.time() * 1000), "duration": duration, "errorMessage": str(e)}
+        )
         await _record_execution_result(workflow_id, exec_id, exec_data)
         raise HTTPException(status_code=404, detail=str(e))
     except WorkflowCenterError as e:
         duration = time.time() - started
-        exec_data.update({"status": "error", "finishedAt": int(time.time() * 1000),
-                          "duration": duration, "errorMessage": str(e)})
+        exec_data.update(
+            {"status": "error", "finishedAt": int(time.time() * 1000), "duration": duration, "errorMessage": str(e)}
+        )
         await _record_execution_result(workflow_id, exec_id, exec_data)
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         duration = time.time() - started
-        exec_data.update({"status": "error", "finishedAt": int(time.time() * 1000),
-                          "duration": duration, "errorMessage": str(e)})
+        exec_data.update(
+            {"status": "error", "finishedAt": int(time.time() * 1000), "duration": duration, "errorMessage": str(e)}
+        )
         await _record_execution_result(workflow_id, exec_id, exec_data)
         log.error("workflow.center.invoke.error", {"workflow_id": workflow_id, "error": str(e)})
         raise HTTPException(status_code=500, detail=f"Failed to invoke workflow service: {str(e)}")
@@ -1784,6 +1826,7 @@ async def workflow_center_releases(workflow_id: str):
 # API Endpoints - Workflow History
 # =============================================================================
 
+
 @router.get("/workflow/{workflow_id}/history", response_model=List[WorkflowExecutionResponse])
 async def get_workflow_history(
     workflow_id: str,
@@ -1803,33 +1846,17 @@ async def get_workflow_history(
 
         # Keep the list endpoint on summary rows only.  Do not materialize
         # append-only step logs here; details load them separately.
-        all_entries = await Storage.list_raw("workflow_execution/")
+        rows = await WorkflowStore.list_executions(
+            workflow_id,
+            limit=limit,
+            trigger_id=trigger_id,
+            trigger_type=trigger_type,
+        )
         executions = []
-        workflow_marker = f'"workflowId": "{workflow_id}"'
-        compact_marker = f'"workflowId":"{workflow_id}"'
-        for _key, raw_value in all_entries:
-            try:
-                head = raw_value[:500]
-                if workflow_marker not in head and compact_marker not in head:
-                    continue
-                exec_data = json.loads(raw_value)
-                if not isinstance(exec_data, dict):
-                    continue
-                if exec_data.get("workflowId") != workflow_id:
-                    continue
-                if trigger_id and exec_data.get("triggerId") != trigger_id:
-                    continue
-                if trigger_type and exec_data.get("triggerType") != trigger_type:
-                    continue
-                exec_data["executionLog"] = []
-                executions.append(WorkflowExecutionResponse(**exec_data))
-            except Exception as e:
-                log.warning("workflow.history.skip", {"key": _key, "error": str(e)})
-                continue
-
-        # Sort by start time (newest first) and limit
-        executions.sort(key=lambda e: e.startedAt, reverse=True)
-        executions = executions[:limit]
+        for exec_data in rows:
+            item = dict(exec_data)
+            item["executionLog"] = []
+            executions.append(WorkflowExecutionResponse(**item))
 
         log.info("workflow.history", {"id": workflow_id, "count": len(executions)})
         return executions
@@ -1849,16 +1876,18 @@ async def get_execution_details(
 ):
     """
     Get execution details
-    
+
     Returns detailed information about a specific workflow execution.
     """
     try:
-        exec_data = await Storage.read(_workflow_execution_key(exec_id))
-        
+        exec_data = await WorkflowStore.get_execution(exec_id)
+        if not exec_data:
+            raise HTTPException(status_code=404, detail=f"Execution not found: {exec_id}")
+
         # Verify workflow ID matches
         if exec_data.get("workflowId") != workflow_id:
             raise HTTPException(status_code=404, detail="Execution not found for this workflow")
-        
+
         if step_limit == 0:
             inline_log = exec_data.get("executionLog")
             inline_count = len(inline_log) if isinstance(inline_log, list) else 0
@@ -1872,7 +1901,7 @@ async def get_execution_details(
             if total_steps == 0:
                 legacy_steps = compact_history_for_storage(exec_data.get("executionLog"))
                 total_steps = len(legacy_steps)
-                steps = legacy_steps[step_offset:step_offset + step_limit]
+                steps = legacy_steps[step_offset : step_offset + step_limit]
         exec_data = dict(exec_data)
         exec_data["executionLog"] = steps
         exec_data["stepLogOffset"] = step_offset
@@ -1880,8 +1909,6 @@ async def get_execution_details(
         exec_data["stepLogTotal"] = total_steps
         exec_data["stepCount"] = exec_data.get("stepCount") or total_steps
         return WorkflowExecutionResponse(**exec_data)
-    except Storage.NotFoundError:
-        raise HTTPException(status_code=404, detail=f"Execution not found: {exec_id}")
     except HTTPException:
         raise
     except Exception as e:
@@ -1893,11 +1920,12 @@ async def get_execution_details(
 # API Endpoints - Workflow Statistics
 # =============================================================================
 
+
 @router.get("/workflow/stats", response_model=WorkflowStatsResponse)
 async def get_aggregate_stats():
     """
     Get aggregate workflow statistics
-    
+
     Returns statistics across all workflows.
     """
     try:
@@ -1941,7 +1969,7 @@ async def get_aggregate_stats():
 async def get_workflow_stats_endpoint(workflow_id: str):
     """
     Get workflow statistics
-    
+
     Returns statistics for a specific workflow.
     """
     try:
@@ -1949,12 +1977,12 @@ async def get_workflow_stats_endpoint(workflow_id: str):
             raise HTTPException(status_code=404, detail=f"Workflow not found: {workflow_id}")
 
         stats = await _get_workflow_stats(workflow_id)
-        
+
         # Calculate average runtime
         avg_runtime = 0.0
         if stats["callCount"] > 0:
             avg_runtime = stats["totalRuntime"] / stats["callCount"]
-        
+
         result = {
             "workflowId": workflow_id,
             "callCount": stats["callCount"],
@@ -1965,7 +1993,7 @@ async def get_workflow_stats_endpoint(workflow_id: str):
             "thumbsUp": stats["thumbsUp"],
             "thumbsDown": stats["thumbsDown"],
         }
-        
+
         return WorkflowStatsResponse(**result)
     except HTTPException:
         raise
@@ -1977,6 +2005,7 @@ async def get_workflow_stats_endpoint(workflow_id: str):
 # =============================================================================
 # API Endpoints - Import/Export
 # =============================================================================
+
 
 @router.post("/workflow/import", response_model=WorkflowResponse, status_code=status.HTTP_201_CREATED)
 async def import_workflow(workflow_json: Dict[str, Any]):
@@ -2035,7 +2064,7 @@ async def import_workflow(workflow_json: Dict[str, Any]):
 async def export_workflow(workflow_id: str):
     """
     Export workflow
-    
+
     Exports workflow as JSON for download/sharing.
     """
     try:
@@ -2050,7 +2079,7 @@ async def export_workflow(workflow_id: str):
         workflow_json["metadata"]["exportedFrom"] = "flocks"
         workflow_json["metadata"]["exportedAt"] = int(time.time() * 1000)
         workflow_json["name"] = data["name"]
-        
+
         log.info("workflow.exported", {"id": workflow_id})
         return workflow_json
     except HTTPException:
@@ -2101,7 +2130,7 @@ async def _prepare_workflow_api_registry(workflow_id: str) -> tuple[Dict[str, An
     fp = hashlib.sha256(workflow_path.read_bytes()).hexdigest()
     now_ms = int(time.time() * 1000)
 
-    existing_registry = await Storage.read(f"{_REGISTRY_PREFIX_MAIN}{workflow_id}") or {}
+    existing_registry = await WorkflowStore.kv_get(f"{_REGISTRY_PREFIX_MAIN}{workflow_id}") or {}
     registry_entry = {
         "workflowId": workflow_id,
         "name": data["name"],
@@ -2112,7 +2141,7 @@ async def _prepare_workflow_api_registry(workflow_id: str) -> tuple[Dict[str, An
         "registeredAt": existing_registry.get("registeredAt", now_ms),
         "updatedAt": now_ms,
     }
-    await Storage.write(f"{_REGISTRY_PREFIX_MAIN}{workflow_id}", registry_entry)
+    await WorkflowStore.kv_put(f"{_REGISTRY_PREFIX_MAIN}{workflow_id}", registry_entry)
     return data, now_ms
 
 
@@ -2139,13 +2168,15 @@ async def _normalize_listed_api_service(key: Any, entry: Any) -> Optional[Dict[s
     service = dict(entry)
     workflow_id = str(service.get("workflowId") or _workflow_id_from_api_service_key(key))
     service["workflowId"] = workflow_id
-    runtime = await Storage.read(_runtime_key_main(workflow_id))
+    runtime = await WorkflowStore.kv_get(_runtime_key_main(workflow_id))
 
     if isinstance(runtime, dict) and runtime:
         service_url = runtime.get("serviceUrl") or service.get("serviceUrl") or ""
         service["serviceUrl"] = service_url
         service["invokeUrl"] = f"{service_url}/invoke" if service_url else service.get("invokeUrl", "")
-        service["status"] = "running" if runtime.get("status") in {"active", "running"} else service.get("status", "running")
+        service["status"] = (
+            "running" if runtime.get("status") in {"active", "running"} else service.get("status", "running")
+        )
         service["driver"] = runtime.get("driver") or service.get("driver")
         service["containerName"] = runtime.get("containerName") or service.get("containerName", "")
         service["image"] = runtime.get("image") or service.get("image")
@@ -2169,9 +2200,9 @@ async def reconcile_published_workflow_api_services() -> Dict[str, int]:
     if not _workflow_api_autostart_enabled():
         return stats
 
-    keys = await Storage.list_keys(_API_SERVICE_PREFIX)
+    keys = await WorkflowStore.kv_list_keys(_API_SERVICE_PREFIX)
     for key in keys:
-        service = await Storage.read(key)
+        service = await WorkflowStore.kv_get(key)
         if not isinstance(service, dict):
             continue
 
@@ -2189,7 +2220,7 @@ async def reconcile_published_workflow_api_services() -> Dict[str, int]:
         if health.get("ok"):
             service["status"] = "running"
             service["health"] = health
-            await Storage.write(_api_service_key(workflow_id), service)
+            await WorkflowStore.kv_put(_api_service_key(workflow_id), service)
             stats["healthy"] += 1
             continue
 
@@ -2205,27 +2236,29 @@ async def reconcile_published_workflow_api_services() -> Dict[str, int]:
             )
 
             service_url = active_record.get("serviceUrl", "")
-            service.update({
-                "workflowId": workflow_id,
-                "workflowName": service.get("workflowName") or data["name"],
-                "serviceUrl": service_url,
-                "invokeUrl": f"{service_url}/invoke",
-                "apiKey": service.get("apiKey") or active_record.get("apiKey"),
-                "status": "running",
-                "containerName": active_record.get("containerName", ""),
-                "driver": active_record.get("driver") or service.get("driver"),
-                "image": active_record.get("image") or service.get("image"),
-                "restartedAt": int(time.time() * 1000),
-            })
+            service.update(
+                {
+                    "workflowId": workflow_id,
+                    "workflowName": service.get("workflowName") or data["name"],
+                    "serviceUrl": service_url,
+                    "invokeUrl": f"{service_url}/invoke",
+                    "apiKey": service.get("apiKey") or active_record.get("apiKey"),
+                    "status": "running",
+                    "containerName": active_record.get("containerName", ""),
+                    "driver": active_record.get("driver") or service.get("driver"),
+                    "image": active_record.get("image") or service.get("image"),
+                    "restartedAt": int(time.time() * 1000),
+                }
+            )
             service.pop("lastStartError", None)
             service["health"] = {"ok": True, "restarted": True}
-            await Storage.write(_api_service_key(workflow_id), service)
+            await WorkflowStore.kv_put(_api_service_key(workflow_id), service)
             stats["restarted"] += 1
         except Exception as exc:
             service["status"] = "error"
             service["health"] = health
             service["lastStartError"] = str(exc)
-            await Storage.write(_api_service_key(workflow_id), service)
+            await WorkflowStore.kv_put(_api_service_key(workflow_id), service)
             log.warning("workflow.api.autostart_failed", {"id": workflow_id, "error": str(exc)})
             stats["failed"] += 1
     return stats
@@ -2341,7 +2374,7 @@ async def publish_workflow_as_api(
         # Preserve existing API key across re-publishes so callers don't break.
         # The runtime must receive the same key before it starts so /invoke can
         # enforce the key returned to callers.
-        existing_service = await Storage.read(_api_service_key(workflow_id)) or {}
+        existing_service = await WorkflowStore.kv_get(_api_service_key(workflow_id)) or {}
         api_key = existing_service.get("apiKey") or (uuid.uuid4().hex + uuid.uuid4().hex)
 
         # Use center.py to publish the selected runtime.
@@ -2370,7 +2403,7 @@ async def publish_workflow_as_api(
             "driver": driver,
             "image": image,
         }
-        await Storage.write(_api_service_key(workflow_id), service_info)
+        await WorkflowStore.kv_put(_api_service_key(workflow_id), service_info)
 
         log.info("workflow.api.published", {"id": workflow_id, "url": service_url})
         return service_info
@@ -2392,7 +2425,7 @@ async def unpublish_workflow_api(workflow_id: str):
     Stop a published workflow API service.
     """
     try:
-        existing = await Storage.read(_api_service_key(workflow_id))
+        existing = await WorkflowStore.kv_get(_api_service_key(workflow_id))
         if not existing:
             raise HTTPException(status_code=404, detail="No published service found for this workflow")
 
@@ -2403,7 +2436,7 @@ async def unpublish_workflow_api(workflow_id: str):
 
         existing["status"] = "stopped"
         existing["stoppedAt"] = int(time.time() * 1000)
-        await Storage.write(_api_service_key(workflow_id), existing)
+        await WorkflowStore.kv_put(_api_service_key(workflow_id), existing)
 
         log.info("workflow.api.unpublished", {"id": workflow_id})
         return {"ok": True}
@@ -2421,7 +2454,7 @@ async def get_workflow_service(workflow_id: str):
     Returns null if not published.
     """
     try:
-        return await Storage.read(_api_service_key(workflow_id))  # None / null if not found
+        return await WorkflowStore.kv_get(_api_service_key(workflow_id))  # None / null if not found
     except Exception as e:
         log.error("workflow.service.get.error", {"id": workflow_id, "error": str(e)})
         raise HTTPException(status_code=500, detail=f"Failed to get service info: {str(e)}")
@@ -2431,7 +2464,7 @@ async def get_workflow_service(workflow_id: str):
 async def delete_workflow_service(workflow_id: str):
     """Delete the stored API service configuration for a workflow."""
     try:
-        existing = await Storage.read(_api_service_key(workflow_id))
+        existing = await WorkflowStore.kv_get(_api_service_key(workflow_id))
         if not existing:
             raise HTTPException(status_code=404, detail="No published service found for this workflow")
 
@@ -2441,8 +2474,8 @@ async def delete_workflow_service(workflow_id: str):
             pass
 
         try:
-            await Storage.remove(_api_service_key(workflow_id))
-        except Storage.NotFoundError:
+            await WorkflowStore.kv_remove(_api_service_key(workflow_id))
+        except Exception:
             pass
 
         log.info("workflow.api.service_deleted", {"id": workflow_id})
@@ -2504,11 +2537,14 @@ async def update_workflow_config(
     try:
         normalized_config = _normalize_workflow_integration_config_template(workflow_id, data, config)
         config_path = _workflow_config_dir(workflow_id, data) / "config.json"
-        await Storage.write(_workflow_integration_config_key(workflow_id), normalized_config)
-        log.info("workflow.config.updated", {
-            "id": workflow_id,
-            "storage_key": _workflow_integration_config_key(workflow_id),
-        })
+        await WorkflowStore.put_config(workflow_id, normalized_config)
+        log.info(
+            "workflow.config.updated",
+            {
+                "id": workflow_id,
+                "storage_key": _workflow_integration_config_key(workflow_id),
+            },
+        )
         return {
             "ok": True,
             "exists": True,
@@ -2546,11 +2582,14 @@ async def sync_workflow_config(workflow_id: str):
             }
 
         config = await _build_workflow_integration_config(workflow_id, data)
-        await Storage.write(_workflow_integration_config_key(workflow_id), config)
-        log.info("workflow.config.synced", {
-            "id": workflow_id,
-            "storage_key": _workflow_integration_config_key(workflow_id),
-        })
+        await WorkflowStore.put_config(workflow_id, config)
+        log.info(
+            "workflow.config.synced",
+            {
+                "id": workflow_id,
+                "storage_key": _workflow_integration_config_key(workflow_id),
+            },
+        )
         return {
             "ok": True,
             "path": str(config_path),
@@ -2571,10 +2610,10 @@ async def list_workflow_services():
     List all published workflow API services.
     """
     try:
-        keys = await Storage.list_keys(_API_SERVICE_PREFIX)
+        keys = await WorkflowStore.kv_list_keys(_API_SERVICE_PREFIX)
         services = []
         for key in keys:
-            entry = await Storage.read(key)
+            entry = await WorkflowStore.kv_get(key)
             service = await _normalize_listed_api_service(key, entry)
             if service:
                 services.append(service)
@@ -2600,9 +2639,7 @@ def _validate_trigger_type_constraints(triggers: List[TriggerDefinition]) -> Non
         singleton_ids_by_type.setdefault(trigger.type, []).append(trigger.id or "")
 
     duplicates = {
-        trigger_type: trigger_ids
-        for trigger_type, trigger_ids in singleton_ids_by_type.items()
-        if len(trigger_ids) > 1
+        trigger_type: trigger_ids for trigger_type, trigger_ids in singleton_ids_by_type.items() if len(trigger_ids) > 1
     }
     if not duplicates:
         return
@@ -2897,7 +2934,7 @@ async def save_kafka_config(workflow_id: str, req: KafkaConfigRequest):
             "inputs": _strip_execution_only_comments(req.inputs),
             "updatedAt": int(time.time() * 1000),
         }
-        await Storage.write(_kafka_config_key(workflow_id), config)
+        await WorkflowStore.put_config(workflow_id, config, kind="workflow_kafka_config")
         unified_trigger = TriggerDefinition.model_validate(
             {
                 "id": "kafka-default",
@@ -2949,7 +2986,7 @@ async def get_kafka_config(workflow_id: str):
     Get saved Kafka configuration for a workflow.
     """
     try:
-        config = await Storage.read(_kafka_config_key(workflow_id))
+        config = await WorkflowStore.get_config(workflow_id, kind="workflow_kafka_config")
         if config is None:
             data = _read_workflow_from_fs(workflow_id)
             if data:
@@ -3012,7 +3049,7 @@ async def save_workflow_poller_config(workflow_id: str, req: WorkflowPollerConfi
             "inputs": req.inputs,
             "updatedAt": int(time.time() * 1000),
         }
-        await Storage.write(f"workflow_poller_config/{workflow_id}", config)
+        await WorkflowStore.put_config(workflow_id, config, kind="workflow_poller_config")
         unified_trigger = TriggerDefinition.model_validate(
             {
                 "id": "schedule-default",
@@ -3057,7 +3094,7 @@ async def save_workflow_poller_config(workflow_id: str, req: WorkflowPollerConfi
 async def get_workflow_poller_config(workflow_id: str):
     """Get saved poller configuration for a workflow."""
     try:
-        config = await Storage.read(f"workflow_poller_config/{workflow_id}")
+        config = await WorkflowStore.get_config(workflow_id, kind="workflow_poller_config")
         if config is None:
             data = _read_workflow_from_fs(workflow_id)
             if data:
@@ -3128,7 +3165,7 @@ async def save_syslog_config(workflow_id: str, req: SyslogConfigRequest):
             "inputKey": req.input_key,
             "updatedAt": int(time.time() * 1000),
         }
-        await Storage.write(_syslog_config_key(workflow_id), config)
+        await WorkflowStore.put_config(workflow_id, config, kind="workflow_syslog_config")
         unified_trigger = TriggerDefinition.model_validate(
             {
                 "id": "syslog-default",
@@ -3177,7 +3214,7 @@ async def save_syslog_config(workflow_id: str, req: SyslogConfigRequest):
 async def get_syslog_config(workflow_id: str):
     """Get saved syslog configuration for a workflow."""
     try:
-        config = await Storage.read(_syslog_config_key(workflow_id))
+        config = await WorkflowStore.get_config(workflow_id, kind="workflow_syslog_config")
         if config is None:
             data = _read_workflow_from_fs(workflow_id)
             if data:
@@ -3214,8 +3251,10 @@ async def get_syslog_status(workflow_id: str):
 # API Endpoints - Run Single Node
 # =============================================================================
 
+
 class RunNodeRequest(BaseModel):
     """Request to execute a single workflow node."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     node_id: str = Field(..., description="Node ID to execute")
@@ -3227,6 +3266,7 @@ class RunNodeRequest(BaseModel):
 
 class RunNodeResponse(BaseModel):
     """Response from executing a single workflow node."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     node_id: str
@@ -3273,12 +3313,15 @@ async def run_single_node(workflow_id: str, req: RunNodeRequest):
 
             step_result = await asyncio.to_thread(engine.run_node, req.node_id, req.inputs)
 
-            log.info("workflow.run_node", {
-                "workflow_id": workflow_id,
-                "node_id": req.node_id,
-                "success": step_result.error is None,
-                "duration_ms": step_result.duration_ms,
-            })
+            log.info(
+                "workflow.run_node",
+                {
+                    "workflow_id": workflow_id,
+                    "node_id": req.node_id,
+                    "success": step_result.error is None,
+                    "duration_ms": step_result.duration_ms,
+                },
+            )
 
             return RunNodeResponse(
                 node_id=step_result.node_id,
@@ -3310,8 +3353,10 @@ async def run_single_node(workflow_id: str, req: RunNodeRequest):
 # API Endpoints - Sample Inputs
 # =============================================================================
 
+
 class SampleInputsRequest(BaseModel):
     """Request to save sample inputs for a workflow."""
+
     model_config = ConfigDict(populate_by_name=True)
 
     sampleInputs: Dict[str, Any] = Field(default_factory=dict, description="Sample input data")

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -25,11 +25,13 @@ T = TypeVar("T", bound=BaseModel)
 
 class NotFoundError(Exception):
     """Raised when a resource is not found"""
+
     pass
 
 
 class StorageError(Exception):
     """Base storage error"""
+
     pass
 
 
@@ -44,10 +46,7 @@ class CheckpointBusyError(StorageError):
     """
 
     def __init__(self, mode: str, log_pages: int, checkpointed_pages: int) -> None:
-        super().__init__(
-            f"wal_checkpoint({mode}) busy: "
-            f"log_pages={log_pages}, checkpointed_pages={checkpointed_pages}"
-        )
+        super().__init__(f"wal_checkpoint({mode}) busy: log_pages={log_pages}, checkpointed_pages={checkpointed_pages}")
         self.mode = mode
         self.log_pages = log_pages
         self.checkpointed_pages = checkpointed_pages
@@ -56,15 +55,15 @@ class CheckpointBusyError(StorageError):
 class Storage:
     """
     Storage namespace for persistent data operations
-    
+
     Similar to Flocks's Storage namespace.
     Provides both TypeScript-compatible API (key arrays) and Python API (key strings).
     """
-    
+
     NotFoundError = NotFoundError
     StorageError = StorageError
     CheckpointBusyError = CheckpointBusyError
-    
+
     _log = Log.create(service="storage")
     _db_path: Optional[Path] = None
     _initialized = False
@@ -95,21 +94,6 @@ class Storage:
     _sqlite_write_retry_base_delay_s = 0.05
     _multi_db_migration_marker_key = "storage.migration.multi_db.v1"
     _multi_db_migration_batch_size = 500
-    _workflow_key_prefixes = (
-        "workflow/",
-        "workflow_execution/",
-        "workflow_execution_index/",
-        "workflow_execution_step/",
-        "workflow_registry/",
-        "workflow_release/",
-        "workflow_runtime/",
-        "workflow_local_pid/",
-        "workflow_api_service/",
-        "workflow_integration_config/",
-        "workflow_kafka_config/",
-        "workflow_poller_config/",
-        "workflow_syslog_config/",
-    )
 
     # Substrings that mark an SQLite file as unrecoverably damaged at open
     # time.  We deliberately keep this list short and English-only because
@@ -125,11 +109,7 @@ class Storage:
         if prefix is None:
             return True
         normalized = str(prefix)
-        return any(
-            normalized == root.rstrip(":/")
-            or normalized.startswith(root)
-            for root in roots
-        )
+        return any(normalized == root.rstrip(":/") or normalized.startswith(root) for root in roots)
 
     @classmethod
     def _invalidate_runtime_caches(cls, prefix: Optional[str] = None) -> None:
@@ -137,6 +117,7 @@ class Storage:
         if cls._prefix_matches_runtime_cache(prefix, ("session:",)):
             try:
                 from flocks.session.session import Session
+
                 Session.invalidate_cache()
             except Exception:
                 pass
@@ -144,10 +125,11 @@ class Storage:
         if cls._prefix_matches_runtime_cache(prefix, ("message:", "message_parts:")):
             try:
                 from flocks.session.message import Message
+
                 Message.invalidate_cache()
             except Exception:
                 pass
-    
+
     @classmethod
     def get_db_path(cls) -> Path:
         """Return the resolved database file path.
@@ -168,35 +150,20 @@ class Storage:
     @classmethod
     def route_db_path_for_key(cls, key: str) -> Path:
         """Return the storage DB path that owns *key*."""
-        if cls._is_workflow_key(key):
-            return cls.get_workflow_db_path()
         return cls.get_db_path()
 
     @classmethod
     def route_db_path_for_prefix(cls, prefix: Optional[str]) -> Path:
         """Return the storage DB path for a prefix-scoped KV operation."""
-        if prefix and (
-            cls._is_workflow_key(prefix)
-            or f"{prefix}/" in cls._workflow_key_prefixes
-        ):
-            return cls.get_workflow_db_path()
         return cls.get_db_path()
 
     @classmethod
-    def _is_workflow_key(cls, key: str) -> bool:
-        return any(key.startswith(prefix) for prefix in cls._workflow_key_prefixes)
-
-    @classmethod
-    async def configure_connection(
-        cls, conn: aiosqlite.Connection
-    ) -> aiosqlite.Connection:
+    async def configure_connection(cls, conn: aiosqlite.Connection) -> aiosqlite.Connection:
         """Apply the runtime SQLite contract to an async connection."""
         await conn.execute(f"PRAGMA journal_mode={cls._sqlite_journal_mode}")
         await conn.execute(f"PRAGMA synchronous={cls._sqlite_synchronous}")
         await conn.execute(f"PRAGMA busy_timeout={cls._sqlite_busy_timeout_ms}")
-        await conn.execute(
-            f"PRAGMA wal_autocheckpoint={cls._sqlite_wal_autocheckpoint_pages}"
-        )
+        await conn.execute(f"PRAGMA wal_autocheckpoint={cls._sqlite_wal_autocheckpoint_pages}")
         await conn.execute("PRAGMA foreign_keys = ON")
         return conn
 
@@ -206,9 +173,7 @@ class Storage:
         conn.execute(f"PRAGMA journal_mode={cls._sqlite_journal_mode}")
         conn.execute(f"PRAGMA synchronous={cls._sqlite_synchronous}")
         conn.execute(f"PRAGMA busy_timeout={cls._sqlite_busy_timeout_ms}")
-        conn.execute(
-            f"PRAGMA wal_autocheckpoint={cls._sqlite_wal_autocheckpoint_pages}"
-        )
+        conn.execute(f"PRAGMA wal_autocheckpoint={cls._sqlite_wal_autocheckpoint_pages}")
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
 
@@ -301,6 +266,7 @@ class Storage:
             return None
 
         from datetime import UTC
+
         timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
         suffix = f".corrupt.{timestamp}"
 
@@ -315,10 +281,13 @@ class Storage:
         try:
             db_path.rename(new_main)
         except OSError as exc:
-            cls._log.error("storage.quarantine.rename_failed", {
-                "path": str(db_path),
-                "error": str(exc),
-            })
+            cls._log.error(
+                "storage.quarantine.rename_failed",
+                {
+                    "path": str(db_path),
+                    "error": str(exc),
+                },
+            )
             return None
 
         for sidecar_name in (f"{db_path.name}-wal", f"{db_path.name}-shm"):
@@ -328,20 +297,26 @@ class Storage:
             try:
                 side_path.rename(side_path.with_name(sidecar_name + suffix))
             except OSError as exc:
-                cls._log.warn("storage.quarantine.sidecar_rename_failed", {
-                    "path": str(side_path),
-                    "error": str(exc),
-                })
+                cls._log.warn(
+                    "storage.quarantine.sidecar_rename_failed",
+                    {
+                        "path": str(side_path),
+                        "error": str(exc),
+                    },
+                )
 
-        cls._log.error("storage.corruption.quarantined", {
-            "original_path": str(db_path),
-            "quarantined_path": str(new_main),
-            "hint": (
-                "Server is starting with a fresh empty database. "
-                "Run scripts/recover_raw_flocks_db.py against the "
-                "quarantined file to attempt data recovery."
-            ),
-        })
+        cls._log.error(
+            "storage.corruption.quarantined",
+            {
+                "original_path": str(db_path),
+                "quarantined_path": str(new_main),
+                "hint": (
+                    "Server is starting with a fresh empty database. "
+                    "Run scripts/recover_raw_flocks_db.py against the "
+                    "quarantined file to attempt data recovery."
+                ),
+            },
+        )
         return new_main
 
     @classmethod
@@ -418,14 +393,17 @@ class Storage:
                     raise
                 last_exc = exc
                 sleep_s = delay_s * (2 ** (attempt - 1))
-                cls._log.warn("storage.sqlite_write_retry", {
-                    "action": action,
-                    "target": target,
-                    "attempt": attempt,
-                    "max_attempts": attempts,
-                    "sleep_s": round(sleep_s, 3),
-                    "error": str(exc),
-                })
+                cls._log.warn(
+                    "storage.sqlite_write_retry",
+                    {
+                        "action": action,
+                        "target": target,
+                        "attempt": attempt,
+                        "max_attempts": attempts,
+                        "sleep_s": round(sleep_s, 3),
+                        "error": str(exc),
+                    },
+                )
                 await asyncio.sleep(sleep_s)
 
         assert last_exc is not None
@@ -433,9 +411,7 @@ class Storage:
 
     @classmethod
     @asynccontextmanager
-    async def connect(
-        cls, db_path: Optional[Path] = None
-    ) -> AsyncIterator[aiosqlite.Connection]:
+    async def connect(cls, db_path: Optional[Path] = None) -> AsyncIterator[aiosqlite.Connection]:
         """Open a configured async SQLite connection for the active storage DB."""
         target = Path(db_path) if db_path is not None else cls.get_db_path()
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -468,14 +444,14 @@ class Storage:
     def _resolve_key(key: List[str] | str) -> str:
         """
         Convert key to string format
-        
+
         Matches TypeScript's resolve() function:
         - Array keys: ["session", "proj1", "ses1"] -> "session/proj1/ses1"
         - String keys: passed through unchanged
-        
+
         Args:
             key: Key as list or string
-            
+
         Returns:
             Key as string
         """
@@ -486,27 +462,11 @@ class Storage:
     @classmethod
     def _like_prefix_pattern(cls, prefix: str) -> str:
         """Return a SQLite LIKE pattern that treats prefix chars literally."""
-        return (
-            prefix.replace("\\", "\\\\")
-            .replace("%", "\\%")
-            .replace("_", "\\_")
-            + "%"
-        )
+        return prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%"
 
     @classmethod
     def _like_prefix_clause(cls, column: str = "key") -> str:
         return f"{column} LIKE ? ESCAPE '\\'"
-
-    @classmethod
-    def _workflow_prefix_filter(cls) -> tuple[str, tuple[str, ...]]:
-        clause = " OR ".join(
-            cls._like_prefix_clause("key") for _ in cls._workflow_key_prefixes
-        )
-        params = tuple(
-            cls._like_prefix_pattern(prefix)
-            for prefix in cls._workflow_key_prefixes
-        )
-        return clause, params
 
     @staticmethod
     def _marker_row_count(marker: Dict[str, Any], key: str) -> int:
@@ -514,30 +474,6 @@ class Storage:
             return int(marker.get(key) or 0)
         except (TypeError, ValueError):
             return 0
-
-    @classmethod
-    async def _ensure_storage_table(cls, db_path: Path) -> None:
-        """Ensure the generic KV storage table exists in *db_path*."""
-        db_path.parent.mkdir(parents=True, exist_ok=True)
-
-        async def _create_storage_table() -> None:
-            async with cls.connect(db_path) as db:
-                await db.execute("""
-                    CREATE TABLE IF NOT EXISTS storage (
-                        key TEXT PRIMARY KEY,
-                        value TEXT NOT NULL,
-                        type TEXT NOT NULL,
-                        created_at TEXT NOT NULL,
-                        updated_at TEXT NOT NULL
-                    )
-                """)
-                await db.commit()
-
-        await cls._run_write_with_retry(
-            _create_storage_table,
-            action="init.create_storage_table",
-            target=str(db_path),
-        )
 
     @classmethod
     def _read_multi_db_migration_marker_sync(cls) -> Dict[str, Any]:
@@ -590,129 +526,29 @@ class Storage:
             conn.close()
 
     @classmethod
-    def _copy_workflow_kv_to_workflow_db_sync(cls) -> tuple[int, int]:
-        if cls._db_path is None:
-            raise StorageError("Storage DB path is not initialized")
-        workflow_db_path = cls.get_workflow_db_path()
-        source = cls.connect_sync(cls._db_path)
-        target = cls.connect_sync(workflow_db_path)
-        try:
-            clauses, params = cls._workflow_prefix_filter()
-            total_migrated = 0
-            last_key = ""
-            while True:
-                rows = source.execute(
-                    f"""
-                    SELECT key, value, type, created_at, updated_at
-                    FROM storage
-                    WHERE ({clauses}) AND key > ?
-                    ORDER BY key
-                    LIMIT ?
-                    """,
-                    (*params, last_key, cls._multi_db_migration_batch_size),
-                ).fetchall()
-                if not rows:
-                    break
+    async def _ensure_storage_table(cls, db_path: Path) -> None:
+        """Ensure the generic KV storage table exists in *db_path*."""
+        db_path.parent.mkdir(parents=True, exist_ok=True)
 
-                target.executemany(
-                    """
-                    INSERT OR REPLACE INTO storage (key, value, type, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?)
-                    """,
-                    [
-                        (
-                            row["key"],
-                            row["value"],
-                            row["type"],
-                            row["created_at"],
-                            row["updated_at"],
-                        )
-                        for row in rows
-                    ],
-                )
-                target.commit()
-
-                keys = [row["key"] for row in rows]
-                placeholders = ", ".join("?" for _ in keys)
-                copied = target.execute(
-                    f"SELECT COUNT(*) FROM storage WHERE key IN ({placeholders})",
-                    keys,
-                ).fetchone()[0]
-                if copied != len(keys):
-                    raise StorageError(
-                        "Workflow storage migration verification failed: "
-                        f"expected {len(keys)} copied rows, got {copied}"
+        async def _create_storage_table() -> None:
+            async with cls.connect(db_path) as db:
+                await db.execute("""
+                    CREATE TABLE IF NOT EXISTS storage (
+                        key TEXT PRIMARY KEY,
+                        value TEXT NOT NULL,
+                        type TEXT NOT NULL,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
                     )
+                """)
+                await db.commit()
 
-                total_migrated += len(rows)
-                last_key = keys[-1]
+        await cls._run_write_with_retry(
+            _create_storage_table,
+            action="init.create_storage_table",
+            target=str(db_path),
+        )
 
-            return total_migrated, 0
-        except Exception:
-            if source.in_transaction:
-                source.rollback()
-            if target.in_transaction:
-                target.rollback()
-            raise
-        finally:
-            source.close()
-            target.close()
-
-    @classmethod
-    async def _migrate_workflow_storage_to_workflow_db(
-        cls,
-        *,
-        workflow_db_existed_before_init: bool,
-    ) -> None:
-        """Copy legacy workflow-domain KV rows from flocks.db to workflow.db."""
-        marker = await asyncio.to_thread(cls._read_multi_db_migration_marker_sync)
-        if marker.get("workflow_migrated") is True:
-            if (
-                not workflow_db_existed_before_init
-                and cls._marker_row_count(marker, "workflow_rows") > 0
-            ):
-                raise StorageError(
-                    "workflow.db is missing after a completed multi-db migration"
-                )
-            return
-
-        from datetime import UTC
-
-        marker.setdefault("version", 1)
-        marker.setdefault("started_at", datetime.now(UTC).isoformat())
-        marker["source_db"] = str(cls.get_db_path())
-        marker["workflow_db"] = str(cls.get_workflow_db_path())
-        try:
-            migrated, deleted = await asyncio.to_thread(
-                cls._copy_workflow_kv_to_workflow_db_sync
-            )
-            marker["workflow_migrated"] = True
-            marker["workflow_migrated_at"] = datetime.now(UTC).isoformat()
-            marker["workflow_rows"] = migrated
-            marker["workflow_source_rows_deleted"] = deleted
-            marker.pop("workflow_error", None)
-            await asyncio.to_thread(cls._write_multi_db_migration_marker_sync, marker)
-            cls._log.info("storage.multi_db.workflow_migrated", {
-                "rows": migrated,
-                "source_rows_deleted": deleted,
-                "source_db": marker["source_db"],
-                "workflow_db": marker["workflow_db"],
-            })
-        except Exception as exc:
-            marker["workflow_migrated"] = False
-            marker["workflow_error"] = str(exc)
-            marker["workflow_failed_at"] = datetime.now(UTC).isoformat()
-            try:
-                await asyncio.to_thread(cls._write_multi_db_migration_marker_sync, marker)
-            except Exception:
-                pass
-            cls._log.error("storage.multi_db.workflow_migration_failed", {
-                "source_db": marker.get("source_db"),
-                "workflow_db": marker.get("workflow_db"),
-                "error": str(exc),
-            })
-            raise
-    
     @classmethod
     async def init(cls, db_path: Optional[Path] = None) -> None:
         """
@@ -746,10 +582,13 @@ class Storage:
         # SQLite never gets a chance to delete adjacent WAL/SHM sidecars
         # — those sidecars are what the offline recovery script reads.
         if cls._file_has_invalid_sqlite_header(cls._db_path):
-            cls._log.error("storage.corruption.invalid_header", {
-                "db_path": str(cls._db_path),
-                "size": cls._db_path.stat().st_size,
-            })
+            cls._log.error(
+                "storage.corruption.invalid_header",
+                {
+                    "db_path": str(cls._db_path),
+                    "size": cls._db_path.stat().st_size,
+                },
+            )
             quarantined = cls._quarantine_corrupt_db(cls._db_path)
             if quarantined is None:
                 # The pre-flight check confirmed the file is not SQLite,
@@ -777,26 +616,18 @@ class Storage:
         except Exception as exc:
             if not cls._is_db_corruption_error(exc):
                 raise
-            cls._log.error("storage.corruption.detected_on_init", {
-                "db_path": str(cls._db_path),
-                "error": str(exc),
-                "error_type": type(exc).__name__,
-            })
+            cls._log.error(
+                "storage.corruption.detected_on_init",
+                {
+                    "db_path": str(cls._db_path),
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
             quarantined = cls._quarantine_corrupt_db(cls._db_path)
             if quarantined is None:
                 raise
             await cls._bootstrap_schema()
-
-        # Workflow-domain KV rows live in a sibling workflow.db.  Keep the
-        # public Storage API unchanged by routing workflow key prefixes at
-        # the KV-operation seam, while initialising the sibling DB here so
-        # startup fails early if that database is unusable.
-        workflow_db_path = cls.get_workflow_db_path()
-        workflow_db_existed_before_init = workflow_db_path.exists()
-        await cls._ensure_storage_table(workflow_db_path)
-        await cls._migrate_workflow_storage_to_workflow_db(
-            workflow_db_existed_before_init=workflow_db_existed_before_init,
-        )
 
         # Drain any residual WAL frames left by the previous process so the
         # next ``SIGKILL`` does not have to truncate a 4 MB-class WAL during
@@ -810,10 +641,13 @@ class Storage:
 
         cls._init_pid = os.getpid()
         cls._initialized = True
-        cls._log.info("storage.initialized", {
-            "db_path": str(db_path),
-            "pid": cls._init_pid,
-        })
+        cls._log.info(
+            "storage.initialized",
+            {
+                "db_path": str(db_path),
+                "pid": cls._init_pid,
+            },
+        )
 
     @classmethod
     async def _checkpoint(cls, *, mode: str = "TRUNCATE") -> tuple[int, int, int]:
@@ -843,9 +677,7 @@ class Storage:
         if mode_normalised not in valid_modes:
             raise ValueError(f"invalid checkpoint mode: {mode!r}")
         async with cls.connect(cls._db_path) as db:
-            cursor = await db.execute(
-                f"PRAGMA wal_checkpoint({mode_normalised})"
-            )
+            cursor = await db.execute(f"PRAGMA wal_checkpoint({mode_normalised})")
             row = await cursor.fetchone()
             await db.commit()
 
@@ -860,9 +692,7 @@ class Storage:
         log_pages = int(row[1])
         checkpointed_pages = int(row[2])
         if busy != 0:
-            raise CheckpointBusyError(
-                mode_normalised, log_pages, checkpointed_pages
-            )
+            raise CheckpointBusyError(mode_normalised, log_pages, checkpointed_pages)
         return (busy, log_pages, checkpointed_pages)
 
     # Tunables for the shutdown WAL drain.  Kept as class attributes so
@@ -905,51 +735,61 @@ class Storage:
         try:
             for attempt in range(1, attempts + 1):
                 try:
-                    _, log_pages, checkpointed = await cls._checkpoint(
-                        mode="TRUNCATE"
+                    _, log_pages, checkpointed = await cls._checkpoint(mode="TRUNCATE")
+                    cls._log.info(
+                        "storage.shutdown.checkpoint.done",
+                        {
+                            "db_path": str(cls._db_path) if cls._db_path else None,
+                            "log_pages": log_pages,
+                            "checkpointed_pages": checkpointed,
+                            "attempts": attempt,
+                        },
                     )
-                    cls._log.info("storage.shutdown.checkpoint.done", {
-                        "db_path": str(cls._db_path) if cls._db_path else None,
-                        "log_pages": log_pages,
-                        "checkpointed_pages": checkpointed,
-                        "attempts": attempt,
-                    })
                     return
                 except CheckpointBusyError as exc:
                     last_busy = exc
-                    cls._log.warn("storage.shutdown.checkpoint.busy", {
-                        "attempt": attempt,
-                        "max_attempts": attempts,
-                        "mode": exc.mode,
-                        "log_pages": exc.log_pages,
-                        "checkpointed_pages": exc.checkpointed_pages,
-                    })
+                    cls._log.warn(
+                        "storage.shutdown.checkpoint.busy",
+                        {
+                            "attempt": attempt,
+                            "max_attempts": attempts,
+                            "mode": exc.mode,
+                            "log_pages": exc.log_pages,
+                            "checkpointed_pages": exc.checkpointed_pages,
+                        },
+                    )
                     if attempt < attempts:
                         await asyncio.sleep(backoff * attempt)
                 except Exception as exc:
                     last_failure = exc
-                    cls._log.warn("storage.shutdown.checkpoint.failed", {
-                        "db_path": str(cls._db_path) if cls._db_path else None,
-                        "error": str(exc),
-                        "error_type": type(exc).__name__,
-                    })
+                    cls._log.warn(
+                        "storage.shutdown.checkpoint.failed",
+                        {
+                            "db_path": str(cls._db_path) if cls._db_path else None,
+                            "error": str(exc),
+                            "error_type": type(exc).__name__,
+                        },
+                    )
                     break
 
             # Reached only on persistent busy or fatal failure.  Do NOT
             # log "done" — that would mask the residual-WAL risk this
             # whole method exists to prevent.
-            cls._log.warn("storage.shutdown.checkpoint.unfinished", {
-                "db_path": str(cls._db_path) if cls._db_path else None,
-                "busy": last_busy is not None,
-                "log_pages": getattr(last_busy, "log_pages", None),
-                "checkpointed_pages": getattr(last_busy, "checkpointed_pages", None),
-                "fatal_error": str(last_failure) if last_failure else None,
-                "hint": (
-                    "WAL was not truncated; next startup will run WAL "
-                    "recovery and remains at risk of header corruption if "
-                    "killed mid-recovery."
-                ),
-            })
+            cls._log.warn(
+                "storage.shutdown.checkpoint.unfinished",
+                {
+                    "db_path": str(cls._db_path) if cls._db_path else None,
+                    "busy": last_busy is not None,
+                    "log_pages": getattr(last_busy, "log_pages", None),
+                    "checkpointed_pages": getattr(last_busy, "checkpointed_pages", None),
+                    "fatal_error": str(last_failure) if last_failure else None,
+                    "hint": (
+                        "WAL was not truncated; next startup will run WAL "
+                        "recovery and remains at risk of header corruption if "
+                        "killed mid-recovery."
+                    ),
+                },
+            )
         finally:
             cls._initialized = False
             cls._init_pid = None
@@ -968,6 +808,7 @@ class Storage:
         # Initialize vector storage tables (for memory system)
         try:
             from flocks.storage.vector import ensure_vector_tables
+
             vector_status = await ensure_vector_tables(cls._db_path)
             cls._log.info("storage.vector.initialized", vector_status)
         except Exception as e:
@@ -979,6 +820,7 @@ class Storage:
         # Run extension DDLs registered before init
         for ddl in cls._extension_ddls:
             try:
+
                 async def _run_extension_ddl() -> None:
                     async with cls.connect(cls._db_path) as db:
                         await db.executescript(ddl)
@@ -1000,6 +842,7 @@ class Storage:
         (credentials, model settings, default models, custom providers)
         is stored in flocks.json / .secret.json.
         """
+
         async def _create_tables() -> None:
             async with cls.connect(cls._db_path) as db:
                 await db.executescript("""
@@ -1033,7 +876,10 @@ class Storage:
 
                 schema_additions = [
                     ("message_id", "ALTER TABLE usage_records ADD COLUMN message_id TEXT"),
-                    ("cache_write_tokens", "ALTER TABLE usage_records ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0"),
+                    (
+                        "cache_write_tokens",
+                        "ALTER TABLE usage_records ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0",
+                    ),
                     ("source", "ALTER TABLE usage_records ADD COLUMN source TEXT NOT NULL DEFAULT 'live'"),
                     ("backfilled_at", "ALTER TABLE usage_records ADD COLUMN backfilled_at TEXT"),
                 ]
@@ -1063,7 +909,7 @@ class Storage:
             target=str(cls._db_path),
         )
         cls._log.info("storage.model_management_tables_ready")
-    
+
     @classmethod
     async def _ensure_init(cls) -> None:
         """Ensure storage is initialized for the *current* process.
@@ -1081,29 +927,27 @@ class Storage:
         whenever the current PID differs.
         """
         current_pid = os.getpid()
-        forked = (
-            cls._initialized
-            and cls._init_pid is not None
-            and cls._init_pid != current_pid
-        )
+        forked = cls._initialized and cls._init_pid is not None and cls._init_pid != current_pid
         if forked:
-            cls._log.warn("storage.fork_detected", {
-                "parent_pid": cls._init_pid,
-                "child_pid": current_pid,
-                "hint": "Reinitialising Storage to avoid sharing SQLite "
-                        "file descriptors across processes.",
-            })
+            cls._log.warn(
+                "storage.fork_detected",
+                {
+                    "parent_pid": cls._init_pid,
+                    "child_pid": current_pid,
+                    "hint": "Reinitialising Storage to avoid sharing SQLite file descriptors across processes.",
+                },
+            )
             cls._initialized = False
             cls._init_pid = None
 
         if not cls._initialized or cls._db_path is None or not cls._db_path.exists():
             await cls.init(cls._db_path)
-    
+
     @classmethod
     async def set(cls, key: str, value: Any, value_type: str = "json") -> None:
         """
         Store a value
-        
+
         Args:
             key: Storage key
             value: Value to store (will be JSON serialized)
@@ -1111,82 +955,78 @@ class Storage:
         """
         await cls._ensure_init()
         db_path = cls.route_db_path_for_key(key)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
-        
+
         if isinstance(value, BaseModel):
             serialized = value.model_dump_json()
         else:
             serialized = json.dumps(value)
-        
+
         from datetime import UTC
+
         now = datetime.now(UTC).isoformat()
-        
+
         async def _write() -> None:
             async with cls.connect(db_path) as db:
-                await db.execute("""
+                await db.execute(
+                    """
                     INSERT OR REPLACE INTO storage (key, value, type, created_at, updated_at)
                     VALUES (?, ?, ?, 
                         COALESCE((SELECT created_at FROM storage WHERE key = ?), ?),
                         ?)
-                """, (key, serialized, value_type, key, now, now))
+                """,
+                    (key, serialized, value_type, key, now, now),
+                )
                 await db.commit()
 
         await cls._run_write_with_retry(_write, action="set", target=key)
-        
+
         cls._log.debug("storage.set", {"key": key, "type": value_type})
-    
+
     @classmethod
     async def get(cls, key: str, model: Optional[Type[T]] = None) -> Optional[T | Any]:
         """
         Retrieve a value
-        
+
         Args:
             key: Storage key
             model: Optional Pydantic model class to deserialize into
-            
+
         Returns:
             Stored value or None if not found
         """
         await cls._ensure_init()
         db_path = cls.route_db_path_for_key(key)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
-        
+
         async with cls.connect(db_path) as db:
-            async with db.execute(
-                "SELECT value, type FROM storage WHERE key = ?", (key,)
-            ) as cursor:
+            async with db.execute("SELECT value, type FROM storage WHERE key = ?", (key,)) as cursor:
                 row = await cursor.fetchone()
-        
+
         if row is None:
             return None
-        
+
         value_str, value_type = row
-        
+
         if model is not None and hasattr(model, "model_validate_json"):
             return model.model_validate_json(value_str)
         # Fall back to a plain JSON decode when no Pydantic model is supplied
         # (or when callers accidentally pass a builtin container type such as
         # ``dict``/``list``, which is not a Pydantic model).
         return json.loads(value_str)
-    
+
     @classmethod
     async def delete(cls, key: str) -> bool:
         """
         Delete a value
-        
+
         Args:
             key: Storage key
-            
+
         Returns:
             True if deleted, False if not found
         """
         await cls._ensure_init()
         db_path = cls.route_db_path_for_key(key)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
-        
+
         async def _delete() -> bool:
             async with cls.connect(db_path) as db:
                 cursor = await db.execute("DELETE FROM storage WHERE key = ?", (key,))
@@ -1194,32 +1034,29 @@ class Storage:
                 return cursor.rowcount > 0
 
         deleted = await cls._run_write_with_retry(_delete, action="delete", target=key)
-        
+
         if deleted:
             cls._log.debug("storage.delete", {"key": key})
-        
+
         return deleted
-    
+
     @classmethod
     async def list_keys(cls, prefix: Optional[str] = None) -> List[str]:
         """
         List all keys, optionally filtered by prefix
-        
+
         Args:
             prefix: Optional key prefix to filter by
-            
+
         Returns:
             List of matching keys
         """
         await cls._ensure_init()
         if prefix is None:
-            db_paths = (cls.get_db_path(), cls.get_workflow_db_path())
+            db_paths = (cls.get_db_path(),)
         else:
             db_paths = (cls.route_db_path_for_prefix(prefix),)
-        for db_path in db_paths:
-            if db_path != cls.get_db_path():
-                await cls._ensure_storage_table(db_path)
-        
+
         keys: set[str] = set()
         for db_path in db_paths:
             async with cls.connect(db_path) as db:
@@ -1233,7 +1070,7 @@ class Storage:
                 async with db.execute(query, params) as cursor:
                     rows = await cursor.fetchall()
             keys.update(row[0] for row in rows)
-        
+
         return sorted(keys)
 
     @classmethod
@@ -1243,12 +1080,9 @@ class Storage:
         prefix: Optional[str],
     ) -> List[Tuple[str, str]]:
         if prefix is None:
-            db_paths = (cls.get_db_path(), cls.get_workflow_db_path())
+            db_paths = (cls.get_db_path(),)
         else:
             db_paths = (cls.route_db_path_for_prefix(prefix),)
-        for db_path in db_paths:
-            if db_path != cls.get_db_path():
-                await cls._ensure_storage_table(db_path)
 
         rows_by_key: dict[str, str] = {}
         for db_path in db_paths:
@@ -1310,8 +1144,6 @@ class Storage:
         """List one page of entries for a prefix, plus total matching rows."""
         await cls._ensure_init()
         db_path = cls.route_db_path_for_prefix(prefix)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
 
         safe_offset = max(int(offset), 0)
         safe_limit = max(int(limit), 0)
@@ -1368,46 +1200,39 @@ class Storage:
     async def exists(cls, key: str) -> bool:
         """
         Check if a key exists
-        
+
         Args:
             key: Storage key
-            
+
         Returns:
             True if exists, False otherwise
         """
         await cls._ensure_init()
         db_path = cls.route_db_path_for_key(key)
-        if db_path != cls.get_db_path():
-            await cls._ensure_storage_table(db_path)
-        
+
         async with cls.connect(db_path) as db:
-            async with db.execute(
-                "SELECT 1 FROM storage WHERE key = ?", (key,)
-            ) as cursor:
+            async with db.execute("SELECT 1 FROM storage WHERE key = ?", (key,)) as cursor:
                 row = await cursor.fetchone()
-        
+
         return row is not None
-    
+
     @classmethod
     async def clear(cls, prefix: Optional[str] = None) -> int:
         """
         Clear storage, optionally filtered by prefix
-        
+
         Args:
             prefix: Optional key prefix to filter by
-            
+
         Returns:
             Number of deleted entries
         """
         await cls._ensure_init()
         if prefix is None:
-            db_paths = (cls.get_db_path(), cls.get_workflow_db_path())
+            db_paths = (cls.get_db_path(),)
         else:
             db_paths = (cls.route_db_path_for_prefix(prefix),)
-        for db_path in db_paths:
-            if db_path != cls.get_db_path():
-                await cls._ensure_storage_table(db_path)
-        
+
         async def _clear_db(db_path: Path) -> int:
             async with cls.connect(db_path) as db:
                 if prefix:
@@ -1433,73 +1258,73 @@ class Storage:
                 action="clear",
                 target=f"{prefix or '<all>'}@{db_path}",
             )
-        
+
         cls._log.info("storage.clear", {"prefix": prefix, "deleted": deleted})
         cls._invalidate_runtime_caches(prefix)
         return deleted
-    
+
     # ==================== TypeScript-compatible API ====================
-    
+
     @classmethod
     async def read(cls, key: List[str] | str, model: Optional[Type[T]] = None) -> Optional[T | Any]:
         """
         Read a value (TypeScript-compatible API)
-        
+
         Matches TypeScript: Storage.read<T>(key: string[])
-        
+
         Args:
             key: Storage key as list or string
             model: Optional Pydantic model class
-            
+
         Returns:
             Stored value or None if not found
-            
+
         Raises:
             NotFoundError: If key not found (when strict mode needed)
         """
         resolved_key = cls._resolve_key(key)
         return await cls.get(resolved_key, model)
-    
+
     @classmethod
     async def write(cls, key: List[str] | str, content: Any) -> None:
         """
         Write a value (TypeScript-compatible API)
-        
+
         Matches TypeScript: Storage.write<T>(key: string[], content: T)
-        
+
         Args:
             key: Storage key as list or string
             content: Content to store
         """
         resolved_key = cls._resolve_key(key)
         await cls.set(resolved_key, content)
-    
+
     @classmethod
     async def update(cls, key: List[str] | str, fn: callable, model: Optional[Type[T]] = None) -> Optional[T | Any]:
         """
         Update a value in place (TypeScript-compatible API)
-        
+
         Matches TypeScript: Storage.update<T>(key: string[], fn: (draft: T) => void)
-        
+
         Args:
             key: Storage key as list or string
             fn: Function that modifies the content in place
             model: Optional Pydantic model class
-            
+
         Returns:
             Updated value
-            
+
         Raises:
             NotFoundError: If key not found
         """
         resolved_key = cls._resolve_key(key)
-        
+
         # Read current value
         content = await cls.get(resolved_key, model)
-        
+
         if content is None:
             raise NotFoundError(f"Key not found: {resolved_key}")
-        
+
         # If it's a dict, apply function
         if isinstance(content, dict):
             fn(content)
@@ -1512,43 +1337,43 @@ class Storage:
             else:
                 # For other types, try to call fn on it
                 fn(content)
-        
+
         # Write back
         await cls.set(resolved_key, content)
-        
+
         return content
-    
+
     @classmethod
     async def remove(cls, key: List[str] | str) -> bool:
         """
         Remove a value (TypeScript-compatible API)
-        
+
         Matches TypeScript: Storage.remove(key: string[])
-        
+
         Args:
             key: Storage key as list or string
-            
+
         Returns:
             True if deleted, False if not found
         """
         resolved_key = cls._resolve_key(key)
         return await cls.delete(resolved_key)
-    
+
     @classmethod
     async def list(cls, prefix: List[str] | str | None = None) -> List[List[str]]:
         """
         List keys (TypeScript-compatible API)
-        
+
         Matches TypeScript: Storage.list(prefix: string[])
-        
+
         Args:
             prefix: Optional key prefix as list or string
-            
+
         Returns:
             List of keys as lists (e.g., [["session", "proj1", "ses1"], ...])
         """
         prefix_str = cls._resolve_key(prefix) if prefix else None
         keys = await cls.list_keys(prefix_str)
-        
+
         # Convert string keys back to list format
         return [key.split("/") for key in keys]

--- a/flocks/tool/task/run_workflow.py
+++ b/flocks/tool/task/run_workflow.py
@@ -13,10 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional, Dict, Any, Union
 
-from flocks.tool.registry import (
-    ToolRegistry, ToolCategory, ToolParameter, ParameterType, ToolResult, ToolContext
-)
-from flocks.storage.storage import Storage
+from flocks.tool.registry import ToolRegistry, ToolCategory, ToolParameter, ParameterType, ToolResult, ToolContext
 from flocks.utils.log import Log
 from flocks.session.recorder import Recorder
 from flocks.workflow.execution_store import (
@@ -30,9 +27,9 @@ from flocks.workflow.execution_store import (
     record_execution_step,
     record_execution_result,
     resolve_execution_outcome,
-    workflow_execution_key,
 )
 from flocks.workflow.fs_store import read_workflow_from_fs, resolve_workflow_id_from_source
+from flocks.workflow.store import WorkflowStore
 
 
 log = Log.create(service="tool.run_workflow")
@@ -53,7 +50,10 @@ def _get_workflow_runtime():
         return None, None, None
     try:
         # Prefer in-repo integration (flocks.workflow). Fallback to external package if installed.
-        from flocks.workflow import RequirementsInstaller as _ReqInstaller, run_workflow as _run
+        from flocks.workflow import (
+            RequirementsInstaller as _ReqInstaller,
+            run_workflow as _run,
+        )
         from flocks.workflow.runner import RunWorkflowResult as _Result
 
         RequirementsInstaller = _ReqInstaller
@@ -78,6 +78,16 @@ def _get_workflow_runtime():
             _WORKFLOW_AVAILABLE = False
             log.warn("run_workflow.import_failed", {"message": str(e), "fallback_message": str(e2)})
             return None, None, None
+
+
+async def _call_workflow_runtime(runtime_fn, call_kwargs: Dict[str, Any]):
+    """Call either the async process executor or a legacy sync workflow runtime."""
+    if inspect.iscoroutinefunction(runtime_fn):
+        return await runtime_fn(**call_kwargs)
+    result = await asyncio.to_thread(runtime_fn, **call_kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 _BASE_DESCRIPTION = """Execute a workflow definition using the flocks-workflow runtime.
@@ -165,6 +175,7 @@ async def _build_description() -> str:
 
     try:
         from flocks.workflow.center import scan_skill_workflows
+
         entries = await scan_skill_workflows()
         if not entries:
             result = _BASE_DESCRIPTION
@@ -199,93 +210,93 @@ def _format_workflow_result(result: Any, *, include_history: bool = False) -> st
     session tool output stays concise. The structured history remains
     available in metadata and persisted execution records.
     """
-    if hasattr(result, '__dict__'):
+    if hasattr(result, "__dict__"):
         # RunWorkflowResult object
         data = result.__dict__
     elif isinstance(result, dict):
         data = result
     else:
         return str(result)
-    
+
     output_lines = []
     output_lines.append(f"Status: {data.get('status', 'UNKNOWN')}")
-    
-    if data.get('run_id'):
+
+    if data.get("run_id"):
         output_lines.append(f"Run ID: {data.get('run_id')}")
-    
-    if data.get('steps'):
+
+    if data.get("steps"):
         output_lines.append(f"Steps executed: {data.get('steps')}")
-    
-    if data.get('last_node_id'):
+
+    if data.get("last_node_id"):
         output_lines.append(f"Last node: {data.get('last_node_id')}")
-    
-    if data.get('error'):
+
+    if data.get("error"):
         output_lines.append(f"\nError: {data.get('error')}")
-    
-    if data.get('outputs'):
+
+    if data.get("outputs"):
         output_lines.append("\nFinal Outputs:")
         try:
-            outputs_str = json.dumps(data.get('outputs'), indent=2, ensure_ascii=False)
+            outputs_str = json.dumps(data.get("outputs"), indent=2, ensure_ascii=False)
             output_lines.append(outputs_str)
         except Exception:
-            output_lines.append(str(data.get('outputs')))
-    
-    if include_history and data.get('history'):
-        history = data.get('history', [])
+            output_lines.append(str(data.get("outputs")))
+
+    if include_history and data.get("history"):
+        history = data.get("history", [])
         if history:
-            output_lines.append(f"\n{'='*80}")
+            output_lines.append(f"\n{'=' * 80}")
             output_lines.append(f"Execution History ({len(history)} steps):")
-            output_lines.append('='*80)
-            
+            output_lines.append("=" * 80)
+
             for i, step in enumerate(history, 1):
-                node_id = step.get('node_id', 'unknown')
-                duration_ms = step.get('duration_ms')
-                error = step.get('error')
-                
+                node_id = step.get("node_id", "unknown")
+                duration_ms = step.get("duration_ms")
+                error = step.get("error")
+
                 output_lines.append(f"\n[Step {i}] Node: {node_id}")
                 if duration_ms is not None:
                     output_lines.append(f"  Duration: {duration_ms:.2f}ms")
-                
+
                 # Show inputs
-                inputs = step.get('inputs', {})
+                inputs = step.get("inputs", {})
                 if inputs:
                     output_lines.append("  Inputs:")
                     try:
                         inputs_str = json.dumps(inputs, indent=4, ensure_ascii=False)
-                        for line in inputs_str.split('\n'):
+                        for line in inputs_str.split("\n"):
                             output_lines.append(f"    {line}")
                     except Exception:
                         output_lines.append(f"    {str(inputs)}")
-                
+
                 # Show outputs
-                outputs = step.get('outputs', {})
+                outputs = step.get("outputs", {})
                 if outputs:
                     output_lines.append("  Outputs:")
                     try:
                         outputs_str = json.dumps(outputs, indent=4, ensure_ascii=False)
-                        for line in outputs_str.split('\n'):
+                        for line in outputs_str.split("\n"):
                             output_lines.append(f"    {line}")
                     except Exception:
                         output_lines.append(f"    {str(outputs)}")
-                
+
                 # Show stdout if present
-                stdout = step.get('stdout', '')
+                stdout = step.get("stdout", "")
                 if stdout:
                     output_lines.append("  Stdout:")
-                    for line in stdout.split('\n'):
+                    for line in stdout.split("\n"):
                         output_lines.append(f"    {line}")
-                
+
                 # Show error if present
                 if error:
                     output_lines.append(f"  Error: {error}")
-                    traceback_info = step.get('traceback', '')
+                    traceback_info = step.get("traceback", "")
                     if traceback_info:
                         output_lines.append("  Traceback:")
-                        for line in traceback_info.split('\n'):
+                        for line in traceback_info.split("\n"):
                             output_lines.append(f"    {line}")
-            
-            output_lines.append(f"\n{'='*80}")
-    
+
+            output_lines.append(f"\n{'=' * 80}")
+
     return "\n".join(output_lines)
 
 
@@ -343,7 +354,7 @@ async def _record_workflow_tool_result(workflow_id: str, result: Any) -> None:
             name="use_llm",
             type=ParameterType.BOOLEAN,
             description=(
-                "Enable LLM-backed code generation for `type=\"logic\"` nodes (when code is missing). "
+                'Enable LLM-backed code generation for `type="logic"` nodes (when code is missing). '
                 "Recommended to keep enabled for logic-node workflows."
             ),
             required=False,
@@ -354,22 +365,22 @@ async def _record_workflow_tool_result(workflow_id: str, result: Any) -> None:
             type=ParameterType.BOOLEAN,
             description="Whether to automatically install requirements declared in workflow metadata",
             required=False,
-            default=True
+            default=True,
         ),
         ToolParameter(
             name="timeout_s",
             type=ParameterType.NUMBER,
             description="Execution timeout in seconds (optional)",
-            required=False
+            required=False,
         ),
         ToolParameter(
             name="trace",
             type=ParameterType.BOOLEAN,
             description="Enable execution tracing for debugging",
             required=False,
-            default=False
+            default=False,
         ),
-    ]
+    ],
 )
 async def run_workflow_tool(
     ctx: ToolContext,
@@ -382,7 +393,7 @@ async def run_workflow_tool(
 ) -> ToolResult:
     """
     Execute a workflow using flocks-workflow runtime
-    
+
     Args:
         ctx: Tool context
         workflow: Workflow definition (dict), JSON string, or a workflow JSON file path
@@ -391,7 +402,7 @@ async def run_workflow_tool(
         ensure_requirements: Whether to install requirements automatically
         timeout_s: Execution timeout in seconds
         trace: Enable execution tracing
-        
+
     Returns:
         ToolResult with workflow execution results
     """
@@ -402,20 +413,15 @@ async def run_workflow_tool(
 
     req_installer, _run_workflow_fn, RunWorkflowResultCls = _get_workflow_runtime()
     if _run_workflow_fn is None or RunWorkflowResultCls is None:
-        return ToolResult(
-            success=False,
-            error="flocks-workflow package is not available. Please check code"
-        )
-    
+        return ToolResult(success=False, error="flocks-workflow package is not available. Please check code")
+
     # Validate workflow parameter
     if not workflow:
-        return ToolResult(
-            success=False,
-            error="workflow parameter is required"
-        )
-    
+        return ToolResult(success=False, error="workflow parameter is required")
+
     # Accept workflow as dict, JSON string, or file path.
     workflow_source: Union[Dict[str, Any], Path]
+    registered_workflow_id: Optional[str] = None
     if isinstance(workflow, str):
         raw = workflow.strip()
         # Try to parse as JSON first (handles JSON-encoded dicts or strings).
@@ -441,15 +447,17 @@ async def run_workflow_tool(
                     error=(
                         f"Workflow file not found: {parsed!r}. "
                         "Provide a valid workflow JSON file path or a workflow dict."
-                    )
+                    ),
                 )
         elif parsed is None:
             # json.loads raised JSONDecodeError — raw is not JSON.
             # First try to resolve as a registered workflow ID, then fall back to file path.
             existing_workflow = read_workflow_from_fs(raw)
             if existing_workflow is not None:
-                workflow_source = existing_workflow["workflowJson"]
-                raw = existing_workflow["id"]
+                workflow_source = dict(existing_workflow["workflowJson"])
+                registered_workflow_id = str(existing_workflow["id"])
+                workflow_source["id"] = registered_workflow_id
+                raw = registered_workflow_id
             else:
                 p = Path(raw).expanduser()
                 if p.exists() and p.is_file():
@@ -460,7 +468,7 @@ async def run_workflow_tool(
                         error=(
                             "Unsupported workflow string. Provide a workflow ID, workflow JSON string, "
                             "or a valid workflow JSON file path."
-                        )
+                        ),
                     )
         else:
             # json.loads returned list / int / bool — not a valid workflow parameter.
@@ -469,16 +477,15 @@ async def run_workflow_tool(
                 error=(
                     f"Invalid workflow parameter: expected a workflow dict or a file path string, "
                     f"got JSON-decoded {type(parsed).__name__} ({parsed!r})."
-                )
+                ),
             )
     elif isinstance(workflow, dict):
         workflow_source = workflow
     else:
         return ToolResult(
-            success=False,
-            error=f"workflow must be a dictionary or string, got {type(workflow).__name__}"
+            success=False, error=f"workflow must be a dictionary or string, got {type(workflow).__name__}"
         )
-    
+
     # Sanity-check dict workflows: must have at least a `start` field so we
     # surface a clear error instead of a confusing Pydantic validation message.
     if isinstance(workflow_source, dict) and "start" not in workflow_source:
@@ -488,7 +495,7 @@ async def run_workflow_tool(
                 "Invalid workflow definition: the `start` field is required. "
                 "Make sure you pass the workflow JSON (with `start`, `nodes`, `edges`) "
                 "as the `workflow` parameter, not the execution inputs."
-            )
+            ),
         )
 
     # Request permission (workflow execution can run arbitrary code)
@@ -501,11 +508,10 @@ async def run_workflow_tool(
         workflow_id = str(workflow_source)
 
     workflow_inputs = inputs or {}
-    canonical_workflow_id = resolve_workflow_id_from_source(workflow_source)
+    canonical_workflow_id = registered_workflow_id or resolve_workflow_id_from_source(workflow_source)
     display_workflow_id = canonical_workflow_id or workflow_id
     tracked_execution: Optional[Dict[str, Any]] = None
     tracked_step_count = 0
-    tracked_exec_key: Optional[str] = None
     pending_step_index: Optional[int] = None
     pending_step: Optional[Dict[str, Any]] = None
     loop = asyncio.get_running_loop()
@@ -514,22 +520,23 @@ async def run_workflow_tool(
         loop.call_soon_threadsafe(ctx.metadata, metadata)
 
     def _update_execution_progress(update_fields: Dict[str, Any]) -> None:
-        if not tracked_exec_key:
-            return
         try:
             if tracked_execution is None:
                 return
             tracked_execution.update(update_fields)
             asyncio.run_coroutine_threadsafe(
-                Storage.write(tracked_exec_key, compact_execution_summary(tracked_execution)),
+                WorkflowStore.upsert_execution(compact_execution_summary(tracked_execution)),
                 loop,
             ).result(timeout=5)
         except Exception as exc:
-            log.warning("run_workflow.execution_progress.write_failed", {
-                "workflow_id": display_workflow_id,
-                "exec_id": tracked_execution["id"] if tracked_execution else None,
-                "error": str(exc),
-            })
+            log.warning(
+                "run_workflow.execution_progress.write_failed",
+                {
+                    "workflow_id": display_workflow_id,
+                    "exec_id": tracked_execution["id"] if tracked_execution else None,
+                    "error": str(exc),
+                },
+            )
 
     def _on_step_start(
         run_id: Optional[str],
@@ -555,30 +562,34 @@ async def run_workflow_tool(
             "error": "Run cancelled before node completed",
         }
         if tracked_execution is not None:
-            tracked_execution.update({
-                "currentNodeId": current_node_id,
-                "currentNodeType": current_node_type,
-                "currentPhase": "running",
-                "currentStepIndex": step_index,
-                "loopProgress": loop_progress,
-                "updatedAt": int(time.time() * 1000),
-            })
-        _emit_metadata({
-            "title": f"Running workflow: {workflow_name}",
-            "metadata": {
-                "workflow_id": display_workflow_id,
-                "workflow_name": workflow_name,
-                "total_nodes": workflow_total_nodes,
-                "workflow_execution_id": tracked_execution["id"] if tracked_execution else None,
-                "run_id": run_id,
-                "status": "running",
-                "phase": "running",
-                "current_node_id": current_node_id,
-                "current_node_type": current_node_type,
-                "step_index": step_index,
-                "loop_progress": loop_progress,
-            },
-        })
+            _update_execution_progress(
+                {
+                    "currentNodeId": current_node_id,
+                    "currentNodeType": current_node_type,
+                    "currentPhase": "running",
+                    "currentStepIndex": step_index,
+                    "loopProgress": loop_progress,
+                    "updatedAt": int(time.time() * 1000),
+                }
+            )
+        _emit_metadata(
+            {
+                "title": f"Running workflow: {workflow_name}",
+                "metadata": {
+                    "workflow_id": display_workflow_id,
+                    "workflow_name": workflow_name,
+                    "total_nodes": workflow_total_nodes,
+                    "workflow_execution_id": tracked_execution["id"] if tracked_execution else None,
+                    "run_id": run_id,
+                    "status": "running",
+                    "phase": "running",
+                    "current_node_id": current_node_id,
+                    "current_node_type": current_node_type,
+                    "step_index": step_index,
+                    "loop_progress": loop_progress,
+                },
+            }
+        )
         return step_index
 
     def _on_step_complete(step_result: Any) -> None:
@@ -601,15 +612,17 @@ async def run_workflow_tool(
         )
         tracked_step_count = step_index
         if tracked_execution is not None:
-            tracked_execution.update({
-                "stepCount": tracked_step_count,
-                "currentNodeId": step_dict.get("node_id"),
-                "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
-                "currentPhase": "running",
-                "currentStepIndex": tracked_step_count,
-                "loopProgress": loop_progress,
-                "updatedAt": int(time.time() * 1000),
-            })
+            tracked_execution.update(
+                {
+                    "stepCount": tracked_step_count,
+                    "currentNodeId": step_dict.get("node_id"),
+                    "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
+                    "currentPhase": "running",
+                    "currentStepIndex": tracked_step_count,
+                    "loopProgress": loop_progress,
+                    "updatedAt": int(time.time() * 1000),
+                }
+            )
         if tracked_execution is not None:
             try:
                 asyncio.run_coroutine_threadsafe(
@@ -617,46 +630,49 @@ async def run_workflow_tool(
                     loop,
                 ).result(timeout=5)
             except Exception as exc:
-                log.warning("run_workflow.execution_step.write_failed", {
-                    "workflow_id": display_workflow_id,
-                    "exec_id": tracked_execution["id"],
-                    "step_index": step_index,
-                    "error": str(exc),
-                })
+                log.warning(
+                    "run_workflow.execution_step.write_failed",
+                    {
+                        "workflow_id": display_workflow_id,
+                        "exec_id": tracked_execution["id"],
+                        "step_index": step_index,
+                        "error": str(exc),
+                    },
+                )
         if tracked_step_count % _PROGRESS_FLUSH_EVERY_STEPS == 0:
-            _update_execution_progress({
-                "stepCount": tracked_step_count,
-                "currentNodeId": step_dict.get("node_id"),
-                "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
-                "currentPhase": "running",
-                "currentStepIndex": tracked_step_count,
-                "loopProgress": loop_progress,
-                "updatedAt": int(time.time() * 1000),
-            })
-        _emit_metadata({
-            "title": f"Running workflow: {workflow_name}",
-            "metadata": {
-                "workflow_id": display_workflow_id,
-                "workflow_name": workflow_name,
-                "total_nodes": workflow_total_nodes,
-                "workflow_execution_id": tracked_execution["id"] if tracked_execution else None,
-                "status": "running",
-                "phase": "running",
-                "current_node_id": step_dict.get("node_id"),
-                "current_node_type": step_dict.get("node_type") or step_dict.get("type"),
-                "step_index": tracked_step_count,
-                "step_count": tracked_step_count,
-                "loop_progress": loop_progress,
-            },
-        })
+            _update_execution_progress(
+                {
+                    "stepCount": tracked_step_count,
+                    "currentNodeId": step_dict.get("node_id"),
+                    "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
+                    "currentPhase": "running",
+                    "currentStepIndex": tracked_step_count,
+                    "loopProgress": loop_progress,
+                    "updatedAt": int(time.time() * 1000),
+                }
+            )
+        _emit_metadata(
+            {
+                "title": f"Running workflow: {workflow_name}",
+                "metadata": {
+                    "workflow_id": display_workflow_id,
+                    "workflow_name": workflow_name,
+                    "total_nodes": workflow_total_nodes,
+                    "workflow_execution_id": tracked_execution["id"] if tracked_execution else None,
+                    "status": "running",
+                    "phase": "running",
+                    "current_node_id": step_dict.get("node_id"),
+                    "current_node_type": step_dict.get("node_type") or step_dict.get("type"),
+                    "step_index": tracked_step_count,
+                    "step_count": tracked_step_count,
+                    "loop_progress": loop_progress,
+                },
+            }
+        )
         return
 
     async def _flush_pending_step() -> None:
-        if (
-            tracked_execution is None
-            or pending_step_index is None
-            or pending_step is None
-        ):
+        if tracked_execution is None or pending_step_index is None or pending_step is None:
             return
         try:
             await record_execution_step(
@@ -665,13 +681,16 @@ async def run_workflow_tool(
                 pending_step,
             )
         except Exception as exc:
-            log.warning("run_workflow.pending_step.write_failed", {
-                "workflow_id": display_workflow_id,
-                "exec_id": tracked_execution["id"],
-                "step_index": pending_step_index,
-                "error": str(exc),
-            })
-    
+            log.warning(
+                "run_workflow.pending_step.write_failed",
+                {
+                    "workflow_id": display_workflow_id,
+                    "exec_id": tracked_execution["id"],
+                    "step_index": pending_step_index,
+                    "error": str(exc),
+                },
+            )
+
     await ctx.ask(
         permission="run_workflow",
         patterns=[workflow_id, workflow_name],
@@ -681,37 +700,41 @@ async def run_workflow_tool(
             "workflow_name": workflow_name,
             "ensure_requirements": ensure_requirements,
             "use_llm": use_llm,
-        }
+        },
     )
-    
+
     if canonical_workflow_id:
         tracked_execution = await create_execution_record(
             canonical_workflow_id,
             input_params=workflow_inputs,
         )
-        tracked_exec_key = workflow_execution_key(tracked_execution["id"])
 
     # Update metadata to show workflow is running
-    _emit_metadata({
-        "title": f"Running workflow: {workflow_name}",
-        "metadata": {
-            "workflow_id": display_workflow_id,
-            "workflow_name": workflow_name,
-            "total_nodes": workflow_total_nodes,
-            "workflow_execution_id": tracked_execution["id"] if tracked_execution else None,
-            "status": "running",
-            "phase": "queued",
-            "step_index": 0,
-        },
-    })
+    _emit_metadata(
+        {
+            "title": f"Running workflow: {workflow_name}",
+            "metadata": {
+                "workflow_id": display_workflow_id,
+                "workflow_name": workflow_name,
+                "total_nodes": workflow_total_nodes,
+                "workflow_execution_id": tracked_execution["id"] if tracked_execution else None,
+                "status": "running",
+                "phase": "queued",
+                "step_index": 0,
+            },
+        }
+    )
 
     try:
         # Execute workflow
-        log.info("run_workflow.execute.start", {
-            "workflow_id": workflow_id,
-            "workflow_name": workflow_name,
-            "ensure_requirements": ensure_requirements,
-        })
+        log.info(
+            "run_workflow.execute.start",
+            {
+                "workflow_id": workflow_id,
+                "workflow_name": workflow_name,
+                "ensure_requirements": ensure_requirements,
+            },
+        )
         execution_started_at = time.time()
 
         nested_tool_ctx = _create_nested_tool_context(ctx)
@@ -728,29 +751,33 @@ async def run_workflow_tool(
         }
 
         # Backward-compatibility: older runtimes may not accept `use_llm`.
+        supports_workflow_id = False
         supports_use_llm = False
         supports_step_start = False
         supports_cancel = False
         try:
             sig = inspect.signature(_run_workflow_fn)
-            supports_use_llm = (
-                "use_llm" in sig.parameters
-                or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+            supports_workflow_id = "workflow_id" in sig.parameters or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
             )
-            supports_step_start = (
-                "on_step_start" in sig.parameters
-                or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+            supports_use_llm = "use_llm" in sig.parameters or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
             )
-            supports_cancel = (
-                "cancel" in sig.parameters
-                or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+            supports_step_start = "on_step_start" in sig.parameters or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+            )
+            supports_cancel = "cancel" in sig.parameters or any(
+                p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
             )
         except Exception:
             # Best-effort: assume supported.
+            supports_workflow_id = True
             supports_use_llm = True
             supports_step_start = True
             supports_cancel = True
 
+        if supports_workflow_id:
+            call_kwargs["workflow_id"] = display_workflow_id
         if supports_use_llm:
             call_kwargs["use_llm"] = use_llm
         if supports_step_start:
@@ -760,21 +787,24 @@ async def run_workflow_tool(
             call_kwargs["cancel"] = ctx.abort.is_set
 
         try:
-            result = await asyncio.to_thread(_run_workflow_fn, **call_kwargs)
+            result = await _call_workflow_runtime(_run_workflow_fn, call_kwargs)
         except TypeError as te:
             # Fallback if the runtime rejects `use_llm` (unexpected keyword).
-            if supports_use_llm and "use_llm" in str(te):
+            if supports_workflow_id and "workflow_id" in str(te):
+                call_kwargs.pop("workflow_id", None)
+                result = await _call_workflow_runtime(_run_workflow_fn, call_kwargs)
+            elif supports_use_llm and "use_llm" in str(te):
                 call_kwargs.pop("use_llm", None)
-                result = await asyncio.to_thread(_run_workflow_fn, **call_kwargs)
+                result = await _call_workflow_runtime(_run_workflow_fn, call_kwargs)
             elif supports_step_start and "on_step_start" in str(te):
                 call_kwargs.pop("on_step_start", None)
-                result = await asyncio.to_thread(_run_workflow_fn, **call_kwargs)
+                result = await _call_workflow_runtime(_run_workflow_fn, call_kwargs)
             elif supports_cancel and "cancel" in str(te):
                 call_kwargs.pop("cancel", None)
-                result = await asyncio.to_thread(_run_workflow_fn, **call_kwargs)
+                result = await _call_workflow_runtime(_run_workflow_fn, call_kwargs)
             else:
                 raise
-        
+
         # Format result
         if RunWorkflowResultCls and isinstance(result, RunWorkflowResultCls):
             result_dict = result.__dict__
@@ -782,19 +812,22 @@ async def run_workflow_tool(
             result_dict = result
         else:
             result_dict = {"status": "UNKNOWN", "output": str(result)}
-        
+
         status = result_dict.get("status", "UNKNOWN")
         success = status == "SUCCEEDED"
         error = result_dict.get("error")
-        
+
         output = _format_workflow_result(result_dict)
-        
-        log.info("run_workflow.execute.complete", {
-            "workflow_id": workflow_id,
-            "status": status,
-            "success": success,
-            "steps": result_dict.get("steps", 0),
-        })
+
+        log.info(
+            "run_workflow.execute.complete",
+            {
+                "workflow_id": workflow_id,
+                "status": status,
+                "success": success,
+                "steps": result_dict.get("steps", 0),
+            },
+        )
 
         # Append-only recording for audit/replay
         await _record_workflow_tool_result(display_workflow_id, result_dict)
@@ -809,7 +842,7 @@ async def run_workflow_tool(
             final_step_count = tracked_step_count
         if pending_step_index is not None:
             final_step_count = max(final_step_count, pending_step_index)
-        if tracked_execution and canonical_workflow_id and tracked_exec_key:
+        if tracked_execution and canonical_workflow_id:
             current_data = dict(tracked_execution)
             outcome_result = result
             if not hasattr(outcome_result, "status"):
@@ -819,40 +852,44 @@ async def run_workflow_tool(
                     error=result_dict.get("error"),
                 )
             status_value, error_message = resolve_execution_outcome(outcome_result)  # type: ignore[arg-type]
-            current_data.update({
-                "outputResults": compact_outputs_for_storage(result_dict.get("outputs")),
-                "status": status_value,
-                "finishedAt": int(time.time() * 1000),
-                "duration": time.time() - execution_started_at,
-                "executionLog": compacted_history,
-                "stepCount": final_step_count,
-                "errorMessage": error_message,
-                "currentNodeId": result_dict.get("last_node_id"),
-                "currentPhase": status_value,
-                "currentStepIndex": final_step_count,
-                "updatedAt": int(time.time() * 1000),
-            })
+            current_data.update(
+                {
+                    "outputResults": compact_outputs_for_storage(result_dict.get("outputs")),
+                    "status": status_value,
+                    "finishedAt": int(time.time() * 1000),
+                    "duration": time.time() - execution_started_at,
+                    "executionLog": compacted_history,
+                    "stepCount": final_step_count,
+                    "errorMessage": error_message,
+                    "currentNodeId": result_dict.get("last_node_id"),
+                    "currentPhase": status_value,
+                    "currentStepIndex": final_step_count,
+                    "updatedAt": int(time.time() * 1000),
+                }
+            )
             await record_execution_result(
                 canonical_workflow_id,
                 tracked_execution["id"],
                 current_data,
             )
-            _emit_metadata({
-                "title": f"Workflow: {workflow_name}",
-                "metadata": {
-                    "workflow_id": canonical_workflow_id,
-                    "workflow_name": workflow_name,
-                    "total_nodes": workflow_total_nodes,
-                    "workflow_execution_id": tracked_execution["id"],
-                    "run_id": result_dict.get("run_id"),
-                    "status": status_value,
-                    "phase": status_value,
-                    "current_node_id": result_dict.get("last_node_id"),
-                    "step_index": final_step_count,
-                    "step_count": final_step_count,
-                    "loop_progress": current_data.get("loopProgress"),
-                },
-            })
+            _emit_metadata(
+                {
+                    "title": f"Workflow: {workflow_name}",
+                    "metadata": {
+                        "workflow_id": canonical_workflow_id,
+                        "workflow_name": workflow_name,
+                        "total_nodes": workflow_total_nodes,
+                        "workflow_execution_id": tracked_execution["id"],
+                        "run_id": result_dict.get("run_id"),
+                        "status": status_value,
+                        "phase": status_value,
+                        "current_node_id": result_dict.get("last_node_id"),
+                        "step_index": final_step_count,
+                        "step_count": final_step_count,
+                        "loop_progress": current_data.get("loopProgress"),
+                    },
+                }
+            )
 
         compacted_outputs = compact_outputs_for_storage(result_dict.get("outputs"))
 
@@ -875,9 +912,9 @@ async def run_workflow_tool(
                     "outputs": compacted_outputs,
                     "history": [],
                     "history_count": history_count,
-                }
+                },
             )
-        
+
         return ToolResult(
             success=success,
             output=output,
@@ -894,45 +931,52 @@ async def run_workflow_tool(
                 "outputs": compacted_outputs,
                 "history": [],
                 "history_count": history_count,
-            }
+            },
         )
-        
+
     except Exception as e:
         error_msg = str(e)
-        log.error("run_workflow.execute.error", {
-            "workflow_id": workflow_id,
-            "error": error_msg,
-        })
-        if tracked_execution and canonical_workflow_id and tracked_exec_key:
+        log.error(
+            "run_workflow.execute.error",
+            {
+                "workflow_id": workflow_id,
+                "error": error_msg,
+            },
+        )
+        if tracked_execution and canonical_workflow_id:
             current_data = dict(tracked_execution)
-            current_data.update({
-                "status": "error",
-                "finishedAt": int(time.time() * 1000),
-                "errorMessage": error_msg,
-                "executionLog": [],
-                "stepCount": tracked_step_count,
-                "currentPhase": "error",
-                "currentStepIndex": tracked_step_count,
-                "updatedAt": int(time.time() * 1000),
-            })
+            current_data.update(
+                {
+                    "status": "error",
+                    "finishedAt": int(time.time() * 1000),
+                    "errorMessage": error_msg,
+                    "executionLog": [],
+                    "stepCount": tracked_step_count,
+                    "currentPhase": "error",
+                    "currentStepIndex": tracked_step_count,
+                    "updatedAt": int(time.time() * 1000),
+                }
+            )
             await record_execution_result(
                 canonical_workflow_id,
                 tracked_execution["id"],
                 current_data,
             )
-            _emit_metadata({
-                "title": f"Workflow: {workflow_name}",
-                "metadata": {
-                    "workflow_id": canonical_workflow_id,
-                    "workflow_name": workflow_name,
-                    "total_nodes": workflow_total_nodes,
-                    "workflow_execution_id": tracked_execution["id"],
-                    "status": "error",
-                    "phase": "error",
-                    "step_index": tracked_step_count,
-                },
-            })
-        
+            _emit_metadata(
+                {
+                    "title": f"Workflow: {workflow_name}",
+                    "metadata": {
+                        "workflow_id": canonical_workflow_id,
+                        "workflow_name": workflow_name,
+                        "total_nodes": workflow_total_nodes,
+                        "workflow_execution_id": tracked_execution["id"],
+                        "status": "error",
+                        "phase": "error",
+                        "step_index": tracked_step_count,
+                    },
+                }
+            )
+
         return ToolResult(
             success=False,
             error=f"Workflow execution failed: {error_msg}",
@@ -943,5 +987,5 @@ async def run_workflow_tool(
                 "total_nodes": workflow_total_nodes,
                 "workflow_execution_id": tracked_execution["id"] if tracked_execution else None,
                 "status": "FAILED",
-            }
+            },
         )

--- a/flocks/tool/task/run_workflow.py
+++ b/flocks/tool/task/run_workflow.py
@@ -35,6 +35,7 @@ from flocks.workflow.store import WorkflowStore
 log = Log.create(service="tool.run_workflow")
 
 _PROGRESS_FLUSH_EVERY_STEPS = 5
+_FORMATTED_OUTPUT_MAX_CHARS = 8_000
 
 # Lazy import to avoid circular import (flocks.tool <-> flocks.workflow)
 _WORKFLOW_AVAILABLE: Optional[bool] = None
@@ -236,10 +237,22 @@ def _format_workflow_result(result: Any, *, include_history: bool = False) -> st
     if data.get("outputs"):
         output_lines.append("\nFinal Outputs:")
         try:
-            outputs_str = json.dumps(data.get("outputs"), indent=2, ensure_ascii=False)
+            compacted_outputs = compact_outputs_for_storage(data.get("outputs"))
+            outputs_str = json.dumps(compacted_outputs, indent=2, ensure_ascii=False, default=str)
+            if len(outputs_str) > _FORMATTED_OUTPUT_MAX_CHARS:
+                outputs_str = (
+                    outputs_str[:_FORMATTED_OUTPUT_MAX_CHARS]
+                    + f"...[truncated:{len(outputs_str) - _FORMATTED_OUTPUT_MAX_CHARS}]"
+                )
             output_lines.append(outputs_str)
         except Exception:
-            output_lines.append(str(data.get("outputs")))
+            outputs_text = str(compact_outputs_for_storage(data.get("outputs")))
+            if len(outputs_text) > _FORMATTED_OUTPUT_MAX_CHARS:
+                outputs_text = (
+                    outputs_text[:_FORMATTED_OUTPUT_MAX_CHARS]
+                    + f"...[truncated:{len(outputs_text) - _FORMATTED_OUTPUT_MAX_CHARS}]"
+                )
+            output_lines.append(outputs_text)
 
     if include_history and data.get("history"):
         history = data.get("history", [])
@@ -554,13 +567,15 @@ async def run_workflow_tool(
             outputs=None,
         )
         pending_step_index = step_index
-        pending_step = {
-            "node_id": current_node_id,
-            "node_type": current_node_type,
-            "inputs": _inputs if isinstance(_inputs, dict) else {},
-            "outputs": {},
-            "error": "Run cancelled before node completed",
-        }
+        pending_step = compact_step_for_storage(
+            {
+                "node_id": current_node_id,
+                "node_type": current_node_type,
+                "inputs": _inputs if isinstance(_inputs, dict) else {},
+                "outputs": {},
+                "error": "Run cancelled before node completed",
+            }
+        )
         if tracked_execution is not None:
             _update_execution_progress(
                 {
@@ -816,6 +831,7 @@ async def run_workflow_tool(
         status = result_dict.get("status", "UNKNOWN")
         success = status == "SUCCEEDED"
         error = result_dict.get("error")
+        payload_risk_summary = result_dict.get("payload_risk_summary") or result_dict.get("payloadRiskSummary") or {}
 
         output = _format_workflow_result(result_dict)
 
@@ -859,6 +875,7 @@ async def run_workflow_tool(
                     "finishedAt": int(time.time() * 1000),
                     "duration": time.time() - execution_started_at,
                     "executionLog": compacted_history,
+                    "payloadRiskSummary": payload_risk_summary,
                     "stepCount": final_step_count,
                     "errorMessage": error_message,
                     "currentNodeId": result_dict.get("last_node_id"),
@@ -912,6 +929,7 @@ async def run_workflow_tool(
                     "outputs": compacted_outputs,
                     "history": [],
                     "history_count": history_count,
+                    "payload_risk_summary": payload_risk_summary,
                 },
             )
 
@@ -931,6 +949,7 @@ async def run_workflow_tool(
                 "outputs": compacted_outputs,
                 "history": [],
                 "history_count": history_count,
+                "payload_risk_summary": payload_risk_summary,
             },
         )
 

--- a/flocks/workflow/center.py
+++ b/flocks/workflow/center.py
@@ -26,7 +26,7 @@ from urllib import request as url_request
 from flocks.config.config import Config
 from flocks.plugin.loader import DEFAULT_PLUGIN_ROOT
 from flocks.sandbox.docker import docker_container_state, exec_docker
-from flocks.storage.storage import Storage
+from flocks.workflow.store import WorkflowStore
 from flocks.utils.log import Log
 from flocks.workflow.models import Workflow
 from flocks.workflow.requirements import resolve_python_package_index_url
@@ -135,8 +135,8 @@ def resolve_global_workflow_roots() -> list[Path]:
     """
     home = Path.home() / ".flocks"
     return [
-        home / "plugins" / "workflow",   # legacy compat (read-only)
-        home / "workflow",               # legacy compat (read-only)
+        home / "plugins" / "workflow",  # legacy compat (read-only)
+        home / "workflow",  # legacy compat (read-only)
         home / "plugins" / "workflows",  # new canonical (read + write)
     ]
 
@@ -150,8 +150,8 @@ def resolve_project_workflow_roots(base_dir: Optional[Path] = None) -> list[Path
     root = base_dir or Path.cwd()
     flocks = root / ".flocks"
     return [
-        flocks / "plugins" / "workflow",   # legacy compat (read-only)
-        flocks / "workflow",               # legacy compat (read-only)
+        flocks / "plugins" / "workflow",  # legacy compat (read-only)
+        flocks / "workflow",  # legacy compat (read-only)
         flocks / "plugins" / "workflows",  # new canonical (read + write)
     ]
 
@@ -206,14 +206,14 @@ async def _reserved_service_ports() -> set[int]:
     ports: set[int] = set()
     for prefix in (_RUNTIME_PREFIX, _API_SERVICE_PREFIX, _REGISTRY_PREFIX):
         try:
-            keys = await Storage.list_keys(prefix)
+            keys = await WorkflowStore.kv_list_keys(prefix)
         except Exception as exc:
             log.warning("workflow.port.list_reserved_failed", {"prefix": prefix, "error": str(exc)})
             continue
 
         for key in keys:
             try:
-                record = await Storage.read(key)
+                record = await WorkflowStore.kv_get(key)
             except Exception as exc:
                 log.warning("workflow.port.read_reserved_failed", {"key": _key_to_string(key), "error": str(exc)})
                 continue
@@ -223,11 +223,7 @@ async def _reserved_service_ports() -> set[int]:
 
 def _reserved_in_flight_ports() -> set[int]:
     now = time.time()
-    expired = [
-        port
-        for port, expires_at in _IN_FLIGHT_PORT_RESERVATIONS.items()
-        if expires_at <= now
-    ]
+    expired = [port for port, expires_at in _IN_FLIGHT_PORT_RESERVATIONS.items() if expires_at <= now]
     for port in expired:
         _IN_FLIGHT_PORT_RESERVATIONS.pop(port, None)
     return set(_IN_FLIGHT_PORT_RESERVATIONS)
@@ -254,7 +250,7 @@ async def _allocate_port() -> int:
 
 
 async def _read_registry(workflow_id: str) -> Dict[str, Any]:
-    data = await Storage.read(_registry_key(workflow_id))
+    data = await WorkflowStore.kv_get(_registry_key(workflow_id))
     if not data:
         raise WorkflowNotFoundError(f"Workflow not registered: {workflow_id}")
     return data
@@ -276,11 +272,7 @@ async def _scan_workflow_dir(
         try:
             raw = json.loads(workflow_path.read_text(encoding="utf-8"))
             meta_path = workflow_path.parent / "meta.json"
-            meta = (
-                json.loads(meta_path.read_text(encoding="utf-8"))
-                if meta_path.is_file()
-                else None
-            )
+            meta = json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.is_file() else None
             if is_hidden_workflow(raw, meta):
                 continue
             Workflow.from_dict(raw)
@@ -294,7 +286,7 @@ async def _scan_workflow_dir(
         workflow_id = _normalize_workflow_id(workflow_path)
         fp = _fingerprint(workflow_path)
         now_ms = _now_ms()
-        existing = await Storage.read(_registry_key(workflow_id)) or {}
+        existing = await WorkflowStore.kv_get(_registry_key(workflow_id)) or {}
         created_at = existing.get("registeredAt", now_ms)
         draft_changed = bool(existing) and existing.get("fingerprint") != fp
         entry = {
@@ -315,7 +307,7 @@ async def _scan_workflow_dir(
             "serviceKey": existing.get("serviceKey"),
             "serviceUrl": existing.get("serviceUrl"),
         }
-        await Storage.write(_registry_key(workflow_id), entry)
+        await WorkflowStore.kv_put(_registry_key(workflow_id), entry)
         by_id[workflow_id] = entry
 
 
@@ -383,11 +375,11 @@ def format_workflow_entries(
 
 async def list_registry_entries() -> List[Dict[str, Any]]:
     """List registered skill workflows."""
-    keys = await Storage.list(_REGISTRY_PREFIX)
+    keys = await WorkflowStore.kv_list(_REGISTRY_PREFIX)
     items: List[Dict[str, Any]] = []
     for raw_key in keys:
         key = _key_to_string(raw_key)
-        entry = await Storage.read(key)
+        entry = await WorkflowStore.kv_get(key)
         if entry:
             items.append(entry)
     items.sort(key=lambda item: item.get("updatedAt", 0), reverse=True)
@@ -424,10 +416,14 @@ async def _write_requirements_snapshot(release_dir: Path) -> bool:
     Returns True on success, False if the snapshot could not be created.
     """
     import sys
+
     req_file = release_dir / "requirements.txt"
     try:
         proc = await asyncio.create_subprocess_exec(
-            sys.executable, "-m", "pip", "freeze",
+            sys.executable,
+            "-m",
+            "pip",
+            "freeze",
             "--exclude-editable",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -508,16 +504,18 @@ def _docker_proxy_env_value(env_value: str) -> str:
         netloc = f"{userinfo}host.docker.internal"
         if parsed.port:
             netloc += f":{parsed.port}"
-        rewritten = urlunparse((
-            parsed.scheme,
-            netloc,
-            parsed.path,
-            parsed.params,
-            parsed.query,
-            parsed.fragment,
-        ))
+        rewritten = urlunparse(
+            (
+                parsed.scheme,
+                netloc,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            )
+        )
         if not has_scheme and rewritten.startswith("http://"):
-            return rewritten[len("http://"):]
+            return rewritten[len("http://") :]
         return rewritten
     except Exception:
         return env_value
@@ -563,8 +561,7 @@ async def _wait_docker_service_healthy(
             logs = await _docker_logs_tail(container_name)
             detail = logs or "container exited before reporting healthy"
             raise WorkflowCenterError(
-                "Published workflow service container exited before health check "
-                f"passed: {detail}"
+                f"Published workflow service container exited before health check passed: {detail}"
             )
         await asyncio.sleep(interval_s)
     return False
@@ -633,12 +630,12 @@ def _signal_local_process(pid: int, sig: signal.Signals, process_group_id: Optio
 
 async def _stop_local_service(workflow_id: str) -> None:
     """Kill a previously started local workflow service process."""
-    pid_record = await Storage.read(_local_pid_key(workflow_id))
+    pid_record = await WorkflowStore.kv_get(_local_pid_key(workflow_id))
     if not pid_record:
         return
     pid = pid_record.get("pid")
     if not pid:
-        await Storage.remove(_local_pid_key(workflow_id))
+        await WorkflowStore.kv_remove(_local_pid_key(workflow_id))
         return
     pid_int = int(pid)
     process_group_id = pid_record.get("processGroupId")
@@ -651,7 +648,7 @@ async def _stop_local_service(workflow_id: str) -> None:
             _signal_local_process(pid_int, signal.SIGKILL, process_group_id)
             await _wait_for_pid_exit(pid_int, 1.0)
     finally:
-        await Storage.remove(_local_pid_key(workflow_id))
+        await WorkflowStore.kv_remove(_local_pid_key(workflow_id))
 
 
 async def _stop_local_runtime(workflow_id: str, runtime: Dict[str, Any]) -> bool:
@@ -671,7 +668,7 @@ async def _stop_local_runtime(workflow_id: str, runtime: Dict[str, Any]) -> bool
         log.warning("workflow.local.force_kill", {"workflow_id": workflow_id, "pid": pid})
         _signal_local_process(pid, signal.SIGKILL, process_group_id)
         exited = await _wait_for_pid_exit(pid, 1.0)
-    await Storage.remove(_local_pid_key(workflow_id))
+    await WorkflowStore.kv_remove(_local_pid_key(workflow_id))
     return exited
 
 
@@ -692,11 +689,11 @@ def _runtime_driver(runtime: Optional[Dict[str, Any]]) -> str:
 async def _mark_release_inactive(workflow_id: str, release_id: Optional[Any]) -> None:
     if not release_id:
         return
-    release_record = await Storage.read(_release_key(workflow_id, str(release_id))) or {}
+    release_record = await WorkflowStore.kv_get(_release_key(workflow_id, str(release_id))) or {}
     if release_record:
         release_record["status"] = "inactive"
         release_record["deactivatedAt"] = _now_ms()
-        await Storage.write(_release_key(workflow_id, str(release_id)), release_record)
+        await WorkflowStore.kv_put(_release_key(workflow_id, str(release_id)), release_record)
 
 
 async def _stop_runtime_record(
@@ -719,18 +716,18 @@ async def _stop_runtime_record(
             if not stopped:
                 raise WorkflowCenterError(f"Failed to stop Docker container: {container_name}")
 
-    active = (await Storage.read(_active_release_key(workflow_id)) or {}) if clear_runtime_keys else {}
+    active = (await WorkflowStore.kv_get(_active_release_key(workflow_id)) or {}) if clear_runtime_keys else {}
     release_id = runtime.get("releaseId") or active.get("releaseId")
     await _mark_release_inactive(workflow_id, release_id)
     if clear_runtime_keys:
-        await Storage.remove(_runtime_key(workflow_id))
-        await Storage.remove(_active_release_key(workflow_id))
+        await WorkflowStore.kv_remove(_runtime_key(workflow_id))
+        await WorkflowStore.kv_remove(_active_release_key(workflow_id))
 
     if update_registry:
         registry["publishStatus"] = "stopped"
         registry["updatedAt"] = _now_ms()
         registry["serviceUrl"] = None
-        await Storage.write(_registry_key(workflow_id), registry)
+        await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
 
     return {
         "workflowId": workflow_id,
@@ -742,7 +739,7 @@ async def _stop_runtime_record(
 
 async def _stop_existing_runtime_for_publish(workflow_id: str) -> None:
     """Best-effort cleanup before starting a replacement service."""
-    runtime = await Storage.read(_runtime_key(workflow_id))
+    runtime = await WorkflowStore.kv_get(_runtime_key(workflow_id))
     if isinstance(runtime, dict) and runtime:
         await _stop_runtime_record(workflow_id, runtime, update_registry=False)
     else:
@@ -767,7 +764,7 @@ async def publish_workflow_local(workflow_id: str, *, api_key: Optional[str] = N
     now_ms = _now_ms()
     registry["publishStatus"] = "publishing"
     registry["updatedAt"] = now_ms
-    await Storage.write(_registry_key(workflow_id), registry)
+    await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
 
     release_snapshot_file = await _write_release_snapshot(workflow_id, release_id, workflow_json)
 
@@ -784,26 +781,37 @@ async def publish_workflow_local(workflow_id: str, *, api_key: Optional[str] = N
         env[_SERVICE_API_KEY_ENV] = runtime_api_key
         proc = await asyncio.create_subprocess_exec(
             sys.executable,
-            "-m", "flocks.workflow.service_runtime",
-            "--workflow", str(release_snapshot_file),
-            "--workflow-id", workflow_id,
-            "--release-id", release_id,
-            "--host", "127.0.0.1",
-            "--port", str(host_port),
+            "-m",
+            "flocks.workflow.service_runtime",
+            "--workflow",
+            str(release_snapshot_file),
+            "--workflow-id",
+            workflow_id,
+            "--release-id",
+            release_id,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(host_port),
             stdout=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.DEVNULL,
             env=env,
             start_new_session=True,
         )
 
-        await Storage.write(_local_pid_key(workflow_id), {
-            "pid": proc.pid,
-            "processGroupId": proc.pid,
-            "port": host_port,
-        })
+        await WorkflowStore.kv_put(
+            _local_pid_key(workflow_id),
+            {
+                "pid": proc.pid,
+                "processGroupId": proc.pid,
+                "port": host_port,
+            },
+        )
 
         health_retries = int(os.getenv("FLOCKS_WORKFLOW_SERVICE_HEALTH_RETRIES", str(_DEFAULT_HEALTH_RETRIES)))
-        health_interval_s = float(os.getenv("FLOCKS_WORKFLOW_SERVICE_HEALTH_INTERVAL_S", str(_DEFAULT_HEALTH_INTERVAL_S)))
+        health_interval_s = float(
+            os.getenv("FLOCKS_WORKFLOW_SERVICE_HEALTH_INTERVAL_S", str(_DEFAULT_HEALTH_INTERVAL_S))
+        )
 
         healthy = await _wait_service_healthy(service_url, retries=health_retries, interval_s=health_interval_s)
         if not healthy:
@@ -828,8 +836,8 @@ async def publish_workflow_local(workflow_id: str, *, api_key: Optional[str] = N
             "driver": "local",
             "apiKey": runtime_api_key,
         }
-        await Storage.write(_active_release_key(workflow_id), active_record)
-        await Storage.write(_runtime_key(workflow_id), active_record)
+        await WorkflowStore.kv_put(_active_release_key(workflow_id), active_record)
+        await WorkflowStore.kv_put(_runtime_key(workflow_id), active_record)
         _release_port_reservation(host_port)
     except Exception as exc:
         _release_port_reservation(host_port)
@@ -841,7 +849,7 @@ async def publish_workflow_local(workflow_id: str, *, api_key: Optional[str] = N
                 pass
         registry["publishStatus"] = "failed"
         registry["updatedAt"] = _now_ms()
-        await Storage.write(_registry_key(workflow_id), registry)
+        await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
         if isinstance(exc, WorkflowCenterError):
             raise
         raise WorkflowCenterError(str(exc)) from exc
@@ -851,7 +859,7 @@ async def publish_workflow_local(workflow_id: str, *, api_key: Optional[str] = N
     registry["serviceKey"] = service_key
     registry["serviceUrl"] = service_url
     registry["updatedAt"] = _now_ms()
-    await Storage.write(_registry_key(workflow_id), registry)
+    await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
 
     log.info("workflow.local.published", {"id": workflow_id, "port": host_port, "pid": proc.pid})
     return active_record
@@ -861,18 +869,19 @@ async def stop_local_service(workflow_id: str) -> Dict[str, Any]:
     """Stop a local workflow service process."""
     await _stop_local_service(workflow_id)
     registry = await _read_registry(workflow_id)
-    await Storage.remove(_runtime_key(workflow_id))
-    await Storage.remove(_active_release_key(workflow_id))
+    await WorkflowStore.kv_remove(_runtime_key(workflow_id))
+    await WorkflowStore.kv_remove(_active_release_key(workflow_id))
     registry["publishStatus"] = "stopped"
     registry["updatedAt"] = _now_ms()
     registry["serviceUrl"] = None
-    await Storage.write(_registry_key(workflow_id), registry)
+    await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
     return {"workflowId": workflow_id, "status": "stopped", "stopped": True}
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Unified publish / stop entry points (driver-aware)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def _service_driver() -> str:
     return os.getenv("FLOCKS_WORKFLOW_SERVICE_DRIVER", _DEFAULT_SERVICE_DRIVER).lower()
@@ -895,10 +904,10 @@ async def publish_workflow(
 
 async def stop_workflow_service(workflow_id: str) -> Dict[str, Any]:
     """Stop a published workflow service (driver-aware)."""
-    runtime = await Storage.read(_runtime_key(workflow_id))
+    runtime = await WorkflowStore.kv_get(_runtime_key(workflow_id))
     if isinstance(runtime, dict) and runtime:
         return await _stop_runtime_record(workflow_id, runtime, update_registry=True)
-    active = await Storage.read(_active_release_key(workflow_id))
+    active = await WorkflowStore.kv_get(_active_release_key(workflow_id))
     if isinstance(active, dict) and active:
         return await _stop_runtime_record(workflow_id, active, update_registry=True)
 
@@ -925,7 +934,7 @@ async def _publish_workflow_docker(
     now_ms = _now_ms()
     registry["publishStatus"] = "publishing"
     registry["updatedAt"] = now_ms
-    await Storage.write(_registry_key(workflow_id), registry)
+    await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
 
     release_snapshot_file = await _write_release_snapshot(workflow_id, release_id, workflow_json)
     release_runtime_dir = release_snapshot_file.parent
@@ -941,10 +950,10 @@ async def _publish_workflow_docker(
         "activatedAt": None,
         "deactivatedAt": None,
     }
-    await Storage.write(_release_key(workflow_id, release_id), release_record)
+    await WorkflowStore.kv_put(_release_key(workflow_id, release_id), release_record)
 
-    previous_runtime = await Storage.read(_runtime_key(workflow_id)) or {}
-    previous_active = await Storage.read(_active_release_key(workflow_id)) or {}
+    previous_runtime = await WorkflowStore.kv_get(_runtime_key(workflow_id)) or {}
+    previous_active = await WorkflowStore.kv_get(_active_release_key(workflow_id)) or {}
     previous_container_name = previous_active.get("containerName")
     previous_release_id = previous_active.get("releaseId")
 
@@ -956,15 +965,9 @@ async def _publish_workflow_docker(
         "false",
         "no",
     }
-    health_interval_s = float(
-        os.getenv("FLOCKS_WORKFLOW_SERVICE_HEALTH_INTERVAL_S", str(_DEFAULT_HEALTH_INTERVAL_S))
-    )
-    default_retries = (
-        _DEFAULT_RUNTIME_INSTALL_HEALTH_RETRIES if runtime_install else _DEFAULT_HEALTH_RETRIES
-    )
-    health_retries = int(
-        os.getenv("FLOCKS_WORKFLOW_SERVICE_HEALTH_RETRIES", str(default_retries))
-    )
+    health_interval_s = float(os.getenv("FLOCKS_WORKFLOW_SERVICE_HEALTH_INTERVAL_S", str(_DEFAULT_HEALTH_INTERVAL_S)))
+    default_retries = _DEFAULT_RUNTIME_INSTALL_HEALTH_RETRIES if runtime_install else _DEFAULT_HEALTH_RETRIES
+    health_retries = int(os.getenv("FLOCKS_WORKFLOW_SERVICE_HEALTH_RETRIES", str(default_retries)))
     project_root = Path.cwd().resolve()
     user_config_dir = Config.get_config_path().resolve()
     pip_cache_dir = _service_cache_dir("pip")
@@ -1002,7 +1005,7 @@ async def _publish_workflow_docker(
         image_name,
     ]
     if user_config_dir.exists():
-        cmd[cmd.index(image_name):cmd.index(image_name)] = [
+        cmd[cmd.index(image_name) : cmd.index(image_name)] = [
             "-v",
             f"{user_config_dir}:/runtime/.flocks-config:ro",
         ]
@@ -1028,14 +1031,14 @@ async def _publish_workflow_docker(
             proxy_injections.extend(["-e", f"{env_name}={docker_env_value}"])
     if proxy_injections:
         if needs_host_gateway:
-            cmd[cmd.index(image_name):cmd.index(image_name)] = [
+            cmd[cmd.index(image_name) : cmd.index(image_name)] = [
                 "--add-host",
                 "host.docker.internal:host-gateway",
             ]
-        cmd[cmd.index(image_name):cmd.index(image_name)] = proxy_injections
+        cmd[cmd.index(image_name) : cmd.index(image_name)] = proxy_injections
     python_index_url = resolve_python_package_index_url()
     if python_index_url:
-        cmd[cmd.index(image_name):cmd.index(image_name)] = [
+        cmd[cmd.index(image_name) : cmd.index(image_name)] = [
             "-e",
             f"PIP_INDEX_URL={python_index_url}",
             "-e",
@@ -1097,7 +1100,7 @@ async def _publish_workflow_docker(
 
         release_record["status"] = "active"
         release_record["activatedAt"] = _now_ms()
-        await Storage.write(_release_key(workflow_id, release_id), release_record)
+        await WorkflowStore.kv_put(_release_key(workflow_id, release_id), release_record)
 
         active_record = {
             "releaseId": release_id,
@@ -1113,8 +1116,8 @@ async def _publish_workflow_docker(
             "driver": "docker",
             "apiKey": runtime_api_key,
         }
-        await Storage.write(_active_release_key(workflow_id), active_record)
-        await Storage.write(_runtime_key(workflow_id), active_record)
+        await WorkflowStore.kv_put(_active_release_key(workflow_id), active_record)
+        await WorkflowStore.kv_put(_runtime_key(workflow_id), active_record)
         _release_port_reservation(host_port)
 
         registry["publishStatus"] = "active"
@@ -1122,7 +1125,7 @@ async def _publish_workflow_docker(
         registry["serviceKey"] = service_key
         registry["serviceUrl"] = service_url
         registry["updatedAt"] = _now_ms()
-        await Storage.write(_registry_key(workflow_id), registry)
+        await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
 
         if isinstance(previous_runtime, dict) and previous_runtime:
             await _stop_runtime_record(
@@ -1142,22 +1145,24 @@ async def _publish_workflow_docker(
         await _stop_and_remove_container(container_name)
         release_record["status"] = "failed"
         release_record["deactivatedAt"] = _now_ms()
-        await Storage.write(_release_key(workflow_id, release_id), release_record)
+        await WorkflowStore.kv_put(_release_key(workflow_id, release_id), release_record)
 
         registry["publishStatus"] = "failed"
         registry["updatedAt"] = _now_ms()
-        await Storage.write(_registry_key(workflow_id), registry)
+        await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
         raise WorkflowCenterError(str(exc)) from exc
 
 
 async def _stop_workflow_service_docker(workflow_id: str) -> Dict[str, Any]:
     """Stop a published workflow Docker service container."""
     registry = await _read_registry(workflow_id)
-    runtime = await Storage.read(_runtime_key(workflow_id)) or await Storage.read(_active_release_key(workflow_id))
+    runtime = await WorkflowStore.kv_get(_runtime_key(workflow_id)) or await WorkflowStore.kv_get(
+        _active_release_key(workflow_id)
+    )
     if not runtime:
         registry["publishStatus"] = "stopped"
         registry["updatedAt"] = _now_ms()
-        await Storage.write(_registry_key(workflow_id), registry)
+        await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
         return {"workflowId": workflow_id, "status": "stopped", "stopped": False}
 
     container_name = runtime.get("containerName")
@@ -1166,28 +1171,28 @@ async def _stop_workflow_service_docker(workflow_id: str) -> Dict[str, Any]:
         if not stopped:
             raise WorkflowCenterError(f"Failed to stop Docker container: {container_name}")
 
-    active = await Storage.read(_active_release_key(workflow_id)) or {}
+    active = await WorkflowStore.kv_get(_active_release_key(workflow_id)) or {}
     release_id = active.get("releaseId")
     if release_id:
-        release_record = await Storage.read(_release_key(workflow_id, release_id)) or {}
+        release_record = await WorkflowStore.kv_get(_release_key(workflow_id, release_id)) or {}
         if release_record:
             release_record["status"] = "inactive"
             release_record["deactivatedAt"] = _now_ms()
-            await Storage.write(_release_key(workflow_id, str(release_id)), release_record)
+            await WorkflowStore.kv_put(_release_key(workflow_id, str(release_id)), release_record)
 
-    await Storage.remove(_runtime_key(workflow_id))
-    await Storage.remove(_active_release_key(workflow_id))
+    await WorkflowStore.kv_remove(_runtime_key(workflow_id))
+    await WorkflowStore.kv_remove(_active_release_key(workflow_id))
     registry["publishStatus"] = "stopped"
     registry["updatedAt"] = _now_ms()
     registry["serviceUrl"] = None
-    await Storage.write(_registry_key(workflow_id), registry)
+    await WorkflowStore.kv_put(_registry_key(workflow_id), registry)
     return {"workflowId": workflow_id, "status": "stopped", "stopped": True}
 
 
 async def get_workflow_health(workflow_id: str) -> Dict[str, Any]:
     """Get workflow container and HTTP health status."""
     _ = await _read_registry(workflow_id)
-    runtime = await Storage.read(_runtime_key(workflow_id))
+    runtime = await WorkflowStore.kv_get(_runtime_key(workflow_id))
     if not runtime:
         return {"workflowId": workflow_id, "published": False, "containerRunning": False, "ok": False}
 
@@ -1221,7 +1226,9 @@ async def get_workflow_health(workflow_id: str) -> Dict[str, Any]:
             "driver": "local",
         }
 
-    docker_state = await docker_container_state(container_name) if container_name else {"exists": False, "running": False}
+    docker_state = (
+        await docker_container_state(container_name) if container_name else {"exists": False, "running": False}
+    )
 
     endpoint_ok = False
     endpoint_payload: Dict[str, Any] = {}
@@ -1255,7 +1262,7 @@ async def invoke_published_workflow(
 ) -> Dict[str, Any]:
     """Invoke active published workflow service by workflow_id."""
     _ = await _read_registry(workflow_id)
-    runtime = await Storage.read(_runtime_key(workflow_id))
+    runtime = await WorkflowStore.kv_get(_runtime_key(workflow_id))
     if not runtime:
         raise WorkflowNotPublishedError(f"Workflow not published: {workflow_id}")
 
@@ -1288,13 +1295,13 @@ async def invoke_published_workflow(
 async def list_workflow_releases(workflow_id: str) -> List[Dict[str, Any]]:
     """List release history for one workflow."""
     _ = await _read_registry(workflow_id)
-    keys = await Storage.list(f"{_RELEASE_PREFIX}{workflow_id}/")
+    keys = await WorkflowStore.kv_list(f"{_RELEASE_PREFIX}{workflow_id}/")
     releases: List[Dict[str, Any]] = []
     for raw_key in keys:
         key = _key_to_string(raw_key)
         if key.endswith("/active"):
             continue
-        release = await Storage.read(key)
+        release = await WorkflowStore.kv_get(key)
         if release:
             releases.append(release)
     releases.sort(key=lambda item: item.get("createdAt", 0), reverse=True)

--- a/flocks/workflow/engine.py
+++ b/flocks/workflow/engine.py
@@ -226,6 +226,7 @@ class WorkflowEngine:
     workflow_path: Optional[str] = None
     node_timeout_s: Optional[float] = 300.0
     history_mode: Literal["full", "summary"] = "summary"
+    dataflow_mode: Literal["legacy", "vertex_cache"] = "legacy"
     _depth: int = 0
     max_parallel_workers: int = 4
     workflow_loader: Optional[Callable[[str], "Workflow"]] = field(default=None, repr=False)
@@ -237,6 +238,8 @@ class WorkflowEngine:
             raise ValueError("max_parallel_workers must be >= 1")
         if self.history_mode not in ("full", "summary"):
             raise ValueError("history_mode must be 'full' or 'summary'")
+        if self.dataflow_mode not in ("legacy", "vertex_cache"):
+            raise ValueError("dataflow_mode must be 'legacy' or 'vertex_cache'")
         if self.runtime is None:
             self.runtime = PythonExecRuntime()
         if self.code_gen is None:
@@ -294,6 +297,7 @@ class WorkflowEngine:
         run_t0 = time.perf_counter()
         join_inputs: Dict[str, Dict[str, Dict[str, Any]]] = {}
         join_seen_sources: Dict[str, Set[str]] = {}
+        vertex_outputs: Dict[str, Dict[str, Any]] = {}
         payload_risk_summary: Dict[str, Any] = {
             "counts": {},
             "risks": [],
@@ -322,6 +326,10 @@ class WorkflowEngine:
                     "last_node_id": last_node_id,
                     "outputs": last_outputs,
                     "history": history,
+                    "vertex_output_keys": {
+                        node_id: list(outputs.keys())[:_PAYLOAD_SUMMARY_KEY_LIMIT]
+                        for node_id, outputs in vertex_outputs.items()
+                    },
                     "payload_risk_summary": payload_risk_summary,
                 }
 
@@ -820,30 +828,66 @@ class WorkflowEngine:
 
                     # Enqueue downstream (skip for failed node when stop_on_error)
                     if _stop_exc is None:
-                        upstream = dict(_inp)
-                        upstream.update(_eo.outputs)
-                        selected = self._select_edges(_nd, upstream, adj.get(_nid, []))
-                        upstream_payload_summary = _payload_summary(upstream)
-                        has_large_upstream = _payload_has_large(upstream_payload_summary)
-                        if len(selected) > 1 and has_large_upstream:
-                            _record_payload_risk(
-                                "large_payload_fanout",
-                                source_node_id=_nid,
-                                source_node_type=_nd.type,
-                                fanout_count=len(selected),
-                                target_node_ids=[edge.to for edge in selected],
-                                payload_summary=upstream_payload_summary,
-                            )
-                        for edge in selected:
-                            if not edge.mapping and has_large_upstream:
+                        vertex_outputs[_nid] = _eo.outputs
+                        if self.dataflow_mode == "vertex_cache":
+                            selected = self._select_edges_from_scopes(_nd, [_eo.outputs, _inp], adj.get(_nid, []))
+                            downstream_items: list[tuple[Edge, Dict[str, Any], Dict[str, Any]]] = []
+                            for edge in selected:
+                                edge_inputs = self._build_downstream_inputs_from_scopes([_eo.outputs, _inp], edge)
+                                edge_summary = _payload_summary(edge_inputs)
+                                downstream_items.append((edge, edge_inputs, edge_summary))
+                            large_downstream = [item for item in downstream_items if _payload_has_large(item[2])]
+                            if len(selected) > 1 and large_downstream:
                                 _record_payload_risk(
-                                    "implicit_full_payload_edge_large_payload",
-                                    edge_from=edge.from_,
-                                    edge_to=edge.to,
+                                    "large_payload_fanout",
+                                    source_node_id=_nid,
+                                    source_node_type=_nd.type,
                                     fanout_count=len(selected),
+                                    target_node_ids=[edge.to for edge in selected],
+                                    payload_summary={
+                                        "type": "vertex_cache_edge_payloads",
+                                        "large_fields": [
+                                            field
+                                            for _edge, _inputs, summary in large_downstream
+                                            for field in summary.get("large_fields", [])
+                                        ][:_PAYLOAD_SUMMARY_FIELD_LIMIT],
+                                    },
+                                )
+                            for edge, edge_inputs, edge_summary in downstream_items:
+                                if not edge.mapping and _payload_has_large(edge_summary):
+                                    _record_payload_risk(
+                                        "implicit_full_payload_edge_large_payload",
+                                        edge_from=edge.from_,
+                                        edge_to=edge.to,
+                                        fanout_count=len(selected),
+                                        payload_summary=edge_summary,
+                                    )
+                                q.append((edge.to, edge_inputs, _nid))
+                        else:
+                            upstream = dict(_inp)
+                            upstream.update(_eo.outputs)
+                            selected = self._select_edges(_nd, upstream, adj.get(_nid, []))
+                            upstream_payload_summary = _payload_summary(upstream)
+                            has_large_upstream = _payload_has_large(upstream_payload_summary)
+                            if len(selected) > 1 and has_large_upstream:
+                                _record_payload_risk(
+                                    "large_payload_fanout",
+                                    source_node_id=_nid,
+                                    source_node_type=_nd.type,
+                                    fanout_count=len(selected),
+                                    target_node_ids=[edge.to for edge in selected],
                                     payload_summary=upstream_payload_summary,
                                 )
-                            q.append((edge.to, self._build_downstream_inputs(upstream, edge), _nid))
+                            for edge in selected:
+                                if not edge.mapping and has_large_upstream:
+                                    _record_payload_risk(
+                                        "implicit_full_payload_edge_large_payload",
+                                        edge_from=edge.from_,
+                                        edge_to=edge.to,
+                                        fanout_count=len(selected),
+                                        payload_summary=upstream_payload_summary,
+                                    )
+                                q.append((edge.to, self._build_downstream_inputs(upstream, edge), _nid))
 
                 step_count += len(exec_results)
                 if _stop_exc is not None:
@@ -1113,7 +1157,9 @@ class WorkflowEngine:
             trace=self.trace,
             node_timeout_s=self.node_timeout_s,
             history_mode=self.history_mode,
+            dataflow_mode=self.dataflow_mode,
             _depth=self._depth + 1,
+            max_parallel_workers=self.max_parallel_workers,
             workflow_loader=self.workflow_loader,
         )
         result = sub_engine.run(initial_inputs=sub_inputs)
@@ -1130,6 +1176,33 @@ class WorkflowEngine:
         value = self._get_by_path(payload, key)
         selected_label: Optional[str]
         if value is None:
+            selected_label = None
+        elif isinstance(value, bool):
+            selected_label = "true" if value else "false"
+        elif isinstance(value, str):
+            selected_label = value
+        else:
+            selected_label = str(value)
+        matched = [e for e in edges if e.label == selected_label] if selected_label is not None else []
+        if matched:
+            return matched
+        defaults = [e for e in edges if e.label is None]
+        return defaults[:1] if defaults else []
+
+    def _select_edges_from_scopes(
+        self,
+        node: Any,
+        scopes: List[Dict[str, Any]],
+        edges: List[Edge],
+    ) -> List[Edge]:
+        if not edges:
+            return []
+        if node.type in {"python", "tool", "llm", "http_request", "subworkflow"}:
+            return list(edges)
+        key = node.select_key or "result"
+        found, value = self._try_get_by_path_from_scopes(scopes, key)
+        selected_label: Optional[str]
+        if not found or value is None:
             selected_label = None
         elif isinstance(value, bool):
             selected_label = "true" if value else "false"
@@ -1167,6 +1240,54 @@ class WorkflowEngine:
         if edge.const:
             out.update(edge.const)
         return out
+
+    def _build_downstream_inputs_from_scopes(
+        self,
+        scopes: List[Dict[str, Any]],
+        edge: Edge,
+    ) -> Dict[str, Any]:
+        if edge.mapping:
+            out: Dict[str, Any] = {}
+            for dst, src in edge.mapping.items():
+                found, value = self._try_get_by_path_from_scopes(scopes, src)
+                if found:
+                    out[dst] = value
+                elif self.trace:
+                    available_keys = []
+                    for scope in scopes:
+                        available_keys.extend(str(key) for key in list(scope.keys())[:10])
+                    _logger.warning(
+                        "wf.edge.mapping.none_value",
+                        extra={
+                            "edge_from": edge.from_,
+                            "edge_to": edge.to,
+                            "dst_key": dst,
+                            "src_path": src,
+                            "available_keys": available_keys[:10],
+                            "dataflow_mode": self.dataflow_mode,
+                        },
+                    )
+        else:
+            # Compatibility fallback for opt-in workflows that have not yet
+            # enabled strict edge mappings. This preserves legacy input shape,
+            # but does not get the memory benefits of vertex-cache dataflow.
+            out = {}
+            for scope in reversed(scopes):
+                out.update(scope)
+        if edge.const:
+            out.update(edge.const)
+        return out
+
+    def _try_get_by_path_from_scopes(
+        self,
+        scopes: List[Dict[str, Any]],
+        path: str,
+    ) -> tuple[bool, Any]:
+        for scope in scopes:
+            found, value = self._try_get_by_path(scope, path)
+            if found:
+                return True, value
+        return False, None
 
     def _try_get_by_path(self, data: Any, path: str) -> tuple[bool, Any]:
         if path is None:

--- a/flocks/workflow/engine.py
+++ b/flocks/workflow/engine.py
@@ -29,6 +29,7 @@ StepEndHook = Callable[[_T, "StepResult"], None]
 
 class _ExecOutcome(NamedTuple):
     """Result of executing a single node within a batch."""
+
     idx: int
     outputs: Dict[str, Any]
     stdout: str
@@ -50,18 +51,12 @@ def _summarize_for_observability(value: Any, *, depth: int = 0) -> Any:
             return {"_type": "string", "chars": len(value), "preview": value[:200]}
         return value
     if isinstance(value, dict):
-        return {
-            key: _summarize_for_observability(item, depth=depth + 1)
-            for key, item in list(value.items())[:50]
-        }
+        return {key: _summarize_for_observability(item, depth=depth + 1) for key, item in list(value.items())[:50]}
     if isinstance(value, (list, tuple, set)):
         return {
             "_type": type(value).__name__,
             "count": len(value),
-            "preview": [
-                _summarize_for_observability(item, depth=depth + 1)
-                for item in list(value)[:3]
-            ],
+            "preview": [_summarize_for_observability(item, depth=depth + 1) for item in list(value)[:3]],
         }
     if isinstance(value, str) and len(value) > 200:
         return {"_type": "string", "chars": len(value), "preview": value[:200]}
@@ -102,18 +97,25 @@ class ExecutionResult(BaseModel):
 
 
 def _default_workflow_loader(workflow_id: str) -> "Workflow":
-    """Default loader: resolves workflow from Storage by ID (sync wrapper)."""
+    """Default loader: resolves workflow by ID from disk, then legacy KV."""
     import asyncio
 
     async def _load():
+        from flocks.workflow.fs_store import read_workflow_from_fs
         from flocks.storage.storage import Storage
-        data = await Storage.read(f"workflow/{workflow_id}")
+
+        data = read_workflow_from_fs(workflow_id)
+        if data is None:
+            data = await Storage.read(f"workflow/{workflow_id}")
         if data is None:
             raise NodeExecutionError(
                 node_id="<subworkflow>",
                 message=f"Workflow not found: {workflow_id!r}",
             )
         wf_json = data.get("workflowJson") or data
+        if isinstance(wf_json, dict):
+            wf_json = dict(wf_json)
+            wf_json.setdefault("id", workflow_id)
         return Workflow.from_dict(wf_json)
 
     try:
@@ -181,6 +183,7 @@ class WorkflowEngine:
                 globals=dict(self.runtime.globals),
                 tool_registry=self.runtime.tool_registry,
                 cancel_checker=self.runtime.cancel_checker,
+                cleanup_globals_after_execute=self.runtime.cleanup_globals_after_execute,
             )
         return self.runtime
 
@@ -203,9 +206,7 @@ class WorkflowEngine:
             incoming_from.setdefault(e.to, []).append(e.from_)
         for k in incoming_from:
             incoming_from[k].sort()
-        q: Deque[Tuple[str, Dict[str, Any], Optional[str]]] = deque(
-            [(self.workflow.start, initial_inputs or {}, None)]
-        )
+        q: Deque[Tuple[str, Dict[str, Any], Optional[str]]] = deque([(self.workflow.start, initial_inputs or {}, None)])
         history: list[StepResult] = []
         last_outputs: Dict[str, Any] = {}
         step_count = 0
@@ -225,6 +226,7 @@ class WorkflowEngine:
             previous_cancel_checker = self.runtime.cancel_checker
             self.runtime.cancel_checker = cancel
         try:
+
             def _retain_step(step: StepResult) -> None:
                 if retain_history:
                     history.append(step)
@@ -321,7 +323,9 @@ class WorkflowEngine:
                         try:
                             _hash_raw = json.dumps(
                                 {"n": node_id, "i": inputs},
-                                sort_keys=True, ensure_ascii=False, default=str,
+                                sort_keys=True,
+                                ensure_ascii=False,
+                                default=str,
                             )
                             _input_hash = hashlib.sha256(_hash_raw.encode()).hexdigest()[:16]
                         except Exception:
@@ -329,7 +333,8 @@ class WorkflowEngine:
                     if _input_hash and node_id in _dedup_hashes and _dedup_hashes[node_id] == _input_hash:
                         _logger.info(
                             "wf.step.dedup_skip node=%s (identical input hash %s)",
-                            node_id, _input_hash,
+                            node_id,
+                            _input_hash,
                             extra={"run_id": rid, "node_id": node_id, "input_hash": _input_hash},
                         )
                         continue
@@ -352,10 +357,14 @@ class WorkflowEngine:
                         _desc = (_nd.description or "").strip().splitlines()[0:1]
                         _desc_text = _desc[0] if _desc else ""
                         _par_tag = " [parallel]" if use_parallel else ""
-                        print(f"\n[WF] step={step_count+_idx+1} node={_nid} type={_nd.type} {_desc_text}{_par_tag}".rstrip())
+                        print(
+                            f"\n[WF] step={step_count + _idx + 1} node={_nid} type={_nd.type} {_desc_text}{_par_tag}".rstrip()
+                        )
                     _logger.info(
                         "wf.step.start step=%s node=%s type=%s%s",
-                        step_count + _idx + 1, _nid, _nd.type,
+                        step_count + _idx + 1,
+                        _nid,
+                        _nd.type,
                         " (parallel)" if use_parallel else "",
                         extra={"run_id": rid, "step": step_count + _idx + 1, "node_id": _nid, "node_type": _nd.type},
                     )
@@ -383,9 +392,14 @@ class WorkflowEngine:
                             return _ExecOutcome(_pi, _pouts, _pso, None, None, (time.perf_counter() - _t0) * 1000.0)
                         except RunCancelledError as _ce:
                             return _ExecOutcome(
-                                _pi, {}, "", str(_ce), None,
+                                _pi,
+                                {},
+                                "",
+                                str(_ce),
+                                None,
                                 (time.perf_counter() - _t0) * 1000.0,
-                                False, True,
+                                False,
+                                True,
                             )
                         except Exception as _pe:
                             _perr = str(_pe)
@@ -411,13 +425,17 @@ class WorkflowEngine:
                         except FuturesTimeoutError:
                             for _f2, _ci2 in _fut_map.items():
                                 if _ci2 not in _completed_idx:
-                                    exec_results.append(_ExecOutcome(
-                                        idx=_ci2, outputs={}, stdout="",
-                                        error=f"节点执行超时 ({self.node_timeout_s}s)",
-                                        traceback=None,
-                                        duration_ms=(step_timeout_s or 0) * 1000.0,
-                                        is_timeout=True,
-                                    ))
+                                    exec_results.append(
+                                        _ExecOutcome(
+                                            idx=_ci2,
+                                            outputs={},
+                                            stdout="",
+                                            error=f"节点执行超时 ({self.node_timeout_s}s)",
+                                            traceback=None,
+                                            duration_ms=(step_timeout_s or 0) * 1000.0,
+                                            is_timeout=True,
+                                        )
+                                    )
                     finally:
                         try:
                             _pool.shutdown(wait=False, cancel_futures=True)
@@ -434,11 +452,17 @@ class WorkflowEngine:
                                 _outs, _so = _sfut.result(timeout=step_timeout_s)
                             else:
                                 _outs, _so = self._execute_node(_nd, _inp)
-                            exec_results.append(_ExecOutcome(_idx, _outs, _so, None, None, (time.perf_counter() - _t0) * 1000.0))
+                            exec_results.append(
+                                _ExecOutcome(_idx, _outs, _so, None, None, (time.perf_counter() - _t0) * 1000.0)
+                            )
                         except FuturesTimeoutError as _fte:
                             _fte_msg = str(_fte).strip()
                             _err = _fte_msg if _fte_msg else f"节点执行超时 ({self.node_timeout_s}s)"
-                            exec_results.append(_ExecOutcome(_idx, {}, "", _err, None, (time.perf_counter() - _t0) * 1000.0, is_timeout=True))
+                            exec_results.append(
+                                _ExecOutcome(
+                                    _idx, {}, "", _err, None, (time.perf_counter() - _t0) * 1000.0, is_timeout=True
+                                )
+                            )
                             if timeout_executor is not None:
                                 try:
                                     timeout_executor.shutdown(wait=False, cancel_futures=True)
@@ -456,7 +480,9 @@ class WorkflowEngine:
                                 _so = _e.stdout or ""
                             if isinstance(_e, NodeExecutionError) and getattr(_e, "traceback", None):
                                 _tb = _e.traceback
-                            exec_results.append(_ExecOutcome(_idx, {}, _so, _err, _tb, (time.perf_counter() - _t0) * 1000.0))
+                            exec_results.append(
+                                _ExecOutcome(_idx, {}, _so, _err, _tb, (time.perf_counter() - _t0) * 1000.0)
+                            )
 
                 # ── Phase 3: record results, hooks, enqueue downstream ────
                 _stop_exc: Optional[NodeExecutionError] = None
@@ -465,9 +491,7 @@ class WorkflowEngine:
                     _sn = step_count + _eo.idx + 1
                     last_node_id = _nid
                     last_outputs = (
-                        _summarize_for_observability(_eo.outputs)
-                        if self.history_mode == "summary"
-                        else _eo.outputs
+                        _summarize_for_observability(_eo.outputs) if self.history_mode == "summary" else _eo.outputs
                     )
 
                     def _build_step_result(
@@ -535,19 +559,35 @@ class WorkflowEngine:
                         (_logger.warning if _eo.is_timeout else _logger.error)(
                             f"wf.step.{_status}",
                             extra={
-                                "run_id": rid, "step": _sn, "node_id": _nid,
-                                "node_type": _nd.type, "error": _eo.error,
-                                **({"timeout_s": self.node_timeout_s} if _eo.is_timeout else {"traceback": (_eo.traceback or "")[:500]}),
+                                "run_id": rid,
+                                "step": _sn,
+                                "node_id": _nid,
+                                "node_type": _nd.type,
+                                "error": _eo.error,
+                                **(
+                                    {"timeout_s": self.node_timeout_s}
+                                    if _eo.is_timeout
+                                    else {"traceback": (_eo.traceback or "")[:500]}
+                                ),
                             },
                         )
                         outputs_keys = list(_eo.outputs.keys())
                         _logger.info(
                             "wf.step.end step=%s node=%s type=%s status=%s duration_ms=%.3f outputs_keys=%s",
-                            _sn, _nid, _nd.type, _status, _eo.duration_ms, outputs_keys,
+                            _sn,
+                            _nid,
+                            _nd.type,
+                            _status,
+                            _eo.duration_ms,
+                            outputs_keys,
                             extra={
-                                "run_id": rid, "step": _sn, "node_id": _nid,
-                                "node_type": _nd.type, "status": _status,
-                                "duration_ms": _eo.duration_ms, "outputs_keys": outputs_keys,
+                                "run_id": rid,
+                                "step": _sn,
+                                "node_id": _nid,
+                                "node_type": _nd.type,
+                                "status": _status,
+                                "duration_ms": _eo.duration_ms,
+                                "outputs_keys": outputs_keys,
                                 "error": _eo.error,
                             },
                         )
@@ -555,10 +595,16 @@ class WorkflowEngine:
                             outputs_for_debug = _outputs_for_log(_eo.outputs)
                             _logger.debug(
                                 "wf.step.outputs step=%s node=%s status=%s outputs=%s",
-                                _sn, _nid, _status, outputs_for_debug,
+                                _sn,
+                                _nid,
+                                _status,
+                                outputs_for_debug,
                                 extra={
-                                    "run_id": rid, "step": _sn, "node_id": _nid,
-                                    "node_type": _nd.type, "status": _status,
+                                    "run_id": rid,
+                                    "step": _sn,
+                                    "node_id": _nid,
+                                    "node_type": _nd.type,
+                                    "status": _status,
                                     "outputs": outputs_for_debug,
                                     "error": _eo.error,
                                 },
@@ -573,8 +619,10 @@ class WorkflowEngine:
                                 )
                         if self.stop_on_error and _stop_exc is None and not _eo.is_timeout:
                             _stop_exc = NodeExecutionError(
-                                node_id=_nid, message=_eo.error,
-                                stdout=_eo.stdout, traceback=_eo.traceback,
+                                node_id=_nid,
+                                message=_eo.error,
+                                stdout=_eo.stdout,
+                                traceback=_eo.traceback,
                                 execution_context={
                                     "run_id": rid,
                                     "steps": step_count + len(exec_results),
@@ -602,11 +650,20 @@ class WorkflowEngine:
                         outputs_keys = list(_eo.outputs.keys())
                         _logger.info(
                             "wf.step.end step=%s node=%s type=%s status=%s duration_ms=%.3f outputs_keys=%s",
-                            _sn, _nid, _nd.type, "ok", _eo.duration_ms, outputs_keys,
+                            _sn,
+                            _nid,
+                            _nd.type,
+                            "ok",
+                            _eo.duration_ms,
+                            outputs_keys,
                             extra={
-                                "run_id": rid, "step": _sn, "node_id": _nid,
-                                "node_type": _nd.type, "status": "ok",
-                                "duration_ms": _eo.duration_ms, "outputs_keys": outputs_keys,
+                                "run_id": rid,
+                                "step": _sn,
+                                "node_id": _nid,
+                                "node_type": _nd.type,
+                                "status": "ok",
+                                "duration_ms": _eo.duration_ms,
+                                "outputs_keys": outputs_keys,
                                 "error": None,
                             },
                         )
@@ -614,10 +671,16 @@ class WorkflowEngine:
                             outputs_for_debug = _outputs_for_log(_eo.outputs)
                             _logger.debug(
                                 "wf.step.outputs step=%s node=%s status=%s outputs=%s",
-                                _sn, _nid, "ok", outputs_for_debug,
+                                _sn,
+                                _nid,
+                                "ok",
+                                outputs_for_debug,
                                 extra={
-                                    "run_id": rid, "step": _sn, "node_id": _nid,
-                                    "node_type": _nd.type, "status": "ok",
+                                    "run_id": rid,
+                                    "step": _sn,
+                                    "node_id": _nid,
+                                    "node_type": _nd.type,
+                                    "status": "ok",
                                     "outputs": outputs_for_debug,
                                     "error": None,
                                 },
@@ -749,9 +812,7 @@ class WorkflowEngine:
             return self._execute_http_request_node(node, inputs)
         if node.type == "subworkflow":
             return self._execute_subworkflow_node(node, inputs, _runtime=_runtime)
-        raise NodeExecutionError(
-            node_id=node_id, message=f"Unsupported node.type={node.type!r}"
-        )
+        raise NodeExecutionError(node_id=node_id, message=f"Unsupported node.type={node.type!r}")
 
     def _execute_tool_node(
         self,
@@ -801,6 +862,7 @@ class WorkflowEngine:
         assert node.prompt, "llm node requires prompt"
         try:
             from jinja2 import Template, TemplateError
+
             rendered = Template(node.prompt).render(**inputs)
         except Exception as e:
             raise NodeExecutionError(
@@ -808,6 +870,7 @@ class WorkflowEngine:
                 message=f"Prompt template render failed: {type(e).__name__}: {e}",
             ) from e
         from .llm import get_llm_client
+
         _rt = _runtime or self.runtime
         cancel_checker = getattr(_rt, "cancel_checker", None)
         try:
@@ -829,6 +892,7 @@ class WorkflowEngine:
         assert node.method, "http_request node requires method"
         try:
             from jinja2 import Template
+
             url = Template(node.url).render(**inputs)
             method = node.method.upper()
             headers = node.headers or {}
@@ -842,6 +906,7 @@ class WorkflowEngine:
             ) from e
         try:
             import httpx
+
             with httpx.Client(timeout=30.0) as client:
                 if method in {"GET", "DELETE", "HEAD"}:
                     resp = client.request(method, url, headers=headers)
@@ -945,7 +1010,13 @@ class WorkflowEngine:
                     available_keys = list(upstream.keys())[:10]
                     _logger.warning(
                         "wf.edge.mapping.none_value",
-                        extra={"edge_from": edge.from_, "edge_to": edge.to, "dst_key": dst, "src_path": src, "available_keys": available_keys},
+                        extra={
+                            "edge_from": edge.from_,
+                            "edge_to": edge.to,
+                            "dst_key": dst,
+                            "src_path": src,
+                            "available_keys": available_keys,
+                        },
                     )
         else:
             out = dict(upstream)

--- a/flocks/workflow/engine.py
+++ b/flocks/workflow/engine.py
@@ -4,6 +4,7 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError, as_completed
 from dataclasses import dataclass, field
 import hashlib
+from itertools import islice
 import logging
 import time
 import traceback
@@ -25,6 +26,12 @@ _T = TypeVar("_T")
 
 StepStartHook = Callable[[str, int, Node, Dict[str, Any]], _T]
 StepEndHook = Callable[[_T, "StepResult"], None]
+_PAYLOAD_RISK_EVENT_LIMIT = 100
+_PAYLOAD_SUMMARY_KEY_LIMIT = 50
+_PAYLOAD_SUMMARY_FIELD_LIMIT = 20
+_LARGE_SEQUENCE_THRESHOLD = 1_000
+_LARGE_STRING_CHARS_THRESHOLD = 20_000
+_LARGE_DICT_KEYS_THRESHOLD = 200
 
 
 class _ExecOutcome(NamedTuple):
@@ -46,17 +53,24 @@ def _summarize_for_observability(value: Any, *, depth: int = 0) -> Any:
         if isinstance(value, (list, tuple, set)):
             return {"_type": type(value).__name__, "count": len(value)}
         if isinstance(value, dict):
-            return {"_type": "dict", "keys": list(value.keys())[:20]}
+            return {"_type": "dict", "keys": list(islice(value.keys(), 20))}
         if isinstance(value, str) and len(value) > 200:
             return {"_type": "string", "chars": len(value), "preview": value[:200]}
         return value
     if isinstance(value, dict):
-        return {key: _summarize_for_observability(item, depth=depth + 1) for key, item in list(value.items())[:50]}
+        return {
+            key: _summarize_for_observability(item, depth=depth + 1)
+            for key, item in islice(value.items(), 50)
+        }
     if isinstance(value, (list, tuple, set)):
+        if isinstance(value, (list, tuple)):
+            preview_items = value[:3]
+        else:
+            preview_items = islice(value, 3)
         return {
             "_type": type(value).__name__,
             "count": len(value),
-            "preview": [_summarize_for_observability(item, depth=depth + 1) for item in list(value)[:3]],
+            "preview": [_summarize_for_observability(item, depth=depth + 1) for item in preview_items],
         }
     if isinstance(value, str) and len(value) > 200:
         return {"_type": "string", "chars": len(value), "preview": value[:200]}
@@ -78,6 +92,70 @@ def _outputs_for_log(outputs: Dict[str, Any], *, max_chars: int = 4000) -> str:
     return text[:max_chars] + f"...[truncated:{len(text) - max_chars}]"
 
 
+def _payload_field_summary(key: str, value: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(value, (list, tuple, set)):
+        count = len(value)
+        return {
+            "key": key,
+            "type": type(value).__name__,
+            "count": count,
+            "large": count > _LARGE_SEQUENCE_THRESHOLD,
+        }
+    if isinstance(value, str):
+        chars = len(value)
+        return {
+            "key": key,
+            "type": "string",
+            "chars": chars,
+            "large": chars > _LARGE_STRING_CHARS_THRESHOLD,
+        }
+    if isinstance(value, dict):
+        key_count = len(value)
+        return {
+            "key": key,
+            "type": "dict",
+            "key_count": key_count,
+            "large": key_count > _LARGE_DICT_KEYS_THRESHOLD,
+        }
+    return None
+
+
+def _payload_summary(payload: Any) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {
+            "type": type(payload).__name__,
+            "key_count": 0,
+            "keys": [],
+            "fields": [],
+            "large_fields": [],
+        }
+
+    fields: list[Dict[str, Any]] = []
+    large_fields: list[Dict[str, Any]] = []
+    for key, value in islice(payload.items(), _PAYLOAD_SUMMARY_KEY_LIMIT):
+        field = _payload_field_summary(str(key), value)
+        if field is None:
+            continue
+        if len(fields) < _PAYLOAD_SUMMARY_FIELD_LIMIT:
+            fields.append(field)
+        if field.get("large"):
+            large_fields.append(field)
+            if len(large_fields) >= _PAYLOAD_SUMMARY_FIELD_LIMIT:
+                break
+
+    return {
+        "type": "dict",
+        "key_count": len(payload),
+        "keys": [str(key) for key in islice(payload.keys(), _PAYLOAD_SUMMARY_KEY_LIMIT)],
+        "fields": fields,
+        "large_fields": large_fields,
+    }
+
+
+def _payload_has_large(summary: Dict[str, Any]) -> bool:
+    return bool(summary.get("large_fields"))
+
+
 class StepResult(BaseModel):
     node_id: str
     inputs: Dict[str, Any] = Field(default_factory=dict)
@@ -94,6 +172,7 @@ class ExecutionResult(BaseModel):
     last_node_id: Optional[str] = None
     outputs: Dict[str, Any] = Field(default_factory=dict)
     run_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    payload_risk_summary: Dict[str, Any] = Field(default_factory=dict)
 
 
 def _default_workflow_loader(workflow_id: str) -> "Workflow":
@@ -215,6 +294,11 @@ class WorkflowEngine:
         run_t0 = time.perf_counter()
         join_inputs: Dict[str, Dict[str, Dict[str, Any]]] = {}
         join_seen_sources: Dict[str, Set[str]] = {}
+        payload_risk_summary: Dict[str, Any] = {
+            "counts": {},
+            "risks": [],
+            "omitted": 0,
+        }
         # Dedup: track (node_id -> last_input_hash) to skip identical re-executions.
         _dedup_hashes: Dict[str, str] = {}
         step_timeout_s = self.node_timeout_s if (self.node_timeout_s is not None and self.node_timeout_s > 0) else None
@@ -238,12 +322,32 @@ class WorkflowEngine:
                     "last_node_id": last_node_id,
                     "outputs": last_outputs,
                     "history": history,
+                    "payload_risk_summary": payload_risk_summary,
                 }
 
             def _raise_cancelled() -> None:
                 err = RunCancelledError(rid)
                 err.execution_context = _build_execution_context()
                 raise err
+
+            def _record_payload_risk(kind: str, **event: Any) -> None:
+                counts = payload_risk_summary.setdefault("counts", {})
+                counts[kind] = int(counts.get(kind, 0)) + 1
+                risks = payload_risk_summary.setdefault("risks", [])
+                risk_event = {"kind": kind, **event}
+                if len(risks) < _PAYLOAD_RISK_EVENT_LIMIT:
+                    risks.append(risk_event)
+                else:
+                    payload_risk_summary["omitted"] = int(payload_risk_summary.get("omitted", 0)) + 1
+                _logger.warning(
+                    "wf.payload_risk.%s",
+                    kind,
+                    extra={
+                        "run_id": rid,
+                        "risk_kind": kind,
+                        **{k: v for k, v in risk_event.items() if k != "payload_summary"},
+                    },
+                )
 
             while q:
                 if cancel is not None and cancel():
@@ -272,6 +376,16 @@ class WorkflowEngine:
                         src_key = src_node_id or "__start__"
                         buf = by_src.setdefault(src_key, {})
                         buf.update(inputs)
+                        join_payload_summary = _payload_summary(inputs)
+                        if _payload_has_large(join_payload_summary):
+                            _record_payload_risk(
+                                "large_payload_join_buffer",
+                                node_id=node_id,
+                                source_node_id=src_node_id,
+                                seen_source_count=len(by_src),
+                                expected_source_count=len(expected),
+                                payload_summary=join_payload_summary,
+                            )
                         seen = join_seen_sources.setdefault(node_id, set())
                         if src_node_id is not None:
                             if src_node_id in expected:
@@ -493,6 +607,16 @@ class WorkflowEngine:
                     last_outputs = (
                         _summarize_for_observability(_eo.outputs) if self.history_mode == "summary" else _eo.outputs
                     )
+                    input_payload_summary = _payload_summary(_inp)
+                    output_payload_summary = _payload_summary(_eo.outputs)
+                    if _payload_has_large(input_payload_summary) or _payload_has_large(output_payload_summary):
+                        _record_payload_risk(
+                            "large_node_payload",
+                            node_id=_nid,
+                            node_type=_nd.type,
+                            input_summary=input_payload_summary,
+                            output_summary=output_payload_summary,
+                        )
 
                     def _build_step_result(
                         *,
@@ -699,7 +823,26 @@ class WorkflowEngine:
                         upstream = dict(_inp)
                         upstream.update(_eo.outputs)
                         selected = self._select_edges(_nd, upstream, adj.get(_nid, []))
+                        upstream_payload_summary = _payload_summary(upstream)
+                        has_large_upstream = _payload_has_large(upstream_payload_summary)
+                        if len(selected) > 1 and has_large_upstream:
+                            _record_payload_risk(
+                                "large_payload_fanout",
+                                source_node_id=_nid,
+                                source_node_type=_nd.type,
+                                fanout_count=len(selected),
+                                target_node_ids=[edge.to for edge in selected],
+                                payload_summary=upstream_payload_summary,
+                            )
                         for edge in selected:
+                            if not edge.mapping and has_large_upstream:
+                                _record_payload_risk(
+                                    "implicit_full_payload_edge_large_payload",
+                                    edge_from=edge.from_,
+                                    edge_to=edge.to,
+                                    fanout_count=len(selected),
+                                    payload_summary=upstream_payload_summary,
+                                )
                             q.append((edge.to, self._build_downstream_inputs(upstream, edge), _nid))
 
                 step_count += len(exec_results)
@@ -726,6 +869,7 @@ class WorkflowEngine:
                 last_node_id=last_node_id,
                 outputs=last_outputs,
                 run_id=rid,
+                payload_risk_summary=payload_risk_summary,
             )
         finally:
             if isinstance(self.runtime, PythonExecRuntime):

--- a/flocks/workflow/execution_store.py
+++ b/flocks/workflow/execution_store.py
@@ -8,9 +8,9 @@ import uuid
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 from flocks.session.recorder import Recorder
-from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 from flocks.workflow.runner import RunWorkflowResult
+from flocks.workflow.store import WorkflowStore
 
 log = Log.create(service="workflow.execution_store")
 
@@ -63,11 +63,7 @@ def compact_outputs_for_storage(
     key_set = frozenset(keys)
     compacted: Dict[str, Any] = {}
     for k, v in outputs.items():
-        if (
-            k in key_set
-            and isinstance(v, (list, tuple))
-            and len(v) > size_threshold
-        ):
+        if k in key_set and isinstance(v, (list, tuple)) and len(v) > size_threshold:
             compacted[f"_{k}_count"] = len(v)
         else:
             compacted[k] = v
@@ -89,9 +85,7 @@ def compact_step_for_storage(
     for field in ("inputs", "outputs"):
         raw_value = step_copy.get(field)
         if isinstance(raw_value, dict):
-            step_copy[field] = compact_outputs_for_storage(
-                raw_value, keys=keys, size_threshold=size_threshold
-            )
+            step_copy[field] = compact_outputs_for_storage(raw_value, keys=keys, size_threshold=size_threshold)
     return step_copy
 
 
@@ -109,10 +103,7 @@ def compact_history_for_storage(
     """
     if not history:
         return []
-    return [
-        compact_step_for_storage(step, keys=keys, size_threshold=size_threshold)
-        for step in history
-    ]
+    return [compact_step_for_storage(step, keys=keys, size_threshold=size_threshold) for step in history]
 
 
 def _first_value(data: Dict[str, Any], keys: Iterable[str]) -> Any:
@@ -159,23 +150,27 @@ def derive_loop_progress(
     if isinstance(outputs, dict):
         merged.update(outputs)
 
-    iteration = _as_positive_int(_first_value(
-        merged,
-        ("iteration", "loop_index", "current_index", "item_idx", "item_index", "host_idx"),
-    ))
-    total = _as_positive_int(_first_value(
-        merged,
-        (
-            "total_iterations",
-            "total_items",
-            "item_count",
-            "items_count",
-            "total_hosts",
-            "host_count",
-            "hosts_count",
-            "hosts_total",
-        ),
-    ))
+    iteration = _as_positive_int(
+        _first_value(
+            merged,
+            ("iteration", "loop_index", "current_index", "item_idx", "item_index", "host_idx"),
+        )
+    )
+    total = _as_positive_int(
+        _first_value(
+            merged,
+            (
+                "total_iterations",
+                "total_items",
+                "item_count",
+                "items_count",
+                "total_hosts",
+                "host_count",
+                "hosts_count",
+                "hosts_total",
+            ),
+        )
+    )
     if total is None:
         hosts = merged.get("hosts")
         if isinstance(hosts, list):
@@ -197,6 +192,7 @@ def derive_loop_progress(
         "current_inner_node_id": node_id,
         "global_step_index": global_step_index,
     }
+
 
 # Maximum number of execution history records retained per workflow.
 # Keep this intentionally small so high-frequency workflows do not keep
@@ -254,26 +250,15 @@ async def _update_workflow_stats(workflow_id: str, success: bool, duration: floa
     lock = _get_stats_lock(workflow_id)
     async with lock:
         try:
-            key = _workflow_stats_key(workflow_id)
-            try:
-                stats: Dict[str, Any] = await Storage.read(key) or dict(_DEFAULT_STATS)
-            except Exception:
-                stats = dict(_DEFAULT_STATS)
-            stats["callCount"] = stats.get("callCount", 0) + 1
-            if success:
-                stats["successCount"] = stats.get("successCount", 0) + 1
-            else:
-                stats["errorCount"] = stats.get("errorCount", 0) + 1
-            total = stats.get("totalRuntime", 0.0) + duration
-            stats["totalRuntime"] = total
-            call_count = stats["callCount"]
-            stats["avgRuntime"] = (total / call_count) if call_count > 0 else 0.0
-            await Storage.write(key, stats)
+            await WorkflowStore.increment_stats(workflow_id, success=success, duration=duration)
         except Exception as exc:
-            log.warning("workflow.stats.update_failed", {
-                "workflow_id": workflow_id,
-                "error": str(exc),
-            })
+            log.warning(
+                "workflow.stats.update_failed",
+                {
+                    "workflow_id": workflow_id,
+                    "error": str(exc),
+                },
+            )
 
 
 def workflow_execution_key(exec_id: str) -> str:
@@ -324,7 +309,7 @@ async def record_execution_step(
 ) -> Dict[str, Any]:
     """Persist one compacted execution step and return the stored payload."""
     step_payload = compact_step_for_storage(step)
-    await Storage.write(workflow_execution_step_key(exec_id, step_index), step_payload)
+    await WorkflowStore.record_step(exec_id, step_index, step_payload)
     return step_payload
 
 
@@ -363,26 +348,31 @@ class ExecutionStepRecorder:
             inputs=step_dict.get("inputs"),
             outputs=step_dict.get("outputs"),
         )
-        self.summary.update({
-            "stepCount": self.step_count,
-            "currentNodeId": step_dict.get("node_id"),
-            "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
-            "currentPhase": "running",
-            "currentStepIndex": self.step_count,
-            "loopProgress": loop_progress,
-            "updatedAt": int(time.time() * 1000),
-        })
+        self.summary.update(
+            {
+                "stepCount": self.step_count,
+                "currentNodeId": step_dict.get("node_id"),
+                "currentNodeType": step_dict.get("node_type") or step_dict.get("type"),
+                "currentPhase": "running",
+                "currentStepIndex": self.step_count,
+                "loopProgress": loop_progress,
+                "updatedAt": int(time.time() * 1000),
+            }
+        )
         try:
             asyncio.run_coroutine_threadsafe(
                 record_execution_step(self.exec_id, self.step_count, step_dict),
                 self.loop,
             ).result(timeout=self.write_timeout_s)
         except Exception as exc:
-            self.logger.warning(self.log_event, {
-                "exec_id": self.exec_id,
-                "step_index": self.step_count,
-                "error": str(exc),
-            })
+            self.logger.warning(
+                self.log_event,
+                {
+                    "exec_id": self.exec_id,
+                    "step_index": self.step_count,
+                    "error": str(exc),
+                },
+            )
 
 
 async def _backfill_execution_steps(
@@ -399,14 +389,17 @@ async def _backfill_execution_steps(
         if not isinstance(step_payload, dict):
             continue
         try:
-            await Storage.write(workflow_execution_step_key(exec_id, step_index), step_payload)
+            await WorkflowStore.record_step(exec_id, step_index, step_payload)
             written += 1
         except Exception as exc:
-            log.warning("workflow.execution_step.backfill_failed", {
-                "exec_id": exec_id,
-                "step_index": step_index,
-                "error": str(exc),
-            })
+            log.warning(
+                "workflow.execution_step.backfill_failed",
+                {
+                    "exec_id": exec_id,
+                    "step_index": step_index,
+                    "error": str(exc),
+                },
+            )
     return written
 
 
@@ -418,14 +411,11 @@ async def load_execution_steps(
 ) -> Tuple[List[Dict[str, Any]], int]:
     """Load persisted step logs for an execution, sorted by step key."""
     page_limit = 500 if limit is None else max(limit, 0)
-    selected, total = await Storage.list_entries_page(
-        workflow_execution_step_prefix(exec_id),
+    return await WorkflowStore.list_steps(
+        exec_id,
         offset=max(offset, 0),
         limit=page_limit,
     )
-    return [
-        value for _key, value in selected if isinstance(value, dict)
-    ], total
 
 
 def normalize_execution_status(status: str) -> str:
@@ -462,9 +452,7 @@ def resolve_execution_outcome(result: RunWorkflowResult) -> tuple[str, Optional[
     if result.outputs.get("workflow_success") is False:
         return (
             "error",
-            error_message
-            or _extract_business_failure_message(result.outputs)
-            or "Workflow reported business failure.",
+            error_message or _extract_business_failure_message(result.outputs) or "Workflow reported business failure.",
         )
 
     return status_value, error_message
@@ -510,14 +498,7 @@ async def create_execution_record(
         input_params=compacted_params,
         exec_id=exec_id,
     )
-    exec_key = workflow_execution_key(exec_data["id"])
-    await Storage.write(exec_key, compact_execution_summary(exec_data))
-    await _write_execution_index(
-        workflow_id=workflow_id,
-        exec_id=str(exec_data["id"]),
-        execution_key=exec_key,
-        started_at=int(exec_data.get("startedAt") or 0),
-    )
+    await WorkflowStore.upsert_execution(compact_execution_summary(exec_data))
     return exec_data
 
 
@@ -533,13 +514,7 @@ async def record_execution_result(
     if backfilled_steps and (existing_step_count is None or existing_step_count < backfilled_steps):
         summary_data["stepCount"] = backfilled_steps
 
-    await Storage.write(workflow_execution_key(exec_id), compact_execution_summary(summary_data))
-    await _write_execution_index(
-        workflow_id=workflow_id,
-        exec_id=exec_id,
-        execution_key=workflow_execution_key(exec_id),
-        started_at=int(summary_data.get("startedAt") or 0),
-    )
+    await WorkflowStore.upsert_execution(compact_execution_summary(summary_data))
 
     # Update call/success/error counters so all trigger paths (HTTP, syslog, etc.)
     # are reflected in the UI stats panel.
@@ -556,6 +531,7 @@ async def record_execution_result(
     # Run it as a background task so the syslog/HTTP dispatcher can release the
     # concurrency slot immediately instead of waiting on session-history I/O.
     try:
+
         async def _record_audit() -> None:
             try:
                 await Recorder.record_workflow_execution(
@@ -564,10 +540,13 @@ async def record_execution_result(
                     run_result=exec_data,
                 )
             except Exception as exc:
-                log.debug("workflow.audit.record_failed", {
-                    "exec_id": exec_id,
-                    "error": str(exc),
-                })
+                log.debug(
+                    "workflow.audit.record_failed",
+                    {
+                        "exec_id": exec_id,
+                        "error": str(exc),
+                    },
+                )
 
         asyncio.create_task(_record_audit(), name=f"audit-{exec_id}")
     except RuntimeError:
@@ -587,51 +566,14 @@ async def record_execution_result(
     try:
         await _trim_execution_history(workflow_id)
     except Exception as exc:
-        log.error("workflow.history.trim_failed", {
-            "workflow_id": workflow_id,
-            "exec_id": exec_id,
-            "error": str(exc),
-        })
-
-
-async def _write_execution_index(
-    *,
-    workflow_id: str,
-    exec_id: str,
-    execution_key: str,
-    started_at: int,
-) -> str:
-    index_key = workflow_execution_index_key(workflow_id, started_at, exec_id)
-    await Storage.write(
-        index_key,
-        {
-            "workflowId": workflow_id,
-            "execId": exec_id,
-            "executionKey": execution_key,
-            "startedAt": started_at,
-        },
-    )
-    return index_key
-
-
-async def _list_workflow_execution_entries(
-    workflow_id: str,
-) -> List[Tuple[str, int, Optional[str]]]:
-    """Return indexed ``(execution_key, started_at, index_key)`` rows for one workflow."""
-    indexed_rows = await Storage.list_entries(workflow_execution_index_prefix(workflow_id))
-    entries: List[Tuple[str, int, Optional[str]]] = []
-    for index_key, value in indexed_rows:
-        if not isinstance(value, dict):
-            continue
-        exec_key = value.get("executionKey")
-        exec_id = value.get("execId")
-        if not isinstance(exec_key, str) and isinstance(exec_id, str):
-            exec_key = workflow_execution_key(exec_id)
-        if not isinstance(exec_key, str):
-            continue
-        started_at = _as_positive_int(value.get("startedAt")) or 0
-        entries.append((exec_key, started_at, index_key))
-    return entries
+        log.error(
+            "workflow.history.trim_failed",
+            {
+                "workflow_id": workflow_id,
+                "exec_id": exec_id,
+                "error": str(exc),
+            },
+        )
 
 
 async def _delete_execution_history_record(
@@ -640,18 +582,19 @@ async def _delete_execution_history_record(
     index_key: Optional[str] = None,
 ) -> None:
     exec_id = execution_key.rsplit("/", 1)[-1]
-    deleted_steps = await Storage.clear(workflow_execution_step_prefix(exec_id))
-    removed_execution = await Storage.remove(execution_key)
-    if index_key:
-        await Storage.remove(index_key)
+    deleted_steps = await WorkflowStore.clear_steps(exec_id)
+    removed_execution = await WorkflowStore.delete_execution(exec_id)
     record_path = Recorder.paths().workflow_dir / f"{exec_id}.jsonl"
     await asyncio.to_thread(record_path.unlink, missing_ok=True)
-    log.debug("workflow.history.trim_deleted", {
-        "exec_id": exec_id,
-        "execution_key": execution_key,
-        "steps": deleted_steps,
-        "removed_execution": removed_execution,
-    })
+    log.debug(
+        "workflow.history.trim_deleted",
+        {
+            "exec_id": exec_id,
+            "execution_key": execution_key,
+            "steps": deleted_steps,
+            "removed_execution": removed_execution,
+        },
+    )
 
 
 async def _trim_execution_history(workflow_id: str) -> None:
@@ -668,27 +611,24 @@ async def _trim_execution_history(workflow_id: str) -> None:
     """
     lock = _get_trim_lock(workflow_id)
     async with lock:
-        wf_entries = await _list_workflow_execution_entries(workflow_id)
-        if len(wf_entries) <= _MAX_EXECUTION_HISTORY_PER_WORKFLOW:
-            return
-
-        # Sort ascending by startedAt and remove the oldest excess records.
-        wf_entries.sort(key=lambda kd: kd[1])
-        excess = len(wf_entries) - _MAX_EXECUTION_HISTORY_PER_WORKFLOW
         failures: List[str] = []
-        for key, _started_at, index_key in wf_entries[:excess]:
+        for exec_id in await WorkflowStore.trim_executions(
+            workflow_id,
+            keep=_MAX_EXECUTION_HISTORY_PER_WORKFLOW,
+        ):
             try:
-                await _delete_execution_history_record(key, index_key=index_key)
+                record_path = Recorder.paths().workflow_dir / f"{exec_id}.jsonl"
+                await asyncio.to_thread(record_path.unlink, missing_ok=True)
             except Exception as exc:
-                failures.append(f"{key}: {exc}")
-                log.warning("workflow.history.trim_delete_failed", {
-                    "workflow_id": workflow_id,
-                    "key": key,
-                    "error": str(exc),
-                })
+                failures.append(f"{exec_id}: {exc}")
+                log.warning(
+                    "workflow.history.trim_delete_failed",
+                    {
+                        "workflow_id": workflow_id,
+                        "exec_id": exec_id,
+                        "error": str(exc),
+                    },
+                )
 
         if failures:
-            raise RuntimeError(
-                "Failed to trim workflow execution history: "
-                + "; ".join(failures[:3])
-            )
+            raise RuntimeError("Failed to trim workflow execution history: " + "; ".join(failures[:3]))

--- a/flocks/workflow/execution_store.py
+++ b/flocks/workflow/execution_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from itertools import islice
 import time
 import uuid
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
@@ -33,6 +34,105 @@ DEFAULT_LARGE_LIST_KEYS: frozenset[str] = frozenset(
 # protects against accidentally stripping small metadata lists that happen
 # to share a name with a known large-list key.
 DEFAULT_COMPACT_SIZE_THRESHOLD: int = 100
+DEFAULT_GENERIC_SEQUENCE_THRESHOLD: int = 1_000
+DEFAULT_MAX_INLINE_STRING_CHARS: int = 20_000
+DEFAULT_MAX_INLINE_DICT_KEYS: int = 200
+DEFAULT_PREVIEW_ITEMS: int = 3
+DEFAULT_PREVIEW_CHARS: int = 500
+
+
+def _sequence_preview(value: Any, *, limit: int = DEFAULT_PREVIEW_ITEMS) -> list[Any]:
+    if isinstance(value, (list, tuple)):
+        items = value[:limit]
+    else:
+        items = islice(value, limit)
+    return [_summarize_large_value(item, depth=1) for item in items]
+
+
+def _summarize_large_value(value: Any, *, depth: int = 0) -> Dict[str, Any]:
+    if isinstance(value, str):
+        return {
+            "_type": "string",
+            "chars": len(value),
+            "preview": value[:DEFAULT_PREVIEW_CHARS],
+        }
+    if isinstance(value, dict):
+        return {
+            "_type": "dict",
+            "key_count": len(value),
+            "keys": list(islice(value.keys(), DEFAULT_PREVIEW_ITEMS * 10)),
+        }
+    if isinstance(value, (list, tuple, set)):
+        summary: Dict[str, Any] = {
+            "_type": type(value).__name__,
+            "count": len(value),
+        }
+        if depth == 0:
+            summary["preview"] = _sequence_preview(value)
+        return summary
+    return {
+        "_type": type(value).__name__,
+        "preview": str(value)[:DEFAULT_PREVIEW_CHARS],
+    }
+
+
+def _compact_value_for_storage(
+    value: Any,
+    *,
+    key: Optional[str],
+    known_large_keys: frozenset[str],
+    size_threshold: int,
+    generic_sequence_threshold: int,
+    max_inline_string_chars: int,
+    max_inline_dict_keys: int,
+    depth: int = 0,
+) -> Any:
+    if (
+        key in known_large_keys
+        and isinstance(value, (list, tuple))
+        and len(value) > size_threshold
+    ):
+        return {f"_{key}_count": len(value)}
+
+    if isinstance(value, str):
+        if len(value) > max_inline_string_chars:
+            return _summarize_large_value(value)
+        return value
+
+    if isinstance(value, (list, tuple, set)):
+        if len(value) > generic_sequence_threshold:
+            return _summarize_large_value(value)
+        return value
+
+    if isinstance(value, dict):
+        if len(value) > max_inline_dict_keys:
+            return _summarize_large_value(value)
+        if depth >= 2:
+            return value
+        compacted: Dict[str, Any] = {}
+        changed = False
+        for child_key, child_value in value.items():
+            child_compacted = _compact_value_for_storage(
+                child_value,
+                key=str(child_key),
+                known_large_keys=known_large_keys,
+                size_threshold=size_threshold,
+                generic_sequence_threshold=generic_sequence_threshold,
+                max_inline_string_chars=max_inline_string_chars,
+                max_inline_dict_keys=max_inline_dict_keys,
+                depth=depth + 1,
+            )
+            if isinstance(child_compacted, dict) and len(child_compacted) == 1:
+                marker_key = next(iter(child_compacted))
+                if marker_key.startswith("_") and marker_key.endswith("_count"):
+                    compacted[marker_key] = child_compacted[marker_key]
+                    changed = True
+                    continue
+            compacted[child_key] = child_compacted
+            changed = changed or child_compacted is not child_value
+        return compacted if changed else value
+
+    return value
 
 
 def compact_outputs_for_storage(
@@ -40,33 +140,37 @@ def compact_outputs_for_storage(
     *,
     keys: Iterable[str] = DEFAULT_LARGE_LIST_KEYS,
     size_threshold: int = DEFAULT_COMPACT_SIZE_THRESHOLD,
+    generic_sequence_threshold: int = DEFAULT_GENERIC_SEQUENCE_THRESHOLD,
+    max_inline_string_chars: int = DEFAULT_MAX_INLINE_STRING_CHARS,
+    max_inline_dict_keys: int = DEFAULT_MAX_INLINE_DICT_KEYS,
 ) -> Dict[str, Any]:
-    """Return a copy of *outputs* with large alert lists replaced by counts.
+    """Return a bounded copy of *outputs* safe for execution records.
 
-    Only **list or tuple** values whose key is in *keys* AND whose length
-    exceeds *size_threshold* are compacted to ``_<key>_count``; everything
-    else is passed through unchanged.  This prevents megabytes of alert data
-    from being serialised into the ``workflow_execution`` SQLite row on every
-    invocation, while still keeping small sequences (e.g. error details, short
-    configuration arrays) fully inspectable in the execution-history UI.
-
-    **Keys that are compacted by default** (see ``DEFAULT_LARGE_LIST_KEYS``):
-    ``enriched_alerts``, ``unique_alerts``, ``raw_alerts``,
-    ``normalized_alerts``, ``filtered_alerts``.  Keys outside this set — such
-    as a generic ``alerts`` parameter — are *not* compacted unless the caller
-    passes a custom *keys* argument.  Callers who depend on inspecting the
-    full list contents of compacted keys must read the data from the JSONL
-    files written by the workflow itself.
+    Known large-list keys keep the historical ``_<key>_count`` shape. Other
+    oversized strings, sequences, and dictionaries are replaced with bounded
+    summaries so unknown workflow payload names cannot inflate SQLite rows or
+    tool metadata.
     """
     if not isinstance(outputs, dict):
         return {}
-    key_set = frozenset(keys)
+    known_large_keys = frozenset(keys)
     compacted: Dict[str, Any] = {}
     for k, v in outputs.items():
-        if k in key_set and isinstance(v, (list, tuple)) and len(v) > size_threshold:
-            compacted[f"_{k}_count"] = len(v)
-        else:
-            compacted[k] = v
+        value = _compact_value_for_storage(
+            v,
+            key=str(k),
+            known_large_keys=known_large_keys,
+            size_threshold=size_threshold,
+            generic_sequence_threshold=generic_sequence_threshold,
+            max_inline_string_chars=max_inline_string_chars,
+            max_inline_dict_keys=max_inline_dict_keys,
+        )
+        if isinstance(value, dict) and len(value) == 1:
+            marker_key = next(iter(value))
+            if marker_key == f"_{k}_count":
+                compacted[marker_key] = value[marker_key]
+                continue
+        compacted[k] = value
     return compacted
 
 

--- a/flocks/workflow/poller_manager.py
+++ b/flocks/workflow/poller_manager.py
@@ -15,7 +15,6 @@ from typing import Any, Dict
 
 from croniter import croniter
 
-from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 from flocks.workflow.execution_store import (
     compact_outputs_for_storage,
@@ -26,6 +25,7 @@ from flocks.workflow.execution_store import (
 )
 from flocks.workflow.fs_store import read_workflow_from_fs
 from flocks.workflow.runner import RunWorkflowResult, run_workflow
+from flocks.workflow.store import WorkflowStore
 
 WORKFLOW_POLLER_CONFIG_PREFIX = "workflow_poller_config/"
 DEFAULT_INTERVAL_SECONDS = 30
@@ -180,21 +180,13 @@ class WorkflowPollerManager:
 
     async def start_all(self) -> None:
         try:
-            keys = await Storage.list_keys(WORKFLOW_POLLER_CONFIG_PREFIX)
+            configs = await WorkflowStore.list_configs(kind="workflow_poller_config")
         except Exception as exc:
-            log.warning("poller.list_keys_failed", {"error": str(exc)})
+            log.warning("poller.list_configs_failed", {"error": str(exc)})
             return
 
-        for key in keys:
-            if not key.startswith(WORKFLOW_POLLER_CONFIG_PREFIX):
-                continue
-            workflow_id = key[len(WORKFLOW_POLLER_CONFIG_PREFIX):]
+        for workflow_id, data in configs:
             if not workflow_id:
-                continue
-            try:
-                data = await Storage.read(key)
-            except Exception as exc:
-                log.warning("poller.config_read_failed", {"key": key, "error": str(exc)})
                 continue
             if isinstance(data, dict) and data.get("enabled"):
                 await self.restart_workflow(workflow_id)
@@ -238,7 +230,7 @@ class WorkflowPollerManager:
     async def restart_workflow(self, workflow_id: str) -> Dict[str, Any]:
         await self.stop_workflow(workflow_id)
         try:
-            stored = await Storage.read(self._config_key(workflow_id))
+            stored = await WorkflowStore.get_config(workflow_id, kind="workflow_poller_config")
         except Exception as exc:
             log.warning("poller.restart_read_failed", {"workflow_id": workflow_id, "error": str(exc)})
             return {"workflowId": workflow_id, "state": "failed", "error": str(exc)}
@@ -298,7 +290,7 @@ class WorkflowPollerManager:
 
     async def run_once(self, workflow_id: str) -> Dict[str, Any]:
         try:
-            stored = await Storage.read(self._config_key(workflow_id))
+            stored = await WorkflowStore.get_config(workflow_id, kind="workflow_poller_config")
         except Exception as exc:
             log.warning("poller.run_once_read_failed", {"workflow_id": workflow_id, "error": str(exc)})
             current = self.get_status(workflow_id)
@@ -448,23 +440,25 @@ class WorkflowPollerManager:
             summary = self._summarize_outputs(result.outputs)
             step_count = step_recorder.step_count or result.steps
             exec_data.update(step_recorder.summary)
-            exec_data.update({
-                "outputResults": compact_outputs_for_storage(result.outputs),
-                "status": status_value,
-                "finishedAt": _now_ms(),
-                "duration": duration_s,
-                "executionLog": [],
-                "errorMessage": error_message,
-                "stepCount": step_count,
-                "currentNodeId": result.last_node_id,
-                "currentPhase": status_value,
-                "currentStepIndex": step_count,
-                "triggerId": "schedule-default",
-                "triggerType": "schedule",
-                "deliveryId": inputs.get("_flocks", {}).get("trigger", {}).get("deliveryId"),
-                "attempt": 1,
-                "triggerSource": "poller",
-            })
+            exec_data.update(
+                {
+                    "outputResults": compact_outputs_for_storage(result.outputs),
+                    "status": status_value,
+                    "finishedAt": _now_ms(),
+                    "duration": duration_s,
+                    "executionLog": [],
+                    "errorMessage": error_message,
+                    "stepCount": step_count,
+                    "currentNodeId": result.last_node_id,
+                    "currentPhase": status_value,
+                    "currentStepIndex": step_count,
+                    "triggerId": "schedule-default",
+                    "triggerType": "schedule",
+                    "deliveryId": inputs.get("_flocks", {}).get("trigger", {}).get("deliveryId"),
+                    "attempt": 1,
+                    "triggerSource": "poller",
+                }
+            )
             current = self._status.get(workflow_id) or self._base_status(workflow_id)
             current.update(summary)
             current["lastRunAt"] = started_at_ms
@@ -483,19 +477,21 @@ class WorkflowPollerManager:
             status_value = "cancelled" if cancel_event.is_set() else "error"
             finished_at_ms = _now_ms()
             exec_data.update(step_recorder.summary)
-            exec_data.update({
-                "status": status_value,
-                "finishedAt": finished_at_ms,
-                "duration": duration_s,
-                "errorMessage": str(exc),
-                "executionLog": [],
-                "currentPhase": status_value,
-                "triggerId": "schedule-default",
-                "triggerType": "schedule",
-                "deliveryId": inputs.get("_flocks", {}).get("trigger", {}).get("deliveryId"),
-                "attempt": 1,
-                "triggerSource": "poller",
-            })
+            exec_data.update(
+                {
+                    "status": status_value,
+                    "finishedAt": finished_at_ms,
+                    "duration": duration_s,
+                    "errorMessage": str(exc),
+                    "executionLog": [],
+                    "currentPhase": status_value,
+                    "triggerId": "schedule-default",
+                    "triggerType": "schedule",
+                    "deliveryId": inputs.get("_flocks", {}).get("trigger", {}).get("deliveryId"),
+                    "attempt": 1,
+                    "triggerSource": "poller",
+                }
+            )
             current = self._status.get(workflow_id) or self._base_status(workflow_id)
             current["lastRunAt"] = started_at_ms
             current["lastDurationMs"] = duration_ms

--- a/flocks/workflow/poller_manager.py
+++ b/flocks/workflow/poller_manager.py
@@ -447,6 +447,7 @@ class WorkflowPollerManager:
                     "finishedAt": _now_ms(),
                     "duration": duration_s,
                     "executionLog": [],
+                    "payloadRiskSummary": result.payload_risk_summary,
                     "errorMessage": error_message,
                     "stepCount": step_count,
                     "currentNodeId": result.last_node_id,

--- a/flocks/workflow/repl_runtime.py
+++ b/flocks/workflow/repl_runtime.py
@@ -54,8 +54,6 @@ class PythonExecRuntime(Runtime):
     _RUNTIME_GLOBAL_KEYS: ClassVar[frozenset[str]] = frozenset(
         {
             "__builtins__",
-            "inputs",
-            "outputs",
             "cancelled",
             "is_cancelled",
             "llm",
@@ -141,73 +139,80 @@ class PythonExecRuntime(Runtime):
             return _cancel_trace
 
         try:
-            if self.cancel_checker is not None:
-                previous_trace = sys.gettrace()
-                sys.settrace(_cancel_trace)
-            with contextlib.redirect_stdout(buf):
-                exec(code, g, g)
-        except SystemExit:
-            # Node code called exit() / sys.exit() — treat as early return with
-            # whatever has been written to outputs so far.  Do NOT propagate
-            # SystemExit; that would kill the asyncio event loop.
-            pass
-        except RunCancelledError:
-            raise
-        except _FuturesTimeoutError:
-            raise
-        except SyntaxError as e:
-            tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            raise NodeExecutionError(
-                node_id="<runtime>",
-                message=f"Syntax error in code at line {e.lineno}: {e.msg}",
-                stdout=buf.getvalue(),
-                traceback=tb_str
-            ) from e
-        except AttributeError as e:
-            tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            error_msg = f"AttributeError: {e}"
-            if "'NoneType' object has no attribute" in str(e):
-                attr_name = str(e).split("'")[-2] if "'" in str(e) else "unknown"
-                error_msg += f"\n提示: 对象为 None，无法访问属性 '{attr_name}'。"
-            raise NodeExecutionError(node_id="<runtime>", message=error_msg, stdout=buf.getvalue(), traceback=tb_str) from e
-        except KeyError as e:
-            tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            raise NodeExecutionError(
-                node_id="<runtime>",
-                message=f"Missing required input key: {e}",
-                stdout=buf.getvalue(),
-                traceback=tb_str
-            ) from e
-        except NameError as e:
-            tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            raise NodeExecutionError(
-                node_id="<runtime>",
-                message=f"Undefined variable or function: {e}",
-                stdout=buf.getvalue(),
-                traceback=tb_str
-            ) from e
-        except TypeError as e:
-            tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            error_msg = f"Type error during execution: {e}"
-            raise NodeExecutionError(node_id="<runtime>", message=error_msg, stdout=buf.getvalue(), traceback=tb_str) from e
-        except Exception as e:
-            tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            error_msg = f"Runtime error ({type(e).__name__}): {e}"
-            raise NodeExecutionError(node_id="<runtime>", message=error_msg, stdout=buf.getvalue(), traceback=tb_str) from e
+            try:
+                if self.cancel_checker is not None:
+                    previous_trace = sys.gettrace()
+                    sys.settrace(_cancel_trace)
+                with contextlib.redirect_stdout(buf):
+                    exec(code, g, g)
+            except SystemExit:
+                # Node code called exit() / sys.exit() — treat as early return with
+                # whatever has been written to outputs so far.  Do NOT propagate
+                # SystemExit; that would kill the asyncio event loop.
+                pass
+            except RunCancelledError:
+                raise
+            except _FuturesTimeoutError:
+                raise
+            except SyntaxError as e:
+                tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                raise NodeExecutionError(
+                    node_id="<runtime>",
+                    message=f"Syntax error in code at line {e.lineno}: {e.msg}",
+                    stdout=buf.getvalue(),
+                    traceback=tb_str,
+                ) from e
+            except AttributeError as e:
+                tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                error_msg = f"AttributeError: {e}"
+                if "'NoneType' object has no attribute" in str(e):
+                    attr_name = str(e).split("'")[-2] if "'" in str(e) else "unknown"
+                    error_msg += f"\n提示: 对象为 None，无法访问属性 '{attr_name}'。"
+                raise NodeExecutionError(
+                    node_id="<runtime>", message=error_msg, stdout=buf.getvalue(), traceback=tb_str
+                ) from e
+            except KeyError as e:
+                tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                raise NodeExecutionError(
+                    node_id="<runtime>",
+                    message=f"Missing required input key: {e}",
+                    stdout=buf.getvalue(),
+                    traceback=tb_str,
+                ) from e
+            except NameError as e:
+                tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                raise NodeExecutionError(
+                    node_id="<runtime>",
+                    message=f"Undefined variable or function: {e}",
+                    stdout=buf.getvalue(),
+                    traceback=tb_str,
+                ) from e
+            except TypeError as e:
+                tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                error_msg = f"Type error during execution: {e}"
+                raise NodeExecutionError(
+                    node_id="<runtime>", message=error_msg, stdout=buf.getvalue(), traceback=tb_str
+                ) from e
+            except Exception as e:
+                tb_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                error_msg = f"Runtime error ({type(e).__name__}): {e}"
+                raise NodeExecutionError(
+                    node_id="<runtime>", message=error_msg, stdout=buf.getvalue(), traceback=tb_str
+                ) from e
+
+            out_obj = g.get("outputs", {})
+            if out_obj is None:
+                out_obj = {}
+            if not isinstance(out_obj, dict):
+                raise NodeExecutionError(node_id="<runtime>", message="`outputs` must be a dict")
+            return dict(out_obj), buf.getvalue()
         finally:
             if self.cancel_checker is not None:
                 sys.settrace(previous_trace)
-
-        out_obj = g.get("outputs", {})
-        if out_obj is None:
-            out_obj = {}
-        if not isinstance(out_obj, dict):
-            raise NodeExecutionError(node_id="<runtime>", message="`outputs` must be a dict")
-        if self.cleanup_globals_after_execute:
-            for key in list(g.keys()):
-                if key not in self._RUNTIME_GLOBAL_KEYS:
-                    g.pop(key, None)
-        return out_obj, buf.getvalue()
+            if self.cleanup_globals_after_execute:
+                for key in list(g.keys()):
+                    if key not in self._RUNTIME_GLOBAL_KEYS:
+                        g.pop(key, None)
 
     def reset(self) -> None:
         self.globals.clear()
@@ -646,7 +651,7 @@ class PythonREPLRuntime(Runtime):
         outputs: Dict[str, Any] = {}
         for line in stdout.splitlines():
             if line.startswith(marker):
-                payload = line[len(marker):]
+                payload = line[len(marker) :]
                 try:
                     obj = json.loads(payload) if payload else {}
                 except Exception:

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Dict, Literal, Optional, Union
 
 from flocks.config.config import Config
 from flocks.sandbox.context import resolve_sandbox_context
-from .errors import FlocksWorkflowError, RunCancelledError, RunTimeoutError
+from .errors import FlocksWorkflowError, RunCancelledError, RunTimeoutError, WorkflowValidationError
 from .io import dump_workflow, load_workflow
 from .compiler import default_exec_path, compile_workflow, workflow_has_logic_nodes
 from .models import Workflow
@@ -302,9 +302,9 @@ def run_workflow(
 ) -> RunWorkflowResult:
     # 确保日志已配置
     _ensure_logging_configured()
-    
+
     _logger.debug("=== 开始执行 workflow ===")
-    
+
     workflow_path_for_engine: Optional[str] = None
     effective_use_llm: Optional[bool] = use_llm
     if isinstance(workflow, Workflow):
@@ -366,15 +366,20 @@ def run_workflow(
         effective_use_llm = workflow_has_logic_nodes(wf)
 
     _logger.debug("workflow 信息: nodes=%s, edges=%s, start=%s", len(wf.nodes), len(wf.edges), wf.start)
-    
+
     try:
         lint_results = lint_workflow(wf)
         lint_errors = [r for r in lint_results if r.get("severity") == "error"]
         lint_warnings = [r for r in lint_results if r.get("severity") != "error"]
         if lint_errors:
             _logger.error(f"workflow lint 检查发现 {len(lint_errors)} 个错误: {lint_errors[:5]}")
+            strict_mapping_errors = [item for item in lint_errors if item.get("kind") == "implicit_full_payload_edge"]
+            if strict_mapping_errors:
+                raise WorkflowValidationError(f"Workflow strict edge mapping failed: {strict_mapping_errors[:5]}")
         if lint_warnings:
             _logger.warning(f"workflow lint 检查发现 {len(lint_warnings)} 个警告: {lint_warnings[:5]}")
+    except WorkflowValidationError:
+        raise
     except Exception:
         pass
 
@@ -420,7 +425,7 @@ def run_workflow(
             tool_registry=registry,
             cleanup_globals_after_execute=(history_mode == "summary"),
         )
-    
+
     _logger.debug(
         "创建执行引擎 (use_llm=%s, trace=%s, node_timeout=%ss, parallel_workers=%s, history_mode=%s)",
         effective_use_llm,
@@ -439,7 +444,7 @@ def run_workflow(
         max_parallel_workers=max_parallel_workers,
         history_mode=history_mode,
     )
-    
+
     initial_inputs = _build_initial_inputs(inputs, workflow_path_for_engine)
     _logger.debug(
         "开始执行 workflow (timeout=%ss, inputs=%s)",
@@ -450,12 +455,16 @@ def run_workflow(
     _on_step_start = None
     _on_step_end = None
     if on_step_start is not None:
+
         def _on_step_start(_rid, _step, _node, _inp):
             return on_step_start(_rid, _step, _node, _inp)
     elif on_step_complete is not None:
+
         def _on_step_start(_rid, _step, _node, _inp):
             return True
+
     if on_step_complete is not None:
+
         def _on_step_end(_token, step_result):
             return on_step_complete(step_result)
 
@@ -470,17 +479,17 @@ def run_workflow(
         )
     except FlocksWorkflowError as e:
         # Extract execution context from error if available
-        exec_ctx = getattr(e, 'execution_context', {})
-        history_from_error = exec_ctx.get('history', [])
-        
+        exec_ctx = getattr(e, "execution_context", {})
+        history_from_error = exec_ctx.get("history", [])
+
         # Convert StepResult objects to dicts if needed
-        if history_from_error and hasattr(history_from_error[0], 'model_dump'):
+        if history_from_error and hasattr(history_from_error[0], "model_dump"):
             history_from_error = [s.model_dump(mode="json") for s in history_from_error]
-        
-        last_outputs = exec_ctx.get('outputs') or (
-            history_from_error[-1].get('outputs', {}) if history_from_error else {}
+
+        last_outputs = exec_ctx.get("outputs") or (
+            history_from_error[-1].get("outputs", {}) if history_from_error else {}
         )
-        
+
         status = "FAILED"
         if isinstance(e, RunCancelledError):
             status = "CANCELLED"
@@ -490,9 +499,9 @@ def run_workflow(
         return RunWorkflowResult(
             status=status,
             error=f"{type(e).__name__}: {e}",
-            run_id=exec_ctx.get('run_id'),
-            steps=exec_ctx.get('steps', 0),
-            last_node_id=exec_ctx.get('last_node_id'),
+            run_id=exec_ctx.get("run_id"),
+            steps=exec_ctx.get("steps", 0),
+            last_node_id=exec_ctx.get("last_node_id"),
             outputs=last_outputs,
             history=history_from_error,
         )
@@ -510,9 +519,11 @@ def run_workflow(
             history=history,
             error=f"RunCancelledError: Run cancelled: run_id={result.run_id}",
         )
-    
-    _logger.info(f"=== workflow 执行成功 === run_id={result.run_id}, steps={result.steps}, last_node={result.last_node_id}")
-    
+
+    _logger.info(
+        f"=== workflow 执行成功 === run_id={result.run_id}, steps={result.steps}, last_node={result.last_node_id}"
+    )
+
     return RunWorkflowResult(
         status="SUCCEEDED",
         run_id=result.run_id,

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -162,6 +162,38 @@ def _resolve_workflow_node_timeout(
     return requested_timeout_s
 
 
+def _resolve_workflow_dataflow_mode(workflow_metadata: Optional[Dict[str, Any]]) -> Literal["legacy", "vertex_cache"]:
+    """Resolve workflow dataflow mode from metadata.
+
+    Missing metadata intentionally stays legacy so historical workflow files run
+    with their original full-payload edge semantics.
+    """
+    if not isinstance(workflow_metadata, dict):
+        return "legacy"
+
+    candidates: list[Any] = [
+        workflow_metadata.get("dataflow_mode"),
+        workflow_metadata.get("dataflowMode"),
+    ]
+    for section_key in ("runtime", "runtime_defaults", "runtimeDefaults"):
+        section = workflow_metadata.get(section_key)
+        if isinstance(section, dict):
+            candidates.extend(
+                [
+                    section.get("dataflow_mode"),
+                    section.get("dataflowMode"),
+                ]
+            )
+
+    for value in candidates:
+        normalized = str(value or "").strip().lower().replace("-", "_")
+        if normalized in {"vertex_cache", "vertex", "cache"}:
+            return "vertex_cache"
+        if normalized in {"legacy", "classic", "default"}:
+            return "legacy"
+    return "legacy"
+
+
 def _resolve_sandbox_payload_from_config(tool_context: Optional[Any]) -> Optional[Dict[str, Any]]:
     """Resolve sandbox payload directly from config for workflow sandbox default."""
     config_data = _load_config_data()
@@ -390,6 +422,7 @@ def run_workflow(
         node_timeout_s,
         wf.metadata,
     )
+    dataflow_mode = _resolve_workflow_dataflow_mode(wf.metadata)
 
     reqs = requirements_from_workflow_metadata(wf.metadata)
     if ensure_requirements:
@@ -430,12 +463,13 @@ def run_workflow(
         )
 
     _logger.debug(
-        "创建执行引擎 (use_llm=%s, trace=%s, node_timeout=%ss, parallel_workers=%s, history_mode=%s)",
+        "创建执行引擎 (use_llm=%s, trace=%s, node_timeout=%ss, parallel_workers=%s, history_mode=%s, dataflow_mode=%s)",
         effective_use_llm,
         trace,
         effective_node_timeout_s,
         max_parallel_workers,
         history_mode,
+        dataflow_mode,
     )
     engine = WorkflowEngine(
         wf,
@@ -446,6 +480,7 @@ def run_workflow(
         node_timeout_s=effective_node_timeout_s,
         max_parallel_workers=max_parallel_workers,
         history_mode=history_mode,
+        dataflow_mode=dataflow_mode,
     )
 
     initial_inputs = _build_initial_inputs(inputs, workflow_path_for_engine)

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -253,6 +253,7 @@ class RunWorkflowResult:
     last_node_id: Optional[str] = None
     outputs: Dict[str, Any] = None  # type: ignore[assignment]
     history: list[Dict[str, Any]] = None  # type: ignore[assignment]
+    payload_risk_summary: Dict[str, Any] = None  # type: ignore[assignment]
     error: Optional[str] = None
 
     def __post_init__(self) -> None:
@@ -260,6 +261,8 @@ class RunWorkflowResult:
             self.outputs = {}
         if self.history is None:
             self.history = []
+        if self.payload_risk_summary is None:
+            self.payload_risk_summary = {}
 
 
 def _build_initial_inputs(
@@ -504,6 +507,7 @@ def run_workflow(
             last_node_id=exec_ctx.get("last_node_id"),
             outputs=last_outputs,
             history=history_from_error,
+            payload_risk_summary=exec_ctx.get("payload_risk_summary") or {},
         )
 
     history = [s.model_dump(mode="json") for s in result.history] if result.history else []
@@ -517,6 +521,7 @@ def run_workflow(
             last_node_id=result.last_node_id,
             outputs=last_outputs,
             history=history,
+            payload_risk_summary=result.payload_risk_summary,
             error=f"RunCancelledError: Run cancelled: run_id={result.run_id}",
         )
 
@@ -531,4 +536,5 @@ def run_workflow(
         last_node_id=result.last_node_id,
         outputs=last_outputs,
         history=history,
+        payload_risk_summary=result.payload_risk_summary,
     )

--- a/flocks/workflow/store.py
+++ b/flocks/workflow/store.py
@@ -1,0 +1,766 @@
+"""SQLite persistence for workflow runtime data."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import aiosqlite
+
+from flocks.storage.storage import Storage
+from flocks.utils.log import Log
+
+log = Log.create(service="workflow.store")
+
+_MIGRATION_MARKER_KEY = "workflow_store.migration.tables.v1"
+_JSON_TYPE = "json"
+_WORKFLOW_KV_PREFIXES = (
+    "workflow_registry/",
+    "workflow_release/",
+    "workflow_runtime/",
+    "workflow_local_pid/",
+    "workflow_api_service/",
+)
+_WORKFLOW_TABLE_PREFIXES = (
+    "workflow_execution/",
+    "workflow_execution_index/",
+    "workflow_execution_step/",
+    "workflow/",
+    "workflow_integration_config/",
+    "workflow_kafka_config/",
+    "workflow_poller_config/",
+    "workflow_syslog_config/",
+)
+_WORKFLOW_PREFIXES = _WORKFLOW_KV_PREFIXES + _WORKFLOW_TABLE_PREFIXES
+
+
+class WorkflowStore:
+    """Workflow-domain store backed by ``workflow.db`` tables."""
+
+    _initialized = False
+    _conn: Optional[aiosqlite.Connection] = None
+    _init_pid: Optional[int] = None
+    _db_path: Optional[Path] = None
+
+    @classmethod
+    def get_db_path(cls) -> Path:
+        return Storage.get_workflow_db_path()
+
+    @classmethod
+    async def init(cls) -> None:
+        current_pid = os.getpid()
+        db_path = cls.get_db_path()
+        if cls._initialized and cls._init_pid == current_pid and cls._db_path == db_path:
+            return
+        if cls._initialized and (
+            (cls._init_pid is not None and cls._init_pid != current_pid)
+            or (cls._db_path is not None and cls._db_path != db_path)
+        ):
+            log.warn(
+                "workflow.store.fork_detected",
+                {
+                    "parent_pid": cls._init_pid,
+                    "child_pid": current_pid,
+                    "old_db_path": str(cls._db_path) if cls._db_path else None,
+                    "new_db_path": str(db_path),
+                },
+            )
+            if cls._conn:
+                await cls._conn.close()
+            cls._conn = None
+            cls._initialized = False
+            cls._init_pid = None
+
+        await Storage._ensure_init()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            cls._conn = await aiosqlite.connect(
+                db_path,
+                timeout=Storage._sqlite_timeout_s,
+            )
+            cls._conn.row_factory = aiosqlite.Row
+            await Storage.configure_connection(cls._conn)
+            await cls._conn.executescript(_WORKFLOW_DDL)
+            for stmt in _INDEX_STMTS:
+                await cls._conn.execute(stmt)
+            await cls._conn.commit()
+            cls._initialized = True
+            cls._init_pid = current_pid
+            cls._db_path = db_path
+            await cls._migrate_legacy_kv()
+            log.info("workflow.store.initialized")
+        except Exception:
+            if cls._conn:
+                await cls._conn.close()
+            cls._conn = None
+            cls._initialized = False
+            cls._init_pid = None
+            cls._db_path = None
+            raise
+
+    @classmethod
+    async def close(cls) -> None:
+        if cls._conn:
+            await cls._conn.close()
+        cls._conn = None
+        cls._initialized = False
+        cls._init_pid = None
+        cls._db_path = None
+
+    @classmethod
+    async def _db(cls) -> aiosqlite.Connection:
+        if cls._initialized and cls._init_pid is not None and cls._init_pid != os.getpid():
+            await cls.init()
+        if not cls._conn or not cls._initialized:
+            await cls.init()
+        return cls._conn  # type: ignore[return-value]
+
+    @classmethod
+    async def raw_db(cls) -> aiosqlite.Connection:
+        return await cls._db()
+
+    @staticmethod
+    def _json_dumps(value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False, default=str)
+
+    @staticmethod
+    def _json_loads(value: Optional[str], default: Any = None) -> Any:
+        if value is None:
+            return default
+        try:
+            return json.loads(value)
+        except Exception:
+            return default
+
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now(UTC).isoformat()
+
+    @staticmethod
+    def _now_ms() -> int:
+        return int(datetime.now(UTC).timestamp() * 1000)
+
+    @staticmethod
+    def _as_int(value: Any) -> Optional[int]:
+        if isinstance(value, bool):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _as_float(value: Any) -> Optional[float]:
+        if isinstance(value, bool):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _quote_identifier(identifier: str) -> str:
+        return '"' + identifier.replace('"', '""') + '"'
+
+    @classmethod
+    def _legacy_table_exists(cls, conn: sqlite3.Connection) -> bool:
+        row = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name = 'storage'").fetchone()
+        return row is not None
+
+    @classmethod
+    def _legacy_rows_from_db(cls, db_path: Path) -> list[sqlite3.Row]:
+        if not db_path.exists():
+            return []
+        conn = Storage.connect_sync(db_path)
+        try:
+            if not cls._legacy_table_exists(conn):
+                return []
+            clauses = " OR ".join("key LIKE ?" for _ in _WORKFLOW_PREFIXES)
+            params = tuple(f"{prefix}%" for prefix in _WORKFLOW_PREFIXES)
+            return conn.execute(
+                f"""
+                SELECT key, value, type, created_at, updated_at
+                FROM storage
+                WHERE {clauses}
+                ORDER BY key
+                """,
+                params,
+            ).fetchall()
+        finally:
+            conn.close()
+
+    @classmethod
+    async def _migrate_legacy_kv(cls) -> None:
+        if await cls.kv_get(_MIGRATION_MARKER_KEY) is not None:
+            return
+        rows_by_key: dict[str, sqlite3.Row] = {}
+        for db_path in (Storage.get_db_path(), cls.get_db_path()):
+            for row in await asyncio.to_thread(cls._legacy_rows_from_db, db_path):
+                rows_by_key[str(row["key"])] = row
+
+        counts = {
+            "executions": 0,
+            "steps": 0,
+            "stats": 0,
+            "configs": 0,
+            "kv": 0,
+            "skipped": 0,
+        }
+        for key, row in rows_by_key.items():
+            value = cls._json_loads(str(row["value"]), None)
+            if value is None:
+                counts["skipped"] += 1
+                continue
+            if key.startswith("workflow_execution_step/") and isinstance(value, dict):
+                parts = key.split("/")
+                if len(parts) >= 3:
+                    try:
+                        await cls.record_step(parts[1], int(parts[2]), value)
+                        counts["steps"] += 1
+                    except Exception:
+                        counts["skipped"] += 1
+                continue
+            if key.startswith("workflow_execution/") and isinstance(value, dict):
+                await cls.upsert_execution(value)
+                counts["executions"] += 1
+                continue
+            if key.startswith("workflow/") and key.endswith("/stats") and isinstance(value, dict):
+                workflow_id = key[len("workflow/") : -len("/stats")]
+                await cls.put_stats(workflow_id, value)
+                counts["stats"] += 1
+                continue
+            if key.startswith("workflow_integration_config/") and isinstance(value, dict):
+                workflow_id = key[len("workflow_integration_config/") :]
+                await cls.put_config(workflow_id, value)
+                counts["configs"] += 1
+                continue
+            if key.startswith(_WORKFLOW_KV_PREFIXES):
+                await cls.kv_put(key, value)
+                counts["kv"] += 1
+                continue
+            if key.startswith(
+                (
+                    "workflow_kafka_config/",
+                    "workflow_poller_config/",
+                    "workflow_syslog_config/",
+                )
+            ) and isinstance(value, dict):
+                workflow_id = key.rsplit("/", 1)[-1]
+                await cls.put_config(workflow_id, value, kind=key.split("/", 1)[0])
+                counts["configs"] += 1
+
+        await cls.kv_put(
+            _MIGRATION_MARKER_KEY,
+            {
+                "version": 1,
+                "migrated_at": cls._now_iso(),
+                "source_db": str(Storage.get_db_path()),
+                "workflow_db": str(cls.get_db_path()),
+                **counts,
+            },
+        )
+        log.info("workflow.store.legacy_kv_migrated", counts)
+
+    @classmethod
+    async def upsert_execution(cls, exec_data: Dict[str, Any]) -> None:
+        db = await cls._db()
+        payload = dict(exec_data)
+        exec_id = str(payload.get("id") or "")
+        workflow_id = str(payload.get("workflowId") or payload.get("workflow_id") or "")
+        if not exec_id or not workflow_id:
+            raise ValueError("workflow execution requires id and workflowId")
+        await db.execute(
+            """
+            INSERT OR REPLACE INTO workflow_executions
+            (id, workflow_id, status, current_phase, current_node_id, current_node_type,
+             current_step_index, step_count, input_params, output_results, error_message,
+             trigger_id, trigger_type, started_at, finished_at, duration, updated_at, payload)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                exec_id,
+                workflow_id,
+                str(payload.get("status") or "running"),
+                payload.get("currentPhase"),
+                payload.get("currentNodeId"),
+                payload.get("currentNodeType"),
+                cls._as_int(payload.get("currentStepIndex")),
+                cls._as_int(payload.get("stepCount")) or 0,
+                cls._json_dumps(payload.get("inputParams") or {}),
+                cls._json_dumps(payload.get("outputResults") or {}),
+                payload.get("errorMessage"),
+                payload.get("triggerId"),
+                payload.get("triggerType"),
+                cls._as_int(payload.get("startedAt")) or cls._now_ms(),
+                cls._as_int(payload.get("finishedAt")),
+                cls._as_float(payload.get("duration")),
+                cls._as_int(payload.get("updatedAt")) or cls._now_ms(),
+                cls._json_dumps(payload),
+            ),
+        )
+        await db.commit()
+
+    @classmethod
+    async def get_execution(cls, exec_id: str) -> Optional[Dict[str, Any]]:
+        db = await cls._db()
+        async with db.execute(
+            "SELECT payload FROM workflow_executions WHERE id = ?",
+            (exec_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return None
+        value = cls._json_loads(row["payload"], None)
+        return value if isinstance(value, dict) else None
+
+    @classmethod
+    async def list_executions(
+        cls,
+        workflow_id: str,
+        *,
+        limit: int = 50,
+        trigger_id: Optional[str] = None,
+        trigger_type: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        db = await cls._db()
+        clauses = ["workflow_id = ?"]
+        params: list[Any] = [workflow_id]
+        if trigger_id:
+            clauses.append("trigger_id = ?")
+            params.append(trigger_id)
+        if trigger_type:
+            clauses.append("trigger_type = ?")
+            params.append(trigger_type)
+        params.append(max(int(limit), 0))
+        async with db.execute(
+            f"""
+            SELECT payload FROM workflow_executions
+            WHERE {" AND ".join(clauses)}
+            ORDER BY started_at DESC
+            LIMIT ?
+            """,
+            tuple(params),
+        ) as cur:
+            rows = await cur.fetchall()
+        items: List[Dict[str, Any]] = []
+        for row in rows:
+            value = cls._json_loads(row["payload"], None)
+            if isinstance(value, dict):
+                items.append(value)
+        return items
+
+    @classmethod
+    async def delete_execution(cls, exec_id: str) -> bool:
+        db = await cls._db()
+        await db.execute("DELETE FROM workflow_execution_steps WHERE exec_id = ?", (exec_id,))
+        cur = await db.execute("DELETE FROM workflow_executions WHERE id = ?", (exec_id,))
+        await db.commit()
+        return cur.rowcount > 0
+
+    @classmethod
+    async def delete_executions_for_workflow(cls, workflow_id: str) -> int:
+        db = await cls._db()
+        async with db.execute(
+            "SELECT id FROM workflow_executions WHERE workflow_id = ?",
+            (workflow_id,),
+        ) as cur:
+            exec_ids = [str(row["id"]) for row in await cur.fetchall()]
+        for exec_id in exec_ids:
+            await db.execute("DELETE FROM workflow_execution_steps WHERE exec_id = ?", (exec_id,))
+        cur = await db.execute("DELETE FROM workflow_executions WHERE workflow_id = ?", (workflow_id,))
+        await db.commit()
+        return cur.rowcount
+
+    @classmethod
+    async def trim_executions(cls, workflow_id: str, *, keep: int) -> List[str]:
+        db = await cls._db()
+        async with db.execute(
+            """
+            SELECT id FROM workflow_executions
+            WHERE workflow_id = ?
+            ORDER BY started_at DESC
+            LIMIT -1 OFFSET ?
+            """,
+            (workflow_id, max(int(keep), 0)),
+        ) as cur:
+            exec_ids = [str(row["id"]) for row in await cur.fetchall()]
+        for exec_id in exec_ids:
+            await db.execute("DELETE FROM workflow_execution_steps WHERE exec_id = ?", (exec_id,))
+            await db.execute("DELETE FROM workflow_executions WHERE id = ?", (exec_id,))
+        await db.commit()
+        return exec_ids
+
+    @classmethod
+    async def record_step(
+        cls,
+        exec_id: str,
+        step_index: int,
+        step_payload: Dict[str, Any],
+    ) -> None:
+        db = await cls._db()
+        await db.execute(
+            """
+            INSERT OR REPLACE INTO workflow_execution_steps
+            (exec_id, step_index, node_id, node_type, inputs, outputs, error, payload)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                exec_id,
+                int(step_index),
+                step_payload.get("node_id"),
+                step_payload.get("node_type") or step_payload.get("type"),
+                cls._json_dumps(step_payload.get("inputs") or {}),
+                cls._json_dumps(step_payload.get("outputs") or {}),
+                step_payload.get("error"),
+                cls._json_dumps(step_payload),
+            ),
+        )
+        await db.commit()
+
+    @classmethod
+    async def list_steps(
+        cls,
+        exec_id: str,
+        *,
+        offset: int = 0,
+        limit: int = 500,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        db = await cls._db()
+        safe_offset = max(int(offset), 0)
+        safe_limit = max(int(limit), 0)
+        async with db.execute(
+            "SELECT COUNT(*) AS total FROM workflow_execution_steps WHERE exec_id = ?",
+            (exec_id,),
+        ) as cur:
+            row = await cur.fetchone()
+            total = int(row["total"]) if row else 0
+        if safe_limit == 0:
+            return [], total
+        async with db.execute(
+            """
+            SELECT payload FROM workflow_execution_steps
+            WHERE exec_id = ?
+            ORDER BY step_index
+            LIMIT ? OFFSET ?
+            """,
+            (exec_id, safe_limit, safe_offset),
+        ) as cur:
+            rows = await cur.fetchall()
+        steps: List[Dict[str, Any]] = []
+        for row in rows:
+            value = cls._json_loads(row["payload"], None)
+            if isinstance(value, dict):
+                steps.append(value)
+        return steps, total
+
+    @classmethod
+    async def clear_steps(cls, exec_id: str) -> int:
+        db = await cls._db()
+        cur = await db.execute("DELETE FROM workflow_execution_steps WHERE exec_id = ?", (exec_id,))
+        await db.commit()
+        return cur.rowcount
+
+    @classmethod
+    async def get_stats(cls, workflow_id: str) -> Optional[Dict[str, Any]]:
+        db = await cls._db()
+        async with db.execute(
+            "SELECT * FROM workflow_stats WHERE workflow_id = ?",
+            (workflow_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return None
+        return {
+            "callCount": int(row["call_count"] or 0),
+            "successCount": int(row["success_count"] or 0),
+            "errorCount": int(row["error_count"] or 0),
+            "totalRuntime": float(row["total_runtime"] or 0.0),
+            "avgRuntime": float(row["avg_runtime"] or 0.0),
+            "thumbsUp": int(row["thumbs_up"] or 0),
+            "thumbsDown": int(row["thumbs_down"] or 0),
+        }
+
+    @classmethod
+    async def put_stats(cls, workflow_id: str, stats: Dict[str, Any]) -> None:
+        db = await cls._db()
+        await db.execute(
+            """
+            INSERT OR REPLACE INTO workflow_stats
+            (workflow_id, call_count, success_count, error_count, total_runtime,
+             avg_runtime, thumbs_up, thumbs_down, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                workflow_id,
+                int(stats.get("callCount") or stats.get("call_count") or 0),
+                int(stats.get("successCount") or stats.get("success_count") or 0),
+                int(stats.get("errorCount") or stats.get("error_count") or 0),
+                float(stats.get("totalRuntime") or stats.get("total_runtime") or 0.0),
+                float(stats.get("avgRuntime") or stats.get("avg_runtime") or 0.0),
+                int(stats.get("thumbsUp") or stats.get("thumbs_up") or 0),
+                int(stats.get("thumbsDown") or stats.get("thumbs_down") or 0),
+                cls._now_ms(),
+            ),
+        )
+        await db.commit()
+
+    @classmethod
+    async def delete_stats(cls, workflow_id: str) -> bool:
+        db = await cls._db()
+        cur = await db.execute("DELETE FROM workflow_stats WHERE workflow_id = ?", (workflow_id,))
+        await db.commit()
+        return cur.rowcount > 0
+
+    @classmethod
+    async def increment_stats(cls, workflow_id: str, *, success: bool, duration: float) -> None:
+        db = await cls._db()
+        runtime = float(duration)
+        success_delta = 1 if success else 0
+        error_delta = 0 if success else 1
+        updated_at = cls._now_ms()
+        await db.execute(
+            """
+            INSERT INTO workflow_stats (
+                workflow_id,
+                call_count,
+                success_count,
+                error_count,
+                total_runtime,
+                avg_runtime,
+                thumbs_up,
+                thumbs_down,
+                updated_at
+            )
+            VALUES (?, 1, ?, ?, ?, ?, 0, 0, ?)
+            ON CONFLICT(workflow_id) DO UPDATE SET
+                call_count = workflow_stats.call_count + 1,
+                success_count = workflow_stats.success_count + excluded.success_count,
+                error_count = workflow_stats.error_count + excluded.error_count,
+                total_runtime = workflow_stats.total_runtime + excluded.total_runtime,
+                avg_runtime = (
+                    workflow_stats.total_runtime + excluded.total_runtime
+                ) / (workflow_stats.call_count + 1),
+                updated_at = excluded.updated_at
+            """,
+            (
+                workflow_id,
+                success_delta,
+                error_delta,
+                runtime,
+                runtime,
+                updated_at,
+            ),
+        )
+        await db.commit()
+
+    @classmethod
+    async def put_config(
+        cls,
+        workflow_id: str,
+        config: Dict[str, Any],
+        *,
+        kind: Optional[str] = None,
+    ) -> None:
+        db = await cls._db()
+        config_kind = kind or str(config.get("kind") or "workflow.integration-config")
+        version = cls._as_int(config.get("version"))
+        await db.execute(
+            """
+            INSERT OR REPLACE INTO workflow_configs
+            (workflow_id, kind, version, config, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (workflow_id, config_kind, version, cls._json_dumps(config), cls._now_ms()),
+        )
+        await db.commit()
+
+    @classmethod
+    async def get_config(
+        cls,
+        workflow_id: str,
+        *,
+        kind: str = "workflow.integration-config",
+    ) -> Optional[Dict[str, Any]]:
+        db = await cls._db()
+        async with db.execute(
+            "SELECT config FROM workflow_configs WHERE workflow_id = ? AND kind = ?",
+            (workflow_id, kind),
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return None
+        value = cls._json_loads(row["config"], None)
+        return value if isinstance(value, dict) else None
+
+    @classmethod
+    async def list_configs(cls, *, kind: str) -> List[Tuple[str, Dict[str, Any]]]:
+        db = await cls._db()
+        async with db.execute(
+            "SELECT workflow_id, config FROM workflow_configs WHERE kind = ? ORDER BY workflow_id",
+            (kind,),
+        ) as cur:
+            rows = await cur.fetchall()
+        items: List[Tuple[str, Dict[str, Any]]] = []
+        for row in rows:
+            value = cls._json_loads(row["config"], None)
+            if isinstance(value, dict):
+                items.append((str(row["workflow_id"]), value))
+        return items
+
+    @classmethod
+    async def delete_config(cls, workflow_id: str, *, kind: Optional[str] = None) -> int:
+        db = await cls._db()
+        if kind:
+            cur = await db.execute(
+                "DELETE FROM workflow_configs WHERE workflow_id = ? AND kind = ?",
+                (workflow_id, kind),
+            )
+        else:
+            cur = await db.execute("DELETE FROM workflow_configs WHERE workflow_id = ?", (workflow_id,))
+        await db.commit()
+        return cur.rowcount
+
+    @classmethod
+    async def kv_put(cls, key: str, value: Any, value_type: str = _JSON_TYPE) -> None:
+        db = await cls._db()
+        now = cls._now_iso()
+        await db.execute(
+            """
+            INSERT OR REPLACE INTO workflow_kv (key, value, type, created_at, updated_at)
+            VALUES (?, ?, ?,
+                COALESCE((SELECT created_at FROM workflow_kv WHERE key = ?), ?),
+                ?)
+            """,
+            (key, cls._json_dumps(value), value_type, key, now, now),
+        )
+        await db.commit()
+
+    @classmethod
+    async def kv_get(cls, key: str) -> Optional[Any]:
+        db = await cls._db()
+        async with db.execute("SELECT value FROM workflow_kv WHERE key = ?", (key,)) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return None
+        return cls._json_loads(row["value"], None)
+
+    @classmethod
+    async def kv_remove(cls, key: str) -> bool:
+        db = await cls._db()
+        cur = await db.execute("DELETE FROM workflow_kv WHERE key = ?", (key,))
+        await db.commit()
+        return cur.rowcount > 0
+
+    @classmethod
+    async def kv_list_keys(cls, prefix: str) -> List[str]:
+        db = await cls._db()
+        async with db.execute(
+            "SELECT key FROM workflow_kv WHERE key LIKE ? ESCAPE '\\' ORDER BY key",
+            (Storage._like_prefix_pattern(prefix),),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [str(row["key"]) for row in rows]
+
+    @classmethod
+    async def kv_list(cls, prefix: str) -> List[str]:
+        return await cls.kv_list_keys(prefix)
+
+    @classmethod
+    async def kv_entries(cls, prefix: str) -> List[Tuple[str, Any]]:
+        db = await cls._db()
+        async with db.execute(
+            "SELECT key, value FROM workflow_kv WHERE key LIKE ? ESCAPE '\\' ORDER BY key",
+            (Storage._like_prefix_pattern(prefix),),
+        ) as cur:
+            rows = await cur.fetchall()
+        entries: List[Tuple[str, Any]] = []
+        for row in rows:
+            entries.append((str(row["key"]), cls._json_loads(row["value"], None)))
+        return entries
+
+    @classmethod
+    async def kv_clear(cls, prefix: str) -> int:
+        db = await cls._db()
+        cur = await db.execute(
+            "DELETE FROM workflow_kv WHERE key LIKE ? ESCAPE '\\'",
+            (Storage._like_prefix_pattern(prefix),),
+        )
+        await db.commit()
+        return cur.rowcount
+
+
+_WORKFLOW_DDL = """
+CREATE TABLE IF NOT EXISTS workflow_executions (
+    id                 TEXT PRIMARY KEY,
+    workflow_id        TEXT NOT NULL,
+    status             TEXT NOT NULL,
+    current_phase      TEXT,
+    current_node_id    TEXT,
+    current_node_type  TEXT,
+    current_step_index INTEGER,
+    step_count         INTEGER NOT NULL DEFAULT 0,
+    input_params       TEXT NOT NULL DEFAULT '{}',
+    output_results     TEXT NOT NULL DEFAULT '{}',
+    error_message      TEXT,
+    trigger_id         TEXT,
+    trigger_type       TEXT,
+    started_at         INTEGER NOT NULL,
+    finished_at        INTEGER,
+    duration           REAL,
+    updated_at         INTEGER,
+    payload            TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workflow_execution_steps (
+    exec_id    TEXT NOT NULL,
+    step_index INTEGER NOT NULL,
+    node_id    TEXT,
+    node_type  TEXT,
+    inputs     TEXT NOT NULL DEFAULT '{}',
+    outputs    TEXT NOT NULL DEFAULT '{}',
+    error      TEXT,
+    payload    TEXT NOT NULL,
+    PRIMARY KEY (exec_id, step_index)
+);
+
+CREATE TABLE IF NOT EXISTS workflow_stats (
+    workflow_id   TEXT PRIMARY KEY,
+    call_count    INTEGER NOT NULL DEFAULT 0,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    error_count   INTEGER NOT NULL DEFAULT 0,
+    total_runtime REAL NOT NULL DEFAULT 0,
+    avg_runtime   REAL NOT NULL DEFAULT 0,
+    thumbs_up     INTEGER NOT NULL DEFAULT 0,
+    thumbs_down   INTEGER NOT NULL DEFAULT 0,
+    updated_at    INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS workflow_configs (
+    workflow_id TEXT NOT NULL,
+    kind        TEXT NOT NULL,
+    version     INTEGER,
+    config      TEXT NOT NULL,
+    updated_at  INTEGER,
+    PRIMARY KEY (workflow_id, kind)
+);
+
+CREATE TABLE IF NOT EXISTS workflow_kv (
+    key        TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    type       TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+"""
+
+_INDEX_STMTS = [
+    "CREATE INDEX IF NOT EXISTS idx_workflow_executions_workflow_started ON workflow_executions(workflow_id, started_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_workflow_executions_workflow_status ON workflow_executions(workflow_id, status)",
+    "CREATE INDEX IF NOT EXISTS idx_workflow_executions_trigger ON workflow_executions(workflow_id, trigger_type, trigger_id)",
+    "CREATE INDEX IF NOT EXISTS idx_workflow_execution_steps_exec_step ON workflow_execution_steps(exec_id, step_index)",
+]

--- a/flocks/workflow/triggers/runtime.py
+++ b/flocks/workflow/triggers/runtime.py
@@ -234,6 +234,7 @@ class TriggerRuntime:
                     "duration": time.time() - started_at,
                     "errorMessage": error_message,
                     "executionLog": compact_history_for_storage(result.history),
+                    "payloadRiskSummary": result.payload_risk_summary,
                     "currentNodeId": result.last_node_id,
                     "currentPhase": status_value,
                     "currentStepIndex": result.steps,

--- a/flocks/workflow/triggers/runtime.py
+++ b/flocks/workflow/triggers/runtime.py
@@ -7,7 +7,6 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-from flocks.storage.storage import Storage
 from flocks.utils.log import Log
 from flocks.workflow.execution_store import (
     compact_history_for_storage,
@@ -18,6 +17,7 @@ from flocks.workflow.execution_store import (
 )
 from flocks.workflow.fs_store import read_workflow_dir, workflow_scan_dirs
 from flocks.workflow.runner import run_workflow
+from flocks.workflow.store import WorkflowStore
 
 from .compat import (
     LEGACY_KAFKA_CONFIG_PREFIX,
@@ -45,6 +45,16 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
+def _config_kind_from_legacy_key(key: str) -> Optional[str]:
+    if key.startswith(LEGACY_POLLER_CONFIG_PREFIX):
+        return "workflow_poller_config"
+    if key.startswith(LEGACY_SYSLOG_CONFIG_PREFIX):
+        return "workflow_syslog_config"
+    if key.startswith(LEGACY_KAFKA_CONFIG_PREFIX):
+        return "workflow_kafka_config"
+    return None
+
+
 class TriggerRuntime:
     """Unified trigger runtime that wraps legacy managers and custom adapters."""
 
@@ -70,17 +80,20 @@ class TriggerRuntime:
 
     async def _write_disabled_legacy_configs(self, workflow_id: str) -> None:
         now_ms = _now_ms()
-        await Storage.write(
-            f"{LEGACY_POLLER_CONFIG_PREFIX}{workflow_id}",
+        await WorkflowStore.put_config(
+            workflow_id,
             {"workflowId": workflow_id, "enabled": False, "updatedAt": now_ms},
+            kind="workflow_poller_config",
         )
-        await Storage.write(
-            f"{LEGACY_SYSLOG_CONFIG_PREFIX}{workflow_id}",
+        await WorkflowStore.put_config(
+            workflow_id,
             {"workflowId": workflow_id, "enabled": False, "updatedAt": now_ms},
+            kind="workflow_syslog_config",
         )
-        await Storage.write(
-            f"{LEGACY_KAFKA_CONFIG_PREFIX}{workflow_id}",
+        await WorkflowStore.put_config(
+            workflow_id,
             {"workflowId": workflow_id, "enabled": False, "updatedAt": now_ms},
+            kind="workflow_kafka_config",
         )
 
     @staticmethod
@@ -88,7 +101,9 @@ class TriggerRuntime:
         payload = trigger.model_dump(mode="json", exclude_none=True)
         return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
-    async def _sync_legacy_configs_from_workflow(self, workflow_id: str, workflow_json: Dict[str, Any]) -> List[TriggerDefinition]:
+    async def _sync_legacy_configs_from_workflow(
+        self, workflow_id: str, workflow_json: Dict[str, Any]
+    ) -> List[TriggerDefinition]:
         triggers = workflow_trigger_definitions_from_json(workflow_json)
         if not triggers:
             if workflow_json_declares_triggers(workflow_json):
@@ -99,22 +114,27 @@ class TriggerRuntime:
         for trigger in triggers:
             key, value = trigger_to_legacy_config(workflow_id, trigger)
             if key and value is not None:
-                await Storage.write(key, value)
+                kind = _config_kind_from_legacy_key(key)
+                if kind:
+                    await WorkflowStore.put_config(workflow_id, value, kind=kind)
 
         if "schedule" not in by_type:
-            await Storage.write(
-                f"{LEGACY_POLLER_CONFIG_PREFIX}{workflow_id}",
+            await WorkflowStore.put_config(
+                workflow_id,
                 {"workflowId": workflow_id, "enabled": False, "updatedAt": _now_ms()},
+                kind="workflow_poller_config",
             )
         if "syslog" not in by_type:
-            await Storage.write(
-                f"{LEGACY_SYSLOG_CONFIG_PREFIX}{workflow_id}",
+            await WorkflowStore.put_config(
+                workflow_id,
                 {"workflowId": workflow_id, "enabled": False, "updatedAt": _now_ms()},
+                kind="workflow_syslog_config",
             )
         if "kafka" not in by_type:
-            await Storage.write(
-                f"{LEGACY_KAFKA_CONFIG_PREFIX}{workflow_id}",
+            await WorkflowStore.put_config(
+                workflow_id,
                 {"workflowId": workflow_id, "enabled": False, "updatedAt": _now_ms()},
+                kind="workflow_kafka_config",
             )
         return triggers
 
@@ -307,12 +327,11 @@ class TriggerRuntime:
                 continue
             key = (workflow_id, trigger.id or "")
             trigger_signature = desired_signatures[key]
-            if (
-                key in self._custom_adapter_tasks
-                and self._custom_adapter_signatures.get(key) == trigger_signature
-            ):
+            if key in self._custom_adapter_tasks and self._custom_adapter_signatures.get(key) == trigger_signature:
                 continue
-            plugin_id = str((trigger.source or {}).get("adapterId") or (trigger.source or {}).get("pluginId") or "").strip()
+            plugin_id = str(
+                (trigger.source or {}).get("adapterId") or (trigger.source or {}).get("pluginId") or ""
+            ).strip()
             plugin_spec = next((item for item in list_trigger_plugins() if item.get("id") == plugin_id), None)
             if plugin_spec is None:
                 self._custom_status[key] = {
@@ -352,11 +371,15 @@ class TriggerRuntime:
                 continue
 
             async def _emit(payload: Any, *, _trigger: TriggerDefinition = trigger) -> Dict[str, Any]:
-                event = payload if isinstance(payload, TriggerEvent) else build_trigger_event(
-                    workflow_id=workflow_id,
-                    trigger=_trigger,
-                    body=payload,
-                    raw=payload,
+                event = (
+                    payload
+                    if isinstance(payload, TriggerEvent)
+                    else build_trigger_event(
+                        workflow_id=workflow_id,
+                        trigger=_trigger,
+                        body=payload,
+                        raw=payload,
+                    )
                 )
                 try:
                     result = await self.dispatch_event(

--- a/flocks/workflow/workflow_lint.py
+++ b/flocks/workflow/workflow_lint.py
@@ -15,9 +15,7 @@ _CN_BULLET_KEY_RE = re.compile(r"^\s*[-*]\s*(?P<key>[A-Za-z0-9_\-]+)\s*[:：]\s*
 _CN_SECTION_OUTPUT_RE = re.compile(r"^\s*输出要求\s*[:：]?\s*$")
 
 # Patterns that indicate an "expensive" node (LLM call / file write).
-_EXPENSIVE_CALL_RE = re.compile(
-    r"""llm\.ask\s*\(|tool\.run\s*\(\s*['"]write['"]"""
-)
+_EXPENSIVE_CALL_RE = re.compile(r"""llm\.ask\s*\(|tool\.run\s*\(\s*['"]write['"]""")
 
 
 def _split_keys(raw: str) -> list[str]:
@@ -69,6 +67,61 @@ def estimate_node_output_keys(node: Node) -> Set[str]:
     return keys
 
 
+def _strict_edge_mapping_enabled(workflow: Workflow) -> bool:
+    metadata = workflow.metadata if isinstance(workflow.metadata, dict) else {}
+    candidates = [
+        metadata.get("strict_edge_mapping"),
+        metadata.get("strictEdgeMapping"),
+    ]
+    for section_key in ("runtime", "runtime_defaults", "runtimeDefaults"):
+        section = metadata.get(section_key)
+        if isinstance(section, dict):
+            candidates.extend(
+                [
+                    section.get("strict_edge_mapping"),
+                    section.get("strictEdgeMapping"),
+                ]
+            )
+    for value in candidates:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "off"}:
+                return False
+    return False
+
+
+def lint_implicit_full_payload_edges(workflow: Workflow) -> List[Dict[str, Any]]:
+    nodes = workflow.nodes_by_id()
+    strict = _strict_edge_mapping_enabled(workflow)
+    severity = "error" if strict else "warning"
+    results: list[dict[str, Any]] = []
+    for edge in workflow.edges:
+        if edge.mapping:
+            continue
+        upstream = nodes.get(edge.from_)
+        downstream = nodes.get(edge.to)
+        results.append(
+            {
+                "kind": "implicit_full_payload_edge",
+                "severity": severity,
+                "edge_from": edge.from_,
+                "edge_to": edge.to,
+                "upstream_type": getattr(upstream, "type", None),
+                "downstream_type": getattr(downstream, "type", None),
+                "strict_edge_mapping": strict,
+                "message": (
+                    f"edge {edge.from_!r}->{edge.to!r} has no mapping; the full upstream "
+                    "payload will be passed to the downstream node"
+                ),
+            }
+        )
+    return results
+
+
 def lint_workflow_mappings(workflow: Workflow) -> List[Dict[str, Any]]:
     nodes = workflow.nodes_by_id()
     warnings: list[dict[str, Any]] = []
@@ -85,32 +138,36 @@ def lint_workflow_mappings(workflow: Workflow) -> List[Dict[str, Any]]:
                 src_path = src_path[2:]
             top_key = src_path.split(".", 1)[0] if src_path else ""
             if top_key and upstream_out and top_key not in upstream_out:
-                warnings.append({
-                    "kind": "mapping_src_key_not_in_upstream_outputs",
-                    "edge_from": e.from_,
-                    "edge_to": e.to,
-                    "dst_key": dst,
-                    "src_path": src,
-                    "upstream_type": getattr(upstream, "type", None),
-                    "estimated_upstream_output_keys": sorted(upstream_out)[:50],
-                    "message": (
-                        f"edge.mapping maps src {src!r} but upstream node {e.from_!r} "
-                        "does not appear to write that key to outputs; mapping may produce missing value"
-                    ),
-                })
+                warnings.append(
+                    {
+                        "kind": "mapping_src_key_not_in_upstream_outputs",
+                        "edge_from": e.from_,
+                        "edge_to": e.to,
+                        "dst_key": dst,
+                        "src_path": src,
+                        "upstream_type": getattr(upstream, "type", None),
+                        "estimated_upstream_output_keys": sorted(upstream_out)[:50],
+                        "message": (
+                            f"edge.mapping maps src {src!r} but upstream node {e.from_!r} "
+                            "does not appear to write that key to outputs; mapping may produce missing value"
+                        ),
+                    }
+                )
             if dst == src and not (e.const or {}):
-                warnings.append({
-                    "kind": "scheme_a_suggest_omit_identity_mapping",
-                    "severity": "warning",
-                    "edge_from": e.from_,
-                    "edge_to": e.to,
-                    "dst_key": dst,
-                    "src_path": src,
-                    "message": (
-                        "edge.mapping is an identity mapping. Scheme A recommends omitting mapping "
-                        "to pass through the full payload and reduce missing-key issues."
-                    ),
-                })
+                warnings.append(
+                    {
+                        "kind": "scheme_a_suggest_omit_identity_mapping",
+                        "severity": "warning",
+                        "edge_from": e.from_,
+                        "edge_to": e.to,
+                        "dst_key": dst,
+                        "src_path": src,
+                        "message": (
+                            "edge.mapping is an identity mapping. Scheme A recommends omitting mapping "
+                            "to pass through the full payload and reduce missing-key issues."
+                        ),
+                    }
+                )
     return warnings
 
 
@@ -184,18 +241,20 @@ def lint_join_requirements(workflow: Workflow) -> List[Dict[str, Any]]:
                 break
 
         if not is_exclusive:
-            results.append({
-                "kind": "multi_incoming_no_join",
-                "severity": "error",
-                "node_id": nid,
-                "sources": sorted(sources),
-                "message": (
-                    f"Node {nid!r} has {len(sources)} incoming edges from "
-                    f"non-exclusive sources {sorted(unique_sources)} but join=false. "
-                    "This will cause the node to execute multiple times. "
-                    "Set join=true on this node or restructure edges."
-                ),
-            })
+            results.append(
+                {
+                    "kind": "multi_incoming_no_join",
+                    "severity": "error",
+                    "node_id": nid,
+                    "sources": sorted(sources),
+                    "message": (
+                        f"Node {nid!r} has {len(sources)} incoming edges from "
+                        f"non-exclusive sources {sorted(unique_sources)} but join=false. "
+                        "This will cause the node to execute multiple times. "
+                        "Set join=true on this node or restructure edges."
+                    ),
+                }
+            )
     return results
 
 
@@ -234,18 +293,20 @@ def lint_expensive_node_multi_trigger(workflow: Workflow) -> List[Dict[str, Any]
                 break
 
         if not is_exclusive:
-            results.append({
-                "kind": "expensive_node_multi_trigger",
-                "severity": "error",
-                "node_id": nid,
-                "sources": sorted(sources),
-                "message": (
-                    f"Expensive node {nid!r} (contains LLM/write calls) has "
-                    f"{len(sources)} non-exclusive incoming edges but join=false. "
-                    "This may cause costly duplicate execution. "
-                    "Add a join node before this expensive node."
-                ),
-            })
+            results.append(
+                {
+                    "kind": "expensive_node_multi_trigger",
+                    "severity": "error",
+                    "node_id": nid,
+                    "sources": sorted(sources),
+                    "message": (
+                        f"Expensive node {nid!r} (contains LLM/write calls) has "
+                        f"{len(sources)} non-exclusive incoming edges but join=false. "
+                        "This may cause costly duplicate execution. "
+                        "Add a join node before this expensive node."
+                    ),
+                }
+            )
     return results
 
 
@@ -266,15 +327,17 @@ def lint_subworkflow_depth(workflow: Workflow) -> List[Dict[str, Any]]:
     results: List[Dict[str, Any]] = []
     for node in workflow.nodes:
         if node.type == "subworkflow":
-            results.append({
-                "kind": "SW-001",
-                "severity": "error",
-                "node_id": node.id,
-                "message": (
-                    f"Node {node.id!r} is a subworkflow node. "
-                    "Sub-workflows cannot nest further sub-workflows (max depth=1)."
-                ),
-            })
+            results.append(
+                {
+                    "kind": "SW-001",
+                    "severity": "error",
+                    "node_id": node.id,
+                    "message": (
+                        f"Node {node.id!r} is a subworkflow node. "
+                        "Sub-workflows cannot nest further sub-workflows (max depth=1)."
+                    ),
+                }
+            )
     return results
 
 
@@ -294,23 +357,27 @@ def lint_subworkflow_ids(
         if node.type == "subworkflow":
             wid = node.workflow_id or ""
             if not wid:
-                results.append({
-                    "kind": "SW-002",
-                    "severity": "error",
-                    "node_id": node.id,
-                    "message": f"subworkflow node {node.id!r} has no workflow_id set.",
-                })
+                results.append(
+                    {
+                        "kind": "SW-002",
+                        "severity": "error",
+                        "node_id": node.id,
+                        "message": f"subworkflow node {node.id!r} has no workflow_id set.",
+                    }
+                )
             elif wid not in known_workflow_ids:
-                results.append({
-                    "kind": "SW-002",
-                    "severity": "error",
-                    "node_id": node.id,
-                    "workflow_id": wid,
-                    "message": (
-                        f"subworkflow node {node.id!r} references workflow_id={wid!r} "
-                        "which was not found in the known workflow registry."
-                    ),
-                })
+                results.append(
+                    {
+                        "kind": "SW-002",
+                        "severity": "error",
+                        "node_id": node.id,
+                        "workflow_id": wid,
+                        "message": (
+                            f"subworkflow node {node.id!r} references workflow_id={wid!r} "
+                            "which was not found in the known workflow registry."
+                        ),
+                    }
+                )
     return results
 
 
@@ -338,6 +405,7 @@ def lint_workflow(
             subworkflow nodes.
     """
     results: List[Dict[str, Any]] = []
+    results.extend(lint_implicit_full_payload_edges(workflow))
     # Existing mapping checks (warnings)
     for item in lint_workflow_mappings(workflow):
         item.setdefault("severity", "warning")

--- a/flocks/workflow/workflow_lint.py
+++ b/flocks/workflow/workflow_lint.py
@@ -16,6 +16,7 @@ _CN_SECTION_OUTPUT_RE = re.compile(r"^\s*输出要求\s*[:：]?\s*$")
 
 # Patterns that indicate an "expensive" node (LLM call / file write).
 _EXPENSIVE_CALL_RE = re.compile(r"""llm\.ask\s*\(|tool\.run\s*\(\s*['"]write['"]""")
+_STRICT_MAPPING_TRIGGER_TYPES = {"syslog", "kafka", "schedule"}
 
 
 def _split_keys(raw: str) -> list[str]:
@@ -94,6 +95,19 @@ def _strict_edge_mapping_enabled(workflow: Workflow) -> bool:
     return False
 
 
+def _workflow_has_strict_mapping_setting(workflow: Workflow) -> bool:
+    metadata = workflow.metadata if isinstance(workflow.metadata, dict) else {}
+    if "strict_edge_mapping" in metadata or "strictEdgeMapping" in metadata:
+        return True
+    for section_key in ("runtime", "runtime_defaults", "runtimeDefaults"):
+        section = metadata.get(section_key)
+        if isinstance(section, dict) and (
+            "strict_edge_mapping" in section or "strictEdgeMapping" in section
+        ):
+            return True
+    return False
+
+
 def lint_implicit_full_payload_edges(workflow: Workflow) -> List[Dict[str, Any]]:
     nodes = workflow.nodes_by_id()
     strict = _strict_edge_mapping_enabled(workflow)
@@ -120,6 +134,39 @@ def lint_implicit_full_payload_edges(workflow: Workflow) -> List[Dict[str, Any]]
             }
         )
     return results
+
+
+def lint_recommend_strict_edge_mapping(workflow: Workflow) -> List[Dict[str, Any]]:
+    """Recommend strict edge mapping for high-volume trigger workflows.
+
+    This intentionally stays a warning so existing workflow execution remains
+    compatible unless the workflow explicitly opts into strict mode.
+    """
+    if _workflow_has_strict_mapping_setting(workflow):
+        return []
+
+    trigger_types = sorted(
+        {
+            trigger.type
+            for trigger in workflow.triggers
+            if getattr(trigger, "type", None) in _STRICT_MAPPING_TRIGGER_TYPES
+        }
+    )
+    if not trigger_types:
+        return []
+
+    return [
+        {
+            "kind": "recommend_strict_edge_mapping",
+            "severity": "warning",
+            "trigger_types": trigger_types,
+            "message": (
+                "workflows triggered by syslog, kafka, or schedule can process high-volume "
+                "payloads; set metadata.runtime.strict_edge_mapping=true and use explicit "
+                "edge mappings for new workflow definitions"
+            ),
+        }
+    ]
 
 
 def lint_workflow_mappings(workflow: Workflow) -> List[Dict[str, Any]]:
@@ -150,21 +197,6 @@ def lint_workflow_mappings(workflow: Workflow) -> List[Dict[str, Any]]:
                         "message": (
                             f"edge.mapping maps src {src!r} but upstream node {e.from_!r} "
                             "does not appear to write that key to outputs; mapping may produce missing value"
-                        ),
-                    }
-                )
-            if dst == src and not (e.const or {}):
-                warnings.append(
-                    {
-                        "kind": "scheme_a_suggest_omit_identity_mapping",
-                        "severity": "warning",
-                        "edge_from": e.from_,
-                        "edge_to": e.to,
-                        "dst_key": dst,
-                        "src_path": src,
-                        "message": (
-                            "edge.mapping is an identity mapping. Scheme A recommends omitting mapping "
-                            "to pass through the full payload and reduce missing-key issues."
                         ),
                     }
                 )
@@ -406,6 +438,7 @@ def lint_workflow(
     """
     results: List[Dict[str, Any]] = []
     results.extend(lint_implicit_full_payload_edges(workflow))
+    results.extend(lint_recommend_strict_edge_mapping(workflow))
     # Existing mapping checks (warnings)
     for item in lint_workflow_mappings(workflow):
         item.setdefault("severity", "warning")

--- a/flocks/workflow/workflow_lint.py
+++ b/flocks/workflow/workflow_lint.py
@@ -162,8 +162,9 @@ def lint_recommend_strict_edge_mapping(workflow: Workflow) -> List[Dict[str, Any
             "trigger_types": trigger_types,
             "message": (
                 "workflows triggered by syslog, kafka, or schedule can process high-volume "
-                "payloads; set metadata.runtime.strict_edge_mapping=true and use explicit "
-                "edge mappings for new workflow definitions"
+                "payloads; set metadata.runtime.strict_edge_mapping=true, "
+                "metadata.runtime.dataflow_mode='vertex_cache', and use explicit edge "
+                "mappings for new workflow definitions"
             ),
         }
     ]

--- a/tests/ingest/test_kafka_manager.py
+++ b/tests/ingest/test_kafka_manager.py
@@ -167,10 +167,12 @@ async def test_restart_disabled_config_reports_stopped(monkeypatch: pytest.Monke
 
     manager = kafka_manager.KafkaManager()
 
-    async def _fake_read(key):  # noqa: ANN001
+    async def _fake_get_config(workflow_id: str, *, kind: str) -> dict:
+        assert workflow_id == "wf-disabled"
+        assert kind == "workflow_kafka_config"
         return {"enabled": False}
 
-    monkeypatch.setattr(kafka_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(kafka_manager.WorkflowStore, "get_config", _fake_get_config)
 
     status = await manager.restart_workflow("wf-disabled")
     assert status == {"state": "stopped", "error": None}
@@ -182,10 +184,12 @@ async def test_restart_missing_broker_reports_failed(monkeypatch: pytest.MonkeyP
 
     manager = kafka_manager.KafkaManager()
 
-    async def _fake_read(key):  # noqa: ANN001
+    async def _fake_get_config(workflow_id: str, *, kind: str) -> dict:
+        assert workflow_id == "wf-no-broker"
+        assert kind == "workflow_kafka_config"
         return {"enabled": True, "inputBroker": "", "inputTopic": ""}
 
-    monkeypatch.setattr(kafka_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(kafka_manager.WorkflowStore, "get_config", _fake_get_config)
 
     status = await manager.restart_workflow("wf-no-broker")
     assert status["state"] == "failed"
@@ -201,7 +205,9 @@ async def test_restart_workflow_cleans_resources_after_connect_failure(
     manager = kafka_manager.KafkaManager()
     workflow_id = "wf-connect-failed"
 
-    async def _fake_read(key):  # noqa: ANN001
+    async def _fake_get_config(workflow_id_value: str, *, kind: str) -> dict:
+        assert workflow_id_value == workflow_id
+        assert kind == "workflow_kafka_config"
         return {
             "enabled": True,
             "inputBroker": "localhost:9092",
@@ -220,7 +226,7 @@ async def test_restart_workflow_cleans_resources_after_connect_failure(
         async def stop(self) -> None:
             self.stopped = True
 
-    monkeypatch.setattr(kafka_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(kafka_manager.WorkflowStore, "get_config", _fake_get_config)
     monkeypatch.setattr(
         kafka_manager,
         "read_workflow_from_fs",

--- a/tests/server/routes/test_workflow_poller_routes.py
+++ b/tests/server/routes/test_workflow_poller_routes.py
@@ -16,8 +16,8 @@ async def test_save_poller_config_restarts_manager(
 ) -> None:
     writes: list[tuple[str, dict[str, Any]]] = []
 
-    async def _fake_write(key: Any, value: dict[str, Any]) -> None:
-        writes.append((key, value))
+    async def _fake_put_config(workflow_id: str, config: dict[str, Any], *, kind: str | None = None) -> None:
+        writes.append((f"{kind}/{workflow_id}", config))
 
     async def _fake_restart(workflow_id: str) -> dict[str, Any]:
         assert workflow_id == "wf-1"
@@ -26,9 +26,11 @@ async def test_save_poller_config_restarts_manager(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {"workflowJson": {"start": "n1", "nodes": [], "edges": []}} if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {"workflowJson": {"start": "n1", "nodes": [], "edges": []}} if workflow_id == "wf-1" else None
+        ),
     )
-    monkeypatch.setattr(workflow_routes.Storage, "write", _fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "put_config", _fake_put_config)
     monkeypatch.setattr(
         "flocks.workflow.poller_manager.default_manager",
         SimpleNamespace(restart_workflow=_fake_restart),
@@ -64,8 +66,8 @@ async def test_save_poller_config_preserves_cron_schedule(
     writes: list[tuple[str, dict[str, Any]]] = []
     persisted_sources: list[dict[str, Any]] = []
 
-    async def _fake_write(key: Any, value: dict[str, Any]) -> None:
-        writes.append((key, value))
+    async def _fake_put_config(workflow_id: str, config: dict[str, Any], *, kind: str | None = None) -> None:
+        writes.append((f"{kind}/{workflow_id}", config))
 
     async def _fake_persist(
         _workflow_id: str,
@@ -81,9 +83,11 @@ async def test_save_poller_config_preserves_cron_schedule(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {"workflowJson": {"start": "n1", "nodes": [], "edges": []}} if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {"workflowJson": {"start": "n1", "nodes": [], "edges": []}} if workflow_id == "wf-1" else None
+        ),
     )
-    monkeypatch.setattr(workflow_routes.Storage, "write", _fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "put_config", _fake_put_config)
     monkeypatch.setattr(workflow_routes, "_persist_workflow_triggers", _fake_persist)
     monkeypatch.setattr(
         "flocks.workflow.poller_manager.default_manager",
@@ -119,8 +123,8 @@ async def test_get_poller_config_returns_saved_data(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _fake_read(_key: Any, *_args: Any, **_kwargs: Any) -> dict[str, Any] | None:
-        if _key != "workflow_poller_config/wf-1":
+    async def _fake_get_config(workflow_id: str, *, kind: str = "workflow.integration-config") -> dict[str, Any] | None:
+        if workflow_id != "wf-1" or kind != "workflow_poller_config":
             return None
         return {
             "workflowId": "wf-1",
@@ -131,7 +135,7 @@ async def test_get_poller_config_returns_saved_data(
             "inputs": {"dedup_source_workflow_name": "stream_alert_denoise_gt_fast"},
         }
 
-    monkeypatch.setattr(workflow_routes.Storage, "read", _fake_read)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "get_config", _fake_get_config)
 
     response = await client.get("/api/workflow/wf-1/poller-config")
     assert response.status_code == 200, response.text
@@ -178,7 +182,9 @@ async def test_run_poller_once_returns_latest_status(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {"workflowJson": {"start": "n1", "nodes": [], "edges": []}} if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {"workflowJson": {"start": "n1", "nodes": [], "edges": []}} if workflow_id == "wf-1" else None
+        ),
     )
     monkeypatch.setattr(
         "flocks.workflow.poller_manager.default_manager",

--- a/tests/server/routes/test_workflow_publish_api.py
+++ b/tests/server/routes/test_workflow_publish_api.py
@@ -20,16 +20,20 @@ async def test_publish_workflow_as_api_reuses_key_for_runtime(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda requested_id: {
-            "id": requested_id,
-            "name": "Demo Workflow",
-            "workflowJson": {
+        lambda requested_id: (
+            {
                 "id": requested_id,
-                "start": "n1",
-                "nodes": [{"id": "n1", "type": "python", "code": "outputs['ok'] = True"}],
-                "edges": [],
-            },
-        } if requested_id == workflow_id else None,
+                "name": "Demo Workflow",
+                "workflowJson": {
+                    "id": requested_id,
+                    "start": "n1",
+                    "nodes": [{"id": "n1", "type": "python", "code": "outputs['ok'] = True"}],
+                    "edges": [],
+                },
+            }
+            if requested_id == workflow_id
+            else None
+        ),
     )
     monkeypatch.setattr(workflow_routes.Config, "get_data_path", lambda: tmp_path)
 
@@ -47,12 +51,14 @@ async def test_publish_workflow_as_api_reuses_key_for_runtime(
         driver: str | None = None,
         api_key: str | None = None,
     ) -> dict[str, Any]:
-        publish_calls.append({
-            "workflow_id": requested_id,
-            "image": image,
-            "driver": driver,
-            "api_key": api_key,
-        })
+        publish_calls.append(
+            {
+                "workflow_id": requested_id,
+                "image": image,
+                "driver": driver,
+                "api_key": api_key,
+            }
+        )
         return {
             "serviceUrl": "http://127.0.0.1:19000",
             "containerName": "local-wf-1",
@@ -60,8 +66,8 @@ async def test_publish_workflow_as_api_reuses_key_for_runtime(
             "apiKey": api_key,
         }
 
-    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", fake_read)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_put", fake_write)
     monkeypatch.setattr(workflow_routes, "publish_workflow", fake_publish_workflow)
 
     result = await workflow_routes.publish_workflow_as_api(
@@ -69,12 +75,14 @@ async def test_publish_workflow_as_api_reuses_key_for_runtime(
         workflow_routes.WorkflowCenterPublishRequest(driver="local"),
     )
 
-    assert publish_calls == [{
-        "workflow_id": workflow_id,
-        "image": None,
-        "driver": "local",
-        "api_key": existing_key,
-    }]
+    assert publish_calls == [
+        {
+            "workflow_id": workflow_id,
+            "image": None,
+            "driver": "local",
+            "api_key": existing_key,
+        }
+    ]
     assert result["apiKey"] == existing_key
     assert writes[workflow_routes._api_service_key(workflow_id)]["apiKey"] == existing_key
 
@@ -124,12 +132,14 @@ async def test_reconcile_published_workflow_api_services_restarts_unhealthy_serv
         driver: str | None = None,
         api_key: str | None = None,
     ) -> dict[str, Any]:
-        publish_calls.append({
-            "workflow_id": requested_id,
-            "image": image,
-            "driver": driver,
-            "api_key": api_key,
-        })
+        publish_calls.append(
+            {
+                "workflow_id": requested_id,
+                "image": image,
+                "driver": driver,
+                "api_key": api_key,
+            }
+        )
         return {
             "serviceUrl": "http://127.0.0.1:19001",
             "containerName": "flocks-wf-wf-1-rel-1",
@@ -138,9 +148,9 @@ async def test_reconcile_published_workflow_api_services_restarts_unhealthy_serv
             "apiKey": api_key,
         }
 
-    monkeypatch.setattr(workflow_routes.Storage, "list_keys", fake_list_keys)
-    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_list_keys", fake_list_keys)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", fake_read)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_put", fake_write)
     monkeypatch.setattr(workflow_routes, "get_workflow_health", fake_health)
     monkeypatch.setattr(workflow_routes, "_prepare_workflow_api_registry", fake_prepare_registry)
     monkeypatch.setattr(workflow_routes, "publish_workflow", fake_publish_workflow)
@@ -149,12 +159,14 @@ async def test_reconcile_published_workflow_api_services_restarts_unhealthy_serv
 
     assert result["checked"] == 1
     assert result["restarted"] == 1
-    assert publish_calls == [{
-        "workflow_id": workflow_id,
-        "image": "custom-image:latest",
-        "driver": "docker",
-        "api_key": existing_key,
-    }]
+    assert publish_calls == [
+        {
+            "workflow_id": workflow_id,
+            "image": "custom-image:latest",
+            "driver": "docker",
+            "api_key": existing_key,
+        }
+    ]
     assert store[service_key]["status"] == "running"
     assert store[service_key]["apiKey"] == existing_key
     assert store[service_key]["serviceUrl"] == "http://127.0.0.1:19001"
@@ -208,9 +220,9 @@ async def test_reconcile_published_workflow_api_services_restarts_health_marked_
             "apiKey": api_key,
         }
 
-    monkeypatch.setattr(workflow_routes.Storage, "list_keys", fake_list_keys)
-    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_list_keys", fake_list_keys)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", fake_read)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_put", fake_write)
     monkeypatch.setattr(workflow_routes, "get_workflow_health", fake_health)
     monkeypatch.setattr(workflow_routes, "_prepare_workflow_api_registry", fake_prepare_registry)
     monkeypatch.setattr(workflow_routes, "publish_workflow", fake_publish_workflow)
@@ -251,8 +263,8 @@ async def test_reconcile_published_workflow_api_services_skips_manually_stopped_
         health_calls.append(requested_id)
         return {"ok": True}
 
-    monkeypatch.setattr(workflow_routes.Storage, "list_keys", fake_list_keys)
-    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_list_keys", fake_list_keys)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", fake_read)
     monkeypatch.setattr(workflow_routes, "get_workflow_health", fake_health)
 
     result = await workflow_routes.reconcile_published_workflow_api_services()
@@ -286,8 +298,8 @@ async def test_get_workflow_service_does_not_probe_runtime_health(
         health_calls.append(requested_id)
         return {"ok": False, "published": False}
 
-    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", fake_read)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_put", fake_write)
     monkeypatch.setattr(workflow_routes, "get_workflow_health", fake_health)
 
     result = await workflow_routes.get_workflow_service(workflow_id)
@@ -327,9 +339,9 @@ async def test_list_workflow_services_marks_stale_running_service_stopped_in_res
     async def fake_write(key: Any, value: Any) -> None:
         writes.append((key, value))
 
-    monkeypatch.setattr(workflow_routes.Storage, "list_keys", fake_list_keys)
-    monkeypatch.setattr(workflow_routes.Storage, "read", fake_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_list_keys", fake_list_keys)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", fake_read)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_put", fake_write)
 
     result = await workflow_routes.list_workflow_services()
 

--- a/tests/server/routes/test_workflow_run_route.py
+++ b/tests/server/routes/test_workflow_run_route.py
@@ -8,6 +8,73 @@ from flocks.tool import ToolContext
 import flocks.server.routes.workflow as workflow_module
 
 
+def _minimal_workflow_json(metadata=None):
+    workflow = {
+        "name": "minimal",
+        "start": "start",
+        "nodes": [{"id": "start", "type": "python", "code": "outputs['ok'] = True"}],
+        "edges": [],
+    }
+    if metadata is not None:
+        workflow["metadata"] = metadata
+    return workflow
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_applies_vertex_cache_runtime_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    writes: list[dict] = []
+
+    def _fake_write_workflow_to_fs(workflow_id, workflow_json, meta, *args, **kwargs):
+        writes.append({"workflow_id": workflow_id, "workflow_json": workflow_json, "meta": meta})
+
+    monkeypatch.setattr(workflow_module, "_write_workflow_to_fs", _fake_write_workflow_to_fs)
+    monkeypatch.setattr(workflow_module, "_get_workflow_stats", AsyncMock(return_value={}))
+    monkeypatch.setattr(workflow_module, "publish_event", AsyncMock(return_value=None))
+
+    req = workflow_module.WorkflowCreateRequest(
+        name="new workflow",
+        workflowJson=_minimal_workflow_json(),
+    )
+
+    result = await workflow_module.create_workflow(req)
+
+    runtime = result.workflowJson["metadata"]["runtime"]
+    assert runtime["strict_edge_mapping"] is True
+    assert runtime["dataflow_mode"] == "vertex_cache"
+    assert writes[0]["workflow_json"]["metadata"]["runtime"] == runtime
+
+
+@pytest.mark.asyncio
+async def test_create_workflow_preserves_explicit_runtime_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    writes: list[dict] = []
+
+    def _fake_write_workflow_to_fs(workflow_id, workflow_json, meta, *args, **kwargs):
+        writes.append({"workflow_id": workflow_id, "workflow_json": workflow_json, "meta": meta})
+
+    monkeypatch.setattr(workflow_module, "_write_workflow_to_fs", _fake_write_workflow_to_fs)
+    monkeypatch.setattr(workflow_module, "_get_workflow_stats", AsyncMock(return_value={}))
+    monkeypatch.setattr(workflow_module, "publish_event", AsyncMock(return_value=None))
+
+    req = workflow_module.WorkflowCreateRequest(
+        name="legacy workflow",
+        workflowJson=_minimal_workflow_json(
+            {
+                "runtime": {
+                    "strict_edge_mapping": False,
+                    "dataflow_mode": "legacy",
+                }
+            }
+        ),
+    )
+
+    result = await workflow_module.create_workflow(req)
+
+    runtime = result.workflowJson["metadata"]["runtime"]
+    assert runtime["strict_edge_mapping"] is False
+    assert runtime["dataflow_mode"] == "legacy"
+    assert writes[0]["workflow_json"]["metadata"]["runtime"] == runtime
+
+
 @pytest.mark.asyncio
 async def test_run_workflow_execution_task_reuses_existing_mcp_without_reinit(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/routes/test_workflow_run_route.py
+++ b/tests/server/routes/test_workflow_run_route.py
@@ -64,7 +64,7 @@ async def test_save_kafka_config_persists_consumer_settings(
 ) -> None:
     from flocks.ingest.kafka import manager as kafka_manager
 
-    storage_write = AsyncMock(return_value=None)
+    put_config = AsyncMock(return_value=None)
     restart_workflow = AsyncMock(return_value={"state": "running", "error": None})
     persisted_triggers: list[list[str]] = []
 
@@ -73,7 +73,7 @@ async def test_save_kafka_config_persists_consumer_settings(
         "_read_workflow_from_fs",
         lambda _workflow_id: {"id": "wf-input", "workflowJson": {}},
     )
-    monkeypatch.setattr(workflow_module.Storage, "write", storage_write)
+    monkeypatch.setattr(workflow_module.WorkflowStore, "put_config", put_config)
     monkeypatch.setattr(kafka_manager.default_manager, "restart_workflow", restart_workflow)
     monkeypatch.setattr(workflow_module, "_get_workflow_trigger_defs", AsyncMock(return_value=[]))
 
@@ -105,8 +105,10 @@ async def test_save_kafka_config_persists_consumer_settings(
     response = await workflow_module.save_kafka_config("wf-input", req)
 
     assert response == {"ok": True, "consumer": {"state": "running", "error": None}}
-    storage_write.assert_awaited_once()
-    _, saved_config = storage_write.await_args.args
+    put_config.assert_awaited_once()
+    workflow_id, saved_config = put_config.await_args.args
+    assert workflow_id == "wf-input"
+    assert put_config.await_args.kwargs["kind"] == "workflow_kafka_config"
     assert saved_config["enabled"] is True
     assert saved_config["inputBroker"] == "localhost:9092"
     assert saved_config["inputTopic"] == "workflow-input"
@@ -129,7 +131,7 @@ async def test_save_syslog_config_persists_listener_settings(
 ) -> None:
     from flocks.ingest.syslog import manager as syslog_manager
 
-    storage_write = AsyncMock(return_value=None)
+    put_config = AsyncMock(return_value=None)
     restart_workflow = AsyncMock(return_value={"state": "listening", "error": None})
     persisted_triggers: list[list[str]] = []
 
@@ -138,7 +140,7 @@ async def test_save_syslog_config_persists_listener_settings(
         "_read_workflow_from_fs",
         lambda _workflow_id: {"id": "wf-input", "workflowJson": {}},
     )
-    monkeypatch.setattr(workflow_module.Storage, "write", storage_write)
+    monkeypatch.setattr(workflow_module.WorkflowStore, "put_config", put_config)
     monkeypatch.setattr(syslog_manager.default_manager, "restart_workflow", restart_workflow)
     monkeypatch.setattr(workflow_module, "_get_workflow_trigger_defs", AsyncMock(return_value=[]))
 
@@ -166,8 +168,10 @@ async def test_save_syslog_config_persists_listener_settings(
     response = await workflow_module.save_syslog_config("wf-input", req)
 
     assert response == {"ok": True, "listener": {"state": "listening", "error": None}}
-    storage_write.assert_awaited_once()
-    _, saved_config = storage_write.await_args.args
+    put_config.assert_awaited_once()
+    workflow_id, saved_config = put_config.await_args.args
+    assert workflow_id == "wf-input"
+    assert put_config.await_args.kwargs["kind"] == "workflow_syslog_config"
     assert saved_config["enabled"] is True
     assert saved_config["protocol"] == "udp"
     assert saved_config["host"] == "0.0.0.0"

--- a/tests/server/routes/test_workflow_trigger_routes.py
+++ b/tests/server/routes/test_workflow_trigger_routes.py
@@ -20,22 +20,26 @@ async def test_list_workflow_triggers_returns_unified_status(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {
-            "id": workflow_id,
-            "workflowJson": {
-                "start": "n1",
-                "nodes": [{"id": "n1", "type": "python", "code": "result = {'ok': True}"}],
-                "edges": [],
-                "triggers": [
-                    {
-                        "id": "schedule-default",
-                        "type": "schedule",
-                        "enabled": True,
-                        "source": {"intervalSeconds": 60},
-                    }
-                ],
-            },
-        } if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {
+                "id": workflow_id,
+                "workflowJson": {
+                    "start": "n1",
+                    "nodes": [{"id": "n1", "type": "python", "code": "result = {'ok': True}"}],
+                    "edges": [],
+                    "triggers": [
+                        {
+                            "id": "schedule-default",
+                            "type": "schedule",
+                            "enabled": True,
+                            "source": {"intervalSeconds": 60},
+                        }
+                    ],
+                },
+            }
+            if workflow_id == "wf-1"
+            else None
+        ),
     )
 
     async def _fake_statuses(_workflow_id: str, _workflow_json: dict[str, Any]) -> list[dict[str, Any]]:
@@ -70,15 +74,19 @@ async def test_list_workflow_triggers_respects_explicit_empty_trigger_list(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {
-            "id": workflow_id,
-            "workflowJson": {
-                "start": "n1",
-                "nodes": [{"id": "n1", "type": "python", "code": "result = {'ok': True}"}],
-                "edges": [],
-                "triggers": [],
-            },
-        } if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {
+                "id": workflow_id,
+                "workflowJson": {
+                    "start": "n1",
+                    "nodes": [{"id": "n1", "type": "python", "code": "result = {'ok': True}"}],
+                    "edges": [],
+                    "triggers": [],
+                },
+            }
+            if workflow_id == "wf-1"
+            else None
+        ),
     )
 
     async def _fake_legacy_triggers(_workflow_id: str) -> list[Any]:
@@ -148,27 +156,31 @@ async def test_workflow_config_response_keeps_template_separate_from_runtime(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {
-            "id": workflow_id,
-            "name": "demo",
-            "workflowJson": {
-                "start": "n1",
-                "nodes": [{"id": "n1", "type": "python", "code": "result = {'ok': True}"}],
-                "edges": [],
-                "triggers": [
-                    {
-                        "id": "syslog-default",
-                        "type": "syslog",
-                        "enabled": True,
-                    }
-                ],
-            },
-        } if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {
+                "id": workflow_id,
+                "name": "demo",
+                "workflowJson": {
+                    "start": "n1",
+                    "nodes": [{"id": "n1", "type": "python", "code": "result = {'ok': True}"}],
+                    "edges": [],
+                    "triggers": [
+                        {
+                            "id": "syslog-default",
+                            "type": "syslog",
+                            "enabled": True,
+                        }
+                    ],
+                },
+            }
+            if workflow_id == "wf-1"
+            else None
+        ),
     )
 
     stored_writes: dict[str, Any] = {}
 
-    async def _fake_read(key: Any, _model: Any = None) -> dict[str, Any] | None:
+    async def _fake_kv_get(key: Any) -> dict[str, Any] | None:
         if key == workflow_routes._api_service_key("wf-1"):
             return {
                 "workflowId": "wf-1",
@@ -177,8 +189,8 @@ async def test_workflow_config_response_keeps_template_separate_from_runtime(
             }
         return None
 
-    async def _fake_write(key: Any, value: Any) -> None:
-        stored_writes[str(key)] = value
+    async def _fake_put_config(workflow_id: str, config: dict[str, Any], *, kind: str | None = None) -> None:
+        stored_writes[workflow_routes._workflow_integration_config_key(workflow_id)] = config
 
     async def _fake_statuses(_workflow_id: str, _workflow_json: dict[str, Any]) -> list[dict[str, Any]]:
         return [
@@ -190,8 +202,8 @@ async def test_workflow_config_response_keeps_template_separate_from_runtime(
             }
         ]
 
-    monkeypatch.setattr(workflow_routes.Storage, "read", _fake_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", _fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", _fake_kv_get)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "put_config", _fake_put_config)
     monkeypatch.setattr(
         workflow_routes,
         "default_trigger_runtime",
@@ -251,26 +263,30 @@ async def test_workflow_config_prefers_storage_over_config_file(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {
-            "id": workflow_id,
-            "name": "demo",
-            "workflowJson": {"start": "n1", "nodes": [], "edges": [], "triggers": []},
-        } if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {
+                "id": workflow_id,
+                "name": "demo",
+                "workflowJson": {"start": "n1", "nodes": [], "edges": [], "triggers": []},
+            }
+            if workflow_id == "wf-1"
+            else None
+        ),
     )
 
-    async def _fake_read(key: Any, _model: Any = None) -> dict[str, Any] | None:
-        if key == workflow_routes._workflow_integration_config_key("wf-1"):
+    async def _fake_get_config(workflow_id: str, *, kind: str = "workflow.integration-config") -> dict[str, Any] | None:
+        if workflow_id == "wf-1" and kind == "workflow.integration-config":
             return stored_config
         return None
 
-    async def _fake_write(key: Any, value: Any) -> None:
-        write_calls.append((key, value))
+    async def _fake_put_config(workflow_id: str, config: dict[str, Any], *, kind: str | None = None) -> None:
+        write_calls.append((workflow_routes._workflow_integration_config_key(workflow_id), config))
 
     async def _fake_statuses(_workflow_id: str, _workflow_json: dict[str, Any]) -> list[dict[str, Any]]:
         return []
 
-    monkeypatch.setattr(workflow_routes.Storage, "read", _fake_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", _fake_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "get_config", _fake_get_config)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "put_config", _fake_put_config)
     monkeypatch.setattr(
         workflow_routes,
         "default_trigger_runtime",
@@ -323,10 +339,9 @@ async def test_update_workflow_config_writes_template_without_mutating_runtime(
     monkeypatch.chdir(workspace)
     monkeypatch.setattr(fs_store, "_workspace_root", None)
 
-    original_storage_read = workflow_routes.Storage.read
     stored_writes: dict[str, Any] = {}
 
-    async def _fake_storage_read(key: Any, *args: Any, **kwargs: Any) -> Any:
+    async def _fake_kv_get(key: Any) -> Any:
         if key == workflow_routes._api_service_key(workflow_id):
             return {
                 "workflowId": workflow_id,
@@ -338,10 +353,10 @@ async def test_update_workflow_config_writes_template_without_mutating_runtime(
                 "driver": "local",
                 "publishedAt": 123,
             }
-        return await original_storage_read(key, *args, **kwargs)
+        return None
 
-    async def _fake_storage_write(key: Any, value: Any) -> None:
-        stored_writes[str(key)] = value
+    async def _fake_put_config(workflow_id: str, config: dict[str, Any], *, kind: str | None = None) -> None:
+        stored_writes[workflow_routes._workflow_integration_config_key(workflow_id)] = config
 
     async def _fake_statuses(_workflow_id: str, _workflow_json: dict[str, Any]) -> list[dict[str, Any]]:
         return [
@@ -353,8 +368,8 @@ async def test_update_workflow_config_writes_template_without_mutating_runtime(
             }
         ]
 
-    monkeypatch.setattr(workflow_routes.Storage, "read", _fake_storage_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", _fake_storage_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", _fake_kv_get)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "put_config", _fake_put_config)
     monkeypatch.setattr(
         workflow_routes,
         "default_trigger_runtime",
@@ -422,7 +437,7 @@ async def test_delete_workflow_service_removes_runtime_service_record(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow_id = "wf-service-delete"
-    await workflow_routes.Storage.write(
+    await workflow_routes.WorkflowStore.kv_put(
         workflow_routes._api_service_key(workflow_id),
         {
             "workflowId": workflow_id,
@@ -448,7 +463,7 @@ async def test_delete_workflow_service_removes_runtime_service_record(
     assert response.status_code == 200, response.text
     assert response.json() == {"ok": True, "workflowId": workflow_id}
     assert stopped == [workflow_id]
-    assert await workflow_routes.Storage.read(workflow_routes._api_service_key(workflow_id)) is None
+    assert await workflow_routes.WorkflowStore.kv_get(workflow_routes._api_service_key(workflow_id)) is None
 
 
 @pytest.mark.asyncio
@@ -459,11 +474,15 @@ async def test_update_workflow_config_rejects_mismatched_workflow_id(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {
-            "id": workflow_id,
-            "name": "demo",
-            "workflowJson": {"start": "n1", "nodes": [], "edges": []},
-        } if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {
+                "id": workflow_id,
+                "name": "demo",
+                "workflowJson": {"start": "n1", "nodes": [], "edges": []},
+            }
+            if workflow_id == "wf-1"
+            else None
+        ),
     )
 
     response = await client.put(
@@ -506,27 +525,35 @@ async def test_delete_workflow_cleans_directory_and_storage(
     monkeypatch.chdir(workspace)
     monkeypatch.setattr(fs_store, "_workspace_root", None)
 
-    storage_keys = [
-        workflow_routes._workflow_stats_key(workflow_id),
-        workflow_routes._workflow_integration_config_key(workflow_id),
+    await workflow_routes.WorkflowStore.put_stats(workflow_id, {"callCount": 1})
+    await workflow_routes.WorkflowStore.put_config(workflow_id, {"workflowId": workflow_id})
+    await workflow_routes.WorkflowStore.put_config(
+        workflow_id,
+        {"workflowId": workflow_id},
+        kind="workflow_syslog_config",
+    )
+    await workflow_routes.WorkflowStore.put_config(
+        workflow_id,
+        {"workflowId": workflow_id},
+        kind="workflow_kafka_config",
+    )
+    await workflow_routes.WorkflowStore.put_config(
+        workflow_id,
+        {"workflowId": workflow_id},
+        kind="workflow_poller_config",
+    )
+    kv_keys = [
         workflow_routes._api_service_key(workflow_id),
-        workflow_routes._syslog_config_key(workflow_id),
-        workflow_routes._kafka_config_key(workflow_id),
-        f"workflow_poller_config/{workflow_id}",
         f"workflow_registry/{workflow_id}",
         f"workflow_runtime/{workflow_id}",
         f"workflow_local_pid/{workflow_id}",
         f"workflow_release/{workflow_id}/active",
         f"workflow_release/{workflow_id}/rel-1",
-        workflow_routes._workflow_execution_key("exec-delete"),
-        "workflow_execution_step/exec-delete/00000001",
-        f"workflow_execution_index/{workflow_id}/00000000000000000001/exec-delete",
     ]
-    for key in storage_keys:
-        payload = {"workflowId": workflow_id}
-        if key == workflow_routes._workflow_execution_key("exec-delete"):
-            payload = {"id": "exec-delete", "workflowId": workflow_id}
-        await workflow_routes.Storage.write(key, payload)
+    for key in kv_keys:
+        await workflow_routes.WorkflowStore.kv_put(key, {"workflowId": workflow_id})
+    await workflow_routes.WorkflowStore.upsert_execution({"id": "exec-delete", "workflowId": workflow_id})
+    await workflow_routes.WorkflowStore.record_step("exec-delete", 1, {"workflowId": workflow_id})
 
     stopped: list[Any] = []
 
@@ -552,9 +579,15 @@ async def test_delete_workflow_cleans_directory_and_storage(
     assert not service_dir.exists()
     assert ("service", workflow_id) in stopped
     assert ("triggers", workflow_id, {"triggers": []}) in stopped
-    for key in storage_keys:
-        assert await workflow_routes.Storage.read(key) is None
-    assert await workflow_routes.Storage.list(f"workflow_release/{workflow_id}/") == []
+    assert await workflow_routes.WorkflowStore.get_stats(workflow_id) is None
+    assert await workflow_routes.WorkflowStore.get_config(workflow_id) is None
+    assert await workflow_routes.WorkflowStore.get_config(workflow_id, kind="workflow_syslog_config") is None
+    assert await workflow_routes.WorkflowStore.get_config(workflow_id, kind="workflow_kafka_config") is None
+    assert await workflow_routes.WorkflowStore.get_config(workflow_id, kind="workflow_poller_config") is None
+    assert await workflow_routes.WorkflowStore.get_execution("exec-delete") is None
+    for key in kv_keys:
+        assert await workflow_routes.WorkflowStore.kv_get(key) is None
+    assert await workflow_routes.WorkflowStore.kv_list(f"workflow_release/{workflow_id}/") == []
 
 
 @pytest.mark.asyncio
@@ -675,22 +708,26 @@ async def test_create_workflow_trigger_rejects_multiple_legacy_singletons(
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
-        lambda workflow_id: {
-            "id": workflow_id,
-            "workflowJson": {
-                "start": "n1",
-                "nodes": [{"id": "n1", "type": "python", "code": "result = {'ok': True}"}],
-                "edges": [],
-                "triggers": [
-                    {
-                        "id": "schedule-default",
-                        "type": "schedule",
-                        "enabled": True,
-                        "source": {"intervalSeconds": 60},
-                    }
-                ],
-            },
-        } if workflow_id == "wf-1" else None,
+        lambda workflow_id: (
+            {
+                "id": workflow_id,
+                "workflowJson": {
+                    "start": "n1",
+                    "nodes": [{"id": "n1", "type": "python", "code": "result = {'ok': True}"}],
+                    "edges": [],
+                    "triggers": [
+                        {
+                            "id": "schedule-default",
+                            "type": "schedule",
+                            "enabled": True,
+                            "source": {"intervalSeconds": 60},
+                        }
+                    ],
+                },
+            }
+            if workflow_id == "wf-1"
+            else None
+        ),
     )
 
     response = await client.post(
@@ -982,10 +1019,9 @@ async def test_sync_workflow_config_writes_publish_and_trigger_capabilities(
     monkeypatch.chdir(workspace)
     monkeypatch.setattr(fs_store, "_workspace_root", None)
 
-    original_storage_read = workflow_routes.Storage.read
     stored_writes: dict[str, Any] = {}
 
-    async def _fake_storage_read(key: Any, *args: Any, **kwargs: Any) -> Any:
+    async def _fake_kv_get(key: Any) -> Any:
         if key == workflow_routes._api_service_key(workflow_id):
             return {
                 "workflowId": workflow_id,
@@ -997,13 +1033,13 @@ async def test_sync_workflow_config_writes_publish_and_trigger_capabilities(
                 "driver": "local",
                 "publishedAt": 123,
             }
-        return await original_storage_read(key, *args, **kwargs)
+        return None
 
-    async def _fake_storage_write(key: Any, value: Any) -> None:
-        stored_writes[str(key)] = value
+    async def _fake_put_config(workflow_id: str, config: dict[str, Any], *, kind: str | None = None) -> None:
+        stored_writes[workflow_routes._workflow_integration_config_key(workflow_id)] = config
 
-    monkeypatch.setattr(workflow_routes.Storage, "read", _fake_storage_read)
-    monkeypatch.setattr(workflow_routes.Storage, "write", _fake_storage_write)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", _fake_kv_get)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "put_config", _fake_put_config)
 
     response = await client.post(f"/api/workflow/{workflow_id}/config/sync")
 
@@ -1049,10 +1085,10 @@ async def test_persist_workflow_triggers_does_not_overwrite_config_template(
     monkeypatch.chdir(workspace)
     monkeypatch.setattr(fs_store, "_workspace_root", None)
 
-    async def _fake_storage_read(_key: Any, *_args: Any, **_kwargs: Any) -> None:
+    async def _fake_kv_get_none(_key: Any) -> None:
         return None
 
-    monkeypatch.setattr(workflow_routes.Storage, "read", _fake_storage_read)
+    monkeypatch.setattr(workflow_routes.WorkflowStore, "kv_get", _fake_kv_get_none)
 
     workflow_data = {
         "id": workflow_id,
@@ -1129,5 +1165,5 @@ async def test_sync_workflow_config_preserves_existing_template(
     assert body["config"]["publish"] == {"type": "api_service"}
     assert body["config"]["triggers"] == []
     assert config_path.read_text(encoding="utf-8") == before
-    stored = await workflow_routes.Storage.read(workflow_routes._workflow_integration_config_key(workflow_id))
+    stored = await workflow_routes.WorkflowStore.get_config(workflow_id)
     assert stored == body["config"]

--- a/tests/storage/test_multi_db_routing.py
+++ b/tests/storage/test_multi_db_routing.py
@@ -6,9 +6,10 @@ from pathlib import Path
 import pytest
 
 from flocks.config.config import Config
-from flocks.storage.storage import Storage, StorageError
+from flocks.storage.storage import Storage
 from flocks.task.models import TaskExecution, TaskScheduler
 from flocks.task.store import TaskStore, _TASKS_DDL
+from flocks.workflow.store import WorkflowStore
 
 
 def _reset_state() -> None:
@@ -20,6 +21,10 @@ def _reset_state() -> None:
     TaskStore._initialized = False
     TaskStore._conn = None
     TaskStore._init_pid = None
+    WorkflowStore._initialized = False
+    WorkflowStore._conn = None
+    WorkflowStore._init_pid = None
+    WorkflowStore._db_path = None
 
 
 def _fetch_storage_value(db_path: Path, key: str):
@@ -27,6 +32,18 @@ def _fetch_storage_value(db_path: Path, key: str):
     try:
         row = conn.execute(
             "SELECT value FROM storage WHERE key = ?",
+            (key,),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _fetch_workflow_kv_value(db_path: Path, key: str):
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT value FROM workflow_kv WHERE key = ?",
             (key,),
         ).fetchone()
         return row[0] if row else None
@@ -50,11 +67,12 @@ async def isolated_multi_db_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     _reset_state()
     yield
     await TaskStore.close()
+    await WorkflowStore.close()
     _reset_state()
 
 
 @pytest.mark.asyncio
-async def test_workflow_keys_route_to_workflow_db() -> None:
+async def test_storage_no_longer_routes_workflow_keys_to_workflow_db() -> None:
     await Storage.init()
 
     await Storage.write("workflow/wf-1", {"name": "workflow"})
@@ -63,10 +81,9 @@ async def test_workflow_keys_route_to_workflow_db() -> None:
     flocks_db = Storage.get_db_path()
     workflow_db = Storage.get_workflow_db_path()
 
-    assert _fetch_storage_value(workflow_db, "workflow/wf-1") is not None
-    assert _fetch_storage_value(flocks_db, "workflow/wf-1") is None
+    assert _fetch_storage_value(flocks_db, "workflow/wf-1") is not None
     assert _fetch_storage_value(flocks_db, "project/proj-1") is not None
-    assert _fetch_storage_value(workflow_db, "project/proj-1") is None
+    assert not workflow_db.exists()
     assert await Storage.read("workflow/wf-1") == {"name": "workflow"}
     assert await Storage.list_keys("workflow") == ["workflow/wf-1"]
 
@@ -78,11 +95,11 @@ async def test_short_non_workflow_prefix_stays_on_flocks_db() -> None:
     await Storage.write("workspace/item-1", {"name": "workspace"})
     await Storage.write("workflow/item-1", {"name": "workflow"})
 
-    assert await Storage.list_keys("work") == ["workspace/item-1"]
+    assert await Storage.list_keys("work") == ["workflow/item-1", "workspace/item-1"]
 
 
 @pytest.mark.asyncio
-async def test_clear_without_prefix_clears_flocks_and_workflow_dbs() -> None:
+async def test_clear_without_prefix_clears_flocks_db_only() -> None:
     await Storage.init()
 
     await Storage.write("project/proj-1", {"name": "project"})
@@ -148,7 +165,7 @@ async def test_session_and_message_prefix_clear_invalidate_matching_runtime_cach
 
 
 @pytest.mark.asyncio
-async def test_list_without_prefix_merges_flocks_and_workflow_dbs() -> None:
+async def test_list_without_prefix_reads_flocks_db_only() -> None:
     await Storage.init()
 
     await Storage.write("project/proj-1", {"name": "project"})
@@ -194,16 +211,15 @@ async def test_workflow_kv_migrates_from_legacy_flocks_db() -> None:
     finally:
         conn.close()
 
-    await Storage.init()
+    await WorkflowStore.init()
 
     workflow_db = Storage.get_workflow_db_path()
-    assert _fetch_storage_value(workflow_db, "workflow_registry/wf-legacy") == '{"ok": true}'
+    assert _fetch_workflow_kv_value(workflow_db, "workflow_registry/wf-legacy") == '{"ok": true}'
     assert _fetch_storage_value(flocks_db, "workflow_registry/wf-legacy") == '{"ok": true}'
-    assert _fetch_storage_value(workflow_db, "session:legacy") is None
-    marker = await Storage.get(Storage._multi_db_migration_marker_key)
-    assert marker["workflow_migrated"] is True
-    assert marker["workflow_rows"] == 1
-    assert marker["workflow_source_rows_deleted"] == 0
+    assert _fetch_workflow_kv_value(workflow_db, "session:legacy") is None
+    assert await WorkflowStore.kv_get("workflow_registry/wf-legacy") == {"ok": True}
+    marker = await WorkflowStore.kv_get("workflow_store.migration.tables.v1")
+    assert marker["kv"] == 1
 
 
 @pytest.mark.asyncio
@@ -235,18 +251,19 @@ async def test_workflow_prefix_migration_treats_underscore_literally() -> None:
     finally:
         conn.close()
 
-    await Storage.init()
+    await WorkflowStore.init()
 
     workflow_db = Storage.get_workflow_db_path()
-    assert _fetch_storage_value(workflow_db, "workflow_registry/wf-ok") == '{"ok": true}'
-    assert _fetch_storage_value(workflow_db, "workflowXregistry/wf-bad") is None
+    assert _fetch_workflow_kv_value(workflow_db, "workflow_registry/wf-ok") == '{"ok": true}'
+    assert _fetch_workflow_kv_value(workflow_db, "workflowXregistry/wf-bad") is None
     assert _fetch_storage_value(flocks_db, "workflow_registry/wf-ok") == '{"ok": true}'
     assert _fetch_storage_value(flocks_db, "workflowXregistry/wf-bad") == '{"bad": true}'
     assert await Storage.list_keys("workflow_registry/") == ["workflow_registry/wf-ok"]
+    assert await WorkflowStore.kv_list_keys("workflow_registry/") == ["workflow_registry/wf-ok"]
 
 
 @pytest.mark.asyncio
-async def test_completed_workflow_migration_fails_if_workflow_db_disappears() -> None:
+async def test_workflow_store_recreates_workflow_db_if_it_disappears() -> None:
     flocks_db = Config.get_data_path() / "flocks.db"
     flocks_db.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(flocks_db)
@@ -264,20 +281,23 @@ async def test_completed_workflow_migration_fails_if_workflow_db_disappears() ->
         )
         conn.execute(
             "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
-            ("workflow/wf-legacy", '{"ok": true}', "json", "old", "old"),
+            ("workflow_registry/wf-legacy", '{"ok": true}', "json", "old", "old"),
         )
         conn.commit()
     finally:
         conn.close()
 
-    await Storage.init()
+    await WorkflowStore.init()
     workflow_db = Storage.get_workflow_db_path()
     assert workflow_db.exists()
+    assert await WorkflowStore.kv_get("workflow_registry/wf-legacy") == {"ok": True}
+    await WorkflowStore.close()
     workflow_db.unlink()
     _reset_state()
 
-    with pytest.raises(StorageError, match="workflow.db is missing"):
-        await Storage.init()
+    await WorkflowStore.init()
+    assert Storage.get_workflow_db_path().exists()
+    assert await WorkflowStore.kv_get("workflow_registry/wf-legacy") == {"ok": True}
 
 
 @pytest.mark.asyncio

--- a/tests/workflow/test_execution_store_compact.py
+++ b/tests/workflow/test_execution_store_compact.py
@@ -29,11 +29,9 @@ from flocks.workflow.execution_store import (
     compact_outputs_for_storage,
     compact_step_for_storage,
     record_execution_result,
-    workflow_execution_index_key,
-    workflow_execution_step_prefix,
     workflow_execution_step_key,
 )
-from flocks.storage.storage import Storage
+from flocks.workflow.store import WorkflowStore
 
 
 def _make_alerts(n: int) -> List[Dict[str, Any]]:
@@ -157,7 +155,7 @@ def test_compact_outputs_drastically_reduces_serialised_size() -> None:
     after = len(json.dumps(compact_outputs_for_storage(outputs)).encode())
 
     assert before > 1_000_000  # ≥ 1 MB before
-    assert after < 1_000        # < 1 KB after
+    assert after < 1_000  # < 1 KB after
     assert before / after > 1_000
 
 
@@ -267,15 +265,13 @@ def test_compact_execution_summary_drops_execution_log() -> None:
 
 
 def test_workflow_execution_step_key_is_append_only_namespaced() -> None:
-    assert (
-        workflow_execution_step_key("exec-1", 12)
-        == "workflow_execution_step/exec-1/00000012"
-    )
+    assert workflow_execution_step_key("exec-1", 12) == "workflow_execution_step/exec-1/00000012"
 
 
 @pytest.mark.asyncio
 async def test_record_execution_result_backfills_execution_log_steps() -> None:
-    storage_write = AsyncMock(return_value=None)
+    record_step = AsyncMock(return_value=None)
+    upsert_execution = AsyncMock(return_value=None)
     update_stats = AsyncMock(return_value=None)
     exec_data = {
         "id": "exec-1",
@@ -292,22 +288,25 @@ async def test_record_execution_result_backfills_execution_log_steps() -> None:
         coro.close()
         raise RuntimeError
 
-    with patch.object(Storage, "write", storage_write), \
-         patch("flocks.workflow.execution_store._update_workflow_stats", update_stats), \
-         patch("flocks.session.recorder.Recorder.record_workflow_execution", AsyncMock(return_value=None)), \
-         patch("flocks.workflow.execution_store.asyncio.create_task", side_effect=raise_create_task), \
-         patch("flocks.workflow.execution_store._trim_execution_history", AsyncMock(return_value=None)):
+    with (
+        patch.object(WorkflowStore, "record_step", record_step),
+        patch.object(WorkflowStore, "upsert_execution", upsert_execution),
+        patch("flocks.workflow.execution_store._update_workflow_stats", update_stats),
+        patch("flocks.session.recorder.Recorder.record_workflow_execution", AsyncMock(return_value=None)),
+        patch("flocks.workflow.execution_store.asyncio.create_task", side_effect=raise_create_task),
+        patch("flocks.workflow.execution_store._trim_execution_history", AsyncMock(return_value=None)),
+    ):
         await record_execution_result("wf", "exec-1", exec_data)
 
-    write_calls = storage_write.await_args_list
-    assert write_calls[0].args[0] == "workflow_execution_step/exec-1/00000001"
-    assert write_calls[0].args[1]["outputs"] == {"_raw_alerts_count": 150}
-    assert write_calls[1].args[0] == "workflow_execution_step/exec-1/00000002"
-    assert write_calls[1].args[1]["inputs"] == {"_filtered_alerts_count": 150}
-    assert write_calls[2].args[0] == "workflow_execution/exec-1"
-    assert write_calls[2].args[1]["executionLog"] == []
-    assert write_calls[2].args[1]["stepCount"] == 2
-    assert write_calls[3].args[0].startswith("workflow_execution_index/wf/")
+    step_calls = record_step.await_args_list
+    assert step_calls[0].args[:2] == ("exec-1", 1)
+    assert step_calls[0].args[2]["outputs"] == {"_raw_alerts_count": 150}
+    assert step_calls[1].args[:2] == ("exec-1", 2)
+    assert step_calls[1].args[2]["inputs"] == {"_filtered_alerts_count": 150}
+    upsert_execution.assert_awaited_once()
+    summary = upsert_execution.await_args.args[0]
+    assert summary["executionLog"] == []
+    assert summary["stepCount"] == 2
 
 
 def test_compact_history_compacts_each_step_inputs() -> None:
@@ -398,19 +397,8 @@ async def test_trim_execution_history_keeps_only_30_and_deletes_matching_jsonl(
     tmp_path,
 ) -> None:
     workflow_id = "wf-trim"
-    indexed_rows = []
     for idx in range(32):
         exec_id = f"exec-{idx:02d}"
-        index_key = workflow_execution_index_key(workflow_id, idx, exec_id)
-        indexed_rows.append((
-            index_key,
-            {
-                "workflowId": workflow_id,
-                "execId": exec_id,
-                "executionKey": f"workflow_execution/{exec_id}",
-                "startedAt": idx,
-            },
-        ))
         workflow_record = tmp_path / "workflow" / f"{exec_id}.jsonl"
         workflow_record.parent.mkdir(parents=True, exist_ok=True)
         workflow_record.write_text('{"type":"workflow.summary"}\n', encoding="utf-8")
@@ -421,28 +409,15 @@ async def test_trim_execution_history_keeps_only_30_and_deletes_matching_jsonl(
     other_record.parent.mkdir(parents=True, exist_ok=True)
     other_record.write_text('{"type":"workflow.summary"}\n', encoding="utf-8")
 
-    remove_mock = AsyncMock(return_value=None)
-    clear_mock = AsyncMock(return_value=2)
-    list_raw_mock = AsyncMock(return_value=[])
+    trim_mock = AsyncMock(return_value=["exec-00", "exec-01"])
 
-    with patch.object(Storage, "list_entries", AsyncMock(return_value=indexed_rows)), \
-         patch.object(Storage, "list_raw", list_raw_mock), \
-         patch.object(Storage, "clear", clear_mock), \
-         patch.object(Storage, "remove", remove_mock), \
-         patch("flocks.session.recorder._record_dir", return_value=tmp_path):
+    with (
+        patch.object(WorkflowStore, "trim_executions", trim_mock),
+        patch("flocks.session.recorder._record_dir", return_value=tmp_path),
+    ):
         await _trim_execution_history(workflow_id)
 
-    list_raw_mock.assert_not_awaited()
-    removed_keys = [call.args[0] for call in remove_mock.await_args_list]
-    assert "workflow_execution/exec-00" in removed_keys
-    assert "workflow_execution/exec-01" in removed_keys
-    assert workflow_execution_index_key(workflow_id, 0, "exec-00") in removed_keys
-    assert workflow_execution_index_key(workflow_id, 1, "exec-01") in removed_keys
-    cleared_prefixes = [call.args[0] for call in clear_mock.await_args_list]
-    assert cleared_prefixes == [
-        workflow_execution_step_prefix("exec-00"),
-        workflow_execution_step_prefix("exec-01"),
-    ]
+    trim_mock.assert_awaited_once_with(workflow_id, keep=30)
     assert not (tmp_path / "workflow" / "exec-00.jsonl").exists()
     assert not (tmp_path / "workflow" / "exec-01.jsonl").exists()
     assert (tmp_path / "workflow" / "exec-02.jsonl").exists()
@@ -452,64 +427,28 @@ async def test_trim_execution_history_keeps_only_30_and_deletes_matching_jsonl(
 @pytest.mark.asyncio
 async def test_trim_execution_history_uses_index_without_full_scan(tmp_path) -> None:
     workflow_id = "wf-indexed"
-    indexed_rows = []
     for idx in range(32):
         exec_id = f"exec-{idx:02d}"
-        index_key = workflow_execution_index_key(workflow_id, idx, exec_id)
-        indexed_rows.append((
-            index_key,
-            {
-                "workflowId": workflow_id,
-                "execId": exec_id,
-                "executionKey": f"workflow_execution/{exec_id}",
-                "startedAt": idx,
-            },
-        ))
         workflow_record = tmp_path / "workflow" / f"{exec_id}.jsonl"
         workflow_record.parent.mkdir(parents=True, exist_ok=True)
         workflow_record.write_text('{"type":"workflow.summary"}\n', encoding="utf-8")
 
-    list_raw_mock = AsyncMock(return_value=[])
-    clear_mock = AsyncMock(return_value=1)
-    remove_mock = AsyncMock(return_value=True)
+    trim_mock = AsyncMock(return_value=["exec-00", "exec-01"])
 
-    with patch.object(Storage, "list_entries", AsyncMock(return_value=indexed_rows)), \
-         patch.object(Storage, "list_raw", list_raw_mock), \
-         patch.object(Storage, "clear", clear_mock), \
-         patch.object(Storage, "remove", remove_mock), \
-         patch("flocks.session.recorder._record_dir", return_value=tmp_path):
+    with (
+        patch.object(WorkflowStore, "trim_executions", trim_mock),
+        patch("flocks.session.recorder._record_dir", return_value=tmp_path),
+    ):
         await _trim_execution_history(workflow_id)
 
-    list_raw_mock.assert_not_awaited()
-    assert [call.args[0] for call in clear_mock.await_args_list] == [
-        workflow_execution_step_prefix("exec-00"),
-        workflow_execution_step_prefix("exec-01"),
-    ]
-    removed = [call.args[0] for call in remove_mock.await_args_list]
-    assert "workflow_execution/exec-00" in removed
-    assert workflow_execution_index_key(workflow_id, 0, "exec-00") in removed
+    trim_mock.assert_awaited_once_with(workflow_id, keep=30)
+    assert not (tmp_path / "workflow" / "exec-00.jsonl").exists()
+    assert not (tmp_path / "workflow" / "exec-01.jsonl").exists()
 
 
 @pytest.mark.asyncio
 async def test_trim_execution_history_surfaces_delete_failures() -> None:
     workflow_id = "wf-trim-fail"
-    indexed_rows = [
-        (
-            workflow_execution_index_key(workflow_id, idx, f"exec-{idx:02d}"),
-            {
-                "workflowId": workflow_id,
-                "execId": f"exec-{idx:02d}",
-                "executionKey": f"workflow_execution/exec-{idx:02d}",
-                "startedAt": idx,
-            },
-        )
-        for idx in range(31)
-    ]
-    list_raw_mock = AsyncMock(return_value=[])
-
-    with patch.object(Storage, "list_entries", AsyncMock(return_value=indexed_rows)), \
-         patch.object(Storage, "list_raw", list_raw_mock), \
-         patch.object(Storage, "clear", AsyncMock(side_effect=RuntimeError("locked"))):
-        with pytest.raises(RuntimeError, match="Failed to trim workflow execution history"):
+    with patch.object(WorkflowStore, "trim_executions", AsyncMock(side_effect=RuntimeError("locked"))):
+        with pytest.raises(RuntimeError, match="locked"):
             await _trim_execution_history(workflow_id)
-    list_raw_mock.assert_not_awaited()

--- a/tests/workflow/test_execution_store_compact.py
+++ b/tests/workflow/test_execution_store_compact.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from flocks.workflow.execution_store import (
     DEFAULT_COMPACT_SIZE_THRESHOLD,
+    DEFAULT_GENERIC_SEQUENCE_THRESHOLD,
     DEFAULT_LARGE_LIST_KEYS,
     _trim_execution_history,
     compact_history_for_storage,
@@ -75,15 +76,26 @@ def test_compact_outputs_keeps_small_lists_verbatim() -> None:
     assert "_enriched_alerts_count" not in compacted
 
 
-def test_compact_outputs_ignores_unknown_keys() -> None:
-    big_unknown = _make_alerts(5_000)
+def test_compact_outputs_summarizes_unknown_large_sequences() -> None:
+    big_unknown = _make_alerts(DEFAULT_GENERIC_SEQUENCE_THRESHOLD + 1)
     outputs = {"some_other_alerts": big_unknown}
 
     compacted = compact_outputs_for_storage(outputs)
 
-    # Unknown keys are not in the default large-list set; they must pass
-    # through even if huge, so callers don't get surprising drops.
-    assert compacted["some_other_alerts"] is big_unknown
+    assert compacted["some_other_alerts"]["_type"] == "list"
+    assert compacted["some_other_alerts"]["count"] == DEFAULT_GENERIC_SEQUENCE_THRESHOLD + 1
+    assert len(compacted["some_other_alerts"]["preview"]) == 3
+    assert compacted["some_other_alerts"] is not big_unknown
+
+
+def test_compact_outputs_summarizes_large_strings() -> None:
+    outputs = {"huge_text": "x" * 25_000}
+
+    compacted = compact_outputs_for_storage(outputs)
+
+    assert compacted["huge_text"]["_type"] == "string"
+    assert compacted["huge_text"]["chars"] == 25_000
+    assert len(compacted["huge_text"]["preview"]) < 25_000
 
 
 def test_compact_outputs_accepts_custom_keys_and_threshold() -> None:

--- a/tests/workflow/test_poller_manager.py
+++ b/tests/workflow/test_poller_manager.py
@@ -16,10 +16,10 @@ from flocks.workflow.runner import RunWorkflowResult
 async def test_restart_disabled_config_reports_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = poller_manager.WorkflowPollerManager()
 
-    async def _fake_read(_key: str) -> dict[str, Any]:
+    async def _fake_get_config(_workflow_id: str, *, kind: str) -> dict[str, Any]:
         return {"enabled": False}
 
-    monkeypatch.setattr(poller_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(poller_manager.WorkflowStore, "get_config", _fake_get_config)
 
     status = await manager.restart_workflow("wf-disabled")
     assert status["state"] == "stopped"
@@ -30,10 +30,10 @@ async def test_restart_disabled_config_reports_stopped(monkeypatch: pytest.Monke
 async def test_restart_missing_workflow_reports_failed(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = poller_manager.WorkflowPollerManager()
 
-    async def _fake_read(_key: str) -> dict[str, Any]:
+    async def _fake_get_config(_workflow_id: str, *, kind: str) -> dict[str, Any]:
         return {"enabled": True, "intervalSeconds": 30}
 
-    monkeypatch.setattr(poller_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(poller_manager.WorkflowStore, "get_config", _fake_get_config)
     monkeypatch.setattr(poller_manager, "read_workflow_from_fs", lambda _workflow_id: None)
 
     status = await manager.restart_workflow("wf-missing")
@@ -46,7 +46,7 @@ async def test_run_once_injects_dynamic_inputs_and_summary(monkeypatch: pytest.M
     manager = poller_manager.WorkflowPollerManager()
     captured_inputs: dict[str, Any] = {}
 
-    async def _fake_read(_key: str) -> dict[str, Any]:
+    async def _fake_get_config(_workflow_id: str, *, kind: str) -> dict[str, Any]:
         return {
             "enabled": False,
             "timeoutSeconds": 9,
@@ -78,7 +78,7 @@ async def test_run_once_injects_dynamic_inputs_and_summary(monkeypatch: pytest.M
             },
         )
 
-    monkeypatch.setattr(poller_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(poller_manager.WorkflowStore, "get_config", _fake_get_config)
     monkeypatch.setattr(
         poller_manager,
         "read_workflow_from_fs",
@@ -87,16 +87,19 @@ async def test_run_once_injects_dynamic_inputs_and_summary(monkeypatch: pytest.M
     monkeypatch.setattr(
         poller_manager,
         "create_execution_record",
-        lambda workflow_id, *, input_params=None, exec_id=None: asyncio.sleep(0, result={
-            "id": exec_id or f"exec-{workflow_id}",
-            "workflowId": workflow_id,
-            "inputParams": input_params or {},
-            "status": "running",
-            "startedAt": 111,
-            "executionLog": [],
-            "currentPhase": "queued",
-            "currentStepIndex": 0,
-        }),
+        lambda workflow_id, *, input_params=None, exec_id=None: asyncio.sleep(
+            0,
+            result={
+                "id": exec_id or f"exec-{workflow_id}",
+                "workflowId": workflow_id,
+                "inputParams": input_params or {},
+                "status": "running",
+                "startedAt": 111,
+                "executionLog": [],
+                "currentPhase": "queued",
+                "currentStepIndex": 0,
+            },
+        ),
     )
     monkeypatch.setattr(
         poller_manager,
@@ -127,7 +130,7 @@ async def test_run_once_records_execution_and_normalizes_business_failure(
     recorded_results: list[dict[str, Any]] = []
     recorded_steps: list[tuple[str, int, dict[str, Any]]] = []
 
-    async def _fake_read(_key: str) -> dict[str, Any]:
+    async def _fake_get_config(_workflow_id: str, *, kind: str) -> dict[str, Any]:
         return {
             "enabled": False,
             "timeoutSeconds": 9,
@@ -191,7 +194,7 @@ async def test_run_once_records_execution_and_normalizes_business_failure(
                     "inputs": {"iteration": 1, "total_iterations": 2},
                     "outputs": {"load_stats": {"record_count": 9}},
                 }
-            )
+            ),
         )
         return RunWorkflowResult(
             status="SUCCEEDED",
@@ -205,7 +208,7 @@ async def test_run_once_records_execution_and_normalizes_business_failure(
             },
         )
 
-    monkeypatch.setattr(poller_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(poller_manager.WorkflowStore, "get_config", _fake_get_config)
     monkeypatch.setattr(
         poller_manager,
         "read_workflow_from_fs",
@@ -239,7 +242,7 @@ async def test_no_overlap_skips_when_previous_run_is_still_active(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = poller_manager.WorkflowPollerManager()
-    threading_event = asyncio.Event()
+    threading_event = threading.Event()
 
     config = {
         "enabled": True,
@@ -261,23 +264,26 @@ async def test_no_overlap_skips_when_previous_run_is_still_active(
         _ = workflow, inputs, timeout_s, trace, cancel
         _ = on_step_complete
         # Keep the run active until the test releases it so a second tick skips.
-        asyncio.run(asyncio.wait_for(threading_event.wait(), timeout=2.0))
+        assert threading_event.wait(timeout=2.0)
         return RunWorkflowResult(status="success", outputs={"load_stats": {"record_count": 1}})
 
     monkeypatch.setattr(poller_manager, "run_workflow", _fake_run_workflow)
     monkeypatch.setattr(
         poller_manager,
         "create_execution_record",
-        lambda workflow_id, *, input_params=None, exec_id=None: asyncio.sleep(0, result={
-            "id": exec_id or f"exec-{workflow_id}",
-            "workflowId": workflow_id,
-            "inputParams": input_params or {},
-            "status": "running",
-            "startedAt": 111,
-            "executionLog": [],
-            "currentPhase": "queued",
-            "currentStepIndex": 0,
-        }),
+        lambda workflow_id, *, input_params=None, exec_id=None: asyncio.sleep(
+            0,
+            result={
+                "id": exec_id or f"exec-{workflow_id}",
+                "workflowId": workflow_id,
+                "inputParams": input_params or {},
+                "status": "running",
+                "startedAt": 111,
+                "executionLog": [],
+                "currentPhase": "queued",
+                "currentStepIndex": 0,
+            },
+        ),
     )
     monkeypatch.setattr(
         poller_manager,
@@ -344,7 +350,7 @@ async def test_stop_workflow_keeps_unfinished_run_tracked_until_thread_exits(
     ):
         _ = workflow, inputs, timeout_s, trace, cancel
         _ = on_step_complete
-        release_run.wait(timeout=0.2)
+        release_run.wait(0.2)
         return RunWorkflowResult(status="SUCCEEDED", run_id="run-stop")
 
     monkeypatch.setattr(poller_manager, "RUN_SHUTDOWN_GRACE_SECONDS", 0.01)
@@ -372,21 +378,17 @@ async def test_start_all_only_restarts_enabled_configs(monkeypatch: pytest.Monke
     manager = poller_manager.WorkflowPollerManager()
     restarted: list[str] = []
 
-    async def _fake_list_keys(_prefix: str) -> list[str]:
+    async def _fake_list_configs(*, kind: str) -> list[tuple[str, dict[str, Any]]]:
         return [
-            "workflow_poller_config/wf-enabled",
-            "workflow_poller_config/wf-disabled",
+            ("wf-enabled", {"enabled": True}),
+            ("wf-disabled", {"enabled": False}),
         ]
-
-    async def _fake_read(key: str) -> dict[str, Any]:
-        return {"enabled": key.endswith("wf-enabled")}
 
     async def _fake_restart(workflow_id: str) -> dict[str, Any]:
         restarted.append(workflow_id)
         return {"workflowId": workflow_id, "state": "running"}
 
-    monkeypatch.setattr(poller_manager.Storage, "list_keys", _fake_list_keys)
-    monkeypatch.setattr(poller_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(poller_manager.WorkflowStore, "list_configs", _fake_list_configs)
     monkeypatch.setattr(manager, "restart_workflow", _fake_restart)
 
     await manager.start_all()
@@ -398,13 +400,13 @@ async def test_restart_workflow_replaces_existing_task(monkeypatch: pytest.Monke
     manager = poller_manager.WorkflowPollerManager()
     config = {"enabled": True, "intervalSeconds": 30, "timeoutSeconds": 10, "noOverlap": True, "inputs": {}}
 
-    async def _fake_read(_key: str) -> dict[str, Any]:
+    async def _fake_get_config(_workflow_id: str, *, kind: str) -> dict[str, Any]:
         return config
 
     async def _fake_loop(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
         await asyncio.sleep(60)
 
-    monkeypatch.setattr(poller_manager.Storage, "read", _fake_read)
+    monkeypatch.setattr(poller_manager.WorkflowStore, "get_config", _fake_get_config)
     monkeypatch.setattr(
         poller_manager,
         "read_workflow_from_fs",

--- a/tests/workflow/test_tool_run_workflow.py
+++ b/tests/workflow/test_tool_run_workflow.py
@@ -51,6 +51,7 @@ def _make_large_alerts(count: int) -> list[dict[str, Any]]:
 # Fixtures
 # =============================================================================
 
+
 @pytest.fixture(autouse=True)
 def init_tool_registry():
     """Ensure ToolRegistry is initialized before each test"""
@@ -73,10 +74,10 @@ def tool_context():
 def tool_context_with_permission():
     """Create a tool context with permission tracking"""
     permissions_requested = []
-    
+
     async def track_permission(request):
         permissions_requested.append(request)
-    
+
     ctx = ToolContext(
         session_id="test-session-workflow-perm",
         message_id="test-message-workflow-perm",
@@ -97,13 +98,9 @@ def simple_workflow():
         "metadata": {},
         "start": "node-1",
         "nodes": [
-            {
-                "id": "node-1",
-                "type": "python",
-                "code": "result = {'message': 'Hello from workflow!', 'value': 42}"
-            }
+            {"id": "node-1", "type": "python", "code": "result = {'message': 'Hello from workflow!', 'value': 42}"}
         ],
-        "edges": []
+        "edges": [],
     }
 
 
@@ -114,18 +111,10 @@ def workflow_with_requirements():
         "id": "test-workflow-002",
         "name": "Test Workflow with Requirements",
         "start": "node-1",
-        "metadata": {
-            "requirements": ["requests>=2.31,<3"]
-        },
+        "metadata": {"requirements": ["requests>=2.31,<3"]},
         "start": "node-1",
-        "nodes": [
-            {
-                "id": "node-1",
-                "type": "python",
-                "code": "result = {'status': 'ok'}"
-            }
-        ],
-        "edges": []
+        "nodes": [{"id": "node-1", "type": "python", "code": "result = {'status': 'ok'}"}],
+        "edges": [],
     }
 
 
@@ -142,10 +131,10 @@ def workflow_with_inputs():
             {
                 "id": "node-1",
                 "type": "python",
-                "code": "greeting = f'Hello, {inputs.get(\"name\", \"World\")}!'; result = {'greeting': greeting}"
+                "code": "greeting = f'Hello, {inputs.get(\"name\", \"World\")}!'; result = {'greeting': greeting}",
             }
         ],
-        "edges": []
+        "edges": [],
     }
 
 
@@ -153,9 +142,10 @@ def workflow_with_inputs():
 # Test Tool Registration
 # =============================================================================
 
+
 class TestRunWorkflowToolRegistration:
     """Test run_workflow tool registration"""
-    
+
     def test_run_workflow_tool_exists(self):
         """Test that run_workflow tool is registered"""
         ToolRegistry.init()
@@ -164,7 +154,7 @@ class TestRunWorkflowToolRegistration:
         assert tool.info.name == "run_workflow"
         assert tool.info.category.value == "system"
         assert tool.info.requires_confirmation is True
-    
+
     def test_run_workflow_tool_schema(self):
         """Test run_workflow tool schema"""
         ToolRegistry.init()
@@ -182,9 +172,10 @@ class TestRunWorkflowToolRegistration:
 # Test Error Handling (flocks_workflow not available)
 # =============================================================================
 
+
 class TestRunWorkflowToolWithoutDependency:
     """Test run_workflow tool when flocks_workflow is not available"""
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_without_flocks_workflow(self, tool_context, simple_workflow):
         """Test that tool returns error when flocks_workflow is not available"""
@@ -202,9 +193,10 @@ class TestRunWorkflowToolWithoutDependency:
 # Test Parameter Validation
 # =============================================================================
 
+
 class TestRunWorkflowToolValidation:
     """Test run_workflow tool parameter validation"""
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_missing_workflow(self, tool_context):
         """Test that missing workflow parameter returns error"""
@@ -217,7 +209,7 @@ class TestRunWorkflowToolValidation:
             )
             assert result.success is False
             assert "workflow parameter is required" in result.error
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_invalid_workflow_type(self, tool_context):
         """Test that invalid workflow type returns error"""
@@ -230,7 +222,7 @@ class TestRunWorkflowToolValidation:
             )
             assert result.success is False
             assert "workflow must be a dictionary or string" in result.error
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_empty_workflow(self, tool_context):
         """Test that empty workflow returns error"""
@@ -249,32 +241,36 @@ class TestRunWorkflowToolValidation:
 # Test Workflow Execution (with mocked flocks_workflow)
 # =============================================================================
 
+
 class TestRunWorkflowToolExecution:
     """Test run_workflow tool execution with mocked dependencies"""
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_success(self, tool_context_with_permission, simple_workflow):
         """Test successful workflow execution"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-123",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {"message": "Hello from workflow!", "value": 42},
-            "history": [
-                {"node_id": "node-1", "status": "SUCCEEDED", "outputs": {"message": "Hello from workflow!", "value": 42}}
-            ],
-            "error": None
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-123",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {"message": "Hello from workflow!", "value": 42},
+                "history": [
+                    {
+                        "node_id": "node-1",
+                        "status": "SUCCEEDED",
+                        "outputs": {"message": "Hello from workflow!", "value": 42},
+                    }
+                ],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
-                "run_workflow",
-                ctx=tool_context_with_permission,
-                workflow=simple_workflow,
-                inputs={}
+                "run_workflow", ctx=tool_context_with_permission, workflow=simple_workflow, inputs={}
             )
-            
+
             assert result.success is True
             assert "SUCCEEDED" in result.output
             assert "run-123" in result.output
@@ -282,7 +278,7 @@ class TestRunWorkflowToolExecution:
             assert result.metadata["status"] == "success"
             assert result.metadata["steps"] == 1
             assert result.metadata["run_id"] == "run-123"
-            
+
             # Check that permission was requested
             assert len(tool_context_with_permission._permissions_requested) > 0
 
@@ -297,11 +293,13 @@ class TestRunWorkflowToolExecution:
 
         def run_side_effect(**kwargs):
             kwargs["on_step_start"]("run-registered", 1, MagicMock(id="node-1", type="python"), {})
-            kwargs["on_step_complete"]({
-                "node_id": "node-1",
-                "node_type": "python",
-                "outputs": {"message": "ok"},
-            })
+            kwargs["on_step_complete"](
+                {
+                    "node_id": "node-1",
+                    "node_type": "python",
+                    "outputs": {"message": "ok"},
+                }
+            )
             return FakeRunWorkflowResult(
                 status="SUCCEEDED",
                 run_id="run-registered",
@@ -313,32 +311,31 @@ class TestRunWorkflowToolExecution:
             )
 
         mock_run = Mock(name="run_workflow", side_effect=run_side_effect)
-        create_execution = AsyncMock(return_value={
-            "id": "exec-registered",
-            "workflowId": "test-workflow-001",
-            "inputParams": {"name": "Flocks"},
-            "status": "running",
-            "startedAt": 1,
-            "executionLog": [],
-        })
-        storage_read = AsyncMock(return_value={
-            "id": "exec-registered",
-            "workflowId": "test-workflow-001",
-            "inputParams": {"name": "Flocks"},
-            "status": "running",
-            "startedAt": 1,
-            "executionLog": [],
-        })
-        storage_write = AsyncMock(return_value=None)
+        create_execution = AsyncMock(
+            return_value={
+                "id": "exec-registered",
+                "workflowId": "test-workflow-001",
+                "inputParams": {"name": "Flocks"},
+                "status": "running",
+                "startedAt": 1,
+                "executionLog": [],
+            }
+        )
+        upsert_execution = AsyncMock(return_value=None)
         record_result = AsyncMock(return_value=None)
 
-        with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)), \
-             patch.object(run_workflow_module, "read_workflow_from_fs", return_value={"id": "test-workflow-001", "workflowJson": simple_workflow}), \
-             patch.object(run_workflow_module, "resolve_workflow_id_from_source", return_value="test-workflow-001"), \
-             patch.object(run_workflow_module, "create_execution_record", create_execution), \
-             patch.object(run_workflow_module.Storage, "read", storage_read), \
-             patch.object(run_workflow_module.Storage, "write", storage_write), \
-             patch.object(run_workflow_module, "record_execution_result", record_result):
+        with (
+            patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)),
+            patch.object(
+                run_workflow_module,
+                "read_workflow_from_fs",
+                return_value={"id": "test-workflow-001", "workflowJson": simple_workflow},
+            ),
+            patch.object(run_workflow_module, "resolve_workflow_id_from_source", return_value="test-workflow-001"),
+            patch.object(run_workflow_module, "create_execution_record", create_execution),
+            patch.object(run_workflow_module.WorkflowStore, "upsert_execution", upsert_execution),
+            patch.object(run_workflow_module, "record_execution_result", record_result),
+        ):
             result = await ToolRegistry.execute(
                 "run_workflow",
                 ctx=tool_context_with_permission,
@@ -350,8 +347,70 @@ class TestRunWorkflowToolExecution:
         assert result.metadata["workflow_execution_id"] == "exec-registered"
         create_execution.assert_awaited_once()
         record_result.assert_awaited_once()
-        assert storage_write.await_count >= 1
+        assert upsert_execution.await_count >= 1
         assert any(update.get("workflow_execution_id") == "exec-registered" for update in metadata_updates)
+
+    @pytest.mark.anyio
+    async def test_run_workflow_registered_id_overrides_missing_workflow_json_id(
+        self,
+        tool_context_with_permission,
+    ):
+        workflow_without_id = {
+            "name": "Display Name Only",
+            "start": "node-1",
+            "nodes": [{"id": "node-1", "type": "python", "code": "outputs['ok'] = True"}],
+            "edges": [],
+        }
+        captured_kwargs: dict[str, Any] = {}
+
+        def run_side_effect(**kwargs):
+            captured_kwargs.update(kwargs)
+            return FakeRunWorkflowResult(
+                status="SUCCEEDED",
+                run_id="run-directory-id",
+                steps=1,
+                last_node_id="node-1",
+                outputs={"workflow_id": kwargs.get("workflow_id")},
+                history=[],
+                error=None,
+            )
+
+        mock_run = Mock(name="run_workflow", side_effect=run_side_effect)
+        create_execution = AsyncMock(
+            return_value={
+                "id": "exec-directory-id",
+                "workflowId": "wf-directory-id",
+                "inputParams": {},
+                "status": "running",
+                "startedAt": 1,
+                "executionLog": [],
+            }
+        )
+
+        with (
+            patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)),
+            patch.object(
+                run_workflow_module,
+                "read_workflow_from_fs",
+                return_value={"id": "wf-directory-id", "workflowJson": workflow_without_id},
+            ),
+            patch.object(run_workflow_module, "create_execution_record", create_execution),
+            patch.object(run_workflow_module.WorkflowStore, "upsert_execution", AsyncMock(return_value=None)),
+            patch.object(run_workflow_module, "record_execution_result", AsyncMock(return_value=None)),
+        ):
+            result = await ToolRegistry.execute(
+                "run_workflow",
+                ctx=tool_context_with_permission,
+                workflow="wf-directory-id",
+                inputs={},
+            )
+
+        assert result.success is True
+        assert result.metadata["workflow_id"] == "wf-directory-id"
+        assert captured_kwargs["workflow_id"] == "wf-directory-id"
+        assert captured_kwargs["workflow"]["id"] == "wf-directory-id"
+        create_execution.assert_awaited_once()
+        assert create_execution.await_args.args[0] == "wf-directory-id"
 
     @pytest.mark.anyio
     async def test_run_workflow_compacts_large_outputs_for_progress_and_final_record(
@@ -365,12 +424,14 @@ class TestRunWorkflowToolExecution:
 
         def run_side_effect(**kwargs):
             kwargs["on_step_start"]("run-compacted", 1, MagicMock(id="node-1", type="python"), {})
-            kwargs["on_step_complete"]({
-                "node_id": "node-1",
-                "node_type": "python",
-                "inputs": {"raw_alerts": large_alerts, "source": "syslog"},
-                "outputs": {"raw_alerts": large_alerts, "message": "ok"},
-            })
+            kwargs["on_step_complete"](
+                {
+                    "node_id": "node-1",
+                    "node_type": "python",
+                    "inputs": {"raw_alerts": large_alerts, "source": "syslog"},
+                    "outputs": {"raw_alerts": large_alerts, "message": "ok"},
+                }
+            )
             return FakeRunWorkflowResult(
                 status="SUCCEEDED",
                 run_id="run-compacted",
@@ -382,32 +443,29 @@ class TestRunWorkflowToolExecution:
             )
 
         mock_run = Mock(name="run_workflow", side_effect=run_side_effect)
-        create_execution = AsyncMock(return_value={
-            "id": "exec-compacted",
-            "workflowId": "test-workflow-001",
-            "inputParams": {},
-            "status": "running",
-            "startedAt": 1,
-            "executionLog": [],
-        })
-        storage_read = AsyncMock(return_value={
-            "id": "exec-compacted",
-            "workflowId": "test-workflow-001",
-            "inputParams": {},
-            "status": "running",
-            "startedAt": 1,
-            "executionLog": [],
-        })
-        storage_write = AsyncMock(return_value=None)
+        create_execution = AsyncMock(
+            return_value={
+                "id": "exec-compacted",
+                "workflowId": "test-workflow-001",
+                "inputParams": {},
+                "status": "running",
+                "startedAt": 1,
+                "executionLog": [],
+            }
+        )
+        upsert_execution = AsyncMock(return_value=None)
+        record_step = AsyncMock(return_value=None)
         record_result = AsyncMock(return_value=None)
 
-        with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)), \
-             patch.object(run_workflow_module, "resolve_workflow_id_from_source", return_value="test-workflow-001"), \
-             patch.object(run_workflow_module, "create_execution_record", create_execution), \
-             patch.object(run_workflow_module.Storage, "read", storage_read), \
-             patch.object(run_workflow_module.Storage, "write", storage_write), \
-             patch.object(run_workflow_module, "record_execution_result", record_result), \
-             patch.object(run_workflow_module, "_record_workflow_tool_result", AsyncMock(return_value=None)):
+        with (
+            patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)),
+            patch.object(run_workflow_module, "resolve_workflow_id_from_source", return_value="test-workflow-001"),
+            patch.object(run_workflow_module, "create_execution_record", create_execution),
+            patch.object(run_workflow_module.WorkflowStore, "upsert_execution", upsert_execution),
+            patch.object(run_workflow_module, "record_execution_step", record_step),
+            patch.object(run_workflow_module, "record_execution_result", record_result),
+            patch.object(run_workflow_module, "_record_workflow_tool_result", AsyncMock(return_value=None)),
+        ):
             result = await ToolRegistry.execute(
                 "run_workflow",
                 ctx=tool_context_with_permission,
@@ -416,9 +474,8 @@ class TestRunWorkflowToolExecution:
             )
 
         assert result.success is True
-        step_write = storage_write.await_args_list[-1]
-        assert step_write.args[0] == "workflow_execution_step/exec-compacted/00000001"
-        step_payload = step_write.args[1]
+        record_step.assert_awaited()
+        step_payload = record_step.await_args.args[2]
         assert step_payload["inputs"] == {
             "_raw_alerts_count": 150,
             "source": "syslog",
@@ -485,112 +542,112 @@ class TestRunWorkflowToolExecution:
         assert nested_ctx.event_publish_callback == tool_context_with_permission.event_publish_callback
         assert nested_ctx._permission_callback == tool_context_with_permission._permission_callback
         assert nested_ctx._metadata_callback is None
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_with_inputs(self, tool_context_with_permission, workflow_with_inputs):
         """Test workflow execution with input parameters"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-456",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {"greeting": "Hello, Flocks!"},
-            "history": [
-                {"node_id": "node-1", "status": "SUCCEEDED", "outputs": {"greeting": "Hello, Flocks!"}}
-            ],
-            "error": None
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-456",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {"greeting": "Hello, Flocks!"},
+                "history": [{"node_id": "node-1", "status": "SUCCEEDED", "outputs": {"greeting": "Hello, Flocks!"}}],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
                 "run_workflow",
                 ctx=tool_context_with_permission,
                 workflow=workflow_with_inputs,
-                inputs={"name": "Flocks"}
+                inputs={"name": "Flocks"},
             )
-            
+
             assert result.success is True
             assert "SUCCEEDED" in result.output
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_with_requirements(self, tool_context_with_permission, workflow_with_requirements):
         """Test workflow execution with requirements installation"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-789",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {"status": "ok"},
-            "history": [
-                {"node_id": "node-1", "status": "SUCCEEDED", "outputs": {"status": "ok"}}
-            ],
-            "error": None
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-789",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {"status": "ok"},
+                "history": [{"node_id": "node-1", "status": "SUCCEEDED", "outputs": {"status": "ok"}}],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         installer_cls = Mock(name="RequirementsInstaller")
-        with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run, installer_cls=installer_cls)):
+        with patch.object(
+            run_workflow_module,
+            "_get_workflow_runtime",
+            return_value=_runtime_tuple(run_fn=mock_run, installer_cls=installer_cls),
+        ):
             result = await ToolRegistry.execute(
                 "run_workflow",
                 ctx=tool_context_with_permission,
                 workflow=workflow_with_requirements,
                 inputs={},
-                ensure_requirements=True
+                ensure_requirements=True,
             )
-            
+
             assert result.success is True
             assert installer_cls.called is True
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_with_timeout(self, tool_context_with_permission, simple_workflow):
         """Test workflow execution with timeout"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-timeout",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {},
-            "history": [],
-            "error": None
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-timeout",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {},
+                "history": [],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
-                "run_workflow",
-                ctx=tool_context_with_permission,
-                workflow=simple_workflow,
-                inputs={},
-                timeout_s=300.0
+                "run_workflow", ctx=tool_context_with_permission, workflow=simple_workflow, inputs={}, timeout_s=300.0
             )
-            
+
             assert result.success is True
             # Verify timeout was passed to run_workflow
             mock_run.assert_called_once()
             call_kwargs = mock_run.call_args[1]
             assert call_kwargs.get("timeout_s") == 300.0
             assert call_kwargs.get("use_llm") is True
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_with_trace(self, tool_context_with_permission, simple_workflow):
         """Test workflow execution with tracing enabled"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-trace",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {},
-            "history": [],
-            "error": None
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-trace",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {},
+                "history": [],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
-                "run_workflow",
-                ctx=tool_context_with_permission,
-                workflow=simple_workflow,
-                inputs={},
-                trace=True
+                "run_workflow", ctx=tool_context_with_permission, workflow=simple_workflow, inputs={}, trace=True
             )
-            
+
             assert result.success is True
             # Verify trace was passed to run_workflow
             call_kwargs = mock_run.call_args[1]
@@ -600,15 +657,17 @@ class TestRunWorkflowToolExecution:
     @pytest.mark.anyio
     async def test_run_workflow_passes_cancel_callback(self, tool_context_with_permission, simple_workflow):
         """Session abort should be forwarded to workflow runtime cancellation."""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-cancel",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {},
-            "history": [],
-            "error": None,
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-cancel",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {},
+                "history": [],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
@@ -629,15 +688,17 @@ class TestRunWorkflowToolExecution:
     @pytest.mark.anyio
     async def test_run_workflow_disable_llm(self, tool_context_with_permission, simple_workflow):
         """Test workflow execution with use_llm disabled"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-no-llm",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {},
-            "history": [],
-            "error": None
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-no-llm",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {},
+                "history": [],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
@@ -651,7 +712,7 @@ class TestRunWorkflowToolExecution:
             assert result.success is True
             call_kwargs = mock_run.call_args[1]
             assert call_kwargs.get("use_llm") is False
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_execution_failure(self, tool_context_with_permission, simple_workflow):
         """Test workflow execution failure handling"""
@@ -659,37 +720,33 @@ class TestRunWorkflowToolExecution:
         mock_run = Mock(name="run_workflow", side_effect=Exception("Workflow execution failed"))
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
-                "run_workflow",
-                ctx=tool_context_with_permission,
-                workflow=simple_workflow,
-                inputs={}
+                "run_workflow", ctx=tool_context_with_permission, workflow=simple_workflow, inputs={}
             )
-            
+
             assert result.success is False
             assert "Workflow execution failed" in result.error
             assert result.metadata["status"] == "FAILED"
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_failed_status(self, tool_context_with_permission, simple_workflow):
         """Test workflow execution with FAILED status"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "FAILED",
-            "run_id": "run-failed",
-            "steps": 0,
-            "last_node_id": None,
-            "outputs": {},
-            "history": [],
-            "error": "NodeExecutionError: Error in node 'node-1'"
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "FAILED",
+                "run_id": "run-failed",
+                "steps": 0,
+                "last_node_id": None,
+                "outputs": {},
+                "history": [],
+                "error": "NodeExecutionError: Error in node 'node-1'",
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
-                "run_workflow",
-                ctx=tool_context_with_permission,
-                workflow=simple_workflow,
-                inputs={}
+                "run_workflow", ctx=tool_context_with_permission, workflow=simple_workflow, inputs={}
             )
-            
+
             assert result.success is False
             assert "FAILED" in result.output
             assert result.metadata["status"] == "error"
@@ -699,40 +756,37 @@ class TestRunWorkflowToolExecution:
 # Test Result Formatting
 # =============================================================================
 
+
 class TestRunWorkflowToolResultFormatting:
     """Test run_workflow tool result formatting"""
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_result_formatting(self, tool_context_with_permission, simple_workflow):
         """Test that workflow results are properly formatted"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-format",
-            "steps": 3,
-            "last_node_id": "node-3",
-            "outputs": {
-                "result": "processed",
-                "count": 42
-            },
-            "history": [
-                {"node_id": "node-1", "status": "SUCCEEDED"},
-                {"node_id": "node-2", "status": "SUCCEEDED"},
-                {"node_id": "node-3", "status": "SUCCEEDED"},
-            ],
-            "error": None
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-format",
+                "steps": 3,
+                "last_node_id": "node-3",
+                "outputs": {"result": "processed", "count": 42},
+                "history": [
+                    {"node_id": "node-1", "status": "SUCCEEDED"},
+                    {"node_id": "node-2", "status": "SUCCEEDED"},
+                    {"node_id": "node-3", "status": "SUCCEEDED"},
+                ],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
-                "run_workflow",
-                ctx=tool_context_with_permission,
-                workflow=simple_workflow,
-                inputs={}
+                "run_workflow", ctx=tool_context_with_permission, workflow=simple_workflow, inputs={}
             )
-            
+
             assert result.success is True
             output = result.output
-            
+
             # Check that all key information is present
             assert "Status: SUCCEEDED" in output
             assert "Run ID: run-format" in output
@@ -742,28 +796,27 @@ class TestRunWorkflowToolResultFormatting:
             assert "Execution History" not in output
         assert result.metadata["history"] == []
         assert result.metadata["history_count"] == len(fake.history)
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_result_with_error(self, tool_context_with_permission, simple_workflow):
         """Test result formatting when workflow has error"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "FAILED",
-            "run_id": "run-error",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {},
-            "history": [],
-            "error": "NodeExecutionError: Invalid code"
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "FAILED",
+                "run_id": "run-error",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {},
+                "history": [],
+                "error": "NodeExecutionError: Invalid code",
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
-                "run_workflow",
-                ctx=tool_context_with_permission,
-                workflow=simple_workflow,
-                inputs={}
+                "run_workflow", ctx=tool_context_with_permission, workflow=simple_workflow, inputs={}
             )
-            
+
             assert result.success is False
             assert "Error:" in result.output
             assert "NodeExecutionError" in result.output
@@ -773,30 +826,30 @@ class TestRunWorkflowToolResultFormatting:
 # Test Permission Handling
 # =============================================================================
 
+
 class TestRunWorkflowToolPermissions:
     """Test run_workflow tool permission handling"""
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_requests_permission(self, tool_context_with_permission, simple_workflow):
         """Test that workflow execution requests permission"""
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-perm",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {},
-            "history": [],
-            "error": None
-        })
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-perm",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {},
+                "history": [],
+                "error": None,
+            }
+        )
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             await ToolRegistry.execute(
-                "run_workflow",
-                ctx=tool_context_with_permission,
-                workflow=simple_workflow,
-                inputs={}
+                "run_workflow", ctx=tool_context_with_permission, workflow=simple_workflow, inputs={}
             )
-            
+
             # Verify permission was requested
             assert len(tool_context_with_permission._permissions_requested) == 1
             perm_request = tool_context_with_permission._permissions_requested[0]
@@ -810,74 +863,73 @@ class TestRunWorkflowToolPermissions:
 # JSON Parsing Tests (simulating LLM-generated tool calls)
 # =============================================================================
 
+
 class TestRunWorkflowToolJSONParsing:
     """Test JSON parsing scenarios that occur when LLM generates tool calls."""
-    
+
     @pytest.mark.anyio
     async def test_workflow_path_with_quotes_valid_json(self, tool_context_with_permission, tmp_path):
         """Test that workflow path with quotes is valid JSON and can be parsed."""
         import json
-        
+
         # Create a workflow file
         workflow_path = str(tmp_path / "test_workflow.json")
         workflow_content = {
             "id": "test-json-parsing",
             "name": "Test JSON Parsing",
             "start": "node-1",
-            "nodes": [
-                {
-                    "id": "node-1",
-                    "type": "python",
-                    "code": "outputs['result'] = 'success'"
-                }
-            ],
-            "edges": []
+            "nodes": [{"id": "node-1", "type": "python", "code": "outputs['result'] = 'success'"}],
+            "edges": [],
         }
-        with open(workflow_path, 'w') as f:
+        with open(workflow_path, "w") as f:
             json.dump(workflow_content, f)
-        
+
         # Simulate LLM generating JSON with QUOTED path (correct)
-        arguments_json_string = json.dumps({
-            "workflow": workflow_path,  # This will be properly quoted in JSON
-            "inputs": {}
-        })
-        
+        arguments_json_string = json.dumps(
+            {
+                "workflow": workflow_path,  # This will be properly quoted in JSON
+                "inputs": {},
+            }
+        )
+
         # Verify it's valid JSON
         parsed_args = json.loads(arguments_json_string)
         assert parsed_args["workflow"] == workflow_path
-        
+
         # Now execute with the parsed arguments
-        fake = FakeRunWorkflowResult(**{
-            "status": "SUCCEEDED",
-            "run_id": "run-json-test",
-            "steps": 1,
-            "last_node_id": "node-1",
-            "outputs": {"result": "success"},
-            "history": []
-        })
-        
+        fake = FakeRunWorkflowResult(
+            **{
+                "status": "SUCCEEDED",
+                "run_id": "run-json-test",
+                "steps": 1,
+                "last_node_id": "node-1",
+                "outputs": {"result": "success"},
+                "history": [],
+            }
+        )
+
         mock_run = Mock(name="run_workflow", return_value=fake)
         with patch.object(run_workflow_module, "_get_workflow_runtime", return_value=_runtime_tuple(run_fn=mock_run)):
             result = await ToolRegistry.execute(
                 "run_workflow",
                 ctx=tool_context_with_permission,
-                **parsed_args  # Unpack parsed arguments
+                **parsed_args,  # Unpack parsed arguments
             )
-            
+
             assert result.success is True
-    
+
     @pytest.mark.anyio
     async def test_workflow_path_without_quotes_invalid_json(self):
         """Test that workflow path without quotes is INVALID JSON and cannot be parsed."""
         import json
-        
+
         # Simulate LLM generating JSON with UNQUOTED path (incorrect - this is the bug)
         invalid_json_string = '{"workflow": workflow/alert_triage/workflow.json, "inputs": {}}'
-        
+
         # Verify it's INVALID JSON
         with pytest.raises(json.JSONDecodeError):
             json.loads(invalid_json_string)
-        
+
         # This is exactly what causes "Failed to parse tool arguments" error in production
 
 
@@ -885,9 +937,10 @@ class TestRunWorkflowToolJSONParsing:
 # Integration Test (if flocks_workflow is available)
 # =============================================================================
 
+
 class TestRunWorkflowToolIntegration:
     """Integration tests with the real in-repo workflow runtime."""
-    
+
     @pytest.mark.anyio
     async def test_run_workflow_integration(self, tool_context_with_permission):
         """Integration test that exercises the tool end-to-end."""
@@ -897,23 +950,19 @@ class TestRunWorkflowToolIntegration:
             "metadata": {},
             "start": "node-1",
             "nodes": [
-                {
-                    "id": "node-1",
-                    "type": "python",
-                    "code": "outputs['result'] = {'test': 'integration', 'value': 100}"
-                }
+                {"id": "node-1", "type": "python", "code": "outputs['result'] = {'test': 'integration', 'value': 100}"}
             ],
-            "edges": []
+            "edges": [],
         }
-        
+
         result = await ToolRegistry.execute(
             "run_workflow",
             ctx=tool_context_with_permission,
             workflow=workflow,
             inputs={},
-            ensure_requirements=False  # Skip requirements for test
+            ensure_requirements=False,  # Skip requirements for test
         )
-        
+
         assert result is not None
         assert result.success is True
         assert "Status: SUCCEEDED" in (result.output or "")

--- a/tests/workflow/test_tool_run_workflow.py
+++ b/tests/workflow/test_tool_run_workflow.py
@@ -47,6 +47,25 @@ def _make_large_alerts(count: int) -> list[dict[str, Any]]:
     return [{"id": idx, "payload": "x" * 20} for idx in range(count)]
 
 
+def test_format_workflow_result_compacts_large_outputs() -> None:
+    large_alerts = _make_large_alerts(5_000)
+
+    text = run_workflow_module._format_workflow_result(
+        {
+            "status": "SUCCEEDED",
+            "steps": 1,
+            "outputs": {
+                "enriched_alerts": large_alerts,
+                "message": "done",
+            },
+        }
+    )
+
+    assert "_enriched_alerts_count" in text
+    assert "5000" in text
+    assert "payload" not in text
+
+
 # =============================================================================
 # Fixtures
 # =============================================================================

--- a/tests/workflow/test_tool_run_workflow_simple.py
+++ b/tests/workflow/test_tool_run_workflow_simple.py
@@ -24,7 +24,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from flocks.tool import ToolRegistry, ToolContext
+from flocks.tool import ToolContext, ToolRegistry  # noqa: E402
 
 
 def _dump_tool_result(result) -> str:
@@ -71,7 +71,7 @@ async def run_simple_workflow_full_result():
     print(_dump_tool_result(result))
 
     assert result.success is True
-    assert result.metadata.get("status") == "SUCCEEDED"
+    assert result.metadata.get("status") == "success"
     assert "Status: SUCCEEDED" in (result.output or "")
 
 
@@ -148,7 +148,7 @@ async def run_specified_workflow_file_full_result(workflow_path=None, query=None
 
     # 基础断言：工作流应该成功执行
     assert result.success is True, f"Workflow execution failed: {result.error}"
-    assert result.metadata.get("status") == "SUCCEEDED", f"Expected SUCCEEDED status, got: {result.metadata.get('status')}"
+    assert result.metadata.get("status") == "success", f"Expected success status, got: {result.metadata.get('status')}"
     assert "Status: SUCCEEDED" in (result.output or ""), "Output should contain success status"
     
     # 验证最终节点：应该是 finalize_output

--- a/tests/workflow/test_trigger_runtime.py
+++ b/tests/workflow/test_trigger_runtime.py
@@ -14,10 +14,10 @@ async def test_sync_legacy_configs_disables_explicit_empty_trigger_list(
 ) -> None:
     writes: list[tuple[str, dict]] = []
 
-    async def _fake_write(key: str, value: dict) -> None:
-        writes.append((key, value))
+    async def _fake_put_config(workflow_id: str, config: dict, *, kind: str) -> None:
+        writes.append((f"{kind}/{workflow_id}", config))
 
-    monkeypatch.setattr(runtime_module.Storage, "write", _fake_write)
+    monkeypatch.setattr(runtime_module.WorkflowStore, "put_config", _fake_put_config)
 
     runtime = runtime_module.TriggerRuntime()
     triggers = await runtime._sync_legacy_configs_from_workflow(  # noqa: SLF001
@@ -26,9 +26,7 @@ async def test_sync_legacy_configs_disables_explicit_empty_trigger_list(
     )
 
     assert triggers == []
-    assert {
-        key for key, _value in writes
-    } == {
+    assert {key for key, _value in writes} == {
         "workflow_poller_config/wf-empty",
         "workflow_syslog_config/wf-empty",
         "workflow_kafka_config/wf-empty",
@@ -62,9 +60,7 @@ async def test_custom_adapter_restarts_when_definition_changes(
     monkeypatch.setattr(
         runtime_module,
         "load_trigger_plugin_module",
-        lambda _plugin_spec: SimpleNamespace(
-            create_trigger_adapter=lambda definition: _FakeAdapter(definition)
-        ),
+        lambda _plugin_spec: SimpleNamespace(create_trigger_adapter=lambda definition: _FakeAdapter(definition)),
     )
 
     runtime = runtime_module.TriggerRuntime()

--- a/tests/workflow/test_workflow_center_lifecycle.py
+++ b/tests/workflow/test_workflow_center_lifecycle.py
@@ -54,9 +54,9 @@ async def test_stop_workflow_service_uses_persisted_runtime_driver(monkeypatch) 
         return True
 
     monkeypatch.setenv("FLOCKS_WORKFLOW_SERVICE_DRIVER", "local")
-    monkeypatch.setattr(center.Storage, "read", fake_read)
-    monkeypatch.setattr(center.Storage, "write", fake_write)
-    monkeypatch.setattr(center.Storage, "remove", fake_remove)
+    monkeypatch.setattr(center.WorkflowStore, "kv_get", fake_read)
+    monkeypatch.setattr(center.WorkflowStore, "kv_put", fake_write)
+    monkeypatch.setattr(center.WorkflowStore, "kv_remove", fake_remove)
     monkeypatch.setattr(center, "_stop_and_remove_container", fake_stop_container)
 
     result = await center.stop_workflow_service("wf-1")
@@ -108,9 +108,9 @@ async def test_publish_cleanup_uses_previous_runtime_driver(monkeypatch) -> None
         stopped_containers.append(container_name)
         return True
 
-    monkeypatch.setattr(center.Storage, "read", fake_read)
-    monkeypatch.setattr(center.Storage, "write", fake_write)
-    monkeypatch.setattr(center.Storage, "remove", fake_remove)
+    monkeypatch.setattr(center.WorkflowStore, "kv_get", fake_read)
+    monkeypatch.setattr(center.WorkflowStore, "kv_put", fake_write)
+    monkeypatch.setattr(center.WorkflowStore, "kv_remove", fake_remove)
     monkeypatch.setattr(center, "_stop_and_remove_container", fake_stop_container)
 
     await center._stop_existing_runtime_for_publish("wf-1")
@@ -152,8 +152,8 @@ async def test_allocate_port_skips_reserved_service_records(monkeypatch) -> None
 
     monkeypatch.setenv("FLOCKS_WORKFLOW_SERVICE_PORT_START", "19000")
     monkeypatch.setenv("FLOCKS_WORKFLOW_SERVICE_PORT_END", "19003")
-    monkeypatch.setattr(center.Storage, "list_keys", fake_list_keys)
-    monkeypatch.setattr(center.Storage, "read", fake_read)
+    monkeypatch.setattr(center.WorkflowStore, "kv_list_keys", fake_list_keys)
+    monkeypatch.setattr(center.WorkflowStore, "kv_get", fake_read)
     monkeypatch.setattr(center, "_is_port_available", lambda _port: True)
 
     assert await center._allocate_port() == 19003
@@ -169,7 +169,7 @@ async def test_allocate_port_reserves_in_flight_allocations(monkeypatch) -> None
 
     monkeypatch.setenv("FLOCKS_WORKFLOW_SERVICE_PORT_START", "19000")
     monkeypatch.setenv("FLOCKS_WORKFLOW_SERVICE_PORT_END", "19001")
-    monkeypatch.setattr(center.Storage, "list_keys", fake_list_keys)
+    monkeypatch.setattr(center.WorkflowStore, "kv_list_keys", fake_list_keys)
     monkeypatch.setattr(center, "_is_port_available", lambda _port: True)
 
     try:
@@ -187,12 +187,14 @@ async def test_publish_workflow_local_releases_reserved_port_on_spawn_failure(
     workflow_id = "wf-local-spawn-fail"
     workflow_path = tmp_path / "workflow.json"
     workflow_path.write_text(
-        json.dumps({
-            "id": workflow_id,
-            "start": "n1",
-            "nodes": [{"id": "n1", "type": "python", "code": "outputs['ok'] = True"}],
-            "edges": [],
-        }),
+        json.dumps(
+            {
+                "id": workflow_id,
+                "start": "n1",
+                "nodes": [{"id": "n1", "type": "python", "code": "outputs['ok'] = True"}],
+                "edges": [],
+            }
+        ),
         encoding="utf-8",
     )
     store: dict[str, Any] = {
@@ -223,8 +225,8 @@ async def test_publish_workflow_local_releases_reserved_port_on_spawn_failure(
         raise OSError("spawn failed")
 
     center._IN_FLIGHT_PORT_RESERVATIONS.clear()
-    monkeypatch.setattr(center.Storage, "read", fake_read)
-    monkeypatch.setattr(center.Storage, "write", fake_write)
+    monkeypatch.setattr(center.WorkflowStore, "kv_get", fake_read)
+    monkeypatch.setattr(center.WorkflowStore, "kv_put", fake_write)
     monkeypatch.setattr(center, "_stop_existing_runtime_for_publish", fake_stop_existing_runtime_for_publish)
     monkeypatch.setattr(center, "_write_release_snapshot", fake_write_release_snapshot)
     monkeypatch.setattr(center, "_allocate_port", fake_allocate_port)

--- a/tests/workflow/test_workflow_fixes.py
+++ b/tests/workflow/test_workflow_fixes.py
@@ -7,17 +7,24 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from flocks.tool import Tool, ToolCategory, ToolContext, ToolInfo, ToolRegistry, ToolResult
+from flocks.workflow.errors import WorkflowValidationError
 from flocks.workflow.models import Workflow
 from flocks.workflow.engine import WorkflowEngine
+from flocks.workflow import fs_store
 from flocks.workflow.repl_runtime import PythonExecRuntime
+from flocks.workflow.runner import run_workflow
+from flocks.workflow import tools_adapter as tools_adapter_module
 from flocks.workflow.tools import ToolFacade
 from flocks.workflow.tools_adapter import FlocksToolAdapter
 from flocks.workflow.workflow_lint import (
+    lint_implicit_full_payload_edges,
     lint_expensive_node_multi_trigger,
     lint_join_requirements,
     lint_workflow,
@@ -27,6 +34,7 @@ from flocks.workflow.workflow_lint import (
 # ---------------------------------------------------------------------------
 # Helper: mock adapter that returns controllable outputs
 # ---------------------------------------------------------------------------
+
 
 class _MockToolAdapter(FlocksToolAdapter):
     """FlocksToolAdapter subclass that bypasses real tool registry."""
@@ -42,9 +50,58 @@ class _MockToolAdapter(FlocksToolAdapter):
             val = self._outputs[name]
             if isinstance(val, Exception):
                 from flocks.workflow.errors import NodeExecutionError
+
                 raise NodeExecutionError(node_id="<tool>", message=str(val))
             return val
         return f"mock_output_for_{name}"
+
+
+def test_subworkflow_loader_reads_filesystem_workflow_without_legacy_kv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    workflow_id = "child-filesystem-workflow"
+    workflow_dir = tmp_path / ".flocks" / "plugins" / "workflows" / workflow_id
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "workflow.json").write_text(
+        json.dumps(
+            {
+                "name": "Child Filesystem Workflow",
+                "start": "child_node",
+                "nodes": [
+                    {
+                        "id": "child_node",
+                        "type": "python",
+                        "code": "outputs['child_result'] = inputs.get('value', 'missing')",
+                    }
+                ],
+                "edges": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(fs_store, "_workspace_root", None)
+
+    result = run_workflow(
+        workflow={
+            "id": "parent-filesystem-workflow",
+            "start": "call_child",
+            "nodes": [
+                {
+                    "id": "call_child",
+                    "type": "subworkflow",
+                    "workflow_id": workflow_id,
+                }
+            ],
+            "edges": [],
+        },
+        inputs={"value": "ok"},
+        ensure_requirements=False,
+    )
+
+    assert result.status == "SUCCEEDED"
+    assert result.outputs == {"output": {"child_result": "ok"}}
 
 
 # ===================================================================
@@ -64,9 +121,7 @@ class TestRunSafe:
         assert result["error"] is None
 
     def test_run_safe_dict_output(self):
-        adapter = _MockToolAdapter(outputs={
-            "memory_search": {"results": [{"id": 1}], "count": 1}
-        })
+        adapter = _MockToolAdapter(outputs={"memory_search": {"results": [{"id": 1}], "count": 1}})
         result = adapter.run_safe("memory_search", query="test")
         assert result["success"] is True
         assert isinstance(result["text"], str)
@@ -82,9 +137,7 @@ class TestRunSafe:
         assert result["obj"] is None
 
     def test_run_safe_error(self):
-        adapter = _MockToolAdapter(outputs={
-            "bad_tool": Exception("connection timeout")
-        })
+        adapter = _MockToolAdapter(outputs={"bad_tool": Exception("connection timeout")})
         result = adapter.run_safe("bad_tool")
         assert result["success"] is False
         assert result["text"] == ""
@@ -103,9 +156,7 @@ class TestRunSafe:
 
     def test_run_safe_explicit_error(self):
         """Explicit error entry in outputs -> run_safe catches and wraps."""
-        adapter = _MockToolAdapter(outputs={
-            "failing": Exception("service unavailable")
-        })
+        adapter = _MockToolAdapter(outputs={"failing": Exception("service unavailable")})
         result = adapter.run_safe("failing")
         assert result["success"] is False
         assert result["obj"] is None
@@ -117,6 +168,36 @@ class TestRunSafe:
         result = facade.run_safe("websearch", query="test")
         assert result["success"] is True
         assert result["text"] == "search results"
+
+    def test_run_safe_retries_after_lazy_mcp_tool_load(self, monkeypatch: pytest.MonkeyPatch):
+        tool_name = "workflow_lazy_mcp_test_tool"
+        ToolRegistry.unregister(tool_name)
+
+        async def _handler(_ctx: ToolContext) -> ToolResult:
+            return ToolResult(success=True, output="lazy-mcp-ok")
+
+        def _fake_lazy_load() -> None:
+            ToolRegistry.register(
+                Tool(
+                    info=ToolInfo(
+                        name=tool_name,
+                        description="Lazy MCP test tool",
+                        category=ToolCategory.CUSTOM,
+                        parameters=[],
+                    ),
+                    handler=_handler,
+                )
+            )
+
+        monkeypatch.setattr(tools_adapter_module, "_try_lazy_load_mcp_tools", _fake_lazy_load)
+        try:
+            adapter = FlocksToolAdapter()
+            result = adapter.run_safe(tool_name)
+        finally:
+            ToolRegistry.unregister(tool_name)
+
+        assert result["success"] is True
+        assert result["text"] == "lazy-mcp-ok"
 
     def test_run_safe_list_output(self):
         adapter = _MockToolAdapter(outputs={"list_tool": [1, 2, 3]})
@@ -136,19 +217,21 @@ class TestLintJoinRequirements:
 
     def test_multi_incoming_no_join_error(self):
         """Node with 2+ non-exclusive incoming edges and no join -> error."""
-        wf = Workflow.from_dict({
-            "name": "bad_join",
-            "start": "a",
-            "nodes": [
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
-                {"id": "c", "type": "python", "code": "outputs['z'] = inputs.get('x', 0)"},
-            ],
-            "edges": [
-                {"from": "a", "to": "c"},
-                {"from": "b", "to": "c"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "bad_join",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
+                    {"id": "c", "type": "python", "code": "outputs['z'] = inputs.get('x', 0)"},
+                ],
+                "edges": [
+                    {"from": "a", "to": "c"},
+                    {"from": "b", "to": "c"},
+                ],
+            }
+        )
         results = lint_join_requirements(wf)
         assert len(results) == 1
         assert results[0]["kind"] == "multi_incoming_no_join"
@@ -157,66 +240,72 @@ class TestLintJoinRequirements:
 
     def test_exclusive_branch_no_error(self):
         """Edges from same branch with different labels are exclusive -> no error."""
-        wf = Workflow.from_dict({
-            "name": "ok_branch",
-            "start": "start",
-            "nodes": [
-                {"id": "start", "type": "python", "code": "outputs['flag'] = True"},
-                {"id": "br", "type": "branch", "select_key": "flag"},
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['x'] = 2"},
-                {"id": "merge", "type": "python", "code": "outputs['r'] = inputs.get('x')"},
-            ],
-            "edges": [
-                {"from": "start", "to": "br"},
-                {"from": "br", "to": "a", "label": "true"},
-                {"from": "br", "to": "b", "label": "false"},
-                {"from": "a", "to": "merge"},
-                {"from": "b", "to": "merge"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "ok_branch",
+                "start": "start",
+                "nodes": [
+                    {"id": "start", "type": "python", "code": "outputs['flag'] = True"},
+                    {"id": "br", "type": "branch", "select_key": "flag"},
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['x'] = 2"},
+                    {"id": "merge", "type": "python", "code": "outputs['r'] = inputs.get('x')"},
+                ],
+                "edges": [
+                    {"from": "start", "to": "br"},
+                    {"from": "br", "to": "a", "label": "true"},
+                    {"from": "br", "to": "b", "label": "false"},
+                    {"from": "a", "to": "merge"},
+                    {"from": "b", "to": "merge"},
+                ],
+            }
+        )
         results = lint_join_requirements(wf)
         assert len(results) == 0
 
     def test_join_true_no_error(self):
         """Node with join=true should not trigger the lint."""
-        wf = Workflow.from_dict({
-            "name": "ok_join",
-            "start": "a",
-            "nodes": [
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
-                {"id": "c", "type": "python", "code": "pass", "join": True},
-            ],
-            "edges": [
-                {"from": "a", "to": "c"},
-                {"from": "b", "to": "c"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "ok_join",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
+                    {"id": "c", "type": "python", "code": "pass", "join": True},
+                ],
+                "edges": [
+                    {"from": "a", "to": "c"},
+                    {"from": "b", "to": "c"},
+                ],
+            }
+        )
         results = lint_join_requirements(wf)
         assert len(results) == 0
 
     def test_mixed_exclusive_and_non_exclusive(self):
         """Branch targets + extra direct edge -> error (not fully exclusive)."""
-        wf = Workflow.from_dict({
-            "name": "mixed",
-            "start": "start",
-            "nodes": [
-                {"id": "start", "type": "python", "code": "outputs['flag'] = True"},
-                {"id": "br", "type": "branch", "select_key": "flag"},
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['x'] = 2"},
-                {"id": "merge", "type": "python", "code": "pass"},
-            ],
-            "edges": [
-                {"from": "start", "to": "br"},
-                {"from": "br", "to": "a", "label": "true"},
-                {"from": "br", "to": "b", "label": "false"},
-                {"from": "a", "to": "merge"},
-                {"from": "b", "to": "merge"},
-                {"from": "start", "to": "merge"},  # extra non-exclusive edge
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "mixed",
+                "start": "start",
+                "nodes": [
+                    {"id": "start", "type": "python", "code": "outputs['flag'] = True"},
+                    {"id": "br", "type": "branch", "select_key": "flag"},
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['x'] = 2"},
+                    {"id": "merge", "type": "python", "code": "pass"},
+                ],
+                "edges": [
+                    {"from": "start", "to": "br"},
+                    {"from": "br", "to": "a", "label": "true"},
+                    {"from": "br", "to": "b", "label": "false"},
+                    {"from": "a", "to": "merge"},
+                    {"from": "b", "to": "merge"},
+                    {"from": "start", "to": "merge"},  # extra non-exclusive edge
+                ],
+            }
+        )
         results = lint_join_requirements(wf)
         assert len(results) == 1
         assert results[0]["node_id"] == "merge"
@@ -227,23 +316,25 @@ class TestLintExpensiveNodeMultiTrigger:
 
     def test_expensive_node_multi_incoming_error(self):
         """Expensive node (LLM call) with multiple non-exclusive edges -> error."""
-        wf = Workflow.from_dict({
-            "name": "expensive_bad",
-            "start": "a",
-            "nodes": [
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
-                {
-                    "id": "expensive",
-                    "type": "python",
-                    "code": "result = llm.ask('summarize')\noutputs['summary'] = result",
-                },
-            ],
-            "edges": [
-                {"from": "a", "to": "expensive"},
-                {"from": "b", "to": "expensive"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "expensive_bad",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
+                    {
+                        "id": "expensive",
+                        "type": "python",
+                        "code": "result = llm.ask('summarize')\noutputs['summary'] = result",
+                    },
+                ],
+                "edges": [
+                    {"from": "a", "to": "expensive"},
+                    {"from": "b", "to": "expensive"},
+                ],
+            }
+        )
         results = lint_expensive_node_multi_trigger(wf)
         assert len(results) == 1
         assert results[0]["kind"] == "expensive_node_multi_trigger"
@@ -251,41 +342,45 @@ class TestLintExpensiveNodeMultiTrigger:
 
     def test_non_expensive_node_no_error(self):
         """Non-expensive node with multiple edges -> no error from this check."""
-        wf = Workflow.from_dict({
-            "name": "cheap_ok",
-            "start": "a",
-            "nodes": [
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
-                {"id": "c", "type": "python", "code": "outputs['z'] = 3"},
-            ],
-            "edges": [
-                {"from": "a", "to": "c"},
-                {"from": "b", "to": "c"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "cheap_ok",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
+                    {"id": "c", "type": "python", "code": "outputs['z'] = 3"},
+                ],
+                "edges": [
+                    {"from": "a", "to": "c"},
+                    {"from": "b", "to": "c"},
+                ],
+            }
+        )
         results = lint_expensive_node_multi_trigger(wf)
         assert len(results) == 0
 
     def test_write_tool_detected_as_expensive(self):
         """Node calling tool.run('write', ...) is detected as expensive."""
-        wf = Workflow.from_dict({
-            "name": "write_bad",
-            "start": "a",
-            "nodes": [
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
-                {
-                    "id": "writer",
-                    "type": "python",
-                    "code": "tool.run('write', filePath='out.md', content='hi')",
-                },
-            ],
-            "edges": [
-                {"from": "a", "to": "writer"},
-                {"from": "b", "to": "writer"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "write_bad",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
+                    {
+                        "id": "writer",
+                        "type": "python",
+                        "code": "tool.run('write', filePath='out.md', content='hi')",
+                    },
+                ],
+                "edges": [
+                    {"from": "a", "to": "writer"},
+                    {"from": "b", "to": "writer"},
+                ],
+            }
+        )
         results = lint_expensive_node_multi_trigger(wf)
         assert len(results) == 1
         assert results[0]["node_id"] == "writer"
@@ -296,36 +391,94 @@ class TestLintWorkflowUnified:
 
     def test_lint_workflow_combines_all_checks(self):
         """lint_workflow() should return results from all check functions."""
-        wf = Workflow.from_dict({
-            "name": "combined",
-            "start": "a",
-            "nodes": [
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
-                {"id": "c", "type": "python", "code": "pass"},
-            ],
-            "edges": [
-                {"from": "a", "to": "c"},
-                {"from": "b", "to": "c"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "combined",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = 2"},
+                    {"id": "c", "type": "python", "code": "pass"},
+                ],
+                "edges": [
+                    {"from": "a", "to": "c"},
+                    {"from": "b", "to": "c"},
+                ],
+            }
+        )
         results = lint_workflow(wf)
         kinds = {r["kind"] for r in results}
         assert "multi_incoming_no_join" in kinds
 
     def test_lint_workflow_clean(self):
         """A well-formed workflow should produce no lint results."""
-        wf = Workflow.from_dict({
-            "name": "clean",
+        wf = Workflow.from_dict(
+            {
+                "name": "clean",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = inputs.get('mapped_x')"},
+                ],
+                "edges": [{"from": "a", "to": "b", "mapping": {"mapped_x": "x"}}],
+            }
+        )
+        results = lint_workflow(wf)
+        assert len(results) == 0
+
+    def test_missing_edge_mapping_warns_by_default(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "implicit_mapping",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = inputs.get('x')"},
+                ],
+                "edges": [{"from": "a", "to": "b"}],
+            }
+        )
+
+        results = lint_implicit_full_payload_edges(wf)
+
+        assert len(results) == 1
+        assert results[0]["kind"] == "implicit_full_payload_edge"
+        assert results[0]["severity"] == "warning"
+
+    def test_missing_edge_mapping_is_error_when_strict(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "strict_implicit_mapping",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = inputs.get('x')"},
+                ],
+                "edges": [{"from": "a", "to": "b"}],
+                "metadata": {"runtime": {"strict_edge_mapping": True}},
+            }
+        )
+
+        results = lint_implicit_full_payload_edges(wf)
+
+        assert len(results) == 1
+        assert results[0]["kind"] == "implicit_full_payload_edge"
+        assert results[0]["severity"] == "error"
+
+    def test_run_workflow_rejects_strict_implicit_mapping(self):
+        workflow = {
+            "name": "strict_implicit_mapping",
             "start": "a",
             "nodes": [
                 {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
                 {"id": "b", "type": "python", "code": "outputs['y'] = inputs.get('x')"},
             ],
             "edges": [{"from": "a", "to": "b"}],
-        })
-        results = lint_workflow(wf)
-        assert len(results) == 0
+            "metadata": {"runtime": {"strict_edge_mapping": True}},
+        }
+
+        with pytest.raises(WorkflowValidationError):
+            run_workflow(workflow=workflow, ensure_requirements=False)
 
 
 # ===================================================================
@@ -338,21 +491,23 @@ class TestEngineDedup:
 
     def test_dedup_different_inputs_both_execute(self):
         """When a node receives different inputs from two sources, both execute (no dedup)."""
-        wf = Workflow.from_dict({
-            "name": "dedup_test",
-            "start": "a",
-            "nodes": [
-                # a fans out to b and c (python node sends to all outgoing edges)
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                {"id": "b", "type": "python", "code": "outputs['x'] = 2"},
-                {"id": "d", "type": "python", "code": "outputs['result'] = inputs.get('x', 0)"},
-            ],
-            "edges": [
-                {"from": "a", "to": "b"},
-                {"from": "a", "to": "d"},
-                {"from": "b", "to": "d"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "dedup_test",
+                "start": "a",
+                "nodes": [
+                    # a fans out to b and c (python node sends to all outgoing edges)
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['x'] = 2"},
+                    {"id": "d", "type": "python", "code": "outputs['result'] = inputs.get('x', 0)"},
+                ],
+                "edges": [
+                    {"from": "a", "to": "b"},
+                    {"from": "a", "to": "d"},
+                    {"from": "b", "to": "d"},
+                ],
+            }
+        )
         engine = WorkflowEngine(
             wf,
             runtime=PythonExecRuntime(),
@@ -370,19 +525,21 @@ class TestEngineDedup:
 
     def test_dedup_skips_truly_identical_inputs(self):
         """Identical inputs to the same node -> second execution is skipped."""
-        wf = Workflow.from_dict({
-            "name": "dedup_identical",
-            "start": "a",
-            "nodes": [
-                {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
-                # Two edges from a to b (rare but possible)
-                {"id": "b", "type": "python", "code": "outputs['y'] = inputs.get('x')"},
-            ],
-            "edges": [
-                {"from": "a", "to": "b"},
-                {"from": "a", "to": "b"},
-            ],
-        })
+        wf = Workflow.from_dict(
+            {
+                "name": "dedup_identical",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    # Two edges from a to b (rare but possible)
+                    {"id": "b", "type": "python", "code": "outputs['y'] = inputs.get('x')"},
+                ],
+                "edges": [
+                    {"from": "a", "to": "b"},
+                    {"from": "a", "to": "b"},
+                ],
+            }
+        )
         engine = WorkflowEngine(
             wf,
             runtime=PythonExecRuntime(),
@@ -409,6 +566,7 @@ class TestExampleWorkflow:
     def test_example_workflow_loads(self):
         """Example workflow.json should be valid and loadable."""
         import os
+
         wf_path = os.path.join(
             os.path.dirname(__file__),
             "..",
@@ -429,6 +587,7 @@ class TestExampleWorkflow:
     def test_example_workflow_no_lint_errors(self):
         """Example workflow should pass all lint checks (no errors)."""
         import os
+
         wf_path = os.path.join(
             os.path.dirname(__file__),
             "..",
@@ -450,6 +609,7 @@ class TestExampleWorkflow:
     def test_no_exec_json_files(self):
         """workflow-exec.json and workflow-exec-b.json should not exist."""
         import os
+
         base = os.path.join(
             os.path.dirname(__file__),
             "..",

--- a/tests/workflow/test_workflow_fixes.py
+++ b/tests/workflow/test_workflow_fixes.py
@@ -656,6 +656,105 @@ class TestPayloadRiskObservability:
         assert "[0, 1, 2, 3, 4" not in text
 
 
+class TestVertexCacheDataflow:
+    def test_legacy_mode_records_large_fanout_before_mapped_edges(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "legacy_large_source_small_mapped_fanout",
+                "start": "a",
+                "nodes": [
+                    {
+                        "id": "a",
+                        "type": "python",
+                        "code": "outputs['events'] = list(range(1500))\noutputs['count'] = len(outputs['events'])",
+                    },
+                    {"id": "b", "type": "python", "code": "outputs['b_count'] = inputs['count']"},
+                    {"id": "c", "type": "python", "code": "outputs['c_count'] = inputs['count']"},
+                ],
+                "edges": [
+                    {"from": "a", "to": "b", "mapping": {"count": "count"}},
+                    {"from": "a", "to": "c", "mapping": {"count": "count"}},
+                ],
+            }
+        )
+
+        result = WorkflowEngine(wf, runtime=PythonExecRuntime(), dataflow_mode="legacy").run()
+
+        assert result.payload_risk_summary["counts"]["large_payload_fanout"] == 1
+
+    def test_vertex_cache_mode_records_fanout_only_for_resolved_edge_payload(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "vertex_cache_small_mapped_fanout",
+                "start": "a",
+                "nodes": [
+                    {
+                        "id": "a",
+                        "type": "python",
+                        "code": "outputs['events'] = list(range(1500))\noutputs['count'] = len(outputs['events'])",
+                    },
+                    {"id": "b", "type": "python", "code": "outputs['b_count'] = inputs['count']"},
+                    {"id": "c", "type": "python", "code": "outputs['c_count'] = inputs['count']"},
+                ],
+                "edges": [
+                    {"from": "a", "to": "b", "mapping": {"count": "count"}},
+                    {"from": "a", "to": "c", "mapping": {"count": "count"}},
+                ],
+            }
+        )
+
+        result = WorkflowEngine(wf, runtime=PythonExecRuntime(), dataflow_mode="vertex_cache").run()
+
+        counts = result.payload_risk_summary["counts"]
+        assert "large_payload_fanout" not in counts
+        assert "implicit_full_payload_edge_large_payload" not in counts
+
+    def test_vertex_cache_no_mapping_preserves_legacy_shape(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "vertex_cache_no_mapping_fallback",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['events'] = list(range(1500))"},
+                    {"id": "b", "type": "python", "code": "outputs['count'] = len(inputs['events'])"},
+                ],
+                "edges": [{"from": "a", "to": "b"}],
+            }
+        )
+
+        result = WorkflowEngine(wf, runtime=PythonExecRuntime(), dataflow_mode="vertex_cache").run()
+
+        assert result.outputs == {"count": 1500}
+        assert result.payload_risk_summary["counts"]["implicit_full_payload_edge_large_payload"] == 1
+
+    def test_run_workflow_uses_vertex_cache_dataflow_metadata(self):
+        workflow = {
+            "name": "metadata_vertex_cache_small_fanout",
+            "start": "a",
+            "metadata": {"runtime": {"strict_edge_mapping": True, "dataflow_mode": "vertex_cache"}},
+            "nodes": [
+                {
+                    "id": "a",
+                    "type": "python",
+                    "code": "outputs['events'] = list(range(1500))\noutputs['count'] = len(outputs['events'])",
+                },
+                {"id": "b", "type": "python", "code": "outputs['b_count'] = inputs['count']"},
+                {"id": "c", "type": "python", "code": "outputs['c_count'] = inputs['count']"},
+            ],
+            "edges": [
+                {"from": "a", "to": "b", "mapping": {"count": "count"}},
+                {"from": "a", "to": "c", "mapping": {"count": "count"}},
+            ],
+        }
+
+        result = run_workflow(workflow=workflow, ensure_requirements=False)
+
+        assert result.status == "SUCCEEDED"
+        counts = result.payload_risk_summary["counts"]
+        assert "large_payload_fanout" not in counts
+        assert "implicit_full_payload_edge_large_payload" not in counts
+
+
 # ===================================================================
 # 方案 2 Layer 3: Engine dedup
 # ===================================================================

--- a/tests/workflow/test_workflow_fixes.py
+++ b/tests/workflow/test_workflow_fixes.py
@@ -480,6 +480,181 @@ class TestLintWorkflowUnified:
         with pytest.raises(WorkflowValidationError):
             run_workflow(workflow=workflow, ensure_requirements=False)
 
+    def test_identity_mapping_does_not_suggest_omitting_mapping(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "identity_mapping_ok",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['x'] = 1"},
+                    {"id": "b", "type": "python", "code": "outputs['y'] = inputs.get('x')"},
+                ],
+                "edges": [{"from": "a", "to": "b", "mapping": {"x": "x"}}],
+            }
+        )
+
+        results = lint_workflow(wf)
+
+        assert all(item.get("kind") != "scheme_a_suggest_omit_identity_mapping" for item in results)
+
+    def test_trigger_workflow_recommends_strict_edge_mapping(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "kafka_trigger_mapping_recommendation",
+                "start": "a",
+                "nodes": [{"id": "a", "type": "python", "code": "outputs['x'] = 1"}],
+                "edges": [],
+                "triggers": [{"type": "kafka"}],
+            }
+        )
+
+        results = lint_workflow(wf)
+
+        recommendation = next(item for item in results if item["kind"] == "recommend_strict_edge_mapping")
+        assert recommendation["severity"] == "warning"
+        assert recommendation["trigger_types"] == ["kafka"]
+
+    def test_trigger_workflow_with_strict_mapping_does_not_recommend_again(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "strict_kafka_trigger_mapping",
+                "start": "a",
+                "nodes": [{"id": "a", "type": "python", "code": "outputs['x'] = 1"}],
+                "edges": [],
+                "triggers": [{"type": "kafka"}],
+                "metadata": {"runtime": {"strict_edge_mapping": True}},
+            }
+        )
+
+        results = lint_workflow(wf)
+
+        assert all(item.get("kind") != "recommend_strict_edge_mapping" for item in results)
+
+
+class TestPayloadRiskObservability:
+    def test_large_payload_no_mapping_records_risk_without_changing_inputs(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "large_payload_no_mapping",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['raw_alerts'] = list(range(1500))"},
+                    {
+                        "id": "b",
+                        "type": "python",
+                        "code": "outputs['count'] = len(inputs['raw_alerts'])\noutputs['is_list'] = isinstance(inputs['raw_alerts'], list)",
+                    },
+                ],
+                "edges": [{"from": "a", "to": "b"}],
+            }
+        )
+
+        result = WorkflowEngine(wf, runtime=PythonExecRuntime()).run()
+
+        assert result.outputs == {"count": 1500, "is_list": True}
+        counts = result.payload_risk_summary["counts"]
+        assert counts["implicit_full_payload_edge_large_payload"] == 1
+        risk = next(
+            item
+            for item in result.payload_risk_summary["risks"]
+            if item["kind"] == "implicit_full_payload_edge_large_payload"
+        )
+        assert risk["edge_from"] == "a"
+        assert risk["edge_to"] == "b"
+        assert risk["payload_summary"]["large_fields"][0]["key"] == "raw_alerts"
+        assert risk["payload_summary"]["large_fields"][0]["count"] == 1500
+
+    def test_large_payload_with_mapping_does_not_record_implicit_full_payload_risk(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "large_payload_with_mapping",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['raw_alerts'] = list(range(1500))"},
+                    {"id": "b", "type": "python", "code": "outputs['count'] = len(inputs['alerts'])"},
+                ],
+                "edges": [{"from": "a", "to": "b", "mapping": {"alerts": "raw_alerts"}}],
+            }
+        )
+
+        result = WorkflowEngine(wf, runtime=PythonExecRuntime()).run()
+
+        assert result.outputs == {"count": 1500}
+        counts = result.payload_risk_summary["counts"]
+        assert "implicit_full_payload_edge_large_payload" not in counts
+
+    def test_large_payload_fanout_records_risk(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "large_payload_fanout",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['raw_alerts'] = list(range(1500))"},
+                    {"id": "b", "type": "python", "code": "outputs['b_count'] = len(inputs['raw_alerts'])"},
+                    {"id": "c", "type": "python", "code": "outputs['c_count'] = len(inputs['raw_alerts'])"},
+                ],
+                "edges": [{"from": "a", "to": "b"}, {"from": "a", "to": "c"}],
+            }
+        )
+
+        result = WorkflowEngine(wf, runtime=PythonExecRuntime()).run()
+
+        counts = result.payload_risk_summary["counts"]
+        assert counts["large_payload_fanout"] == 1
+        risk = next(item for item in result.payload_risk_summary["risks"] if item["kind"] == "large_payload_fanout")
+        assert risk["source_node_id"] == "a"
+        assert risk["fanout_count"] == 2
+        assert set(risk["target_node_ids"]) == {"b", "c"}
+
+    def test_large_payload_join_buffer_records_risk(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "large_payload_join",
+                "start": "start",
+                "nodes": [
+                    {"id": "start", "type": "python", "code": "outputs['raw_alerts'] = list(range(1500))"},
+                    {"id": "b", "type": "python", "code": "outputs['x'] = 1"},
+                    {
+                        "id": "join",
+                        "type": "python",
+                        "join": True,
+                        "code": "outputs['count'] = len(inputs.get('raw_alerts', []))",
+                    },
+                ],
+                "edges": [
+                    {"from": "start", "to": "join"},
+                    {"from": "start", "to": "b"},
+                    {"from": "b", "to": "join"},
+                ],
+            }
+        )
+
+        result = WorkflowEngine(wf, runtime=PythonExecRuntime()).run()
+
+        assert result.outputs == {"count": 1500}
+        counts = result.payload_risk_summary["counts"]
+        assert counts["large_payload_join_buffer"] >= 1
+
+    def test_payload_risk_summary_does_not_embed_large_payload(self):
+        wf = Workflow.from_dict(
+            {
+                "name": "large_payload_summary_bound",
+                "start": "a",
+                "nodes": [
+                    {"id": "a", "type": "python", "code": "outputs['events'] = list(range(10000))"},
+                    {"id": "b", "type": "python", "code": "outputs['count'] = len(inputs['events'])"},
+                ],
+                "edges": [{"from": "a", "to": "b"}],
+            }
+        )
+
+        result = WorkflowEngine(wf, runtime=PythonExecRuntime()).run()
+
+        text = json.dumps(result.payload_risk_summary)
+        assert len(text) < 20_000
+        assert '"count": 10000' in text
+        assert "[0, 1, 2, 3, 4" not in text
+
 
 # ===================================================================
 # 方案 2 Layer 3: Engine dedup

--- a/tests/workflow/test_workflow_history_mode.py
+++ b/tests/workflow/test_workflow_history_mode.py
@@ -137,4 +137,5 @@ def test_python_runtime_can_cleanup_node_globals_after_execute() -> None:
 
     assert outputs == {"ok": True}
     assert "temporary_payload" not in runtime.globals
-    assert runtime.globals["outputs"] == {"ok": True}
+    assert "inputs" not in runtime.globals
+    assert "outputs" not in runtime.globals

--- a/tests/workflow/test_workflow_store.py
+++ b/tests/workflow/test_workflow_store.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from flocks.config.config import Config
+from flocks.storage.storage import Storage
+from flocks.workflow.store import WorkflowStore
+
+
+def _reset_state() -> None:
+    Config._global_config = None
+    Config._cached_config = None
+    Storage._db_path = None
+    Storage._initialized = False
+    Storage._init_pid = None
+    WorkflowStore._initialized = False
+    WorkflowStore._conn = None
+    WorkflowStore._init_pid = None
+    WorkflowStore._db_path = None
+
+
+@pytest.fixture(autouse=True)
+async def isolated_workflow_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    data_dir = tmp_path / "flocks_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("FLOCKS_DATA_DIR", str(data_dir))
+    _reset_state()
+    yield
+    await WorkflowStore.close()
+    _reset_state()
+
+
+@pytest.mark.asyncio
+async def test_workflow_store_records_execution_steps_config_and_kv() -> None:
+    await WorkflowStore.init()
+
+    await WorkflowStore.upsert_execution(
+        {
+            "id": "exec-1",
+            "workflowId": "wf-1",
+            "status": "running",
+            "startedAt": 100,
+            "triggerId": "trigger-1",
+            "triggerType": "schedule",
+        }
+    )
+    await WorkflowStore.upsert_execution(
+        {
+            "id": "exec-2",
+            "workflowId": "wf-1",
+            "status": "success",
+            "startedAt": 200,
+        }
+    )
+    await WorkflowStore.upsert_execution(
+        {
+            "id": "exec-other",
+            "workflowId": "wf-other",
+            "status": "success",
+            "startedAt": 300,
+        }
+    )
+
+    rows = await WorkflowStore.list_executions("wf-1", limit=10)
+    assert [row["id"] for row in rows] == ["exec-2", "exec-1"]
+    filtered = await WorkflowStore.list_executions(
+        "wf-1",
+        limit=10,
+        trigger_id="trigger-1",
+        trigger_type="schedule",
+    )
+    assert [row["id"] for row in filtered] == ["exec-1"]
+
+    await WorkflowStore.record_step("exec-1", 1, {"node_id": "n1", "outputs": {"ok": 1}})
+    await WorkflowStore.record_step("exec-1", 2, {"node_id": "n2", "outputs": {"ok": 2}})
+    steps, total = await WorkflowStore.list_steps("exec-1", offset=1, limit=1)
+    assert total == 2
+    assert steps == [{"node_id": "n2", "outputs": {"ok": 2}}]
+
+    await WorkflowStore.put_config("wf-1", {"enabled": True}, kind="workflow_poller_config")
+    assert await WorkflowStore.get_config("wf-1", kind="workflow_poller_config") == {"enabled": True}
+    assert await WorkflowStore.list_configs(kind="workflow_poller_config") == [("wf-1", {"enabled": True})]
+
+    await WorkflowStore.kv_put("workflow_runtime/wf-1", {"status": "active"})
+    assert await WorkflowStore.kv_get("workflow_runtime/wf-1") == {"status": "active"}
+    assert await WorkflowStore.kv_list_keys("workflow_runtime/") == ["workflow_runtime/wf-1"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_store_increment_stats_is_atomic_for_concurrent_updates() -> None:
+    await WorkflowStore.init()
+    updates = [(idx % 3 != 0, 1.0) for idx in range(60)]
+
+    await asyncio.gather(
+        *(
+            WorkflowStore.increment_stats("wf-concurrent", success=success, duration=duration)
+            for success, duration in updates
+        )
+    )
+
+    stats = await WorkflowStore.get_stats("wf-concurrent")
+    assert stats is not None
+    assert stats["callCount"] == 60
+    assert stats["successCount"] == sum(1 for success, _ in updates if success)
+    assert stats["errorCount"] == sum(1 for success, _ in updates if not success)
+    assert stats["totalRuntime"] == pytest.approx(60.0)
+    assert stats["avgRuntime"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add lightweight workflow payload risk summaries for large node payloads, implicit full-payload edges, fan-out, and join buffers
- expose payloadRiskSummary through workflow run records, tool metadata, trigger runtime, and poller executions
- keep legacy edge semantics unchanged while strengthening lint guidance toward explicit mappings for high-volume trigger workflows

## Tests
- uv run pytest tests/workflow/test_workflow_fixes.py::TestPayloadRiskObservability tests/workflow/test_workflow_fixes.py::TestLintWorkflowUnified -q
- uv run pytest tests/workflow/test_execution_store_compact.py tests/workflow/test_tool_run_workflow.py::test_format_workflow_result_compacts_large_outputs tests/workflow/test_workflow_history_mode.py -q
- uv run pytest tests/server/routes/test_workflow_run_route.py tests/workflow/test_trigger_runtime.py tests/workflow/test_poller_manager.py -q
- uv run ruff check flocks/workflow/engine.py flocks/workflow/runner.py flocks/tool/task/run_workflow.py flocks/server/routes/workflow.py flocks/workflow/triggers/runtime.py flocks/workflow/poller_manager.py flocks/workflow/workflow_lint.py tests/workflow/test_workflow_fixes.py tests/workflow/test_execution_store_compact.py tests/workflow/test_tool_run_workflow.py