### PR TITLE
fix(cli): hand off Windows doctor before install

### DIFF
--- a/flocks/cli/commands/doctor.py
+++ b/flocks/cli/commands/doctor.py
@@ -27,13 +27,15 @@ def doctor_command() -> None:
     console.print(f"[cyan]Flocks source directory:[/cyan] {source_root}")
     console.print(f"[cyan]Source install command:[/cyan] {_format_command(command)}")
 
-    try:
-        subprocess.run(command, cwd=source_root, check=True, env=env)
-    except FileNotFoundError as error:
-        console.print(f"[red]Failed to start installer: {error}[/red]")
-        raise typer.Exit(1) from error
-    except subprocess.CalledProcessError as error:
-        raise typer.Exit(error.returncode or 1) from error
+    if _needs_windows_handoff():
+        _start_windows_handoff(source_root, env=env)
+        console.print(
+            "[yellow]Windows detected: the installer will continue in this console "
+            "after the current flocks.exe exits.[/yellow]"
+        )
+        return
+
+    _run_source_install(command, source_root=source_root, env=env)
 
     console.print("[green]安装正常[/green]")
     _print_service_diagnosis()
@@ -67,7 +69,7 @@ def _select_source_install_script(source_root: Path) -> Path:
 def _build_source_install_command(script: Path) -> list[str]:
     """Build the subprocess command for the selected installer."""
     if script.suffix == ".ps1":
-        powershell = shutil.which("pwsh") or shutil.which("powershell") or "powershell"
+        powershell = _find_powershell()
         return [
             powershell,
             "-NoProfile",
@@ -78,6 +80,17 @@ def _build_source_install_command(script: Path) -> list[str]:
         ]
 
     return ["bash", str(script)]
+
+
+def _run_source_install(command: list[str], *, source_root: Path, env: dict[str, str] | None) -> None:
+    """Run the selected source installer synchronously."""
+    try:
+        subprocess.run(command, cwd=source_root, check=True, env=env)
+    except FileNotFoundError as error:
+        console.print(f"[red]Failed to start installer: {error}[/red]")
+        raise typer.Exit(1) from error
+    except subprocess.CalledProcessError as error:
+        raise typer.Exit(error.returncode or 1) from error
 
 
 def _build_source_install_env() -> dict[str, str] | None:
@@ -91,6 +104,63 @@ def _build_source_install_env() -> dict[str, str] | None:
             continue
         env.setdefault(key, value)
     return env
