### PR TITLE
CI：Fix autotest artifact download and matching

### DIFF
--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -53,6 +53,7 @@ jobs:
           GITHUB_SHA_VALUE: ${{ github.sha }}
           GITHUB_REF_NAME_VALUE: ${{ github.ref_name }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT_VALUE: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
 
@@ -78,11 +79,15 @@ jobs:
             exit 1
           fi
 
+          artifact_time="$(printf "%02d" "${GITHUB_RUN_ATTEMPT_VALUE:-1}")"
+          artifact_name="flocks-windows-upgrade-${release_tag}-time${artifact_time}"
+
           {
             echo "release_tag=$release_tag"
             echo "release_url=$release_url"
             echo "rollback_version=${INPUT_ROLLBACK_VERSION:-}"
             echo "run_force_fallback=${INPUT_RUN_FORCE_FALLBACK:-false}"
+            echo "artifact_name=$artifact_name"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -95,7 +100,7 @@ jobs:
             echo "- Source sha: ${GITHUB_SHA_VALUE}"
             echo "- Rollback version: ${INPUT_ROLLBACK_VERSION:-}"
             echo "- Run force fallback: ${INPUT_RUN_FORCE_FALLBACK:-false}"
-            echo "- Expected autotest artifact prefix: flocks-windows-upgrade-${release_tag}-time"
+            echo "- Expected autotest artifact: ${artifact_name}"
             echo "- Autotest workflow: https://github.com/AgentFlocks/flocks_autotest/actions/workflows/flocks-release-dispatch.yml"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -105,6 +110,7 @@ jobs:
           RELEASE_URL: ${{ steps.payload.outputs.release_url }}
           ROLLBACK_VERSION: ${{ steps.payload.outputs.rollback_version }}
           RUN_FORCE_FALLBACK: ${{ steps.payload.outputs.run_force_fallback }}
+          ARTIFACT_NAME: ${{ steps.payload.outputs.artifact_name }}
           SOURCE_REPOSITORY: ${{ github.repository }}
           SOURCE_RUN_ID: ${{ github.run_id }}
           SOURCE_SHA: ${{ github.sha }}
@@ -126,6 +132,7 @@ jobs:
                   "source_run_id": os.environ["SOURCE_RUN_ID"],
                   "source_sha": os.environ["SOURCE_SHA"],
                   "source_ref": os.environ["SOURCE_REF"],
+                  "artifact_name": os.environ["ARTIFACT_NAME"],
                   "rollback_version": os.environ.get("ROLLBACK_VERSION", ""),
                   "run_force_fallback": os.environ.get("RUN_FORCE_FALLBACK", "false"),
               },
@@ -158,7 +165,7 @@ jobs:
         timeout-minutes: 210
         env:
           GH_TOKEN: ${{ secrets.AUTOTEST_DISPATCH_TOKEN }}
-          RELEASE_TAG: ${{ steps.payload.outputs.release_tag }}
+          EXPECTED_ARTIFACT_NAME: ${{ steps.payload.outputs.artifact_name }}
           SOURCE_RUN_ID: ${{ github.run_id }}
           AUTOTEST_REPOSITORY: AgentFlocks/flocks_autotest
           AUTOTEST_WORKFLOW_FILE: flocks-release-dispatch.yml
@@ -178,7 +185,7 @@ jobs:
 
           api_root = "https://api.github.com"
           token = os.environ["GH_TOKEN"]
-          release_tag = os.environ["RELEASE_TAG"]
+          expected_artifact_name = os.environ["EXPECTED_ARTIFACT_NAME"]
           source_run_id = os.environ["SOURCE_RUN_ID"]
           autotest_repo = os.environ["AUTOTEST_REPOSITORY"]
           workflow_file = os.environ["AUTOTEST_WORKFLOW_FILE"]
@@ -242,7 +249,6 @@ jobs:
               f"{api_root}/repos/{autotest_repo}/actions/workflows/"
               f"{workflow_ref}/runs?event=repository_dispatch&per_page=30"
           )
