### PR TITLE
Recover from corrupt SQLite stores

### DIFF
--- a/flocks/project/instance.py
+++ b/flocks/project/instance.py
@@ -190,8 +190,17 @@ class Instance:
                 
                 cls._cache[directory] = asyncio.create_task(create_context())
         
-        # Wait for context to be ready
-        ctx = await cls._cache[directory]
+        # Wait for context to be ready.  If initialization fails, drop the
+        # failed task so a later request can retry after transient storage or
+        # startup recovery completes.
+        task = cls._cache[directory]
+        try:
+            ctx = await task
+        except Exception:
+            async with cls._lock:
+                if cls._cache.get(directory) is task:
+                    cls._cache.pop(directory, None)
+            raise
         
         # Execute fn within context
         if fn:

--- a/flocks/storage/storage.py
+++ b/flocks/storage/storage.py
@@ -6,6 +6,8 @@ Provides SQLite-based storage similar to Flocks's Storage namespace
 
 import asyncio
 import os
+import shutil
+import subprocess
 
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -21,6 +23,7 @@ from flocks.config.config import Config
 
 
 T = TypeVar("T", bound=BaseModel)
+R = TypeVar("R")
 
 
 class NotFoundError(Exception):
@@ -94,6 +97,9 @@ class Storage:
     _sqlite_write_retry_base_delay_s = 0.05
     _multi_db_migration_marker_key = "storage.migration.multi_db.v1"
     _multi_db_migration_batch_size = 500
+    _corruption_recovery_lock = asyncio.Lock()
+    _corruption_recovery_generation = 0
+    _sqlite_recover_timeout_s = 30.0
 
     # Substrings that mark an SQLite file as unrecoverably damaged at open
     # time.  We deliberately keep this list short and English-only because
@@ -311,13 +317,258 @@ class Storage:
                 "original_path": str(db_path),
                 "quarantined_path": str(new_main),
                 "hint": (
-                    "Server is starting with a fresh empty database. "
-                    "Run scripts/recover_raw_flocks_db.py against the "
-                    "quarantined file to attempt data recovery."
+                    "Server will attempt sqlite3 .recover against the "
+                    "quarantined file before falling back to a fresh "
+                    "empty database."
                 ),
             },
         )
         return new_main
