### PR TITLE
fix(provider): support max_completion_tokens for openai-compatible

### DIFF
--- a/flocks/provider/provider.py
+++ b/flocks/provider/provider.py
@@ -389,6 +389,7 @@ class Provider:
                             # not enforce auth; let _get_client() fall back to a
                             # sentinel key instead of raising.
                             ALLOW_NO_API_KEY = True
+                            PREFER_MAX_COMPLETION_TOKENS = True
                             
                             def __init__(self):
                                 super().__init__(

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -350,6 +350,97 @@ def _supports_include_usage_fallback(exc: Exception) -> bool:
     )
 
 
+def _supports_max_completion_tokens_fallback(exc: Exception) -> bool:
+    """Return True when the provider rejects ``max_completion_tokens``."""
+    message = str(exc).lower()
+    return "max_completion_tokens" in message and any(
+        marker in message
+        for marker in (
+            "unsupported parameter",
+            "unknown parameter",
+            "unrecognized parameter",
+            "extra inputs are not permitted",
+            "extra fields not permitted",
+            "not permitted",
+        )
+    )
+
+
+def resolve_openai_token_limit(kwargs: Dict[str, Any]) -> Optional[int]:
+    """Resolve output token limits from either OpenAI naming variant."""
+    max_completion_tokens = kwargs.get("max_completion_tokens")
+    if max_completion_tokens is not None:
+        return max_completion_tokens
+    return kwargs.get("max_tokens")
+
+
+def apply_openai_token_limit(
+    params: Dict[str, Any],
+    max_tokens: Optional[int],
+    *,
+    prefer_completion_tokens: bool = False,
+    completion_tokens_explicit: bool = False,
+) -> None:
+    """Apply the preferred token-limit field to an OpenAI-style payload."""
+    if max_tokens is None:
+        return
+    if completion_tokens_explicit or prefer_completion_tokens:
+        params["max_completion_tokens"] = max_tokens
+    else:
+        params["max_tokens"] = max_tokens
+
+
+async def create_chat_completion_with_fallbacks(
+    create_call,
+    params: Dict[str, Any],
+    *,
+    max_tokens: Optional[int],
+    logger: Any,
+    log_prefix: str,
+) -> Any:
+    """Execute a chat completion request with transport compatibility fallbacks."""
+    current_params = dict(params)
+    include_usage_retried = False
+    max_completion_tokens_retried = False
+
+    while True:
+        try:
+            return await create_call(**current_params)
+        except Exception as exc:
+            if (
+                not max_completion_tokens_retried
+                and max_tokens is not None
+                and "max_completion_tokens" in current_params
+                and "max_tokens" not in current_params
+                and _supports_max_completion_tokens_fallback(exc)
+            ):
+                max_completion_tokens_retried = True
+                logger.warn(f"{log_prefix}.max_completion_tokens_unsupported", {
+                    "model": current_params.get("model"),
+                    "error": str(exc),
+                })
+                current_params = dict(current_params)
+                current_params.pop("max_completion_tokens", None)
+                current_params["max_tokens"] = max_tokens
+                continue
+
+            if (
+                not include_usage_retried
+                and "stream_options" in current_params
+                and _supports_include_usage_fallback(exc)
+            ):
+                include_usage_retried = True
+                logger.warn(f"{log_prefix}.stream.include_usage_unsupported", {
+                    "model": current_params.get("model"),
+                    "error": str(exc),
+                })
+                current_params = dict(current_params)
+                current_params.pop("stream_options", None)
+                continue
+
+            raise
+
+
 class ThinkTagExtractor:
     """Extract reasoning content from streaming LLM output.
 
@@ -698,6 +789,7 @@ class OpenAIBaseProvider(BaseProvider):
     ENV_BASE_URL: str = ""
     CATALOG_ID: str = ""
     ALLOW_NO_API_KEY: bool = False
+    PREFER_MAX_COMPLETION_TOKENS: bool = False
     NO_API_KEY_PLACEHOLDER: str = "not-needed"
 
     def __init__(self, provider_id: str, name: str):
@@ -821,6 +913,8 @@ class OpenAIBaseProvider(BaseProvider):
         openai_messages = self._format_messages(messages)
 
         thinking = kwargs.get("thinking")
+        max_tokens = resolve_openai_token_limit(kwargs)
+        max_completion_tokens_explicit = kwargs.get("max_completion_tokens") is not None
 
         params: Dict[str, Any] = {
             "model": model_id,
@@ -837,8 +931,12 @@ class OpenAIBaseProvider(BaseProvider):
         if extra_body:
             params["extra_body"] = extra_body
 
-        if kwargs.get("max_tokens"):
-            params["max_tokens"] = kwargs["max_tokens"]
+        apply_openai_token_limit(
+            params,
+            max_tokens,
+            prefer_completion_tokens=self.PREFER_MAX_COMPLETION_TOKENS,
+            completion_tokens_explicit=max_completion_tokens_explicit,
+        )
         if kwargs.get("tools"):
             params["tools"] = kwargs["tools"]
 
@@ -850,12 +948,18 @@ class OpenAIBaseProvider(BaseProvider):
             "thinking_enabled": bool(thinking),
             "has_extra_body": "extra_body" in params,
             "has_tools": bool(kwargs.get("tools")),
-            "max_tokens": kwargs.get("max_tokens"),
+            "max_tokens": max_tokens,
             "has_temperature": "temperature" in params,
             "message_summary": _summarise_messages(openai_messages),
         })
 
-        response = await client.chat.completions.create(**params)
+        response = await create_chat_completion_with_fallbacks(
+            client.chat.completions.create,
+            params,
+            max_tokens=max_tokens,
+            logger=log,
+            log_prefix="openai_base",
+        )
         if not response.choices:
             extra = getattr(response, "model_extra", {}) or {}
             err_detail = extra.get("error") or extra.get("message") or str(extra) or "no choices returned"
@@ -894,6 +998,8 @@ class OpenAIBaseProvider(BaseProvider):
         openai_messages = self._format_messages(messages)
 
         thinking = kwargs.get("thinking")
+        max_tokens = resolve_openai_token_limit(kwargs)
+        max_completion_tokens_explicit = kwargs.get("max_completion_tokens") is not None
 
         params: Dict[str, Any] = {
             "model": model_id,
@@ -912,8 +1018,12 @@ class OpenAIBaseProvider(BaseProvider):
         if extra_body:
             params["extra_body"] = extra_body
 
-        if kwargs.get("max_tokens"):
-            params["max_tokens"] = kwargs["max_tokens"]
+        apply_openai_token_limit(
+            params,
+            max_tokens,
+            prefer_completion_tokens=self.PREFER_MAX_COMPLETION_TOKENS,
+            completion_tokens_explicit=max_completion_tokens_explicit,
+        )
         if kwargs.get("tools"):
             params["tools"] = kwargs["tools"]
 
@@ -924,24 +1034,19 @@ class OpenAIBaseProvider(BaseProvider):
             "thinking_enabled": bool(thinking),
             "has_extra_body": "extra_body" in params,
             "has_tools": bool(kwargs.get("tools")),
-            "max_tokens": kwargs.get("max_tokens"),
+            "max_tokens": max_tokens,
             "has_temperature": "temperature" in params,
             "include_usage": True,
             "message_summary": _summarise_messages(openai_messages),
         })
 
-        try:
-            stream = await client.chat.completions.create(**params)
-        except Exception as exc:
-            if not _supports_include_usage_fallback(exc):
-                raise
-            log.warn("openai_base.stream.include_usage_unsupported", {
-                "model": model_id,
-                "error": str(exc),
-            })
-            params_without_usage = dict(params)
-            params_without_usage.pop("stream_options", None)
-            stream = await client.chat.completions.create(**params_without_usage)
+        stream = await create_chat_completion_with_fallbacks(
+            client.chat.completions.create,
+            params,
+            max_tokens=max_tokens,
+            logger=log,
+            log_prefix="openai_base",
+        )
         tool_calls: Dict[int, Dict[str, Any]] = {}
         emitted_substantive_chunk = False
         stream_usage: Optional[Dict[str, int]] = None

--- a/flocks/provider/sdk/openai_compatible.py
+++ b/flocks/provider/sdk/openai_compatible.py
@@ -24,14 +24,16 @@ from flocks.provider.provider import (
 from flocks.provider.sdk.openai_base import (
     DEFAULT_HTTP_TIMEOUT,
     ThinkTagExtractor,
+    apply_openai_token_limit,
     build_reasoning_metadata,
+    create_chat_completion_with_fallbacks,
     _coerce_bool,
     _normalize_stream_usage,
-    _supports_include_usage_fallback,
     extract_reasoning_content_with_source,
     extract_reasoning_details,
     format_openai_content,
     format_openai_messages,
+    resolve_openai_token_limit,
     resolve_verify_ssl,
 )
 from flocks.utils.log import Log
@@ -179,7 +181,8 @@ class OpenAICompatibleProvider(BaseProvider):
         formatted_messages = self._format_messages(messages)
         
         # Extract parameters
-        max_tokens = kwargs.get("max_tokens")
+        max_tokens = resolve_openai_token_limit(kwargs)
+        max_completion_tokens_explicit = kwargs.get("max_completion_tokens") is not None
         tools = kwargs.get("tools")
         thinking = kwargs.get("thinking")
 
@@ -201,8 +204,12 @@ class OpenAICompatibleProvider(BaseProvider):
         if extra_body:
             request_params["extra_body"] = extra_body
         
-        if max_tokens:
-            request_params["max_tokens"] = max_tokens
+        apply_openai_token_limit(
+            request_params,
+            max_tokens,
+            prefer_completion_tokens=True,
+            completion_tokens_explicit=max_completion_tokens_explicit,
+        )
         if tools:
             # Some compatible APIs don't support tools
             try:
@@ -210,7 +217,13 @@ class OpenAICompatibleProvider(BaseProvider):
             except Exception:
                 self.log.warn("openai_compatible.tools.not_supported", {"model": model_id})
         
-        response = await client.chat.completions.create(**request_params)
+        response = await create_chat_completion_with_fallbacks(
+            client.chat.completions.create,
+            request_params,
+            max_tokens=max_tokens,
+            logger=self.log,
+            log_prefix="openai_compatible",
+        )
 
         # Format response
         choice = response.choices[0]
@@ -244,7 +257,8 @@ class OpenAICompatibleProvider(BaseProvider):
         formatted_messages = self._format_messages(messages)
         
         # Extract parameters
-        max_tokens = kwargs.get("max_tokens")
+        max_tokens = resolve_openai_token_limit(kwargs)
+        max_completion_tokens_explicit = kwargs.get("max_completion_tokens") is not None
         tools = kwargs.get("tools")
         thinking = kwargs.get("thinking")
 
@@ -274,8 +288,12 @@ class OpenAICompatibleProvider(BaseProvider):
         if extra_body:
             request_params["extra_body"] = extra_body
         
-        if max_tokens:
-            request_params["max_tokens"] = max_tokens
+        apply_openai_token_limit(
+            request_params,
+            max_tokens,
+            prefer_completion_tokens=True,
+            completion_tokens_explicit=max_completion_tokens_explicit,
+        )
         if tools:
             # Some compatible APIs don't support tools
             try:
@@ -291,18 +309,13 @@ class OpenAICompatibleProvider(BaseProvider):
             "include_usage": True,
         })
 
-        try:
-            stream = await client.chat.completions.create(**request_params)
-        except Exception as exc:
-            if not _supports_include_usage_fallback(exc):
-                raise
-            self.log.warn("openai_compatible.stream.include_usage_unsupported", {
-                "model": model_id,
-                "error": str(exc),
-            })
-            request_params = dict(request_params)
-            request_params.pop("stream_options", None)
-            stream = await client.chat.completions.create(**request_params)
+        stream = await create_chat_completion_with_fallbacks(
+            client.chat.completions.create,
+            request_params,
+            max_tokens=max_tokens,
+            logger=self.log,
+            log_prefix="openai_compatible",
+        )
 
         # Stateful extractor to separate <think>...</think> from content.
         think_extractor = ThinkTagExtractor()

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -48,6 +48,12 @@ class MockProviderWithoutCatalog(OpenAIBaseProvider):
         super().__init__(provider_id="custom-provider", name="Custom Provider")
 
 
+class MockProviderPrefersCompletionTokens(MockProviderWithoutCatalog):
+    """Mock OpenAI-compatible provider that opts into newer token naming."""
+
+    PREFER_MAX_COMPLETION_TOKENS = True
+
+
 class TestOpenAIBaseProviderGetModels:
     """Test suite for get_models() method."""
 
@@ -400,6 +406,13 @@ class TestOpenAIBaseProviderTemperature:
         provider._client.chat.completions.create = create
         return provider, create
 
+    def _build_completion_preferring_provider_with_client(self):
+        provider = MockProviderPrefersCompletionTokens()
+        create = AsyncMock()
+        provider._client = MagicMock()
+        provider._client.chat.completions.create = create
+        return provider, create
+
     @staticmethod
     def _mock_chat_response(content: str = "Paris"):
         response = MagicMock()
@@ -413,7 +426,7 @@ class TestOpenAIBaseProviderTemperature:
         return response
 
     @pytest.mark.asyncio
-    async def test_chat_omits_temperature_when_not_provided(self):
+    async def test_chat_uses_max_tokens_by_default_when_max_tokens_provided(self):
         provider, create = self._build_provider_with_client()
         create.return_value = self._mock_chat_response()
 
@@ -429,6 +442,24 @@ class TestOpenAIBaseProviderTemperature:
         assert "temperature" not in kwargs
         assert kwargs["model"] == "kimi-k2.5"
         assert kwargs["max_tokens"] == 20
+        assert "max_completion_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_prefers_max_completion_tokens_when_provider_opts_in(self):
+        provider, create = self._build_completion_preferring_provider_with_client()
+        create.return_value = self._mock_chat_response()
+
+        from flocks.provider.provider import ChatMessage
+
+        await provider.chat(
+            "gpt-5.4",
+            [ChatMessage(role="user", content="hello")],
+            max_completion_tokens=20,
+        )
+
+        kwargs = create.await_args.kwargs
+        assert kwargs["max_completion_tokens"] == 20
+        assert "max_tokens" not in kwargs
 
     @pytest.mark.asyncio
     async def test_chat_passes_explicit_temperature(self):
@@ -445,6 +476,79 @@ class TestOpenAIBaseProviderTemperature:
 
         kwargs = create.await_args.kwargs
         assert kwargs["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_chat_accepts_direct_max_completion_tokens_kwarg(self):
+        provider, create = self._build_provider_with_client()
+        create.return_value = self._mock_chat_response()
+
+        from flocks.provider.provider import ChatMessage
+
+        await provider.chat(
+            "gpt-5.4",
+            [ChatMessage(role="user", content="hello")],
+            max_completion_tokens=33,
+        )
+
+        kwargs = create.await_args.kwargs
+        assert kwargs["max_completion_tokens"] == 33
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_treats_explicit_max_completion_tokens_as_authoritative(self):
+        provider, create = self._build_provider_with_client()
+        create.return_value = self._mock_chat_response()
+
+        from flocks.provider.provider import ChatMessage
+
+        await provider.chat(
+            "gpt-5.4",
+            [ChatMessage(role="user", content="hello")],
+            max_tokens=20,
+            max_completion_tokens=33,
+        )
+
+        kwargs = create.await_args.kwargs
+        assert kwargs["max_completion_tokens"] == 33
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_falls_back_to_max_tokens_when_completion_variant_is_rejected(self):
+        provider, create = self._build_provider_with_client()
+        create.side_effect = [
+            ValueError("unsupported parameter: max_completion_tokens"),
+            self._mock_chat_response(),
+        ]
+
+        from flocks.provider.provider import ChatMessage
+
+        await provider.chat(
+            "gpt-5.4",
+            [ChatMessage(role="user", content="hello")],
+            max_completion_tokens=20,
+        )
+
+        assert create.await_count == 2
+        assert create.await_args_list[0].kwargs["max_completion_tokens"] == 20
+        assert "max_tokens" not in create.await_args_list[0].kwargs
+        assert create.await_args_list[1].kwargs["max_tokens"] == 20
+        assert "max_completion_tokens" not in create.await_args_list[1].kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_does_not_fallback_for_completion_token_value_errors(self):
+        provider, create = self._build_provider_with_client()
+        create.side_effect = ValueError("max_completion_tokens must be <= 4096")
+
+        from flocks.provider.provider import ChatMessage
+
+        with pytest.raises(ValueError, match="max_completion_tokens must be <= 4096"):
+            await provider.chat(
+                "gpt-5.4",
+                [ChatMessage(role="user", content="hello")],
+                max_completion_tokens=200000,
+            )
+
+        assert create.await_count == 1
 
     def test_summarise_messages_compacts_long_history(self):
         summary = openai_base_module._summarise_messages(
@@ -557,6 +661,14 @@ class TestOpenAIBaseProviderStreamingUsage:
     @staticmethod
     def _build_provider_with_stream():
         provider = MockProviderWithoutCatalog()
+        create = AsyncMock()
+        provider._client = MagicMock()
+        provider._client.chat.completions.create = create
+        return provider, create
+
+    @staticmethod
+    def _build_completion_preferring_provider_with_stream():
+        provider = MockProviderPrefersCompletionTokens()
         create = AsyncMock()
         provider._client = MagicMock()
         provider._client.chat.completions.create = create
@@ -676,6 +788,91 @@ class TestOpenAIBaseProviderStreamingUsage:
         assert create.await_count == 2
         assert "stream_options" in create.await_args_list[0].kwargs
         assert "stream_options" not in create.await_args_list[1].kwargs
+        assert chunks[-1].usage == {
+            "prompt_tokens": 5,
+            "completion_tokens": 3,
+            "total_tokens": 8,
+        }
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_falls_back_to_max_tokens_when_completion_variant_is_rejected(self):
+        provider, create = self._build_completion_preferring_provider_with_stream()
+
+        create.side_effect = [
+            ValueError("unsupported parameter: max_completion_tokens"),
+            _stream_from_chunks(
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(content="hello", tool_calls=None),
+                            finish_reason="stop",
+                        )
+                    ],
+                    usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+                )
+            ),
+        ]
+
+        from flocks.provider.provider import ChatMessage
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "gpt-5.4",
+                [ChatMessage(role="user", content="hello")],
+                max_tokens=20,
+            )
+        ]
+
+        assert create.await_count == 2
+        assert create.await_args_list[0].kwargs["max_completion_tokens"] == 20
+        assert "max_tokens" not in create.await_args_list[0].kwargs
+        assert create.await_args_list[1].kwargs["max_tokens"] == 20
+        assert "max_completion_tokens" not in create.await_args_list[1].kwargs
+        assert chunks[-1].usage == {
+            "prompt_tokens": 5,
+            "completion_tokens": 3,
+            "total_tokens": 8,
+        }
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_chains_completion_and_usage_fallbacks(self):
+        provider, create = self._build_completion_preferring_provider_with_stream()
+
+        create.side_effect = [
+            ValueError("unsupported parameter: max_completion_tokens"),
+            ValueError("unsupported parameter: include_usage"),
+            _stream_from_chunks(
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(content="hello", tool_calls=None),
+                            finish_reason="stop",
+                        )
+                    ],
+                    usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+                )
+            ),
+        ]
+
+        from flocks.provider.provider import ChatMessage
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "gpt-5.4",
+                [ChatMessage(role="user", content="hello")],
+                max_tokens=20,
+            )
+        ]
+
+        assert create.await_count == 3
+        assert create.await_args_list[0].kwargs["max_completion_tokens"] == 20
+        assert "stream_options" in create.await_args_list[0].kwargs
+        assert create.await_args_list[1].kwargs["max_tokens"] == 20
+        assert "stream_options" in create.await_args_list[1].kwargs
+        assert create.await_args_list[2].kwargs["max_tokens"] == 20
+        assert "stream_options" not in create.await_args_list[2].kwargs
         assert chunks[-1].usage == {
             "prompt_tokens": 5,
             "completion_tokens": 3,

--- a/tests/provider/test_openai_compatible_provider.py
+++ b/tests/provider/test_openai_compatible_provider.py
@@ -56,8 +56,8 @@ class TestOpenAICompatibleProviderConfiguration:
         assert kwargs["trust_env"] is True
         timeout_arg = kwargs["timeout"]
         assert getattr(timeout_arg, "connect", None) == 30.0
-        assert getattr(timeout_arg, "read", None) == 600.0
-        assert getattr(timeout_arg, "write", None) == 600.0
+        assert getattr(timeout_arg, "read", None) == 180.0
+        assert getattr(timeout_arg, "write", None) == 1800.0
 
         mock_async_openai.assert_called_once_with(
             api_key="test-api-key",
@@ -88,7 +88,7 @@ async def _stream_from_chunks(*chunks):
 
 class TestOpenAICompatibleProviderTemperature:
     @pytest.mark.asyncio
-    async def test_chat_omits_temperature_when_not_provided(self):
+    async def test_chat_prefers_max_completion_tokens_when_max_tokens_provided(self):
         provider, create = _build_provider_with_client()
         create.return_value = _mock_chat_response()
 
@@ -101,7 +101,8 @@ class TestOpenAICompatibleProviderTemperature:
         kwargs = create.await_args.kwargs
         assert "temperature" not in kwargs
         assert kwargs["model"] == "kimi-k2.5"
-        assert kwargs["max_tokens"] == 20
+        assert kwargs["max_completion_tokens"] == 20
+        assert "max_tokens" not in kwargs
 
     @pytest.mark.asyncio
     async def test_chat_passes_explicit_temperature(self):
@@ -116,6 +117,71 @@ class TestOpenAICompatibleProviderTemperature:
 
         kwargs = create.await_args.kwargs
         assert kwargs["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_chat_accepts_direct_max_completion_tokens_kwarg(self):
+        provider, create = _build_provider_with_client()
+        create.return_value = _mock_chat_response()
+
+        await provider.chat(
+            "gpt-5.4",
+            [ChatMessage(role="user", content="hello")],
+            max_completion_tokens=33,
+        )
+
+        kwargs = create.await_args.kwargs
+        assert kwargs["max_completion_tokens"] == 33
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_treats_explicit_max_completion_tokens_as_authoritative(self):
+        provider, create = _build_provider_with_client()
+        create.return_value = _mock_chat_response()
+
+        await provider.chat(
+            "gpt-5.4",
+            [ChatMessage(role="user", content="hello")],
+            max_tokens=20,
+            max_completion_tokens=33,
+        )
+
+        kwargs = create.await_args.kwargs
+        assert kwargs["max_completion_tokens"] == 33
+        assert "max_tokens" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_falls_back_to_max_tokens_when_completion_variant_is_rejected(self):
+        provider, create = _build_provider_with_client()
+        create.side_effect = [
+            ValueError("unsupported parameter: max_completion_tokens"),
+            _mock_chat_response(),
+        ]
+
+        await provider.chat(
+            "gpt-5.4",
+            [ChatMessage(role="user", content="hello")],
+            max_tokens=20,
+        )
+
+        assert create.await_count == 2
+        assert create.await_args_list[0].kwargs["max_completion_tokens"] == 20
+        assert "max_tokens" not in create.await_args_list[0].kwargs
+        assert create.await_args_list[1].kwargs["max_tokens"] == 20
+        assert "max_completion_tokens" not in create.await_args_list[1].kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_does_not_fallback_for_completion_token_value_errors(self):
+        provider, create = _build_provider_with_client()
+        create.side_effect = ValueError("max_completion_tokens must be <= 4096")
+
+        with pytest.raises(ValueError, match="max_completion_tokens must be <= 4096"):
+            await provider.chat(
+                "gpt-5.4",
+                [ChatMessage(role="user", content="hello")],
+                max_completion_tokens=200000,
+            )
+
+        assert create.await_count == 1
 
 
 class TestOpenAICompatibleProviderMiniMaxFallback:
@@ -315,6 +381,85 @@ class TestOpenAICompatibleProviderStreamingUsage:
         assert create.await_count == 2
         assert "stream_options" in create.await_args_list[0].kwargs
         assert "stream_options" not in create.await_args_list[1].kwargs
+        assert chunks[-1].usage == {
+            "prompt_tokens": 5,
+            "completion_tokens": 2,
+            "total_tokens": 7,
+        }
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_falls_back_to_max_tokens_when_completion_variant_is_rejected(self):
+        provider, create = _build_provider_with_client()
+        create.side_effect = [
+            ValueError("unsupported parameter: max_completion_tokens"),
+            _stream_from_chunks(
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(content="hello", tool_calls=None),
+                            finish_reason="stop",
+                        )
+                    ],
+                    usage=SimpleNamespace(prompt_tokens=5, completion_tokens=2, total_tokens=7),
+                )
+            ),
+        ]
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "gpt-5.4",
+                [ChatMessage(role="user", content="hello")],
+                max_tokens=20,
+            )
+        ]
+
+        assert create.await_count == 2
+        assert create.await_args_list[0].kwargs["max_completion_tokens"] == 20
+        assert "max_tokens" not in create.await_args_list[0].kwargs
+        assert create.await_args_list[1].kwargs["max_tokens"] == 20
+        assert "max_completion_tokens" not in create.await_args_list[1].kwargs
+        assert chunks[-1].usage == {
+            "prompt_tokens": 5,
+            "completion_tokens": 2,
+            "total_tokens": 7,
+        }
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_chains_completion_and_usage_fallbacks(self):
+        provider, create = _build_provider_with_client()
+        create.side_effect = [
+            ValueError("unsupported parameter: max_completion_tokens"),
+            ValueError("unsupported parameter: include_usage"),
+            _stream_from_chunks(
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(content="hello", tool_calls=None),
+                            finish_reason="stop",
+                        )
+                    ],
+                    usage=SimpleNamespace(prompt_tokens=5, completion_tokens=2, total_tokens=7),
+                )
+            ),
+        ]
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "gpt-5.4",
+                [ChatMessage(role="user", content="hello")],
+                max_tokens=20,
+            )
+        ]
+
+        assert create.await_count == 3
+        assert create.await_args_list[0].kwargs["max_completion_tokens"] == 20
+        assert "stream_options" in create.await_args_list[0].kwargs
+        assert create.await_args_list[1].kwargs["max_tokens"] == 20
+        assert "stream_options" in create.await_args_list[1].kwargs
+        assert create.await_args_list[2].kwargs["max_tokens"] == 20
+        assert "stream_options" not in create.await_args_list[2].kwargs
         assert chunks[-1].usage == {
             "prompt_tokens": 5,
             "completion_tokens": 2,

--- a/tests/provider/test_provider.py
+++ b/tests/provider/test_provider.py
@@ -132,6 +132,31 @@ def test_resolve_model_prefers_provider_specific_runtime_model(monkeypatch):
     assert resolved.capabilities.interleaved["field"] == "reasoning_content"
 
 
+def test_dynamic_openai_compatible_provider_prefers_max_completion_tokens(monkeypatch):
+    monkeypatch.setattr(Provider, "_providers", {})
+    monkeypatch.setattr(Provider, "_models", {})
+
+    monkeypatch.setattr(
+        "flocks.config.config_writer.ConfigWriter.get_all_providers",
+        lambda: {
+            "custom-gpt5": {
+                "name": "Custom GPT5",
+                "npm": "@ai-sdk/openai-compatible",
+                "options": {"baseURL": "https://example.test/v1"},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "flocks.provider.credential.get_api_key",
+        lambda _provider_id: "test-key",
+    )
+
+    Provider._load_dynamic_providers()
+
+    provider = Provider._providers["custom-gpt5"]
+    assert provider.PREFER_MAX_COMPLETION_TOKENS is True
+
+
 def test_resolve_model_infers_interleaved_for_runtime_discovered_reasoning_model(monkeypatch):
     provider_model = SimpleNamespace(
         id="qwen3-max",


### PR DESCRIPTION
## 背景

部分用户通过 `provider = openai-compatible` 接入 GPT-5.x / GPT-5.4 等 OpenAI-compatible 上游模型时，上游只接受 `max_completion_tokens`，不接受旧的 `max_tokens`。当前 Flocks 内部统一使用 `max_tokens`，导致这些模型请求失败。

本 PR 在 OpenAI-compatible 出口层做兼容处理，保持内部调用接口不变，同时兼容新旧两类上游参数。

## 改动内容

- 为 OpenAI-style 请求增加统一 token limit 处理：
  - 支持 `max_tokens`
  - 支持 `max_completion_tokens`
  - 当两者同时传入时，`max_completion_tokens` 优先
- 内置 `OpenAICompatibleProvider` 默认将内部 `max_tokens` 转为 `max_completion_tokens` 发送。
- 动态创建的 `@ai-sdk/openai-compatible` provider 显式开启 `max_completion_tokens` 优先策略。
- 其他继承 `OpenAIBaseProvider` 的 provider 默认仍保持原有 `max_tokens` 行为，避免扩大回归面。
- 当上游明确返回 `max_completion_tokens` 不支持、未知参数或 extra field 类错误时，自动回退为 `max_tokens` 重试。
- 保留并整合原有 `stream_options.include_usage` fallback 逻辑，支持流式请求 chained fallback。

## 回归影响分析

本次改动的行为边界如下：

- 内置 `openai-compatible`：`max_tokens` 会优先以 `max_completion_tokens` 发出，不支持时回退到 `max_tokens`。
- 动态 `@ai-sdk/openai-compatible` provider：行为同内置 OpenAI-compatible。
- 其他 `OpenAIBaseProvider` 子类：默认仍发送 `max_tokens`，不主动切换到 `max_completion_tokens`。
- 显式传入 `max_completion_tokens` 时，会按调用方意图发送该字段。
- 只有错误信息明确表示字段不支持/未知/不允许时才触发 fallback，避免掩盖 token 数值超限、类型错误等真实问题。

## 测试

已通过以下验证：

```bash
uv run pytest tests/provider/test_openai_compatible_provider.py tests/provider/test_openai_base_provider.py tests/provider/test_provider.py::test_dynamic_openai_compatible_provider_prefers_max_completion_tokens