-          artifact_prefix = f"flocks-windows-upgrade-{release_tag}-time"
           deadline = time.time() + wait_timeout
           matched_run = None
 
@@ -268,7 +274,7 @@ jobs:
                       "",
                       f"- Status: timed out waiting for workflow run",
                       f"- Source run id: {source_run_id}",
-                      f"- Expected artifact prefix: {artifact_prefix}",
+                      f"- Expected artifact: {expected_artifact_name}",
                   ]
               )
               raise SystemExit("Timed out waiting for flocks_autotest workflow run")
@@ -297,19 +303,37 @@ jobs:
                       "",
                       f"- Status: timed out waiting for completion",
                       f"- Run: {run_html_url}",
-                      f"- Expected artifact prefix: {artifact_prefix}",
+                      f"- Expected artifact: {expected_artifact_name}",
                   ]
               )
               raise SystemExit("Timed out waiting for flocks_autotest completion")
 
           conclusion = matched_run.get("conclusion") or "unknown"
           artifacts_url = f"{api_root}/repos/{autotest_repo}/actions/runs/{run_id}/artifacts?per_page=100"
-          artifacts = api_json(artifacts_url).get("artifacts", [])
-          matching_artifacts = [
-              artifact
-              for artifact in artifacts
-              if not artifact.get("expired") and (artifact.get("name") or "").startswith(artifact_prefix)
-          ]
+          artifact_lookup_deadline = time.time() + 120
+          artifacts = []
+          available_artifact_names = []
+          matching_artifacts = []
+          while True:
+              artifacts = api_json(artifacts_url).get("artifacts", [])
+              available_artifact_names = [
+                  artifact.get("name") or ""
+                  for artifact in artifacts
+                  if not artifact.get("expired") and artifact.get("name")
+              ]
+              matching_artifacts = [
+                  artifact
+                  for artifact in artifacts
+                  if not artifact.get("expired") and (artifact.get("name") or "") == expected_artifact_name
+              ]
+              if matching_artifacts or time.time() >= artifact_lookup_deadline:
+                  break
+              available_text = ", ".join(available_artifact_names) if available_artifact_names else "(none)"
+              print(
+                  f"Waiting for artifact {expected_artifact_name}. Available artifacts: {available_text}",
+                  flush=True,
+              )
+              time.sleep(10)
           matching_artifacts.sort(key=lambda artifact: artifact.get("created_at") or "", reverse=True)
 
           artifact_name = ""
@@ -341,13 +365,15 @@ jobs:
               "",
               f"- Run: {run_html_url}",
               f"- Conclusion: {conclusion}",
-              f"- Expected artifact prefix: {artifact_prefix}",
+              f"- Expected artifact: {expected_artifact_name}",
           ]
           if artifact_name:
               summary_lines.append(f"- Artifact: [{artifact_name}]({artifact_html_url})")
               summary_lines.append("- Artifact copy: uploaded to this flocks workflow run")
           else:
               summary_lines.append("- Artifact: not found")
+              available_text = ", ".join(available_artifact_names) if available_artifact_names else "(none)"
+              summary_lines.append(f"- Available artifacts: {available_text}")
           write_summary(summary_lines)
 
           if conclusion != "success":

--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -143,6 +143,7 @@ jobs:
           cat "$RUNNER_TEMP/flocks-autotest-dispatch.json"
 
       - name: Dispatch flocks_autotest
+        id: dispatch
         env:
           GH_TOKEN: ${{ secrets.AUTOTEST_DISPATCH_TOKEN }}
         run: |
@@ -152,6 +153,9 @@ jobs:
             echo "Missing AUTOTEST_DISPATCH_TOKEN secret" >&2
             exit 1
           fi
+
+          dispatch_started_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "started_at=${dispatch_started_at}" >> "$GITHUB_OUTPUT"
 
           curl --fail-with-body -L -X POST \
             -H "Accept: application/vnd.github+json" \
