### PR TITLE
fix: refresh stale channel session bindings

### DIFF
--- a/flocks/channel/inbound/session_binding.py
+++ b/flocks/channel/inbound/session_binding.py
@@ -441,6 +441,33 @@ class SessionBindingService:
         rows = await cursor.fetchall()
         return [self._row_to_binding(r) for r in rows]
 
+    async def latest_active_user_binding(
+        self,
+        *,
+        channel_id: str,
+        account_id: Optional[str] = None,
+        chat_id: Optional[str] = None,
+    ) -> Optional[SessionBinding]:
+        """Return the binding only when a channel target resolves uniquely."""
+        from flocks.session.session import Session
+
+        candidates = await self.list_bindings(channel_id=channel_id)
+        if account_id:
+            candidates = [b for b in candidates if b.account_id == account_id]
+        if chat_id:
+            candidates = [b for b in candidates if b.chat_id == chat_id]
+
+        active_candidates: list[SessionBinding] = []
+        for binding in candidates:
+            session = await Session.get_by_id(binding.session_id)
+            if (
+                session
+                and session.status == "active"
+                and session.category == "user"
+            ):
+                active_candidates.append(binding)
+        return active_candidates[0] if len(active_candidates) == 1 else None
+
     # --- internal helpers ---
 
     async def _find_binding(

--- a/flocks/server/routes/channel.py
+++ b/flocks/server/routes/channel.py
@@ -71,11 +71,26 @@ async def channel_session_send(req: SessionSendRequest):
     svc = SessionBindingService()
     all_bindings = await svc.list_bindings()
     matched = [b for b in all_bindings if b.session_id == req.session_id]
+    resolved_session_id = req.session_id
+
+    if not matched and req.channel_type:
+        latest = await svc.latest_active_user_binding(
+            channel_id=req.channel_type,
+            account_id=req.account_id,
+            chat_id=req.chat_id,
+        )
+        if latest:
+            matched = [latest]
+            resolved_session_id = latest.session_id
 
     if not matched:
         raise HTTPException(
             status_code=404,
-            detail=f"未找到 session '{req.session_id}' 的渠道绑定",
+            detail=(
+                f"未找到 session '{req.session_id}' 的渠道绑定；"
+                "请使用 im_send_message(resolve_only=true) 重新解析当前 IM 目标，"
+                "或让用户确认目标 IM 会话。"
+            ),
         )
 
     if req.channel_type:
@@ -109,7 +124,10 @@ async def channel_session_send(req: SessionSendRequest):
             text=req.text,
             media_url=req.media_url,
         )
-        results = await OutboundDelivery.deliver(out_ctx, session_id=req.session_id)
+        results = await OutboundDelivery.deliver(
+            out_ctx,
+            session_id=resolved_session_id,
+        )
         all_results.extend(results)
         for r in results:
             if not r.success:
@@ -120,6 +138,7 @@ async def channel_session_send(req: SessionSendRequest):
 
     return {
         "ok": True,
+        "session_id": resolved_session_id,
         "message_ids": [r.message_id for r in all_results if r.message_id],
         "channels": list({b.channel_id for b in matched}),
     }

--- a/flocks/tool/channel/channel_message.py
+++ b/flocks/tool/channel/channel_message.py
@@ -98,10 +98,11 @@ async def _http_session_send(
             )
             body = resp.json()
             if resp.status_code == 200:
+                resolved_session_id = body.get("session_id") or session_id
                 return ToolResult(
                     success=True,
                     output=(
-                        f"Message sent to session '{session_id}' "
+                        f"Message sent to session '{resolved_session_id}' "
                         f"via channels {body.get('channels', [])}, "
                         f"ids: {body.get('message_ids', [])}"
                     ),
@@ -217,13 +218,26 @@ async def channel_message(ctx: ToolContext, **kwargs) -> ToolResult:
     svc = SessionBindingService()
     all_bindings = await svc.list_bindings()
     matched = [b for b in all_bindings if b.session_id == session_id]
+    resolved_session_id = session_id
+
+    if not matched and channel_type:
+        latest = await svc.latest_active_user_binding(
+            channel_id=channel_type,
+            account_id=account_id,
+            chat_id=chat_id,
+        )
+        if latest:
+            matched = [latest]
+            resolved_session_id = latest.session_id
 
     if not matched:
         return ToolResult(
             success=False,
             error=(
                 f"No channel binding found for session_id='{session_id}'. "
-                "Make sure the session was initiated via an IM channel."
+                "Resolve the current IM target again with "
+                "im_send_message(resolve_only=true), or ask the user to confirm "
+                "the target IM session."
             ),
         )
 
@@ -266,7 +280,7 @@ async def channel_message(ctx: ToolContext, **kwargs) -> ToolResult:
             text=message,
             media_url=media,
         )