+
+
+def _needs_windows_handoff() -> bool:
+    """Return whether doctor must release the Windows console entrypoint first."""
+    return _is_windows() and os.environ.get("FLOCKS_DOCTOR_WINDOWS_HANDOFF") != "1"
+
+
+def _start_windows_handoff(source_root: Path, *, env: dict[str, str] | None) -> None:
+    """Start a helper that waits for this process to exit before running doctor."""
+    command = _build_windows_handoff_command(source_root, parent_pid=os.getpid())
+    handoff_env = os.environ.copy() if env is None else env.copy()
+    handoff_env["FLOCKS_DOCTOR_WINDOWS_HANDOFF"] = "1"
+
+    try:
+        subprocess.Popen(command, cwd=source_root, env=handoff_env, close_fds=True)
+    except FileNotFoundError as error:
+        console.print(f"[red]Failed to start installer handoff: {error}[/red]")
+        raise typer.Exit(1) from error
+
+
+def _build_windows_handoff_command(source_root: Path, *, parent_pid: int) -> list[str]:
+    """Build a PowerShell command that reruns doctor after the current PID exits."""
+    python_executable = _source_python_executable(source_root)
+    helper_script = "; ".join(
+        [
+            "$ErrorActionPreference = 'Stop'",
+            f"Wait-Process -Id {parent_pid} -ErrorAction SilentlyContinue",
+            f"& {_quote_powershell_string(str(python_executable))} -m flocks.cli.main doctor",
+            "exit $LASTEXITCODE",
+        ]
+    )
+    return [
+        _find_powershell(),
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        helper_script,
+    ]
+
+
+def _source_python_executable(source_root: Path) -> Path:
+    """Return the source venv Python, falling back to the current interpreter."""
+    windows_python = source_root / ".venv" / "Scripts" / "python.exe"
+    if windows_python.exists():
+        return windows_python
+    return Path(sys.executable)
+
+
+def _quote_powershell_string(value: str) -> str:
+    """Quote a string as a PowerShell single-quoted literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _find_powershell() -> str:
+    """Return the preferred PowerShell executable name or path."""
+    return shutil.which("pwsh") or shutil.which("powershell") or "powershell"
 
 
 def _print_service_diagnosis() -> None:

--- a/tests/cli/test_doctor_command.py
+++ b/tests/cli/test_doctor_command.py
@@ -74,6 +74,84 @@ def test_doctor_uses_cn_environment_for_zh_install_profile(monkeypatch, tmp_path
     assert "运行状态异常，请执行 `flocks restart`" in result.stdout
 
 
+def test_doctor_on_windows_starts_handoff_before_running_installer(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FLOCKS_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("FLOCKS_DOCTOR_WINDOWS_HANDOFF", raising=False)
+    monkeypatch.setattr(cli_main.Log, "init", _noop_log_init)
+    monkeypatch.setattr(doctor_cmd, "_is_windows", lambda: True)
+    monkeypatch.setattr(doctor_cmd.os, "getpid", lambda: 4242)
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(command, *, cwd, env, close_fds):
+        captured["command"] = command
+        captured["cwd"] = cwd
+        captured["env"] = env
+        captured["close_fds"] = close_fds
+        return object()
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("Windows doctor should hand off before running the installer")
+
+    monkeypatch.setattr(doctor_cmd.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(doctor_cmd.subprocess, "run", fail_run)
+
+    result = runner.invoke(cli_main.app, ["doctor"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "scripts/install.ps1" in result.stdout
+    assert "installer will continue in this console" in result.stdout
+    assert captured["cwd"] == doctor_cmd._find_source_root()
+    assert captured["close_fds"] is True
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["FLOCKS_DOCTOR_WINDOWS_HANDOFF"] == "1"
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert "-Command" in command
+    assert "Wait-Process -Id 4242" in command[-1]
+    assert "-m flocks.cli.main doctor" in command[-1]
+
+
+def test_doctor_windows_handoff_child_runs_installer_synchronously(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FLOCKS_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("FLOCKS_DOCTOR_WINDOWS_HANDOFF", "1")
+    monkeypatch.setattr(cli_main.Log, "init", _noop_log_init)
+    monkeypatch.setattr(doctor_cmd, "_is_windows", lambda: True)
+
+    captured: dict[str, object] = {}
+
+    def fake_run(command, *, cwd, check, env):
+        captured["command"] = command
+        captured["cwd"] = cwd
+        captured["check"] = check
+        captured["env"] = env
+
+    def fail_popen(*_args, **_kwargs):
+        raise AssertionError("handoff child should run the installer directly")
+
+    monkeypatch.setattr(doctor_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(doctor_cmd.subprocess, "Popen", fail_popen)
+    monkeypatch.setattr(
+        "flocks.cli.service_manager.build_status_lines",
+        lambda: [
+            "[flocks]   daemon: state=running PID=111",
+            "[flocks]   flocks: state=healthy PID=222 URL=http://127.0.0.1:5173",
+        ],
+    )
+
+    result = runner.invoke(cli_main.app, ["doctor"])
+
+    assert result.exit_code == 0, result.stdout
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[-1].endswith("scripts/install.ps1")
+    assert captured["cwd"] == doctor_cmd._find_source_root()
+    assert captured["check"] is True
+    assert "安装正常" in result.stdout
+    assert "运行状态正常" in result.stdout
+
+
 def test_service_status_is_healthy_accepts_current_daemon_status() -> None:
     assert doctor_cmd._service_status_is_healthy(
         [


### PR DESCRIPTION
On Windows, doctor may be invoked through the .venv Scripts flocks.exe entrypoint. Running the source installer synchronously keeps that executable locked while uv sync tries to replace it, which can fail with os error 32.

Start a PowerShell handoff helper that waits for the current process to exit, then reruns doctor from the source venv so the installer can update the environment without self-locking.