@@ -165,8 +169,10 @@ jobs:
         timeout-minutes: 210
         env:
           GH_TOKEN: ${{ secrets.AUTOTEST_DISPATCH_TOKEN }}
+          RELEASE_TAG: ${{ steps.payload.outputs.release_tag }}
           EXPECTED_ARTIFACT_NAME: ${{ steps.payload.outputs.artifact_name }}
           SOURCE_RUN_ID: ${{ github.run_id }}
+          DISPATCH_STARTED_AT: ${{ steps.dispatch.outputs.started_at }}
           AUTOTEST_REPOSITORY: AgentFlocks/flocks_autotest
           AUTOTEST_WORKFLOW_FILE: flocks-release-dispatch.yml
           AUTOTEST_POLL_INTERVAL_SECONDS: "30"
@@ -182,11 +188,14 @@ jobs:
           import urllib.error
           import urllib.parse
           import urllib.request
+          from datetime import datetime, timedelta, timezone
 
           api_root = "https://api.github.com"
           token = os.environ["GH_TOKEN"]
+          release_tag = os.environ["RELEASE_TAG"]
           expected_artifact_name = os.environ["EXPECTED_ARTIFACT_NAME"]
           source_run_id = os.environ["SOURCE_RUN_ID"]
+          dispatch_started_at = os.environ["DISPATCH_STARTED_AT"]
           autotest_repo = os.environ["AUTOTEST_REPOSITORY"]
           workflow_file = os.environ["AUTOTEST_WORKFLOW_FILE"]
           poll_interval = int(os.environ["AUTOTEST_POLL_INTERVAL_SECONDS"])
@@ -244,109 +253,199 @@ jobs:
                   for key, value in values.items():
                       f.write(f"{key}={value}\n")
 
+          def parse_github_time(value):
+              if not value:
+                  return datetime.min.replace(tzinfo=timezone.utc)
+              return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
           workflow_ref = urllib.parse.quote(workflow_file, safe="")
           runs_url = (
               f"{api_root}/repos/{autotest_repo}/actions/workflows/"
-              f"{workflow_ref}/runs?event=repository_dispatch&per_page=30"
+              f"{workflow_ref}/runs?per_page=50"
           )
+          version_title_prefix = f"Windows upgrade {release_tag} "
+          version_artifact_prefix = f"flocks-windows-upgrade-{release_tag}-"
+          dispatch_started = parse_github_time(dispatch_started_at) - timedelta(seconds=30)
           deadline = time.time() + wait_timeout
+          source_discovery_deadline = time.time() + 120
           matched_run = None
 
-          while time.time() < deadline:
-              runs = api_json(runs_url).get("workflow_runs", [])
+          def list_workflow_runs():
+              return api_json(runs_url).get("workflow_runs", [])
+
+          def latest_successful_version_run(runs=None):
+              if runs is None:
+                  runs = list_workflow_runs()
+              candidates = []
               for run in runs:
                   title = run.get("display_title") or run.get("name") or ""
-                  if f"#{source_run_id}" in title:
-                      matched_run = run
+                  if not title.startswith(version_title_prefix):
+                      continue
+                  if run.get("status") != "completed" or run.get("conclusion") != "success":
+                      continue
+                  candidates.append(run)
+              candidates.sort(key=lambda run: run.get("created_at") or "", reverse=True)
+              return candidates[0] if candidates else None
+
+          def find_artifact(run_id, *, exact_name="", name_prefix="", retry_seconds=120):
+              artifacts_url = (
+                  f"{api_root}/repos/{autotest_repo}/actions/runs/{run_id}/artifacts?per_page=100"
+              )
+              lookup_deadline = time.time() + retry_seconds
+              available_artifact_names = []
+              matching_artifacts = []
+              while True:
+                  artifacts = api_json(artifacts_url).get("artifacts", [])
+                  available_artifact_names = [
+                      artifact.get("name") or ""
+                      for artifact in artifacts
+                      if not artifact.get("expired") and artifact.get("name")
+                  ]
+                  matching_artifacts = [
+                      artifact
+                      for artifact in artifacts
+                      if not artifact.get("expired")
+                      and (
+                          (exact_name and (artifact.get("name") or "") == exact_name)
+                          or (name_prefix and (artifact.get("name") or "").startswith(name_prefix))
+                      )
+                  ]
+                  if matching_artifacts or time.time() >= lookup_deadline:
                       break
