### PR TITLE
fix(channel): preserve emails when stripping mentions

### DIFF
--- a/flocks/channel/builtin/feishu/monitor.py
+++ b/flocks/channel/builtin/feishu/monitor.py
@@ -22,6 +22,7 @@ import contextlib
 import hashlib
 import importlib
 import json
+import re
 import threading
 import time
 import uuid
@@ -42,6 +43,7 @@ log = Log.create(service="channel.feishu.monitor")
 _CHAT_LOCKS_MAX = 2000
 _WS_ACCOUNT_RECONNECT_DELAY_S = 1.0
 _WS_ACCOUNT_RECONNECT_MAX_DELAY_S = 30.0
+_MENTION_KEY_EDGE_RE = r"[A-Za-z0-9_.+@-]"
 
 
 class _ObservedWSClient:
@@ -774,7 +776,7 @@ def _parse_event(
     for m in mentions:
         mention_key = m.get("key", "")
         if mention_key:
-            mention_text = mention_text.replace(mention_key, "").strip()
+            mention_text = _strip_mention_key(mention_text, mention_key)
 
     sender_id = sender.get("open_id", "")
     # Some mobile messages may only have user_id, not open_id
@@ -801,6 +803,15 @@ def _parse_event(
         reply_to_id=msg_data.get("parent_id") or None,
         raw=data,
     )
+
+
+def _strip_mention_key(text: str, mention_key: str) -> str:
+    """Remove a Feishu mention key without touching emails or identifiers."""
+    pattern = re.compile(
+        rf"(?<!{_MENTION_KEY_EDGE_RE}){re.escape(mention_key)}"
+        rf"(?!{_MENTION_KEY_EDGE_RE})"
+    )
+    return pattern.sub("", text).strip()
 
 
 # ---------------------------------------------------------------------------

--- a/flocks/channel/builtin/wecom/channel.py
+++ b/flocks/channel/builtin/wecom/channel.py
@@ -32,6 +32,7 @@ log = Log.create(service="channel.wecom")
 
 _FRAME_CACHE_MAX = 500
 _DEFAULT_RECONNECT_TIMEOUT_SECONDS = 60.0
+_LEADING_MENTION_RE = re.compile(r"^\s*(?:@\S+(?:\s+|$))+")
 
 
 class _WeComSdkLogger:
@@ -481,7 +482,7 @@ def _parse_frame(frame: dict, config: dict) -> Optional[InboundMessage]:
     chat_id = body.get("chatid") or from_user
 
     if chat_type == ChatType.GROUP:
-        text = re.sub(r"@\S+", "", text).strip()
+        text = _strip_leading_mentions(text)
 
     # WeCom platform only delivers group messages when the bot is @mentioned,
     # so every group message that reaches here is inherently a mention.
@@ -506,6 +507,11 @@ def _extract_sent_message_id(frame: Any) -> str:
     if not isinstance(body, dict):
         return ""
     return str(body.get("msgid") or body.get("message_id") or "")
+
+
+def _strip_leading_mentions(text: str) -> str:
+    """Remove only the bot mention prefix from a WeCom group message."""
+    return _LEADING_MENTION_RE.sub("", text, count=1).strip()
 
 
 def _extract_content(body: dict) -> tuple[str, Optional[str]]:

--- a/tests/channel/test_feishu.py
+++ b/tests/channel/test_feishu.py
@@ -24,6 +24,7 @@ from flocks.channel.builtin.feishu.inbound_media import download_inbound_media
 from flocks.channel.builtin.feishu.media import send_media_feishu
 from flocks.channel.builtin.feishu.monitor import (
     _build_ws_client,
+    _parse_event,
     _start_single_websocket,
     start_websocket,
 )
@@ -79,6 +80,55 @@ def test_resolve_feishu_group_overrides_uses_normalized_group_config() -> None:
 
     assert scope == "group_topic"
     assert agent == "specific"
+
+
+def _feishu_text_event(
+    text: str,
+    mentions: list[dict] | None = None,
+) -> dict:
+    return {
+        "header": {"event_type": "im.message.receive_v1"},
+        "event": {
+            "sender": {"sender_id": {"open_id": "ou_sender"}},
+            "message": {
+                "message_id": "om_1",
+                "chat_id": "oc_group",
+                "chat_type": "group",
+                "message_type": "text",
+                "content": json.dumps({"text": text}),
+                "mentions": mentions or [
+                    {"key": "@_user_1", "id": {"open_id": "ou_bot"}},
+                ],
+            },
+        },
+    }
+
+
+def test_parse_event_strips_feishu_mention_key() -> None:
+    msg = _parse_event(
+        _feishu_text_event('@_user_1 "friday@park.example.ai"'),
+        {},
+        bot_open_id="ou_bot",
+    )
+
+    assert msg is not None
+    assert msg.mention_text == '"friday@park.example.ai"'
+
+
+def test_parse_event_preserves_email_when_mention_key_matches_domain() -> None:
+    msg = _parse_event(
+        _feishu_text_event(
+            '@ArchSec "friday@park.example.ai", 邮箱域名是park.example.ai',
+            mentions=[{"key": "@park.example.ai", "id": {"open_id": "ou_bot"}}],
+        ),
+        {},
+        bot_open_id="ou_bot",
+    )
+
+    assert msg is not None
+    assert msg.mention_text == (
+        '@ArchSec "friday@park.example.ai", 邮箱域名是park.example.ai'
+    )
 
 
 def test_resolve_webhook_account_config_matches_named_account_token() -> None:

--- a/tests/channel/test_wecom.py
+++ b/tests/channel/test_wecom.py
@@ -577,6 +577,26 @@ class TestParseFrame:
         assert "查一下" in msg.text
         assert msg.mentioned is True
 
+    def test_group_message_preserves_email_after_leading_mention(self):
+        frame = {
+            "body": {
+                "msgid": "msg002b",
+                "chattype": "group",
+                "chatid": "grp_001",
+                "from": {"userid": "lisi"},
+                "msgtype": "text",
+                "text": {
+                    "content": '@ArchSec "friday@park.example.ai", 邮箱域名是park.example.ai'
+                },
+            }
+        }
+
+        msg = _parse_frame(frame, {})
+
+        assert msg is not None
+        assert msg.text == '"friday@park.example.ai", 邮箱域名是park.example.ai'
+        assert msg.mentioned is True
+
     def test_image_message(self):
         frame = {
             "body": {


### PR DESCRIPTION
Limit WeCom group mention cleanup to leading mention prefixes and make Feishu mention-key stripping respect token boundaries so email addresses remain intact.

Add regression coverage for WeCom and Feishu inbound message parsing.