-        results = await OutboundDelivery.deliver(out_ctx, session_id=session_id)
+        results = await OutboundDelivery.deliver(out_ctx, session_id=resolved_session_id)
         all_results.extend(results)
 
         failed = [r for r in results if not r.success]
@@ -284,7 +298,7 @@ async def channel_message(ctx: ToolContext, **kwargs) -> ToolResult:
     return ToolResult(
         success=True,
         output=(
-            f"Message sent to session '{session_id}' "
+            f"Message sent to session '{resolved_session_id}' "
             f"via channels {channels_sent}, "
             f"{len(all_results)} chunk(s), ids: {msg_ids}"
         ),

--- a/tests/channel/test_session_binding.py
+++ b/tests/channel/test_session_binding.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flocks.channel.inbound.session_binding import SessionBindingService
+
+
+@pytest.mark.asyncio
+async def test_latest_active_user_binding_returns_none_when_channel_is_ambiguous() -> None:
+    first = SimpleNamespace(session_id="ses_newest")
+    second = SimpleNamespace(session_id="ses_other")
+    service = SessionBindingService()
+    service.list_bindings = AsyncMock(return_value=[first, second])
+
+    with patch(
+        "flocks.session.session.Session.get_by_id",
+        AsyncMock(
+            side_effect=[
+                SimpleNamespace(status="active", category="user"),
+                SimpleNamespace(status="active", category="user"),
+            ]
+        ),
+    ):
+        result = await service.latest_active_user_binding(channel_id="wecom")
+
+    assert result is None

--- a/tests/server/routes/test_channel_routes.py
+++ b/tests/server/routes/test_channel_routes.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flocks.channel.base import DeliveryResult
+from flocks.server.routes.channel import SessionSendRequest, channel_session_send
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+async def test_channel_session_send_falls_back_to_latest_channel_binding() -> None:
+    latest_binding = SimpleNamespace(
+        session_id="ses_new",
+        channel_id="wecom",
+        account_id="default",
+        chat_id="room_1",
+    )
+    svc = SimpleNamespace(
+        list_bindings=AsyncMock(return_value=[latest_binding]),
+        latest_active_user_binding=AsyncMock(return_value=latest_binding),
+    )
+    deliver_result = DeliveryResult(
+        channel_id="wecom",
+        message_id="msg_new",
+        chat_id="room_1",
+    )
+
+    with patch(
+        "flocks.channel.inbound.session_binding.SessionBindingService",
+        return_value=svc,
+    ), patch(
+        "flocks.channel.outbound.deliver.OutboundDelivery.deliver",
+        AsyncMock(return_value=[deliver_result]),
+    ) as deliver:
+        result = await channel_session_send(
+            SessionSendRequest(
+                session_id="ses_old",
+                text="hello",
+                channel_type="wecom",
+            )
+        )
+
+    assert result["ok"] is True
+    assert result["session_id"] == "ses_new"
+    assert result["message_ids"] == ["msg_new"]
+    svc.latest_active_user_binding.assert_awaited_once_with(
+        channel_id="wecom",
+        account_id=None,
+        chat_id=None,
+    )
+    deliver.assert_awaited_once()
+    assert deliver.await_args.kwargs["session_id"] == "ses_new"
+
+
+@pytest.mark.asyncio
+async def test_channel_session_send_returns_404_when_channel_binding_is_ambiguous() -> None:
+    svc = SimpleNamespace(
+        list_bindings=AsyncMock(return_value=[]),
+        latest_active_user_binding=AsyncMock(return_value=None),
+    )
+
+    with patch(
+        "flocks.channel.inbound.session_binding.SessionBindingService",
+        return_value=svc,
+    ), patch(
+        "flocks.channel.outbound.deliver.OutboundDelivery.deliver",
+        AsyncMock(),
+    ) as deliver:
+        with pytest.raises(HTTPException) as exc_info:
+            await channel_session_send(
+                SessionSendRequest(
+                    session_id="ses_old",
+                    text="hello",
+                    channel_type="wecom",
+                )
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "im_send_message(resolve_only=true)" in str(exc_info.value.detail)
+    svc.latest_active_user_binding.assert_awaited_once_with(
+        channel_id="wecom",
+        account_id=None,
+        chat_id=None,
+    )
+    deliver.assert_not_awaited()

--- a/tests/tool/test_channel_message.py
+++ b/tests/tool/test_channel_message.py
@@ -83,3 +83,85 @@ async def test_channel_message_exact_binding_filters_selected_chat_only() -> Non
     out_ctx = deliver.await_args.args[0]
     assert out_ctx.account_id == "acct_2"
     assert out_ctx.to == "chat_2"
+
+
+@pytest.mark.asyncio
+async def test_channel_message_falls_back_to_latest_channel_binding() -> None:
+    latest_binding = SimpleNamespace(
+        session_id="ses_new",
+        channel_id="wecom",
+        account_id="default",
+        chat_id="room_1",
+    )
+    svc = SimpleNamespace(
+        list_bindings=AsyncMock(return_value=[latest_binding]),
+        latest_active_user_binding=AsyncMock(return_value=latest_binding),
+    )
+    deliver_result = DeliveryResult(
+        channel_id="wecom",
+        message_id="msg_new",
+        chat_id="room_1",
+    )
+
+    with patch(
+        "flocks.tool.channel.channel_message._http_session_send",
+        AsyncMock(return_value=None),
+    ), patch(
+        "flocks.channel.inbound.session_binding.SessionBindingService",
+        return_value=svc,
+    ), patch(
+        "flocks.channel.outbound.deliver.OutboundDelivery.deliver",
+        AsyncMock(return_value=[deliver_result]),
+    ) as deliver:
+        result = await channel_message(
+            ToolContext(session_id="ses_task", message_id="msg_1"),
+            session_id="ses_old",
+            message="hello",
+            channel_type="wecom",
+        )
+
+    assert result.success is True
+    svc.latest_active_user_binding.assert_awaited_once_with(
+        channel_id="wecom",
+        account_id=None,
+        chat_id=None,
+    )
+    deliver.assert_awaited_once()
+    assert deliver.await_args.kwargs["session_id"] == "ses_new"
+    out_ctx = deliver.await_args.args[0]
+    assert out_ctx.account_id == "default"
+    assert out_ctx.to == "room_1"
+
+
+@pytest.mark.asyncio
+async def test_channel_message_does_not_fallback_when_channel_binding_is_ambiguous() -> None:
+    svc = SimpleNamespace(
+        list_bindings=AsyncMock(return_value=[]),
+        latest_active_user_binding=AsyncMock(return_value=None),
+    )
+
+    with patch(
+        "flocks.tool.channel.channel_message._http_session_send",
+        AsyncMock(return_value=None),
+    ), patch(
+        "flocks.channel.inbound.session_binding.SessionBindingService",
+        return_value=svc,
+    ), patch(
+        "flocks.channel.outbound.deliver.OutboundDelivery.deliver",
+        AsyncMock(),
+    ) as deliver:
+        result = await channel_message(
+            ToolContext(session_id="ses_task", message_id="msg_1"),
+            session_id="ses_old",
+            message="hello",
+            channel_type="wecom",
+        )
+
+    assert result.success is False
+    assert "im_send_message(resolve_only=true)" in (result.error or "")
+    svc.latest_active_user_binding.assert_awaited_once_with(
+        channel_id="wecom",
+        account_id=None,
+        chat_id=None,
+    )
+    deliver.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add a latest-active channel binding fallback when channel_message is called with a stale session_id.
- Apply the same fallback to /api/channel/session-send so the preferred HTTP send path no longer returns 404 after /new rebinds a chat.
- Cover both the tool fallback and HTTP route fallback with regression tests.

## Root Cause
Scheduled IM tasks can keep an old session_id. After a group chat uses /new, channel_bindings moves to the new session, so sending with the old session_id fails with a missing channel binding even though the IM channel is still available.

## Validation
- uv run ruff check flocks/channel/inbound/session_binding.py flocks/tool/channel/channel_message.py flocks/server/routes/channel.py tests/tool/test_channel_message.py tests/server/routes/test_channel_routes.py
- uv run pytest tests/tool/test_channel_message.py tests/server/routes/test_channel_routes.py
- uv run pytest tests/channel/test_channel.py::TestFeishuNativeCommands::test_new_command_rebinds_conversation tests/tool/test_channel_message.py::test_channel_message_exact_binding_filters_selected_chat_only tests/tool/test_im_send_message.py::test_im_send_message_reuses_channel_message_after_resolution