### PR TITLE
fix: align home agent count with agent list

### DIFF
--- a/webui/src/api/stats.test.ts
+++ b/webui/src/api/stats.test.ts
@@ -6,12 +6,12 @@ vi.mock('./client', () => ({
   apiClient: { get: (...args: unknown[]) => mockGet(...args) },
 }));
 
-// Helper: build a default mock for every endpoint except /api/skills.
-function defaultMock(skillsData: unknown[]) {
+// Helper: build a default mock for every endpoint except /api/skills and /api/agent.
+function defaultMock(skillsData: unknown[], agentsData: unknown[] = []) {
   mockGet.mockImplementation((url: string) => {
     if (url === '/api/skills') return Promise.resolve({ data: skillsData });
     if (url === '/api/task-system/dashboard') return Promise.resolve({ data: {} });
-    if (url === '/api/agent') return Promise.resolve({ data: [] });
+    if (url === '/api/agent') return Promise.resolve({ data: agentsData });
     if (url === '/api/workflow') return Promise.resolve({ data: [] });
     if (url === '/api/tools') return Promise.resolve({ data: [] });
     if (url === '/api/provider') return Promise.resolve({ data: { all: [], connected: [] } });
@@ -44,6 +44,20 @@ describe('statsApi.getSystemStats', () => {
     const { statsApi } = await import('./stats');
     const result = await statsApi.getSystemStats();
     expect(result.skills.total).toBe(0);
+  });
+
+  it('counts agents with the same visibility rule as the Agent page', async () => {
+    defaultMock([], [
+      { name: 'rex', mode: 'primary', tags: [] },
+      { name: 'custom-helper', mode: 'subagent', tags: [] },
+      { name: 'explore', mode: 'subagent', tags: ['system'] },
+      { name: 'oracle', mode: 'subagent', tags: ['system'] },
+    ]);
+
+    const { statsApi } = await import('./stats');
+    const result = await statsApi.getSystemStats();
+
+    expect(result.agents.total).toBe(2);
   });
 
   it('handles skills API failure gracefully (returns 0)', async () => {

--- a/webui/src/api/stats.ts
+++ b/webui/src/api/stats.ts
@@ -26,6 +26,12 @@ export interface SystemStats {
   };
 }
 
+function shouldCountForAgentPage(agent: any): boolean {
+  if (!agent || typeof agent !== 'object') return false;
+  if (agent.mode === 'primary') return true;
+  return !Array.isArray(agent.tags) || !agent.tags.includes('system');
+}
+
 export const statsApi = {
   getSystemStats: async (): Promise<SystemStats> => {
     try {
@@ -40,7 +46,7 @@ export const statsApi = {
       ]);
 
       const dash = taskDash.data || {};
-      const agentList = Array.isArray(agents.data) ? agents.data : [];
+      const agentList = (Array.isArray(agents.data) ? agents.data : []).filter(shouldCountForAgentPage);
       const workflowList = Array.isArray(workflows.data) ? workflows.data : [];
       // Exclude `system` category skills so the count matches the Skills page,
       // which hides system skills (e.g. onboarding) from the user.


### PR DESCRIPTION
## 背景

有用户反馈首页展示的 Agent 数量与 Agent 列表页数量不一致。

排查后确认，首页统计和列表页使用了不同的口径：
- 首页直接统计 `/api/agent` 返回的总数
- Agent 列表页会额外过滤掉带 `system` tag 的 subagent

这会导致首页数量偏大，与列表页不一致。

## 变更内容

本次修改统一了首页 Agent 数量的统计口径，使其与 Agent 列表页保持一致：

- 保留 `mode === 'primary'` 的 agent
- 排除 `tags` 中包含 `system` 的 subagent
- 其他 agent 继续计入首页统计

同时补充了对应单元测试，覆盖：
- 首页只统计列表页可见的 agent
- system subagent 不计入首页数量