-              if matched_run:
+                  available_text = ", ".join(available_artifact_names) if available_artifact_names else "(none)"
+                  expected_text = exact_name or f"{name_prefix}*"
+                  print(
+                      f"Waiting for artifact {expected_text}. Available artifacts: {available_text}",
+                      flush=True,
+                  )
+                  time.sleep(10)
+              matching_artifacts.sort(key=lambda artifact: artifact.get("created_at") or "", reverse=True)
+              return (matching_artifacts[0] if matching_artifacts else None), available_artifact_names
+
+          selected_run = None
+          selected_artifact = None
+          selected_available_artifacts = []
+          selection_reason = ""
+          source_run_url = ""
+          source_failure = ""
+
+          while time.time() < deadline:
+              runs = list_workflow_runs()
+              source_candidates = []
+              for run in runs:
+                  title = run.get("display_title") or run.get("name") or ""
+                  created_at = parse_github_time(run.get("created_at"))
+                  if f"#{source_run_id}" in title and created_at >= dispatch_started:
+                      source_candidates.append(run)
+              source_candidates.sort(key=lambda run: run.get("created_at") or "", reverse=True)
+              if source_candidates:
+                  matched_run = source_candidates[0]
                   break
+
+              fallback_run = latest_successful_version_run(runs)
+              if fallback_run and time.time() >= source_discovery_deadline:
+                  selected_run = fallback_run
+                  selection_reason = "version_success_fallback_no_source_run"
+                  print(
+                      f"Using latest successful flocks_autotest run for {release_tag}: "
+                      f"{selected_run.get('html_url')}",
+                      flush=True,
+                  )
+                  break
+
               print(
                   f"Waiting for flocks_autotest workflow run with source_run_id={source_run_id}...",
                   flush=True,
               )
               time.sleep(poll_interval)
 
-          if not matched_run:
-              write_summary(
-                  [
-                      "### flocks_autotest result",
-                      "",
-                      f"- Status: timed out waiting for workflow run",
-                      f"- Source run id: {source_run_id}",
-                      f"- Expected artifact: {expected_artifact_name}",
-                  ]
-              )
-              raise SystemExit("Timed out waiting for flocks_autotest workflow run")
+          if matched_run:
+              run_id = matched_run["id"]
+              run_api_url = matched_run["url"]
+              source_run_url = matched_run["html_url"]
+              print(f"Matched flocks_autotest run: {source_run_url}", flush=True)
 
-          run_id = matched_run["id"]
-          run_api_url = matched_run["url"]
-          run_html_url = matched_run["html_url"]
-          print(f"Matched flocks_autotest run: {run_html_url}", flush=True)
+              while time.time() < deadline:
+                  matched_run = api_json(run_api_url)
+                  status = matched_run.get("status")
+                  conclusion = matched_run.get("conclusion") or ""
+                  print(
+                      f"flocks_autotest run {run_id}: status={status} conclusion={conclusion}",
+                      flush=True,
+                  )
+                  if status == "completed":
+                      break
+                  time.sleep(poll_interval)
 
