### PR TITLE
fix(supervisor): remove HTTP health check, use pure liveness probe

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -1042,17 +1042,6 @@ def _is_running_status_response(response: httpx.Response) -> bool:
     return isinstance(payload, dict) and payload.get("status") == "running"
 
 
-def _is_healthy_status_response(response: httpx.Response) -> bool:
-    """Return True when the backend health endpoint reports healthy."""
-    if response.status_code != 200:
-        return False
-    try:
-        payload = response.json()
-    except ValueError:
-        return False
-    return isinstance(payload, dict) and payload.get("status") == "healthy"
-
-
 def wait_for_http(
     urls: Sequence[str],
     name: str,
@@ -1084,10 +1073,6 @@ class _StdoutConsole:
     def print(self, *args, **_kwargs) -> None:
         sys.stdout.write(" ".join(str(arg) for arg in args) + "\n")
         sys.stdout.flush()
-
-
-def _backend_health_url(host: str, port: int) -> str:
-    return f"http://{_format_host_for_url(access_host(host))}:{port}/api/health"
 
 
 def _terminate_process(

--- a/flocks/cli/service_process.py
+++ b/flocks/cli/service_process.py
@@ -7,10 +7,6 @@ import subprocess
 from dataclasses import dataclass
 from typing import Protocol
 
-import httpx
-
-from flocks.cli.service_config import ServiceConfig
-
 
 @dataclass(frozen=True)
 class ServiceProbeResult:
@@ -59,29 +55,7 @@ class BackendProcessAdapter:
             )
         if not tcp_port_accepts_connections(host, port):
             return ServiceProbeResult(healthy=False, reason=f"port {port} is not listening", restart=True)
-
-        from flocks.cli.service_manager import _backend_health_url, _is_healthy_status_response, backend_access_base_url
-
-        url = _backend_health_url(host, port)
-        try:
-            with httpx.Client(timeout=2.0, trust_env=False) as client:
-                response = client.get(url)
-                root_response = client.get(
-                    backend_access_base_url(ServiceConfig(backend_host=host, backend_port=port)),
-                    headers={"Accept": "text/html"},
-                )
-            healthy = _is_healthy_status_response(response) and _is_static_webui_response(root_response)
-            reason = f"health status={response.status_code}, root status={root_response.status_code}"
-        except Exception as exc:
-            healthy = False
-            reason = f"health failed: {exc}"
-        return ServiceProbeResult(healthy=healthy, reason=reason)
-
-
-def _is_static_webui_response(response: httpx.Response) -> bool:
-    """Return True only when the unified service serves the SPA index."""
-    content_type = response.headers.get("content-type", "").lower()
-    return response.status_code == 200 and "text/html" in content_type
+        return ServiceProbeResult(healthy=True, reason="liveness check passed")
 
 
 def tcp_port_accepts_connections(host: str, port: int) -> bool:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -1522,70 +1522,37 @@ def test_supervisor_recovers_backend_when_port_disappears(monkeypatch, tmp_path:
     assert daemon.backend.pid == 333
 
 
-def test_supervisor_waits_for_second_backend_health_failure(monkeypatch, tmp_path: Path) -> None:
+def test_supervisor_liveness_probe_keeps_backend_healthy(monkeypatch, tmp_path: Path) -> None:
+    """Liveness-only probe: process alive + TCP port open = healthy, no HTTP check needed."""
     paths = _make_runtime_paths(tmp_path)
     calls: list[str] = []
     monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
     daemon = service_supervisor.SupervisorDaemon(
         service_manager.ServiceConfig(backend_port=9995, frontend_port=9996),
-        failure_threshold=2,
     )
     daemon.paths = paths
     daemon.backend.process = _fake_process(111, ["backend"])
 
-    class FakeClient:
-        def __init__(self, *_args, **_kwargs) -> None:
-            pass
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args) -> None:
-            return None
-
-        def get(self, _url, **_kwargs):
-            return httpx.Response(503, json={"status": "unhealthy"})
-
-    monkeypatch.setattr(service_process.httpx, "Client", FakeClient)
     monkeypatch.setattr(service_process, "tcp_port_accepts_connections", lambda *_args: True)
     monkeypatch.setattr(service_manager, "_terminate_process", lambda _process, name, _console: calls.append(f"stop:{name}"))
-    monkeypatch.setattr(
-        service_manager,
-        "_start_backend_process",
-        lambda *_args, **_kwargs: calls.append("start:backend") or _fake_process(333, ["backend-new"]),
-    )
 
     daemon.tick()
     assert calls == []
-    assert daemon.backend.state == "degraded"
+    assert daemon.backend.state == "healthy"
 
     daemon.tick()
-    assert calls == ["stop:后端", "start:backend"]
+    assert calls == []
+    assert daemon.backend.state == "healthy"
 
 
-def test_backend_probe_rejects_api_root_when_static_webui_missing(monkeypatch) -> None:
-    class FakeClient:
-        def __init__(self, *_args, **_kwargs) -> None:
-            pass
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args) -> None:
-            return None
-
-        def get(self, url, **_kwargs):
-            if str(url).endswith("/api/health"):
-                return httpx.Response(200, json={"status": "healthy"})
-            return httpx.Response(200, json={"status": "running"})
-
+def test_backend_probe_liveness_only_accepts_alive_process(monkeypatch) -> None:
+    """Liveness-only probe: process alive + TCP port open = healthy regardless of HTTP response."""
     monkeypatch.setattr(service_process, "tcp_port_accepts_connections", lambda *_args: True)
-    monkeypatch.setattr(service_process.httpx, "Client", FakeClient)
 
     result = service_process.BackendProcessAdapter().probe(_fake_process(111, ["backend"]), "127.0.0.1", 5173)
 
-    assert result.healthy is False
-    assert result.reason == "health status=200, root status=200"
+    assert result.healthy is True
+    assert result.reason == "liveness check passed"
 
 
 def test_supervisor_reports_webui_as_static_endpoint(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Replace the multi-step health check with a pure liveness probe. The previous probe required 5 serial steps: process alive → TCP port → `/api/health` HTTP GET → `GET /` SPA check. HTTP-level failures (intermittent DNS timeouts, filesystem stalls, proxy interception) could trigger a false-positive restart after only 2 consecutive failures (~10s).

Now only checks:
- **Process alive**: `process.poll() is None`
- **TCP port open**: `socket.create_connection()` succeeds

Both must fail before a restart triggers. Transient HTTP-level hiccups no longer cause the daemon to SIGKILL the backend.

## Changes

- `flocks/cli/service_process.py`: Remove `httpx` import, `_is_static_webui_response()` helper, and the HTTP health check block in `probe()`. Shorten probe to process + TCP liveness only.
- `tests/cli/test_service_manager.py`: Rewrite `test_supervisor_waits_for_second_backend_health_failure` → `test_supervisor_liveness_probe_keeps_backend_healthy`, and `test_backend_probe_rejects_api_root_when_static_webui_missing` → `test_backend_probe_liveness_only_accepts_alive_process`.

## Test plan

- [x] `pytest tests/cli/test_service_manager.py -x -v` — 104 passed
- [x] `pytest tests/cli/test_service_manager.py -x -k "supervisor"` — 20 passed
- [x] `ast.parse` syntax check on both modified files