### PR TITLE
fix(server): replace task-spawning HTTP middleware

### DIFF
--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -11,13 +11,15 @@ import time
 from dataclasses import dataclass
 from types import SimpleNamespace
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, AsyncGenerator, Callable, Optional
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
+from starlette.datastructures import MutableHeaders
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from flocks.utils.log import Log, LogLevel
 from flocks.config.config import Config
@@ -814,132 +816,277 @@ class _DeferredCORSMiddleware:
         await self._inner(scope, receive, send)
 
 
-@app.middleware("http")
-async def security_headers_middleware(request: Request, call_next):
-    """Attach baseline browser security headers to every HTTP response."""
-    response = await call_next(request)
-    for name, value in _SECURITY_HEADERS.items():
-        response.headers.setdefault(name, value)
-    return response
+class _SecurityHeadersMiddleware:
+    """Attach baseline browser security headers without spawning request tasks."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_security_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                for name, value in _SECURITY_HEADERS.items():
+                    headers.setdefault(name, value)
+            await send(message)
+
+        await self.app(scope, receive, send_with_security_headers)
 
 
-@app.middleware("http")
-async def instance_context_middleware(request: Request, call_next):
-    """
-    Provide Instance context for all requests (except global routes)
-    
-    Middleware that wraps all routes with Instance.provide().
-    Gets directory from:
-    1. Query parameter 'directory'
-    2. Header 'x-flocks-directory'
-    3. Falls back to current working directory
-    """
-    import os
-    from urllib.parse import unquote
-    from flocks.project.instance import Instance
-    from flocks.project.bootstrap import instance_bootstrap
+app.add_middleware(_SecurityHeadersMiddleware)
 
-    # Skip instance context for global routes, static files, and simple endpoints
-    skip_prefixes = {
-        "/global", "/docs", "/redoc", "/openapi.json", "/health",
-        "/path", "/permission", "/question", "/tui",
-    }
-    
-    if any(request.url.path.startswith(prefix) for prefix in skip_prefixes):
-        return await call_next(request)
-    
-    # Get directory from query param, header, or use cwd
-    # Support both x-flocks-directory (native) and x-flocks-directory (TUI compatibility)
-    directory = request.query_params.get("directory")
-    if not directory:
-        directory = request.headers.get("x-flocks-directory")
-    if not directory:
-        directory = request.headers.get("x-flocks-directory")
-    if not directory:
-        directory = os.getcwd()
-    
-    # Decode URL-encoded directory
-    try:
-        directory = unquote(directory)
-    except Exception:
-        pass  # Use original value if decode fails
-    
-    # Provide instance context for the request
-    async def handle_request():
-        return await call_next(request)
-    
-    return await Instance.provide(
-        directory=directory,
-        init=instance_bootstrap,
-        fn=handle_request
+
+class _InstanceContextMiddleware:
+    """Provide the project instance context without buffering the response body."""
+
+    _SKIP_PREFIXES = (
+        "/global",
+        "/docs",
+        "/redoc",
+        "/openapi.json",
+        "/health",
+        "/path",
+        "/permission",
+        "/question",
+        "/tui",
     )
 
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
 
-# Request Logging Middleware
-@app.middleware("http")
-async def log_requests(request: Request, call_next):
-    """Log one completion line for useful requests; suppress successful polling noise."""
-    path = request.url.path
-    started_at = time.monotonic()
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
 
-    try:
-        response = await call_next(request)
-    except Exception as exc:
-        duration_ms = int((time.monotonic() - started_at) * 1000)
-        log.error("request.error", {
-            "method": request.method,
-            "path": path,
-            "duration": duration_ms,
-            "error": str(exc),
-        })
-        raise
+        path = scope.get("path", "")
+        if path.startswith(self._SKIP_PREFIXES):
+            await self.app(scope, receive, send)
+            return
 
-    if _should_log_request(path, response.status_code):
-        duration_ms = int((time.monotonic() - started_at) * 1000)
-        log.info("request.complete", {
-            "method": request.method,
-            "path": path,
-            "status": response.status_code,
-            "duration": duration_ms,
-        })
+        from urllib.parse import unquote
+        from flocks.project.instance import Instance
+        from flocks.project.bootstrap import instance_bootstrap
 
-    return response
+        request = Request(scope, receive=receive)
+        directory = request.query_params.get("directory")
+        if not directory:
+            directory = request.headers.get("x-flocks-directory")
+        if not directory:
+            directory = os.getcwd()
 
+        try:
+            directory = unquote(directory)
+        except Exception:
+            pass
 
-@app.middleware("http")
-async def auth_guard_middleware(request: Request, call_next):
-    """Guard requests with local account auth, except public endpoints."""
-    try:
-        await _run_http_middleware_hooks(request, {"stage": "before_auth"})
-        _blocked, token, _user = await apply_auth_for_request(request)
-    except StarletteHTTPException as exc:
-        return JSONResponse(
-            status_code=exc.status_code,
-            content={"error": "AuthError", "message": exc.detail},
-        )
-    except Exception as exc:
-        log.error("auth.middleware.unexpected", {
-            "path": request.url.path,
-            "error": repr(exc),
-        })
-        return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"error": "InternalError", "message": "鉴权处理异常，请稍后重试"},
+        async def handle_request() -> None:
+            await self.app(scope, receive, send)
+
+        await Instance.provide(
+            directory=directory,
+            init=instance_bootstrap,
+            fn=handle_request,
         )
 
-    try:
-        return await call_next(request)
-    finally:
-        clear_auth_context(token)
+
+app.add_middleware(_InstanceContextMiddleware)
 
 
-@app.middleware("http")
-async def static_webui_middleware(request: Request, call_next):
-    """Serve the SPA shell before auth for browser navigations."""
-    static_response = await maybe_serve_static_webui(request)
-    if static_response is not None:
-        return static_response
-    return await call_next(request)
+class _RequestLoggingMiddleware:
+    """Log response start without retaining an extra task for streaming bodies."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        method = scope.get("method", "")
+        started_at = time.monotonic()
+        response_started = False
+
+        async def send_with_request_log(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start" and not response_started:
+                response_started = True
+                status_code = int(message["status"])
+                if _should_log_request(path, status_code):
+                    duration_ms = int((time.monotonic() - started_at) * 1000)
+                    log.info(
+                        "request.complete",
+                        {
+                            "method": method,
+                            "path": path,
+                            "status": status_code,
+                            "duration": duration_ms,
+                        },
+                    )
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_log)
+        except Exception as exc:
+            if not response_started:
+                duration_ms = int((time.monotonic() - started_at) * 1000)
+                log.error(
+                    "request.error",
+                    {
+                        "method": method,
+                        "path": path,
+                        "duration": duration_ms,
+                        "error": str(exc),
+                    },
+                )
+            raise
+
+
+app.add_middleware(_RequestLoggingMiddleware)
+
+
+class _HookRequest(Request):
+    """Preserve request-receive semantics while auth hooks inspect the body.
+
+    A body read is replayed once to the endpoint, a fully consumed stream is
+    replayed as an empty request, and a partially consumed stream continues
+    from upstream. Once a disconnect is observed, downstream reads keep seeing
+    the disconnect instead of polling upstream again.
+    """
+
+    def __init__(self, scope: Scope, receive: Receive) -> None:
+        self._flocks_upstream_receive = receive
+        self._flocks_request_complete = False
+        self._flocks_disconnected = False
+        self._flocks_cached_body: Optional[bytes] = None
+        self._flocks_stream_consumed = False
+        super().__init__(scope, receive=self._receive_for_hook)
+
+    async def _receive_for_hook(self) -> Message:
+        message = await self._flocks_upstream_receive()
+        if message["type"] == "http.request":
+            if not message.get("more_body", False):
+                self._flocks_request_complete = True
+        elif message["type"] == "http.disconnect":
+            self._flocks_disconnected = True
+        return message
+
+    async def body(self) -> bytes:
+        body = await super().body()
+        self._flocks_cached_body = body
+        return body
+
+    async def stream(self) -> AsyncGenerator[bytes, None]:
+        async for chunk in super().stream():
+            if self._flocks_request_complete:
+                self._flocks_stream_consumed = True
+            yield chunk
+        self._flocks_stream_consumed = True
+
+    def downstream_receive(self) -> Receive:
+        """Return the receive callable that preserves the hook's body reads."""
+        has_replay = self._flocks_cached_body is not None or self._flocks_stream_consumed
+        if not has_replay and not self._flocks_disconnected:
+            return self._flocks_upstream_receive
+
+        replay_pending = has_replay
+        replay_body = self._flocks_cached_body if self._flocks_cached_body is not None else b""
+
+        async def receive_for_downstream() -> Message:
+            nonlocal replay_pending
+            if replay_pending:
+                replay_pending = False
+                return {
+                    "type": "http.request",
+                    "body": replay_body,
+                    "more_body": False,
+                }
+            if self._flocks_disconnected:
+                return {"type": "http.disconnect"}
+
+            message = await self._flocks_upstream_receive()
+            if message["type"] == "http.disconnect":
+                self._flocks_disconnected = True
+                return message
+            if has_replay:
+                raise RuntimeError(f"Unexpected message received: {message['type']}")
+            return message
+
+        return receive_for_downstream
+
+
+class _AuthGuardMiddleware:
+    """Bind request auth context in the same ASGI task as the endpoint."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = _HookRequest(scope, receive)
+        try:
+            await _run_http_middleware_hooks(request, {"stage": "before_auth"})
+            _blocked, token, _user = await apply_auth_for_request(request)
+        except StarletteHTTPException as exc:
+            response = JSONResponse(
+                status_code=exc.status_code,
+                content={"error": "AuthError", "message": exc.detail},
+            )
+            await response(scope, receive, send)
+            return
+        except Exception as exc:
+            log.error(
+                "auth.middleware.unexpected",
+                {
+                    "path": request.url.path,
+                    "error": repr(exc),
+                },
+            )
+            response = JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={"error": "InternalError", "message": "鉴权处理异常，请稍后重试"},
+            )
+            await response(scope, receive, send)
+            return
+
+        try:
+            await self.app(scope, request.downstream_receive(), send)
+        finally:
+            clear_auth_context(token)
+
+
+app.add_middleware(_AuthGuardMiddleware)
+
+
+class _StaticWebUIMiddleware:
+    """Serve the SPA shell before auth without a BaseHTTPMiddleware task."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive=receive)
+        static_response = await maybe_serve_static_webui(request)
+        if static_response is not None:
+            await static_response(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
+
+
+app.add_middleware(_StaticWebUIMiddleware)
 
 
 # Error Handlers

--- a/tests/server/test_asgi_middleware.py
+++ b/tests/server/test_asgi_middleware.py
@@ -1,0 +1,384 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import StreamingResponse
+from starlette.routing import Route
+from starlette.types import ASGIApp, Message, Receive, Scope
+
+from flocks.server import app as server_app
+
+
+def _http_scope(path: str, *, method: str = "GET") -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 8000),
+        "state": {},
+    }
+
+
+async def _run_auth_middleware(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    hook: Callable[[Request, dict], Awaitable[None]],
+    endpoint: ASGIApp,
+    receive: Receive,
+) -> None:
+    async def apply_auth(_request: Request):
+        return None, object(), None
+
+    async def send(_message: Message) -> None:
+        return None
+
+    monkeypatch.setattr(server_app, "_run_http_middleware_hooks", hook)
+    monkeypatch.setattr(server_app, "apply_auth_for_request", apply_auth)
+    monkeypatch.setattr(server_app, "clear_auth_context", lambda _token: None)
+
+    await server_app._AuthGuardMiddleware(endpoint)(
+        _http_scope("/api/session", method="POST"),
+        receive,
+        send,
+    )
+
+
+def test_production_http_middleware_is_pure_asgi_and_keeps_order() -> None:
+    middleware_classes = [entry.cls for entry in server_app.app.user_middleware]
+
+    assert BaseHTTPMiddleware not in middleware_classes
+    assert middleware_classes == [
+        server_app._DeferredCORSMiddleware,
+        server_app._StaticWebUIMiddleware,
+        server_app._AuthGuardMiddleware,
+        server_app._RequestLoggingMiddleware,
+        server_app._InstanceContextMiddleware,
+        server_app._SecurityHeadersMiddleware,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_log_is_emitted_when_stream_headers_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    never = asyncio.Event()
+    response_started = asyncio.Event()
+    logged: list[tuple[str, dict]] = []
+
+    async def streaming_app(_scope, _receive, send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        response_started.set()
+        await never.wait()
+
+    async def receive():
+        await never.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(_message):
+        return None
+
+    monkeypatch.setattr(server_app.log, "info", lambda event, payload: logged.append((event, payload)))
+    middleware = server_app._RequestLoggingMiddleware(streaming_app)
+    request = asyncio.create_task(middleware(_http_scope("/api/provider"), receive, send))
+    try:
+        await response_started.wait()
+
+        assert not request.done()
+        assert logged[0][0] == "request.complete"
+        assert logged[0][1]["status"] == 200
+    finally:
+        request.cancel()
+        await asyncio.gather(request, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_auth_hook_request_body_is_replayed_to_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, object] = {}
+    incoming = iter(
+        [
+            {"type": "http.request", "body": b"hello ", "more_body": True},
+            {"type": "http.request", "body": b"world", "more_body": False},
+        ]
+    )
+
+    async def receive():
+        return next(incoming)
+
+    async def inspect_body(request: Request, _context: dict) -> None:
+        seen["hook"] = await request.body()
+
+    async def endpoint(_scope, downstream_receive, _send) -> None:
+        body = bytearray()
+        messages = []
+        while True:
+            message = await downstream_receive()
+            messages.append(message)
+            body.extend(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        seen["endpoint"] = bytes(body)
+        seen["message_count"] = len(messages)
+        seen["same_body_object"] = messages[0]["body"] is seen["hook"]
+
+    await _run_auth_middleware(
+        monkeypatch,
+        hook=inspect_body,
+        endpoint=endpoint,
+        receive=receive,
+    )
+
+    assert seen == {
+        "hook": b"hello world",
+        "endpoint": b"hello world",
+        "message_count": 1,
+        "same_body_object": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_auth_hook_stream_consumption_keeps_legacy_downstream_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, bytes] = {}
+    incoming = iter(
+        [
+            {"type": "http.request", "body": b"hello ", "more_body": True},
+            {"type": "http.request", "body": b"world", "more_body": False},
+        ]
+    )
+
+    async def receive():
+        return next(incoming)
+
+    async def inspect_stream(request: Request, _context: dict) -> None:
+        body = bytearray()
+        async for chunk in request.stream():
+            body.extend(chunk)
+            if body == b"hello world":
+                break
+        seen["hook"] = bytes(body)
+
+    async def endpoint(scope, downstream_receive, _send) -> None:
+        seen["endpoint"] = await Request(scope, receive=downstream_receive).body()
+
+    await _run_auth_middleware(
+        monkeypatch,
+        hook=inspect_stream,
+        endpoint=endpoint,
+        receive=receive,
+    )
+
+    assert seen == {"hook": b"hello world", "endpoint": b""}
+
+
+@pytest.mark.asyncio
+async def test_auth_hook_partial_stream_read_continues_from_upstream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, bytes] = {}
+    incoming = iter(
+        [
+            {"type": "http.request", "body": b"hello ", "more_body": True},
+            {"type": "http.request", "body": b"world", "more_body": False},
+        ]
+    )
+
+    async def receive():
+        return next(incoming)
+
+    async def inspect_stream(request: Request, _context: dict) -> None:
+        async for chunk in request.stream():
+            seen["hook"] = chunk
+            break
+
+    async def endpoint(scope, downstream_receive, _send) -> None:
+        seen["endpoint"] = await Request(scope, receive=downstream_receive).body()
+
+    await _run_auth_middleware(
+        monkeypatch,
+        hook=inspect_stream,
+        endpoint=endpoint,
+        receive=receive,
+    )
+
+    assert seen == {"hook": b"hello ", "endpoint": b"world"}
+
+
+@pytest.mark.asyncio
+async def test_auth_hook_terminal_empty_break_does_not_block_downstream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict[str, bytes] = {}
+    incoming = iter(
+        [
+            {"type": "http.request", "body": b"hello", "more_body": False},
+        ]
+    )
+
+    async def receive():
+        return next(incoming)
+
+    async def inspect_stream(request: Request, _context: dict) -> None:
+        async for chunk in request.stream():
+            if not chunk:
+                break
+
+    async def endpoint(scope, downstream_receive, _send) -> None:
+        seen["endpoint"] = await Request(scope, receive=downstream_receive).body()
+
+    await _run_auth_middleware(
+        monkeypatch,
+        hook=inspect_stream,
+        endpoint=endpoint,
+        receive=receive,
+    )
+
+    assert seen == {"endpoint": b""}
+
+
+@pytest.mark.asyncio
+async def test_auth_hook_observed_disconnect_is_replayed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[Message] = []
+    incoming = iter(
+        [
+            {"type": "http.request", "body": b"hello", "more_body": False},
+            {"type": "http.disconnect"},
+        ]
+    )
+    never = asyncio.Event()
+
+    async def receive():
+        try:
+            return next(incoming)
+        except StopIteration:
+            await never.wait()
+            return {"type": "http.disconnect"}
+
+    async def inspect_disconnect(request: Request, _context: dict) -> None:
+        await request.body()
+        assert await request.is_disconnected()
+
+    async def endpoint(_scope, downstream_receive, _send) -> None:
+        seen.append(await downstream_receive())
+        seen.append(await downstream_receive())
+        seen.append(await downstream_receive())
+
+    await _run_auth_middleware(
+        monkeypatch,
+        hook=inspect_disconnect,
+        endpoint=endpoint,
+        receive=receive,
+    )
+
+    assert seen == [
+        {"type": "http.request", "body": b"hello", "more_body": False},
+        {"type": "http.disconnect"},
+        {"type": "http.disconnect"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auth_without_body_read_passes_original_receive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint_called = False
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def no_hooks(_request: Request, _context: dict) -> None:
+        return None
+
+    async def endpoint(_scope, downstream_receive, _send) -> None:
+        nonlocal endpoint_called
+        endpoint_called = True
+        assert downstream_receive is receive
+
+    await _run_auth_middleware(
+        monkeypatch,
+        hook=no_hooks,
+        endpoint=endpoint,
+        receive=receive,
+    )
+
+    assert endpoint_called
+
+
+@pytest.mark.asyncio
+async def test_long_lived_streams_do_not_spawn_base_http_middleware_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    never = asyncio.Event()
+    all_streams_started = asyncio.Event()
+    cleared_tokens: list[object] = []
+    started_streams = 0
+
+    async def stream():
+        nonlocal started_streams
+        started_streams += 1
+        if started_streams == 11:
+            all_streams_started.set()
+        yield b"data: connected\n\n"
+        await never.wait()
+
+    async def endpoint(_request: Request) -> StreamingResponse:
+        return StreamingResponse(stream(), media_type="text/event-stream")
+
+    async def apply_auth(_request: Request):
+        return None, object(), None
+
+    async def no_static_response(_request: Request):
+        return None
+
+    monkeypatch.setattr(server_app, "apply_auth_for_request", apply_auth)
+    monkeypatch.setattr(server_app, "clear_auth_context", cleared_tokens.append)
+    monkeypatch.setattr(server_app, "maybe_serve_static_webui", no_static_response)
+    monkeypatch.setattr(server_app, "_should_log_request", lambda *_args: False)
+
+    app = Starlette(routes=[Route("/global/event", endpoint)])
+    app.add_middleware(server_app._SecurityHeadersMiddleware)
+    app.add_middleware(server_app._InstanceContextMiddleware)
+    app.add_middleware(server_app._RequestLoggingMiddleware)
+    app.add_middleware(server_app._AuthGuardMiddleware)
+    app.add_middleware(server_app._StaticWebUIMiddleware)
+
+    scope = _http_scope("/global/event")
+
+    async def receive():
+        await never.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(_message):
+        return None
+
+    requests = [asyncio.create_task(app(dict(scope), receive, send)) for _ in range(11)]
+    try:
+        await asyncio.wait_for(all_streams_started.wait(), timeout=1)
+
+        base_http_tasks = [task for task in asyncio.all_tasks() if "BaseHTTPMiddleware" in task.get_coro().__qualname__]
+
+        assert started_streams == 11
+        assert all(not request.done() for request in requests)
+        assert base_http_tasks == []
+        assert cleared_tokens == []
+    finally:
+        for request in requests:
+            request.cancel()
+        await asyncio.gather(*requests, return_exceptions=True)
+
+    assert len(cleared_tokens) == 11


### PR DESCRIPTION
Use pure ASGI middleware for security headers, instance context, request logging, authentication, and static WebUI handling. Preserve auth-hook request body replay and disconnect semantics with focused regression coverage.