### PR TITLE
fix: use bundled ca for whatsapp bridge node processes

### DIFF
--- a/flocks/channel/builtin/whatsapp/bridge_runtime.py
+++ b/flocks/channel/builtin/whatsapp/bridge_runtime.py
@@ -6,11 +6,14 @@ import asyncio
 import hashlib
 import json
 import os
+import shlex
 import subprocess
 from pathlib import Path
 from typing import Any
 
 from .config import coerce_int
+
+NODE_USE_BUNDLED_CA_OPTION = "--use-bundled-ca"
 
 
 def file_hash(path: Path) -> str:
@@ -23,6 +26,19 @@ def file_hash(path: Path) -> str:
 def config_hash(values: dict[str, Any]) -> str:
     payload = json.dumps(values, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def append_node_options(env: dict[str, str], *options: str) -> None:
+    raw = str(env.get("NODE_OPTIONS") or "").strip()
+    try:
+        current = shlex.split(raw) if raw else []
+    except ValueError:
+        current = raw.split()
+
+    additions = [option for option in options if option and option not in current]
+    if not additions:
+        return
+    env["NODE_OPTIONS"] = " ".join([part for part in [raw, *additions] if part]).strip()
 
 
 async def ensure_bridge_deps(bridge_dir: Path) -> None:

--- a/flocks/channel/builtin/whatsapp/channel.py
+++ b/flocks/channel/builtin/whatsapp/channel.py
@@ -48,7 +48,7 @@ from .config import (
     matches_identifier,
     parse_target,
 )
-from .bridge_runtime import config_hash, ensure_bridge_deps, file_hash
+from .bridge_runtime import NODE_USE_BUNDLED_CA_OPTION, append_node_options, config_hash, ensure_bridge_deps, file_hash
 from .format import format_for_whatsapp
 from .inbound import build_inbound_message
 
@@ -411,6 +411,7 @@ class WhatsAppChannel(ChannelPlugin):
         self._bridge_log_path.parent.mkdir(parents=True, exist_ok=True)
         self._bridge_log_fh = open(self._bridge_log_path, "a", encoding="utf-8")
         env = os.environ.copy()
+        append_node_options(env, NODE_USE_BUNDLED_CA_OPTION)
         env["FLOCKS_WHATSAPP_MEDIA_DIR"] = str(self._media_cache_dir)
         env["FLOCKS_WHATSAPP_BRIDGE_TOKEN"] = self._bridge_token
         env["FLOCKS_WHATSAPP_CONFIG_HASH"] = self._bridge_config_hash()

--- a/flocks/channel/builtin/whatsapp/pairing.py
+++ b/flocks/channel/builtin/whatsapp/pairing.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 from flocks.utils.log import Log
 
-from .bridge_runtime import ensure_bridge_deps
+from .bridge_runtime import NODE_USE_BUNDLED_CA_OPTION, append_node_options, ensure_bridge_deps
 from .config import default_bridge_dir, default_session_path, find_executable
 
 log = Log.create(service="channel.whatsapp.pairing")
@@ -160,6 +160,7 @@ async def start_pairing(
 
         pairing_id = uuid.uuid4().hex
         env = os.environ.copy()
+        append_node_options(env, NODE_USE_BUNDLED_CA_OPTION)
         env.setdefault("FLOCKS_WHATSAPP_PAIR_TIMEOUT_MS", "120000")
 
         proc = await asyncio.create_subprocess_exec(

--- a/tests/channel/test_whatsapp.py
+++ b/tests/channel/test_whatsapp.py
@@ -13,6 +13,7 @@ from flocks.channel.builtin.whatsapp.config import (
     parse_target,
     strip_jid,
 )
+from flocks.channel.builtin.whatsapp.bridge_runtime import NODE_USE_BUNDLED_CA_OPTION, append_node_options
 from flocks.channel.builtin.whatsapp.inbound import build_inbound_message
 from flocks.channel.builtin.whatsapp import pairing
 from flocks.channel.registry import ChannelRegistry
@@ -204,6 +205,55 @@ def test_bridge_identity_requires_matching_session_and_config(tmp_path: Path):
     assert channel._bridge_identity_matches(mismatched, script) is False  # type: ignore[attr-defined]
 
 
+def test_append_node_options_preserves_existing_and_dedupes():
+    env = {"NODE_OPTIONS": "--trace-warnings"}
+    append_node_options(env, NODE_USE_BUNDLED_CA_OPTION)
+
+    assert env["NODE_OPTIONS"] == "--trace-warnings --use-bundled-ca"
+
+    append_node_options(env, NODE_USE_BUNDLED_CA_OPTION)
+
+    assert env["NODE_OPTIONS"] == "--trace-warnings --use-bundled-ca"
+
+
+@pytest.mark.asyncio
+async def test_channel_bridge_process_uses_bundled_ca_node_option(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "bridge.js").write_text("console.log('bridge')", encoding="utf-8")
+
+    channel = WhatsAppChannel()
+    channel._bridge_dir = bridge_dir  # type: ignore[attr-defined]
+    channel._session_path = tmp_path / "session"  # type: ignore[attr-defined]
+    channel._media_cache_dir = tmp_path / "media"  # type: ignore[attr-defined]
+    captured_env: dict[str, str] = {}
+
+    async def fake_reuse(script: Path) -> bool:
+        return False
+
+    async def fake_wait(script: Path) -> None:
+        return None
+
+    class FakePopen:
+        def __init__(self, *args, **kwargs):
+            captured_env.update(kwargs.get("env") or {})
+
+    monkeypatch.setenv("NODE_OPTIONS", "--trace-warnings")
+    monkeypatch.setattr(channel, "_reuse_or_stop_existing_bridge", fake_reuse)
+    monkeypatch.setattr(channel, "_wait_for_bridge", fake_wait)
+    monkeypatch.setattr("flocks.channel.builtin.whatsapp.channel.find_executable", lambda name: "/usr/bin/node")
+    monkeypatch.setattr("flocks.channel.builtin.whatsapp.channel.subprocess.Popen", FakePopen)
+
+    await channel._start_bridge()  # type: ignore[attr-defined]
+    if channel._bridge_log_fh:  # type: ignore[attr-defined]
+        channel._bridge_log_fh.close()  # type: ignore[attr-defined]
+
+    assert captured_env["NODE_OPTIONS"] == "--trace-warnings --use-bundled-ca"
+
+
 @pytest.mark.asyncio
 async def test_pairing_rejects_running_session_after_dependency_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
@@ -291,6 +341,7 @@ async def test_pairing_reset_session_backs_up_existing_credentials(
     session = tmp_path / "session"
     session.mkdir()
     (session / "creds.json").write_text("old", encoding="utf-8")
+    captured_env: dict[str, str] = {}
 
     class FakeStream:
         async def readline(self) -> bytes:
@@ -310,6 +361,7 @@ async def test_pairing_reset_session_backs_up_existing_credentials(
             pass
 
     async def fake_create_subprocess_exec(*args, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
         return FakeProcess()
 
     async def fake_ensure(path: Path) -> None:
@@ -318,6 +370,7 @@ async def test_pairing_reset_session_backs_up_existing_credentials(
     monkeypatch.setattr(pairing, "find_executable", lambda name: "/usr/bin/node")
     monkeypatch.setattr(pairing, "ensure_bridge_deps", fake_ensure)
     monkeypatch.setattr(pairing.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setenv("NODE_OPTIONS", "--trace-warnings")
 
     session_info = await pairing.start_pairing(
         session_path=str(session),
@@ -330,6 +383,7 @@ async def test_pairing_reset_session_backs_up_existing_credentials(
     assert (backups[0] / "creds.json").read_text(encoding="utf-8") == "old"
     assert session.exists()
     assert not (session / "creds.json").exists()
+    assert captured_env["NODE_OPTIONS"] == "--trace-warnings --use-bundled-ca"
 
     await pairing.cancel_pairing(session_info.id)
 


### PR DESCRIPTION
本次修复：
在 WhatsApp 配对进程启动 Node 时自动追加 NODE_OPTIONS=--use-bundled-ca
在 WhatsApp 正式 bridge 进程启动 Node 时自动追加 NODE_OPTIONS=--use-bundled-ca
不覆盖用户已有 NODE_OPTIONS
如果已有 --use-bundled-ca，不会重复追加
新增测试覆盖：NODE_OPTIONS 追加和去重
二维码配对进程使用 bundled CA
正式 WhatsApp bridge 进程使用 bundled CA

验证已通过：
uv run --group dev python -m pytest tests/channel/test_whatsapp.py：21 个测试通过
git diff --check 通过
npm run build 通过