-          while time.time() < deadline:
-              matched_run = api_json(run_api_url)
-              status = matched_run.get("status")
-              conclusion = matched_run.get("conclusion") or ""
-              print(
-                  f"flocks_autotest run {run_id}: status={status} conclusion={conclusion}",
-                  flush=True,
-              )
-              if status == "completed":
-                  break
-              time.sleep(poll_interval)
+              if matched_run.get("status") != "completed":
+                  source_failure = "timed out waiting for source run completion"
+              elif matched_run.get("conclusion") == "success":
+                  artifact, available_names = find_artifact(
+                      run_id,
+                      exact_name=expected_artifact_name,
+                      retry_seconds=120,
+                  )
+                  if artifact:
+                      selected_run = matched_run
+                      selected_artifact = artifact
+                      selected_available_artifacts = available_names
+                      selection_reason = "source_run_exact_artifact"
+                  else:
+                      available_text = ", ".join(available_names) if available_names else "(none)"
+                      selected_available_artifacts = available_names
+                      source_failure = (
+                          f"source run succeeded but expected artifact was not found; "
+                          f"available artifacts: {available_text}"
+                      )
+              else:
+                  source_failure = f"source run concluded with {matched_run.get('conclusion') or 'unknown'}"
 
-          if matched_run.get("status") != "completed":
-              write_summary(
-                  [
-                      "### flocks_autotest result",
-                      "",
-                      f"- Status: timed out waiting for completion",
-                      f"- Run: {run_html_url}",
-                      f"- Expected artifact: {expected_artifact_name}",
-                  ]
-              )
-              raise SystemExit("Timed out waiting for flocks_autotest completion")
-
-          conclusion = matched_run.get("conclusion") or "unknown"
-          artifacts_url = f"{api_root}/repos/{autotest_repo}/actions/runs/{run_id}/artifacts?per_page=100"
-          artifact_lookup_deadline = time.time() + 120
-          artifacts = []
-          available_artifact_names = []
-          matching_artifacts = []
-          while True:
-              artifacts = api_json(artifacts_url).get("artifacts", [])
-              available_artifact_names = [
-                  artifact.get("name") or ""
-                  for artifact in artifacts
-                  if not artifact.get("expired") and artifact.get("name")
-              ]
-              matching_artifacts = [
-                  artifact
-                  for artifact in artifacts
-                  if not artifact.get("expired") and (artifact.get("name") or "") == expected_artifact_name
-              ]
-              if matching_artifacts or time.time() >= artifact_lookup_deadline:
-                  break
-              available_text = ", ".join(available_artifact_names) if available_artifact_names else "(none)"
-              print(
-                  f"Waiting for artifact {expected_artifact_name}. Available artifacts: {available_text}",
-                  flush=True,
-              )
-              time.sleep(10)
-          matching_artifacts.sort(key=lambda artifact: artifact.get("created_at") or "", reverse=True)
+          if not selected_artifact:
+              fallback_run = selected_run or latest_successful_version_run()
+              if fallback_run:
+                  fallback_run_id = fallback_run["id"]
+                  artifact, available_names = find_artifact(
+                      fallback_run_id,
+                      name_prefix=version_artifact_prefix,
+                      retry_seconds=120,
+                  )
+                  if artifact:
+                      selected_run = fallback_run
+                      selected_artifact = artifact
+                      selected_available_artifacts = available_names
+                      if not selection_reason:
+                          selection_reason = "version_success_fallback"
+                      print(
+                          f"Using version fallback artifact from flocks_autotest run "
+                          f"{selected_run.get('html_url')}",
+                          flush=True,
+                      )
+                  else:
+                      available_text = ", ".join(available_names) if available_names else "(none)"
+                      selected_available_artifacts = available_names
+                      source_failure = (
+                          f"{source_failure}; " if source_failure else ""
+                      ) + (
+                          f"latest successful {release_tag} run has no matching artifact; "
+                          f"available artifacts: {available_text}"
+                      )
 
           artifact_name = ""
           artifact_html_url = ""
           artifact_path = ""
-          if matching_artifacts:
-              artifact = matching_artifacts[0]
-              artifact_name = artifact["name"]
+          run_id = ""
+          run_html_url = ""
+          conclusion = "unknown"
+          if selected_run and selected_artifact:
+              run_id = selected_run["id"]
+              run_html_url = selected_run["html_url"]
+              conclusion = selected_run.get("conclusion") or "success"
+              artifact_name = selected_artifact["name"]
               artifact_html_url = (
-                  f"https://github.com/{autotest_repo}/actions/runs/{run_id}/artifacts/{artifact['id']}"
+                  f"https://github.com/{autotest_repo}/actions/runs/{run_id}/artifacts/{selected_artifact['id']}"
               )
               artifact_path = os.path.join(runner_temp, f"{artifact_name}.zip")
