### PR TITLE
[codex] Refresh device templates on page focus

### DIFF
--- a/webui/src/pages/DeviceIntegration/index.test.tsx
+++ b/webui/src/pages/DeviceIntegration/index.test.tsx
@@ -388,7 +388,7 @@ describe('DeviceIntegrationPage', () => {
     mocks.getSessionMessagesPage.mockResolvedValue({ items: [] });
   });
 
-  it('refreshes devices and templates without syncing when the window regains focus', async () => {
+  it('refreshes templates and syncs devices when the window regains focus', async () => {
     render(<DeviceIntegrationPage />);
 
     await screen.findByText('设备接入');
@@ -403,10 +403,10 @@ describe('DeviceIntegrationPage', () => {
 
     await waitFor(() => {
       expect(mocks.listDevices).toHaveBeenCalledWith();
-      expect(mocks.listTemplates).toHaveBeenCalledWith();
+      expect(mocks.listTemplates).toHaveBeenCalledWith({ refresh: true });
       expect(mocks.listGroups).toHaveBeenCalled();
     });
-    expect(mocks.syncDevices).not.toHaveBeenCalled();
+    expect(mocks.syncDevices).toHaveBeenCalledWith({ refresh: true });
   });
 
   it('shows custom guidance and example entries on the add-device workbench', async () => {

--- a/webui/src/pages/DeviceIntegration/index.tsx
+++ b/webui/src/pages/DeviceIntegration/index.tsx
@@ -2024,7 +2024,7 @@ export default function DeviceIntegrationPage() {
     const now = Date.now();
     if (now - lastRefreshRef.current < 1000) return;
     lastRefreshRef.current = now;
-    void fetchData(true);
+    void fetchData(true, true, true);
   }, [fetchData]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Refresh and sync device templates when the Device Integration page regains focus.
- Update the focus refresh regression test to expect template refresh and device sync.

## Why
Device plugins created under tools/device can be missed by an already-open Device Integration page because the resume path only fetched cached data. Matching the Skill page refresh behavior lets the page discover newly created device plugins without requiring a manual toolbar refresh.

## Validation
- npm run test:run -- src/pages/DeviceIntegration/index.test.tsx
- git diff --check