+
+    @classmethod
+    def _integrity_check_sync(cls, db_path: Path) -> tuple[bool, str]:
+        """Return whether SQLite can read *db_path* and reports integrity OK."""
+        try:
+            conn = sqlite3.connect(db_path, timeout=cls._sqlite_timeout_s)
+            try:
+                row = conn.execute("PRAGMA integrity_check").fetchone()
+            finally:
+                conn.close()
+        except Exception as exc:
+            return False, str(exc)
+        if row is None:
+            return False, "integrity_check returned no rows"
+        result = str(row[0])
+        return result.lower() == "ok", result
+
+    @classmethod
+    async def _assert_integrity_check_ok(cls, db_path: Path) -> None:
+        """Raise a corruption-looking SQLite error when integrity check fails."""
+        ok, detail = await asyncio.to_thread(cls._integrity_check_sync, db_path)
+        if ok:
+            return
+        raise sqlite3.DatabaseError(
+            "database disk image is malformed: "
+            f"PRAGMA integrity_check failed for {db_path}: {detail}"
+        )
+
+    @classmethod
+    def _try_sqlite_recover_sync(cls, quarantined_path: Path, target_path: Path) -> Optional[Path]:
+        """Try SQLite's lightweight `.recover` and install the recovered DB.
+
+        This intentionally avoids the heavier raw-page/WAL reconstruction script.
+        It handles the common case where SQLite can still scan a malformed DB
+        enough to emit recoverable SQL.  Failure is non-fatal; callers fall back
+        to bootstrapping an empty database.
+        """
+        sqlite_bin = shutil.which("sqlite3")
+        if sqlite_bin is None:
+            cls._log.warn(
+                "storage.corruption.recovery.skipped",
+                {
+                    "db_path": str(target_path),
+                    "quarantined_path": str(quarantined_path),
+                    "reason": "sqlite3 CLI not found",
+                },
+            )
+            return None
+
+        recovered_path = target_path.with_name(target_path.name + ".recovered")
+        sql_path = target_path.with_name(target_path.name + ".recover.sql")
+        for path in (recovered_path, sql_path):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+        try:
+            completed = subprocess.run(
+                [sqlite_bin, str(quarantined_path), ".recover"],
+                check=False,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=cls._sqlite_recover_timeout_s,
+            )
+        except Exception as exc:
+            cls._log.warn(
+                "storage.corruption.recovery.failed",
+                {
+                    "db_path": str(target_path),
+                    "quarantined_path": str(quarantined_path),
+                    "stage": "recover",
+                    "error": str(exc),
+                },
+            )
+            return None
+
+        recover_sql = completed.stdout or ""
+        sql_path.write_text(recover_sql, encoding="utf-8")
+        if completed.returncode != 0 and not recover_sql.strip():
+            cls._log.warn(
+                "storage.corruption.recovery.failed",
+                {
+                    "db_path": str(target_path),
+                    "quarantined_path": str(quarantined_path),
+                    "stage": "recover",
+                    "error": completed.stderr.strip() or str(completed.returncode),
+                },
+            )
+            return None
+
+        try:
+            materialized = subprocess.run(
+                [sqlite_bin, str(recovered_path)],
+                input=recover_sql,
+                check=False,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=cls._sqlite_recover_timeout_s,
+            )
+        except Exception as exc:
+            cls._log.warn(
+                "storage.corruption.recovery.failed",
+                {
+                    "db_path": str(target_path),
+                    "quarantined_path": str(quarantined_path),
+                    "stage": "materialize",
+                    "error": str(exc),
+                },
+            )
+            return None
+
+        if materialized.returncode != 0:
+            cls._log.warn(
+                "storage.corruption.recovery.failed",
+                {
+                    "db_path": str(target_path),
+                    "quarantined_path": str(quarantined_path),
+                    "stage": "materialize",
+                    "error": materialized.stderr.strip() or str(materialized.returncode),
+                    "recover_sql": str(sql_path),
+                },
+            )
+            return None
+
+        ok, detail = cls._integrity_check_sync(recovered_path)
+        if not ok:
+            cls._log.warn(
+                "storage.corruption.recovery.failed",
+                {
+                    "db_path": str(target_path),
+                    "quarantined_path": str(quarantined_path),
+                    "stage": "integrity_check",
+                    "error": detail,
+                    "recovered_path": str(recovered_path),
+                    "recover_sql": str(sql_path),
+                },
+            )
+            return None
+
+        try:
+            recovered_path.replace(target_path)
+        except OSError as exc:
+            cls._log.warn(
+                "storage.corruption.recovery.failed",
+                {
+                    "db_path": str(target_path),
+                    "quarantined_path": str(quarantined_path),
+                    "stage": "install",
+                    "error": str(exc),
+                    "recovered_path": str(recovered_path),
+                    "recover_sql": str(sql_path),
+                },
+            )
+            return None
+
+        cls._log.warn(
+            "storage.corruption.recovery.succeeded",
+            {
+                "db_path": str(target_path),
+                "quarantined_path": str(quarantined_path),
+                "recover_sql": str(sql_path),
+            },
+        )
+        return target_path
+
+    @classmethod
+    async def recover_corrupt_db(
+        cls,
+        db_path: Path,
+        *,
+        action: str,
+        exc: BaseException,
+        generation: Optional[int] = None,
+        reinitialize: Optional[Callable[[], Awaitable[Any]]] = None,
+    ) -> bool:
+        """Quarantine a corrupt SQLite DB and rebuild it once.
+
+        Returns ``True`` when recovery completed and callers should retry the
+        failed operation.  Returns ``False`` when another task already completed
+        recovery while this caller was waiting for the lock, in which case a
+        retry is still appropriate.
+        """
+        db_path = Path(db_path)
+        async with cls._corruption_recovery_lock:
+            if generation is not None and generation != cls._corruption_recovery_generation:
+                return False
+
+            cls._log.error(
+                "storage.corruption.detected",
+                {
+                    "db_path": str(db_path),
+                    "action": action,
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
+            quarantined = cls._quarantine_corrupt_db(db_path)
+            if quarantined is None:
+                raise exc
+            await asyncio.to_thread(cls._try_sqlite_recover_sync, quarantined, db_path)
+
+            if cls._db_path == db_path:
+                cls._initialized = False
+                cls._init_pid = None
+
+            if reinitialize is not None:
+                await reinitialize()
+            elif cls._db_path == db_path or db_path.name == "flocks.db":
+                await cls.init(db_path)
+
+            cls._corruption_recovery_generation += 1
+            cls._log.warn(
+                "storage.corruption.recovered",
+                {
+                    "db_path": str(db_path),
+                    "quarantined_path": str(quarantined),
+                    "action": action,
+                },
+            )
+            return True
+
+    @classmethod
+    async def _run_with_corruption_recovery(
+        cls,
+        operation: Callable[[], Awaitable[R]],
+        *,
+        db_path: Path,
+        action: str,
+    ) -> R:
+        generation = cls._corruption_recovery_generation
+        try:
+            return await operation()
+        except Exception as exc:
+            if not cls._is_db_corruption_error(exc):
+                raise
+            await cls.recover_corrupt_db(
+                db_path,
+                action=action,
+                exc=exc,
+                generation=generation,
+            )
+            return await operation()
 
     @classmethod
     def _is_sqlite_busy_error(cls, exc: Exception) -> bool:
@@ -627,6 +878,7 @@ class Storage:
             quarantined = cls._quarantine_corrupt_db(cls._db_path)
             if quarantined is None:
                 raise
+            await asyncio.to_thread(cls._try_sqlite_recover_sync, quarantined, cls._db_path)
             await cls._bootstrap_schema()
 
         # Drain any residual WAL frames left by the previous process so the
@@ -834,6 +1086,8 @@ class Storage:
             except Exception as e:
                 cls._log.warn("storage.extension_ddl.failed", {"error": str(e)})
 
+        await cls._assert_integrity_check_ok(cls._db_path)
+
     @classmethod
     async def _create_model_management_tables(cls) -> None:
         """Create dynamic data tables (idempotent).
@@ -978,7 +1232,11 @@ class Storage:
                 )
                 await db.commit()
 
-        await cls._run_write_with_retry(_write, action="set", target=key)
+        await cls._run_with_corruption_recovery(
+            lambda: cls._run_write_with_retry(_write, action="set", target=key),
+            db_path=db_path,
+            action=f"set:{key}",
+        )
 
         cls._log.debug("storage.set", {"key": key, "type": value_type})
 
@@ -997,9 +1255,16 @@ class Storage:
         await cls._ensure_init()
         db_path = cls.route_db_path_for_key(key)
 
-        async with cls.connect(db_path) as db:
-            async with db.execute("SELECT value, type FROM storage WHERE key = ?", (key,)) as cursor:
-                row = await cursor.fetchone()
+        async def _read() -> Optional[Tuple[str, str]]:
+            async with cls.connect(db_path) as db:
+                async with db.execute("SELECT value, type FROM storage WHERE key = ?", (key,)) as cursor:
+                    return await cursor.fetchone()
+
+        row = await cls._run_with_corruption_recovery(
+            _read,
+            db_path=db_path,
+            action=f"get:{key}",
+        )
 
         if row is None:
             return None
@@ -1033,7 +1298,11 @@ class Storage:
                 await db.commit()
                 return cursor.rowcount > 0
 
-        deleted = await cls._run_write_with_retry(_delete, action="delete", target=key)
+        deleted = await cls._run_with_corruption_recovery(
+            lambda: cls._run_write_with_retry(_delete, action="delete", target=key),
+            db_path=db_path,
+            action=f"delete:{key}",
+        )
 
         if deleted:
             cls._log.debug("storage.delete", {"key": key})
@@ -1059,16 +1328,23 @@ class Storage:
 
         keys: set[str] = set()
         for db_path in db_paths:
-            async with cls.connect(db_path) as db:
-                if prefix:
-                    query = f"SELECT key FROM storage WHERE {cls._like_prefix_clause()}"
-                    params = (cls._like_prefix_pattern(prefix),)
-                else:
-                    query = "SELECT key FROM storage"
-                    params = ()
+            async def _read_keys(db_path: Path = db_path):
+                async with cls.connect(db_path) as db:
+                    if prefix:
+                        query = f"SELECT key FROM storage WHERE {cls._like_prefix_clause()}"
+                        params = (cls._like_prefix_pattern(prefix),)
+                    else:
+                        query = "SELECT key FROM storage"
+                        params = ()
 
-                async with db.execute(query, params) as cursor:
-                    rows = await cursor.fetchall()
+                    async with db.execute(query, params) as cursor:
+                        return await cursor.fetchall()
+
+            rows = await cls._run_with_corruption_recovery(
+                _read_keys,
+                db_path=db_path,
+                action=f"list_keys:{prefix or '<all>'}",
+            )
             keys.update(row[0] for row in rows)
 
         return sorted(keys)
@@ -1086,16 +1362,23 @@ class Storage:
 
         rows_by_key: dict[str, str] = {}
         for db_path in db_paths:
-            async with cls.connect(db_path) as db:
-                if prefix:
-                    query = f"SELECT key, value FROM storage WHERE {cls._like_prefix_clause()}"
-                    params = (cls._like_prefix_pattern(prefix),)
-                else:
-                    query = "SELECT key, value FROM storage"
-                    params = ()
+            async def _read_rows(db_path: Path = db_path):
+                async with cls.connect(db_path) as db:
+                    if prefix:
+                        query = f"SELECT key, value FROM storage WHERE {cls._like_prefix_clause()}"
+                        params = (cls._like_prefix_pattern(prefix),)
+                    else:
+                        query = "SELECT key, value FROM storage"
+                        params = ()
 
-                async with db.execute(query, params) as cursor:
-                    rows = await cursor.fetchall()
+                    async with db.execute(query, params) as cursor:
+                        return await cursor.fetchall()
+
+            rows = await cls._run_with_corruption_recovery(
+                _read_rows,
+                db_path=db_path,
+                action=f"list_entries:{prefix or '<all>'}",
+            )
             for key, value in rows:
                 rows_by_key[key] = value
 
@@ -1149,27 +1432,35 @@ class Storage:
         safe_limit = max(int(limit), 0)
         params = (cls._like_prefix_pattern(prefix),)
 
-        async with cls.connect(db_path) as db:
-            async with db.execute(
-                f"SELECT COUNT(*) FROM storage WHERE {cls._like_prefix_clause()}",
-                params,
-            ) as cursor:
-                row = await cursor.fetchone()
-                total = int(row[0]) if row else 0
+        async def _read_page():
+            async with cls.connect(db_path) as db:
+                async with db.execute(
+                    f"SELECT COUNT(*) FROM storage WHERE {cls._like_prefix_clause()}",
+                    params,
+                ) as cursor:
+                    row = await cursor.fetchone()
+                    total = int(row[0]) if row else 0
 
-            if safe_limit == 0:
-                return [], total
+                if safe_limit == 0:
+                    return [], total
 
-            async with db.execute(
-                f"""
-                SELECT key, value FROM storage
-                WHERE {cls._like_prefix_clause()}
-                ORDER BY key
-                LIMIT ? OFFSET ?
-                """,
-                (cls._like_prefix_pattern(prefix), safe_limit, safe_offset),
-            ) as cursor:
-                rows = await cursor.fetchall()
+                async with db.execute(
+                    f"""
+                    SELECT key, value FROM storage
+                    WHERE {cls._like_prefix_clause()}
+                    ORDER BY key
+                    LIMIT ? OFFSET ?
+                    """,
+                    (cls._like_prefix_pattern(prefix), safe_limit, safe_offset),
+                ) as cursor:
+                    rows = await cursor.fetchall()
+                return rows, total
+
+        rows, total = await cls._run_with_corruption_recovery(
+            _read_page,
+            db_path=db_path,
+            action=f"list_entries_page:{prefix}",
+        )
 
         entries: List[Tuple[str, T | Any]] = []
         for key, value_str in rows:
@@ -1210,9 +1501,16 @@ class Storage:
         await cls._ensure_init()
         db_path = cls.route_db_path_for_key(key)
 
-        async with cls.connect(db_path) as db:
-            async with db.execute("SELECT 1 FROM storage WHERE key = ?", (key,)) as cursor:
-                row = await cursor.fetchone()
+        async def _exists():
+            async with cls.connect(db_path) as db:
+                async with db.execute("SELECT 1 FROM storage WHERE key = ?", (key,)) as cursor:
+                    return await cursor.fetchone()
+
+        row = await cls._run_with_corruption_recovery(
+            _exists,
+            db_path=db_path,
+            action=f"exists:{key}",
+        )
 
         return row is not None
 
@@ -1253,10 +1551,14 @@ class Storage:
 
         deleted = 0
         for db_path in db_paths:
-            deleted += await cls._run_write_with_retry(
-                lambda db_path=db_path: _clear_db(db_path),
-                action="clear",
-                target=f"{prefix or '<all>'}@{db_path}",
+            deleted += await cls._run_with_corruption_recovery(
+                lambda db_path=db_path: cls._run_write_with_retry(
+                    lambda db_path=db_path: _clear_db(db_path),
+                    action="clear",
+                    target=f"{prefix or '<all>'}@{db_path}",
+                ),
+                db_path=db_path,
+                action=f"clear:{prefix or '<all>'}",
             )
 
         cls._log.info("storage.clear", {"prefix": prefix, "deleted": deleted})

--- a/flocks/task/store.py
+++ b/flocks/task/store.py
@@ -61,7 +61,8 @@ class TaskStore:
         db_path = cls.get_db_path()
         db_existed_before_init = db_path.exists()
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
+
+        async def _open_and_migrate() -> None:
             cls._conn = await aiosqlite.connect(
                 db_path,
                 timeout=Storage._sqlite_timeout_s,
@@ -78,13 +79,25 @@ class TaskStore:
             cls._initialized = True
             cls._init_pid = current_pid
             await cls._normalize_legacy_paused_executions()
+
+        try:
+            await _open_and_migrate()
             log.info("task.store.initialized")
-        except Exception:
+        except Exception as exc:
             if cls._conn:
                 await cls._conn.close()
             cls._conn = None
             cls._initialized = False
             cls._init_pid = None
+            if Storage._is_db_corruption_error(exc):
+                await Storage.recover_corrupt_db(
+                    db_path,
+                    action="task.store.init",
+                    exc=exc,
+                    reinitialize=_open_and_migrate,
+                )
+                log.info("task.store.initialized")
+                return
             raise
 
     @classmethod

--- a/flocks/workflow/store.py
+++ b/flocks/workflow/store.py
@@ -78,7 +78,8 @@ class WorkflowStore:
 
         await Storage._ensure_init()
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
+
+        async def _open_and_migrate() -> None:
             cls._conn = await aiosqlite.connect(
                 db_path,
                 timeout=Storage._sqlite_timeout_s,
@@ -93,14 +94,26 @@ class WorkflowStore:
             cls._init_pid = current_pid
             cls._db_path = db_path
             await cls._migrate_legacy_kv()
+
+        try:
+            await _open_and_migrate()
             log.info("workflow.store.initialized")
-        except Exception:
+        except Exception as exc:
             if cls._conn:
                 await cls._conn.close()
             cls._conn = None
             cls._initialized = False
             cls._init_pid = None
             cls._db_path = None
+            if Storage._is_db_corruption_error(exc):
+                await Storage.recover_corrupt_db(
+                    db_path,
+                    action="workflow.store.init",
+                    exc=exc,
+                    reinitialize=_open_and_migrate,
+                )
+                log.info("workflow.store.initialized")
+                return
             raise
 
     @classmethod

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -2,8 +2,10 @@
 Tests for storage module
 """
 
+import asyncio
 from contextlib import asynccontextmanager
 import os
+import shutil
 import sqlite3
 import pytest
 from pathlib import Path
@@ -12,7 +14,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from pydantic import BaseModel
 
+from flocks.project.instance import Instance
 from flocks.storage.storage import Storage
+from flocks.task.store import TaskStore
+from flocks.workflow.store import WorkflowStore
 
 
 class StorageTestModel(BaseModel):
@@ -274,9 +279,8 @@ async def test_storage_init_recovers_when_pragma_reports_corruption(tmp_path):
     with patch.object(Storage, "_initialized", False), \
          patch.object(Storage, "_db_path", None):
         await Storage.init(db_path)
-
-    await Storage.set("hello", {"value": 2})
-    assert await Storage.get("hello") == {"value": 2}
+        await Storage.set("hello", {"value": 2})
+        assert await Storage.get("hello") == {"value": 2}
 
     assert db_path.exists()
     quarantined = [
@@ -284,6 +288,270 @@ async def test_storage_init_recovers_when_pragma_reports_corruption(tmp_path):
         if p.name.startswith("flocks.db.corrupt.")
     ]
     assert quarantined, list(tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_storage_get_recovers_corrupt_db_after_init(tmp_path):
+    """A request-time storage read should quarantine corruption and retry once."""
+    db_path = tmp_path / "flocks.db"
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None):
+        await Storage.init(db_path)
+        await Storage.set("hello", {"value": "before"})
+
+        db_path.write_bytes(Storage._SQLITE_MAGIC + b"\xff" * 2048)
+        db_path.with_name("flocks.db-wal").write_bytes(b"fake wal payload")
+        db_path.with_name("flocks.db-shm").write_bytes(b"fake shm payload")
+
+        assert await Storage.get("hello") is None
+        await Storage.set("hello", {"value": "after"})
+        assert await Storage.get("hello") == {"value": "after"}
+
+    siblings = sorted(p.name for p in tmp_path.iterdir())
+    assert "flocks.db" in siblings
+    assert any(name.startswith("flocks.db.corrupt.") for name in siblings), siblings
+
+
+def test_try_sqlite_recover_installs_recovered_db(tmp_path):
+    """The lightweight `.recover` path should install a readable recovered DB."""
+    if shutil.which("sqlite3") is None:
+        pytest.skip("sqlite3 CLI is not available")
+
+    quarantined = tmp_path / "flocks.db.corrupt.test"
+    target = tmp_path / "flocks.db"
+    conn = sqlite3.connect(quarantined)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE storage (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                type TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+            ("hello", '{"value": "recovered"}', "json", "old", "old"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert Storage._try_sqlite_recover_sync(quarantined, target) == target
+    recovered = sqlite3.connect(target)
+    try:
+        assert recovered.execute(
+            "SELECT value FROM storage WHERE key = ?",
+            ("hello",),
+        ).fetchone()[0] == '{"value": "recovered"}'
+        assert recovered.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    finally:
+        recovered.close()
+
+
+@pytest.mark.asyncio
+async def test_storage_init_recovers_real_malformed_sqlite_file(tmp_path):
+    """Startup should recover a real DB that fails SQLite integrity checks."""
+    if shutil.which("sqlite3") is None:
+        pytest.skip("sqlite3 CLI is not available")
+
+    db_path = tmp_path / "flocks.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA journal_mode=DELETE")
+        conn.execute("PRAGMA page_size=4096")
+        conn.execute("VACUUM")
+        conn.execute(
+            """
+            CREATE TABLE storage (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                type TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute("CREATE TABLE junk (id INTEGER PRIMARY KEY, payload BLOB NOT NULL)")
+        conn.execute(
+            "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+            ("hello", '{"value": "survived"}', "json", "old", "old"),
+        )
+        blob = os.urandom(3500)
+        for _ in range(350):
+            conn.execute("INSERT INTO junk (payload) VALUES (?)", (blob,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    page_size = 4096
+    page_count = db_path.stat().st_size // page_size
+    with db_path.open("r+b") as fh:
+        fh.seek((page_count - 3) * page_size)
+        fh.write(b"BROKEN_PAGE_FOR_RECOVERY_TEST" + b"\xff" * 256)
+
+    ok, detail = Storage._integrity_check_sync(db_path)
+    assert ok is False
+    assert "malformed" in detail.lower()
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(Storage, "_init_pid", None):
+        await Storage.init(db_path)
+        assert await Storage.get("hello") == {"value": "survived"}
+        await Storage.shutdown()
+
+    assert Storage._integrity_check_sync(db_path) == (True, "ok")
+    siblings = sorted(p.name for p in tmp_path.iterdir())
+    assert any(name.startswith("flocks.db.corrupt.") for name in siblings), siblings
+    assert "flocks.db.recover.sql" in siblings
+
+
+@pytest.mark.asyncio
+async def test_storage_get_uses_recovered_db_before_empty_rebuild(tmp_path, monkeypatch):
+    """A recovered DB should be installed before retrying the failed read."""
+    db_path = tmp_path / "flocks.db"
+
+    def fake_recover(quarantined_path: Path, target_path: Path):
+        assert quarantined_path.name.startswith("flocks.db.corrupt.")
+        conn = sqlite3.connect(target_path)
+        try:
+            conn.execute(
+                """
+                CREATE TABLE storage (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO storage (key, value, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                ("hello", '{"value": "recovered"}', "json", "old", "old"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return target_path
+
+    monkeypatch.setattr(Storage, "_try_sqlite_recover_sync", staticmethod(fake_recover))
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None):
+        await Storage.init(db_path)
+        db_path.write_bytes(Storage._SQLITE_MAGIC + b"\xff" * 2048)
+
+        assert await Storage.get("hello") == {"value": "recovered"}
+
+
+@pytest.mark.asyncio
+async def test_task_store_init_recovers_corrupt_tasks_db(tmp_path):
+    """TaskStore should quarantine tasks.db corruption and keep task center bootable."""
+    db_path = tmp_path / "flocks.db"
+    tasks_db = tmp_path / "tasks.db"
+    tasks_db.write_bytes(Storage._SQLITE_MAGIC + b"\xff" * 2048)
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(TaskStore, "_initialized", False), \
+         patch.object(TaskStore, "_conn", None), \
+         patch.object(TaskStore, "_init_pid", None):
+        await Storage.init(db_path)
+        await TaskStore.init()
+        await TaskStore.close()
+
+    siblings = sorted(p.name for p in tmp_path.iterdir())
+    assert "tasks.db" in siblings
+    assert any(name.startswith("tasks.db.corrupt.") for name in siblings), siblings
+
+
+@pytest.mark.asyncio
+async def test_task_store_init_recovers_corrupt_tasks_db_after_completed_migration(tmp_path, monkeypatch):
+    """A corrupt existing tasks.db should not be treated like a missing migrated DB."""
+    db_path = tmp_path / "flocks.db"
+    tasks_db = tmp_path / "tasks.db"
+    tasks_db.write_bytes(Storage._SQLITE_MAGIC + b"\xff" * 2048)
+
+    monkeypatch.setattr(Storage, "_try_sqlite_recover_sync", staticmethod(lambda *_args: None))
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(TaskStore, "_initialized", False), \
+         patch.object(TaskStore, "_conn", None), \
+         patch.object(TaskStore, "_init_pid", None):
+        await Storage.init(db_path)
+        await asyncio.to_thread(
+            Storage._write_multi_db_migration_marker_sync,
+            {
+                "version": 1,
+                "tasks_migrated": True,
+                "task_rows": 1,
+            },
+        )
+        await TaskStore.init()
+        await TaskStore.close()
+
+    siblings = sorted(p.name for p in tmp_path.iterdir())
+    assert "tasks.db" in siblings
+    assert any(name.startswith("tasks.db.corrupt.") for name in siblings), siblings
+
+
+@pytest.mark.asyncio
+async def test_workflow_store_init_recovers_corrupt_workflow_db(tmp_path):
+    """WorkflowStore should quarantine workflow.db corruption and rebuild tables."""
+    db_path = tmp_path / "flocks.db"
+    workflow_db = tmp_path / "workflow.db"
+    workflow_db.write_bytes(Storage._SQLITE_MAGIC + b"\xff" * 2048)
+
+    with patch.object(Storage, "_initialized", False), \
+         patch.object(Storage, "_db_path", None), \
+         patch.object(WorkflowStore, "_initialized", False), \
+         patch.object(WorkflowStore, "_conn", None), \
+         patch.object(WorkflowStore, "_init_pid", None), \
+         patch.object(WorkflowStore, "_db_path", None):
+        await Storage.init(db_path)
+        await WorkflowStore.init()
+        await WorkflowStore.close()
+
+    siblings = sorted(p.name for p in tmp_path.iterdir())
+    assert "workflow.db" in siblings
+    assert any(name.startswith("workflow.db.corrupt.") for name in siblings), siblings
+
+
+@pytest.mark.asyncio
+async def test_instance_provide_drops_failed_context_task(monkeypatch):
+    """A failed project-context initialization must not poison later requests."""
+    directory = "/tmp/flocks-instance-retry"
+    Instance._cache.pop(directory, None)
+    calls = {"count": 0}
+
+    async def fake_from_directory(cls, requested_directory):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise sqlite3.DatabaseError("database disk image is malformed")
+        return {
+            "project": SimpleNamespace(id="project"),
+            "sandbox": requested_directory,
+        }
+
+    monkeypatch.setattr(
+        "flocks.project.instance.Project.from_directory",
+        classmethod(fake_from_directory),
+    )
+
+    with pytest.raises(sqlite3.DatabaseError):
+        await Instance.provide(directory=directory, fn=lambda: "unreachable")
+
+    assert directory not in Instance._cache
+    assert await Instance.provide(directory=directory, fn=lambda: "ok") == "ok"
+    assert calls["count"] == 2
+    Instance._cache.pop(directory, None)
 
 
 def test_is_db_corruption_error_recognizes_known_messages():


### PR DESCRIPTION
## Summary
- quarantine and rebuild corrupt SQLite stores when malformed DB errors surface during runtime storage access
- recover corrupt tasks.db and workflow.db during store initialization
- drop failed project instance initialization tasks so later requests can retry after recovery

## Tests
- .venv/bin/python -m pytest tests/storage/test_storage.py
- .venv/bin/python -m pytest tests/workflow/test_workflow_store.py tests/task/test_task.py -q
- .venv/bin/python -m ruff check flocks/storage/storage.py flocks/task/store.py flocks/workflow/store.py flocks/project/instance.py tests/storage/test_storage.py
- git diff --check

Note: uv run pytest could not be used in this environment because resolving hatchling from PyPI failed with a TLS handshake error, so the existing project .venv was used instead.