-              download(artifact["archive_download_url"], artifact_path)
+              download(selected_artifact["archive_download_url"], artifact_path)
               print(f"Downloaded flocks_autotest artifact: {artifact_path}", flush=True)
 
           write_outputs(
@@ -363,23 +462,33 @@ jobs:
           summary_lines = [
               "### flocks_autotest result",
               "",
-              f"- Run: {run_html_url}",
+              f"- Selection: {selection_reason or 'none'}",
+              f"- Selected run: {run_html_url or 'not found'}",
               f"- Conclusion: {conclusion}",
+              f"- Source run: {source_run_url or 'not found'}",
+              f"- Source status: {source_failure or 'ok'}",
+              f"- Version fallback prefix: {version_artifact_prefix}",
               f"- Expected artifact: {expected_artifact_name}",
           ]
           if artifact_name:
               summary_lines.append(f"- Artifact: [{artifact_name}]({artifact_html_url})")
-              summary_lines.append("- Artifact copy: uploaded to this flocks workflow run")
+              summary_lines.append("- Artifact copy: downloaded; upload step will attach it to this flocks workflow run")
           else:
               summary_lines.append("- Artifact: not found")
-              available_text = ", ".join(available_artifact_names) if available_artifact_names else "(none)"
+              available_text = (
+                  ", ".join(selected_available_artifacts)
+                  if selected_available_artifacts
+                  else "(none)"
+              )
               summary_lines.append(f"- Available artifacts: {available_text}")
           write_summary(summary_lines)
 
+          if not selected_run:
+              raise SystemExit(source_failure or "flocks_autotest workflow run was not found")
           if conclusion != "success":
               raise SystemExit(f"flocks_autotest concluded with {conclusion}")
           if not artifact_name:
-              raise SystemExit("flocks_autotest artifact was not found")
+              raise SystemExit(source_failure or "flocks_autotest artifact was not found")
           PY
 
       - name: Upload flocks_autotest artifact copy

--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -199,9 +199,31 @@ jobs:
               with urllib.request.urlopen(request, timeout=30) as response:
                   return json.loads(response.read().decode("utf-8"))
 
+          class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+              def redirect_request(self, req, fp, code, msg, headers, newurl):
+                  return None
+
           def download(url, destination):
               request = urllib.request.Request(url, headers=headers)
-              with urllib.request.urlopen(request, timeout=300) as response:
+              opener = urllib.request.build_opener(NoRedirectHandler)
+              try:
+                  opener.open(request, timeout=30)
+              except urllib.error.HTTPError as error:
+                  if error.code not in (301, 302, 303, 307, 308):
+                      raise
+                  redirect_url = error.headers.get("Location")
+                  if not redirect_url:
+                      raise RuntimeError("Artifact download redirect did not include Location header") from error
+              else:
+                  raise RuntimeError("Artifact download did not return the expected redirect")
+
+              # GitHub returns a short-lived signed URL for the artifact archive.
+              # Do not forward the GitHub PAT to that storage endpoint.
+              redirect_request = urllib.request.Request(
+                  redirect_url,
+                  headers={"Accept": "application/octet-stream"},
+              )
+              with urllib.request.urlopen(redirect_request, timeout=300) as response:
                   with open(destination, "wb") as f:
                       f.write(response.read())
 


### PR DESCRIPTION
## Summary
- Fix flocks-side autotest artifact download by not forwarding the GitHub PAT to the redirected storage URL.
- Send an exact expected artifact name to flocks_autotest and match artifacts by exact name instead of prefix.
- Add a short artifact lookup retry window and list available artifacts when the expected one is missing.

## Testing
- Ran local workflow text checks for exact artifact-name wiring.
- Ran git diff --check.
- Did not trigger GitHub Actions from this branch.