### PR TITLE
fix(browser): harden daemon runtime lifecycle

### DIFF
--- a/.flocks/plugins/skills/browser-use/SKILL.md
+++ b/.flocks/plugins/skills/browser-use/SKILL.md
@@ -79,7 +79,7 @@ flocks browser --doctor
 2. `cdp-headless` 是唯一例外：先读取 `references/cdp-headless.md` 完成浏览器启动与连接，再读取 `references/cdp-direct.md` 执行通用页面操作。
 3. 在 `cdp-headless` 中，如果当前任务自己启动了专用浏览器实例，必须记录 PID / 日志 / 专用 profile，并只在任务结束或明确放弃后清理自己启动的实例；不要关闭用户提供的远程浏览器。
 4. 不要同时加载 `references/cdp-direct.md` 和 `references/agent-browser.md`。
-5. `flocks browser` 的 daemon 文件固定放在 `~/.flocks/browser/`,例如 `bu.sock`、`bu.log`、`bu.pid`、`bu.port`。
+5. `flocks browser` 的 daemon 文件默认放在 `~/.flocks/browser/`（设置 `FLOCKS_ROOT` 时改为 `$FLOCKS_ROOT/browser/`）。默认 session 使用 `bu.*`；命名 session 使用 `bu-<BU_NAME>.*`。`.lock` 是启动互斥文件，可能在 daemon 退出后继续存在，不要手工删除 socket、port、PID 或 lock 文件，应使用 `flocks browser --reload`。
 6. 基础操作能力（打开、观察、点击、输入、滚动、截图、提取、等待、关闭）优先按 `references/cdp-direct.md` 的“基础操作速查”执行
 
 ## 产品经验Skill

--- a/.flocks/plugins/skills/browser-use/references/cdp-headless.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-headless.md
@@ -164,7 +164,7 @@ macOS / Linux：
 
 ```bash
 export BU_CDP_URL="http://127.0.0.1:$BU_HEADLESS_PORT"
-rm -f "$HOME/.flocks/browser/bu.sock"
+flocks browser --reload
 flocks browser --setup
 flocks browser -c 'print(page_info())'
 ```
@@ -188,7 +188,7 @@ flocks browser -c 'print(page_info())'
 - `flocks browser` daemon 生命周期
 - 专用 headless 浏览器进程生命周期
 
-两者不是同一个东西。`restart_daemon()` 只会重启 daemon，不会替你重启或关闭 headless 浏览器。
+两者不是同一个东西。`restart_daemon()` / `flocks browser --reload` 会安全停止 daemon，并由下一次 browser 命令重新拉起；它们不会替你重启或关闭 headless 浏览器进程。
 
 推荐约定：
 
@@ -227,6 +227,6 @@ fi
 - 这种场景必须显式设置 `BU_CDP_WS` 或 `BU_CDP_URL`，让 `flocks browser` 直连你启动的 headless 实例
 - 如果 `9222` 已被其他浏览器实例占用，不要复用它；改用新的专用端口，并同步更新浏览器启动参数与 `BU_CDP_URL` / `BU_CDP_WS`
 - 如果显式切换到了新的 `BU_CDP_URL` / `BU_CDP_WS`，但当前 `BU_NAME` 下还有旧 daemon，优先让 `flocks browser --setup` 重新建连；若仍异常，再执行 `flocks browser -c 'restart_daemon()'`
-- `flocks browser` 的 daemon 文件固定放在 `~/.flocks/browser/`，例如 `bu.sock`、`bu.log`、`bu.pid`、`bu.port`
-- 当 daemon 已经死掉但 POSIX socket 文件还留在 `~/.flocks/browser/` 时，再手动删除 `~/.flocks/browser/bu.sock`；Windows 不需要这一步
+- daemon 文件默认位于 `~/.flocks/browser/`；默认 session 使用 `bu.*`，命名 session 使用 `bu-<BU_NAME>.*`，并各自持有 `.lock`
+- 不要手工删除 socket、port、PID 或 lock 文件；daemon 异常或 endpoint 切换时使用 `flocks browser --reload`，它会按身份和锁状态安全停止或清理
 - 如果失败并出现 `HTTP 403`，优先回头检查 headless Chrome 是否带了 `--remote-allow-origins=*`

--- a/flocks/browser/_ipc.py
+++ b/flocks/browser/_ipc.py
@@ -1,58 +1,149 @@
-"""Daemon IPC plumbing. AF_UNIX on POSIX, TCP loopback on Windows."""
+"""Authenticated daemon IPC over AF_UNIX on POSIX and loopback TCP on Windows."""
+
+from __future__ import annotations
 
 import asyncio
+import json
 import os
-import re
+import secrets
 import socket
 import subprocess
 import sys
+import tempfile
+from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import Any
+
+from .paths import BrowserRuntimePaths, browser_dir, resolve_name, validate_name
 
 
 IS_WINDOWS = sys.platform == "win32"
-BU_TMP_DIR = str(Path.home() / ".flocks" / "browser")
-_TMP = Path(BU_TMP_DIR).expanduser()
-_TMP.mkdir(parents=True, exist_ok=True)
-_NAME_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
+PROTOCOL_VERSION = 1
+MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+LOCK_BUSY_EXIT_CODE = 75
+
+# Compatibility aliases for callers that only need the default location. Runtime
+# operations resolve paths lazily so FLOCKS_ROOT changes remain testable.
+BU_TMP_DIR = str(browser_dir())
 
 
-def _check(name: str) -> str:
-    """Validate daemon names used in socket paths and filenames."""
-    if not _NAME_RE.match(name or ""):
-        raise ValueError(f"invalid BU_NAME {name!r}: must match [A-Za-z0-9_-]{{1,64}}")
-    return name
+class IPCProtocolError(RuntimeError):
+    """Raised when an endpoint does not speak the current daemon protocol."""
 
 
-def _stem(name: str) -> str:
-    """Return the daemon file stem for the given browser session name."""
-    _check(name)
-    return "bu" if BU_TMP_DIR else f"bu-{name}"
+class LegacyProtocolError(IPCProtocolError):
+    """Raised when a responsive daemon explicitly lacks the ping protocol."""
 
 
-def log_path(name: str) -> Path:
-    return _TMP / f"{_stem(name)}.log"
+class EndpointRecordError(RuntimeError):
+    """Raised when a local Windows endpoint record is malformed."""
 
 
-def pid_path(name: str) -> Path:
-    return _TMP / f"{_stem(name)}.pid"
+class DaemonLock:
+    """Cross-platform advisory lock held for a daemon's entire lifetime."""
+
+    def __init__(self, name: str | None = None) -> None:
+        self.paths = BrowserRuntimePaths.resolve(name)
+        self._file = None
+        self.acquired = False
+
+    def acquire(self, blocking: bool = False) -> bool:
+        if self.acquired:
+            return True
+        self.paths.ensure_root()
+        handle = self.paths.lock.open("a+b")
+        try:
+            os.chmod(self.paths.lock, 0o600)
+        except OSError:
+            pass
+        try:
+            if IS_WINDOWS:
+                import msvcrt
+
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                handle.seek(0)
+                mode = msvcrt.LK_LOCK if blocking else msvcrt.LK_NBLCK
+                msvcrt.locking(handle.fileno(), mode, 1)
+            else:
+                import fcntl
+
+                flags = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+                fcntl.flock(handle.fileno(), flags)
+        except (OSError, BlockingIOError):
+            handle.close()
+            return False
+        self._file = handle
+        self.acquired = True
+        return True
+
+    def release(self) -> None:
+        if not self.acquired or self._file is None:
+            return
+        try:
+            if IS_WINDOWS:
+                import msvcrt
+
+                self._file.seek(0)
+                msvcrt.locking(self._file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._file.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._file.close()
+            self._file = None
+            self.acquired = False
+
+    def __enter__(self) -> DaemonLock:
+        if not self.acquire():
+            raise BlockingIOError(f"browser daemon lock is held: {self.paths.lock}")
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.release()
 
 
-def port_path(name: str) -> Path:
-    return _TMP / f"{_stem(name)}.port"
+def runtime_paths(name: str | None = None) -> BrowserRuntimePaths:
+    return BrowserRuntimePaths.resolve(name)
 
 
-def _sock_path(name: str) -> Path:
-    return _TMP / f"{_stem(name)}.sock"
+def runtime_dir() -> Path:
+    return browser_dir()
 
 
-def sock_addr(name: str) -> str:
+def log_path(name: str | None = None) -> Path:
+    return runtime_paths(name).log
+
+
+def pid_path(name: str | None = None) -> Path:
+    return runtime_paths(name).pid
+
+
+def port_path(name: str | None = None) -> Path:
+    return runtime_paths(name).port
+
+
+def screenshot_path(name: str | None = None) -> Path:
+    return runtime_paths(name).screenshot
+
+
+def debug_screenshot_path(sequence: int, name: str | None = None) -> Path:
+    return runtime_paths(name).debug_screenshot(sequence)
+
+
+def sock_addr(name: str | None = None) -> str:
     """Return a human-readable endpoint address for logs."""
+    paths = runtime_paths(name)
     if not IS_WINDOWS:
-        return str(_sock_path(name))
+        return str(paths.socket)
     try:
-        return f"127.0.0.1:{port_path(name).read_text().strip()}"
-    except FileNotFoundError:
-        return f"tcp:{_stem(name)}"
+        port, _token = _read_port_record(paths.port)
+        return f"127.0.0.1:{port}"
+    except (FileNotFoundError, EndpointRecordError):
+        return f"tcp:{paths.stem}"
 
 
 def spawn_kwargs() -> dict[str, object]:
@@ -62,51 +153,236 @@ def spawn_kwargs() -> dict[str, object]:
     return {"start_new_session": True}
 
 
-def connect(name: str, timeout: float = 1.0) -> socket.socket:
-    """Connect to a browser daemon endpoint."""
+def _read_port_record(path: Path) -> tuple[int, str | None]:
+    raw = path.read_text(encoding="utf-8-sig", errors="replace").strip()
+    try:
+        record = json.loads(raw)
+    except json.JSONDecodeError:
+        record = raw
+    if isinstance(record, int) and not isinstance(record, bool):
+        port = record
+        token = None
+    elif isinstance(record, str):
+        try:
+            port = int(record)
+        except ValueError as error:
+            raise EndpointRecordError(f"invalid browser daemon port file: {path}") from error
+        token = None
+    elif isinstance(record, dict):
+        port = record.get("port")
+        token = record.get("token")
+        if type(port) is not int or not isinstance(token, str) or not token:
+            raise EndpointRecordError(f"invalid browser daemon port record: {path}")
+    else:
+        raise EndpointRecordError(f"invalid browser daemon port record: {path}")
+    if not 0 < port < 65536:
+        raise EndpointRecordError(f"invalid browser daemon port: {port}")
+    return port, token
+
+
+def _connect_with_token(name: str | None, timeout: float) -> tuple[socket.socket, str | None]:
+    paths = runtime_paths(name)
     if not IS_WINDOWS:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.settimeout(timeout)
-        sock.connect(str(_sock_path(name)))
-        return sock
-    try:
-        port = int(port_path(name).read_text().strip())
-    except (FileNotFoundError, ValueError) as error:
-        raise FileNotFoundError(str(port_path(name))) from error
+        try:
+            sock.connect(str(paths.socket))
+        except Exception:
+            sock.close()
+            raise
+        return sock, None
+    port, token = _read_port_record(paths.port)
     sock = socket.create_connection(("127.0.0.1", port), timeout=timeout)
     sock.settimeout(timeout)
+    return sock, token
+
+
+def connect(name: str | None = None, timeout: float = 1.0) -> socket.socket:
+    """Connect to a browser daemon endpoint."""
+    sock, _token = _connect_with_token(name, timeout)
     return sock
 
 
-async def serve(name: str, handler) -> None:
-    """Serve daemon requests until cancelled."""
-    if not IS_WINDOWS:
-        path = str(_sock_path(name))
-        if os.path.exists(path):
-            os.unlink(path)
-        server = await asyncio.start_unix_server(handler, path=path)
-        os.chmod(path, 0o600)
-        async with server:
-            await asyncio.Event().wait()
-        return
-
-    server = await asyncio.start_server(handler, "127.0.0.1", 0)
-    port_file = port_path(name)
-    port_file.write_text(str(server.sockets[0].getsockname()[1]))
+def request(name: str | None, payload: dict[str, Any], timeout: float = 3.0) -> dict[str, Any]:
+    """Send one JSON request and return one JSON response."""
+    sock, token = _connect_with_token(name, timeout)
     try:
-        async with server:
-            await asyncio.Event().wait()
+        outgoing = dict(payload)
+        if token:
+            outgoing["_ipc_token"] = token
+        sock.sendall((json.dumps(outgoing, separators=(",", ":")) + "\n").encode("utf-8"))
+        data = bytearray()
+        while not data.endswith(b"\n"):
+            chunk = sock.recv(1 << 16)
+            if not chunk:
+                break
+            data.extend(chunk)
+            if len(data) > MAX_RESPONSE_BYTES:
+                raise IPCProtocolError("browser daemon response exceeded size limit")
+        if not data:
+            raise IPCProtocolError("browser daemon returned an empty response")
+        response = json.loads(data.decode("utf-8", errors="replace"))
+        if not isinstance(response, dict):
+            raise IPCProtocolError("browser daemon response must be a JSON object")
+        return response
+    except json.JSONDecodeError as error:
+        raise IPCProtocolError("browser daemon returned invalid JSON") from error
+    finally:
+        sock.close()
+
+
+def identify(name: str | None = None, timeout: float = 1.0) -> dict[str, Any]:
+    """Return a strictly validated identity for a current daemon."""
+    expected_name = resolve_name(name)
+    response = request(expected_name, {"meta": "ping"}, timeout=timeout)
+    pid = response.get("pid")
+    protocol_version = response.get("protocol_version")
+    instance_id = response.get("instance_id")
+    browser_kind = response.get("browser_kind")
+    if response.get("pong") is not True:
+        error = str(response.get("error") or "")
+        if error.startswith("unknown meta") or error in {"'method'", "method"}:
+            raise LegacyProtocolError("browser daemon predates the ping protocol")
+        raise IPCProtocolError("browser daemon does not support ping")
+    if response.get("name") != expected_name:
+        raise IPCProtocolError("browser daemon session identity mismatch")
+    if type(pid) is not int or pid <= 0:
+        raise IPCProtocolError("browser daemon returned an invalid PID")
+    if type(protocol_version) is not int or protocol_version < 1:
+        raise IPCProtocolError("browser daemon returned an invalid protocol version")
+    if not isinstance(instance_id, str) or not instance_id:
+        raise IPCProtocolError("browser daemon returned an invalid instance ID")
+    if browser_kind not in {"local", "cdp"}:
+        raise IPCProtocolError("browser daemon returned an invalid browser kind")
+    return response
+
+
+def endpoint_reachable(name: str | None = None, timeout: float = 1.0) -> bool:
+    try:
+        sock = connect(name, timeout=timeout)
+    except (
+        EndpointRecordError,
+        IPCProtocolError,
+        FileNotFoundError,
+        ConnectionRefusedError,
+        TimeoutError,
+        socket.timeout,
+        OSError,
+    ):
+        return False
+    sock.close()
+    return True
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Atomically replace a private UTF-8 text file."""
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_name, 0o600)
+        os.replace(temp_name, path)
     finally:
         try:
-            port_file.unlink()
+            os.unlink(temp_name)
         except FileNotFoundError:
             pass
 
 
-def cleanup_endpoint(name: str) -> None:
-    """Best-effort daemon endpoint cleanup."""
-    path = _sock_path(name) if not IS_WINDOWS else port_path(name)
+def write_pid(name: str | None, pid: int) -> None:
+    paths = runtime_paths(name)
+    paths.ensure_root()
+    atomic_write_text(paths.pid, str(pid))
+
+
+async def serve(
+    name: str | None,
+    handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]],
+    lock: DaemonLock,
+) -> None:
+    """Serve authenticated JSON requests while the caller owns ``lock``."""
+    paths = runtime_paths(name)
+    if not lock.acquired or lock.paths != paths:
+        raise RuntimeError("browser daemon endpoint requires its acquired session lock")
+    token = secrets.token_urlsafe(32) if IS_WINDOWS else None
+
+    async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            line = await reader.readline()
+            if not line:
+                return
+            req = json.loads(line.decode("utf-8", errors="replace"))
+            if not isinstance(req, dict):
+                raise IPCProtocolError("request must be a JSON object")
+            supplied_token = req.pop("_ipc_token", None)
+            if token is not None and not secrets.compare_digest(str(supplied_token or ""), token):
+                response = {"error": "unauthorized browser daemon request"}
+            else:
+                response = await handler(req)
+            writer.write((json.dumps(response, default=str) + "\n").encode("utf-8"))
+            await writer.drain()
+        except Exception as error:
+            try:
+                writer.write((json.dumps({"error": str(error)}) + "\n").encode("utf-8"))
+                await writer.drain()
+            except Exception:
+                pass
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    server = None
     try:
-        path.unlink()
-    except FileNotFoundError:
-        pass
+        paths.ensure_root()
+        if not IS_WINDOWS:
+            paths.socket.unlink(missing_ok=True)
+            old_umask = os.umask(0o077)
+            try:
+                server = await asyncio.start_unix_server(handle_client, path=str(paths.socket))
+            finally:
+                os.umask(old_umask)
+            os.chmod(paths.socket, 0o600)
+        else:
+            server = await asyncio.start_server(handle_client, "127.0.0.1", 0)
+            port = server.sockets[0].getsockname()[1]
+            atomic_write_text(paths.port, json.dumps({"port": port, "token": token}))
+        async with server:
+            await server.serve_forever()
+    finally:
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+        cleanup_endpoint(name, lock)
+
+
+def cleanup_endpoint(name: str | None, lock: DaemonLock) -> None:
+    """Remove an endpoint only while holding its session lock."""
+    paths = runtime_paths(name)
+    if not lock.acquired or lock.paths != paths:
+        raise RuntimeError("browser daemon endpoint cleanup requires its acquired session lock")
+    path = paths.port if IS_WINDOWS else paths.socket
+    path.unlink(missing_ok=True)
+
+
+def discover_names() -> list[str]:
+    """Return session names with endpoint or PID artifacts."""
+    root = runtime_dir()
+    if not root.is_dir():
+        return []
+    names: set[str] = set()
+    for suffix in {".port", ".pid"} if IS_WINDOWS else {".sock", ".pid"}:
+        if (root / f"bu{suffix}").exists():
+            names.add("default")
+        for path in root.glob(f"bu-*{suffix}"):
+            raw = path.name[3 : -len(suffix)]
+            try:
+                names.add(validate_name(raw))
+            except ValueError:
+                continue
+    return sorted(names, key=lambda name: (name != "default", name))

--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -232,20 +232,32 @@ def ensure_daemon(
         }
         paths = ipc.runtime_paths(effective_name)
         paths.ensure_root()
-        with paths.log.open("ab", buffering=0) as daemon_log:
-            proc = subprocess.Popen(
-                [sys.executable, "-m", "flocks.browser.daemon"],
-                env=merged_env,
-                stdout=daemon_log,
-                stderr=subprocess.STDOUT,
-                **ipc.spawn_kwargs(),
-            )
+
+        def spawn_daemon():
+            with paths.log.open("ab", buffering=0) as daemon_log:
+                return subprocess.Popen(
+                    [sys.executable, "-m", "flocks.browser.daemon"],
+                    env=merged_env,
+                    stdout=daemon_log,
+                    stderr=subprocess.STDOUT,
+                    **ipc.spawn_kwargs(),
+                )
+
+        proc = spawn_daemon()
         deadline = time.time() + wait
         while time.time() < deadline:
             if daemon_alive(effective_name):
                 return
             return_code = proc.poll()
-            if return_code is not None and return_code != ipc.LOCK_BUSY_EXIT_CODE:
+            if return_code == ipc.LOCK_BUSY_EXIT_CODE:
+                retry_lock = ipc.DaemonLock(effective_name)
+                if retry_lock.acquire():
+                    retry_lock.release()
+                    proc = spawn_daemon()
+                else:
+                    time.sleep(0.2)
+                continue
+            if return_code is not None:
                 break
             time.sleep(0.2)
         msg = _log_tail(effective_name) or ""

--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -5,14 +5,18 @@ import os
 import socket
 import tempfile
 import time
+import urllib.parse
+import urllib.request
 from pathlib import Path
+
+from websockets.sync.client import connect as websocket_connect
 
 from . import BROWSER_LABEL, PROJECT_ROOT, get_browser_version
 from . import _ipc as ipc
+from . import lifecycle
 from .utils import load_env_file
 
 
-NAME = os.environ.get("BU_NAME", "default")
 VERSION_CACHE = Path(tempfile.gettempdir()) / "flocks-browser-version-cache.json"
 VERSION_CACHE_TTL = 24 * 3600
 DOCTOR_TEXT_LIMIT = 140
@@ -31,12 +35,15 @@ def _load_env() -> None:
             continue
         load_env_file(path)
 
+
 _load_env()
+
+NAME = ipc.runtime_paths().name
 
 
 def _log_tail(name: str | None):
     try:
-        return ipc.log_path(name or NAME).read_text().strip().splitlines()[-1]
+        return ipc.log_path(name or NAME).read_text(encoding="utf-8", errors="replace").strip().splitlines()[-1]
     except (FileNotFoundError, IndexError):
         return None
 
@@ -63,46 +70,66 @@ def _configured_cdp_endpoint(env: dict | None = None) -> tuple[str | None, str |
     return None, None
 
 
+def _probe_cdp_websocket(url: str, timeout: float = 3.0) -> tuple[bool, str]:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"ws", "wss"} or not parsed.hostname:
+        return False, "invalid WebSocket URL"
+    try:
+        with websocket_connect(url, open_timeout=timeout, close_timeout=timeout) as websocket:
+            websocket.send(json.dumps({"id": 1, "method": "Browser.getVersion"}))
+            response = json.loads(websocket.recv(timeout=timeout))
+        if not isinstance(response, dict) or response.get("id") != 1 or not isinstance(response.get("result"), dict):
+            return False, "Browser.getVersion returned an invalid response"
+    except Exception as error:
+        return False, f"connection failed ({type(error).__name__})"
+    return True, "CDP handshake succeeded"
+
+
+def _probe_cdp_endpoint(name: str, value: str, timeout: float = 3.0) -> tuple[bool, str]:
+    """Verify that an explicit CDP endpoint is reachable and speaks CDP."""
+    if name == "BU_CDP_WS":
+        return _probe_cdp_websocket(value, timeout)
+    parsed = urllib.parse.urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False, "invalid HTTP URL"
+    try:
+        with urllib.request.urlopen(f"{value.rstrip('/')}/json/version", timeout=timeout) as response:
+            payload = json.loads(response.read())
+        websocket_url = payload.get("webSocketDebuggerUrl")
+        if not isinstance(websocket_url, str):
+            return False, "/json/version did not return webSocketDebuggerUrl"
+    except Exception as error:
+        return False, f"connection failed ({type(error).__name__})"
+    return _probe_cdp_websocket(websocket_url, timeout)
+
+
 def _is_local_chrome_mode(env: dict | None = None) -> bool:
     return _configured_cdp_endpoint(env)[0] is None
 
 
 def daemon_alive(name: str | None = None) -> bool:
     try:
-        conn = ipc.connect(name or NAME, timeout=1.0)
-        conn.close()
+        ipc.identify(name or NAME, timeout=1.0)
         return True
-    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
+    except (
+        ipc.EndpointRecordError,
+        ipc.IPCProtocolError,
+        FileNotFoundError,
+        ConnectionRefusedError,
+        TimeoutError,
+        socket.timeout,
+        OSError,
+    ):
         return False
 
 
 def _daemon_endpoint_names() -> list[str]:
-    suffix = ".port" if ipc.IS_WINDOWS else ".sock"
-    if ipc.BU_TMP_DIR:
-        return [NAME] if (ipc._TMP / f"bu{suffix}").exists() else []
-    names: list[str] = []
-    for path in sorted(ipc._TMP.glob(f"bu-*{suffix}")):
-        raw = path.name[3 : -len(suffix)]
-        try:
-            ipc._check(raw)
-        except ValueError:
-            continue
-        names.append(raw)
-    return names
+    return ipc.discover_names()
 
 
 def _daemon_browser_connection(name: str):
-    conn = None
     try:
-        conn = ipc.connect(name, timeout=1.0)
-        conn.sendall(b'{"meta":"connection_status"}\n')
-        data = b""
-        while not data.endswith(b"\n"):
-            chunk = conn.recv(1 << 16)
-            if not chunk:
-                break
-            data += chunk
-        response = json.loads(data)
+        response = ipc.request(name, {"meta": "connection_status"}, timeout=1.0)
         if "error" in response:
             return None
         page = response.get("page")
@@ -110,6 +137,8 @@ def _daemon_browser_connection(name: str):
             page = {"title": page.get("title") or "(untitled)", "url": page.get("url") or ""}
         return {"name": name, "page": page}
     except (
+        ipc.EndpointRecordError,
+        ipc.IPCProtocolError,
         FileNotFoundError,
         ConnectionRefusedError,
         TimeoutError,
@@ -120,9 +149,6 @@ def _daemon_browser_connection(name: str):
         json.JSONDecodeError,
     ):
         return None
-    finally:
-        if conn:
-            conn.close()
 
 
 def browser_connections() -> list[dict]:
@@ -140,18 +166,11 @@ def active_browser_connections() -> int:
 
 
 def _daemon_probe(name: str | None, req: dict) -> dict | None:
-    conn = None
     try:
-        conn = ipc.connect(name or NAME, timeout=3.0)
-        conn.sendall((json.dumps(req) + "\n").encode())
-        data = b""
-        while not data.endswith(b"\n"):
-            chunk = conn.recv(1 << 16)
-            if not chunk:
-                break
-            data += chunk
-        return json.loads(data)
+        return ipc.request(name or NAME, req, timeout=3.0)
     except (
+        ipc.EndpointRecordError,
+        ipc.IPCProtocolError,
         FileNotFoundError,
         ConnectionRefusedError,
         TimeoutError,
@@ -162,9 +181,6 @@ def _daemon_probe(name: str | None, req: dict) -> dict | None:
         json.JSONDecodeError,
     ):
         return None
-    finally:
-        if conn:
-            conn.close()
 
 
 def _daemon_has_current_protocol(name: str | None = None) -> bool:
@@ -178,9 +194,12 @@ def _daemon_has_current_protocol(name: str | None = None) -> bool:
 
 def stop_all_daemons() -> list[str]:
     """Stop all browser daemons visible from the current environment."""
-    names = _daemon_endpoint_names()
-    for name in names:
-        restart_daemon(name)
+    names, errors = lifecycle.stop_all_daemons()
+    if errors:
+        import sys
+
+        for name, error in errors.items():
+            print(f"{BROWSER_LABEL}: failed to stop browser session {name!r}: {error}", file=sys.stderr)
     return names
 
 
@@ -194,36 +213,48 @@ def ensure_daemon(
     wait: float = 60.0, name: str | None = None, env: dict | None = None, _open_inspect: bool = True
 ) -> None:
     """Ensure a healthy daemon is running, restarting stale sessions when needed."""
-    if daemon_alive(name):
-        if _daemon_has_current_protocol(name):
+    effective_name = ipc.runtime_paths(name or NAME).name
+    if ipc.endpoint_reachable(effective_name):
+        if daemon_alive(effective_name) and _daemon_has_current_protocol(effective_name):
             return
-        restart_daemon(name)
+        lifecycle.stop_daemon(effective_name)
 
     import subprocess
     import sys
 
     local = _is_local_chrome_mode(env)
     for attempt in (0, 1):
-        merged_env = {**os.environ, **({"BU_NAME": name} if name else {}), **(env or {})}
-        proc = subprocess.Popen(
-            [sys.executable, "-m", "flocks.browser.daemon"],
-            env=merged_env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            **ipc.spawn_kwargs(),
-        )
+        merged_env = {
+            **os.environ,
+            **(env or {}),
+            "BU_NAME": effective_name,
+            "PYTHONIOENCODING": "utf-8:replace",
+        }
+        paths = ipc.runtime_paths(effective_name)
+        paths.ensure_root()
+        with paths.log.open("ab", buffering=0) as daemon_log:
+            proc = subprocess.Popen(
+                [sys.executable, "-m", "flocks.browser.daemon"],
+                env=merged_env,
+                stdout=daemon_log,
+                stderr=subprocess.STDOUT,
+                **ipc.spawn_kwargs(),
+            )
         deadline = time.time() + wait
         while time.time() < deadline:
-            if daemon_alive(name):
+            if daemon_alive(effective_name):
                 return
-            if proc.poll() is not None:
+            return_code = proc.poll()
+            if return_code is not None and return_code != ipc.LOCK_BUSY_EXIT_CODE:
                 break
             time.sleep(0.2)
-        msg = _log_tail(name) or ""
+        msg = _log_tail(effective_name) or ""
         if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
-            restart_daemon(name)
+            restart_daemon(effective_name)
             if not _open_inspect:
-                raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
+                raise RuntimeError(
+                    msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}"
+                )
             _open_browser_inspect()
             print(
                 f"{BROWSER_LABEL}: click Allow on your browser's inspect page "
@@ -231,42 +262,12 @@ def ensure_daemon(
                 file=sys.stderr,
             )
             continue
-        raise RuntimeError(msg or f"daemon {name or NAME} didn't come up -- check {ipc.log_path(name or NAME)}")
+        raise RuntimeError(msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}")
 
 
 def restart_daemon(name: str | None = None) -> None:
-    """Best-effort daemon shutdown and endpoint cleanup."""
-    import signal
-
-    pid_file = str(ipc.pid_path(name or NAME))
-    try:
-        conn = ipc.connect(name or NAME, timeout=5.0)
-        conn.sendall(b'{"meta":"shutdown"}\n')
-        conn.recv(1024)
-        conn.close()
-    except Exception:
-        pass
-    try:
-        pid = int(Path(pid_file).read_text())
-    except (FileNotFoundError, ValueError):
-        pid = None
-    if pid:
-        for _ in range(75):
-            try:
-                os.kill(pid, 0)
-                time.sleep(0.2)
-            except (ProcessLookupError, OSError, SystemError):
-                break
-        else:
-            try:
-                os.kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError, SystemError):
-                pass
-    ipc.cleanup_endpoint(name or NAME)
-    try:
-        os.unlink(pid_file)
-    except FileNotFoundError:
-        pass
+    """Safely stop a daemon and clean only artifacts protected by its lock."""
+    lifecycle.stop_daemon(name or NAME)
 
 
 def _version() -> str:
@@ -288,14 +289,14 @@ def _install_mode() -> str:
 
 def _cache_read() -> dict:
     try:
-        return json.loads(VERSION_CACHE.read_text())
+        return json.loads(VERSION_CACHE.read_text(encoding="utf-8-sig", errors="replace"))
     except (FileNotFoundError, ValueError):
         return {}
 
 
 def _cache_write(data: dict) -> None:
     try:
-        VERSION_CACHE.write_text(json.dumps(data))
+        ipc.atomic_write_text(VERSION_CACHE, json.dumps(data))
     except OSError:
         pass
 
@@ -460,7 +461,10 @@ def run_doctor() -> int:
     current = _version()
     mode = _install_mode()
     browser_running = _chrome_running()
-    endpoint_name, _endpoint_value = _configured_cdp_endpoint()
+    endpoint_name, endpoint_value = _configured_cdp_endpoint()
+    endpoint_ok, endpoint_detail = (True, "")
+    if endpoint_name and endpoint_value:
+        endpoint_ok, endpoint_detail = _probe_cdp_endpoint(endpoint_name, endpoint_value)
     daemon = daemon_alive()
     connections = browser_connections()
     latest = _latest_release_tag()
@@ -471,8 +475,10 @@ def run_doctor() -> int:
         mark = "ok  " if ok else "FAIL"
         print(f"  [{mark}] {label}{(' — ' + detail) if detail else ''}")
 
-    target_available = browser_running or bool(endpoint_name)
-    if connections:
+    target_available = endpoint_ok if endpoint_name else browser_running
+    if endpoint_name and not endpoint_ok:
+        next_action = f"fix {endpoint_name}, then run `flocks browser --setup`"
+    elif connections:
         next_action = "ready; use `flocks browser -c 'print(page_info())'`"
     elif target_available and daemon:
         next_action = "attach; run `flocks browser -c 'print(page_info())'` before setup"
@@ -490,7 +496,10 @@ def run_doctor() -> int:
     else:
         print("  latest release    (not configured)")
     if endpoint_name:
-        row("browser target", True, f"configured via {endpoint_name}")
+        detail = (
+            f"configured via {endpoint_name}" if endpoint_ok else f"{endpoint_name} is unreachable: {endpoint_detail}"
+        )
+        row("browser target", endpoint_ok, detail)
     else:
         row(
             "browser running",

--- a/flocks/browser/daemon.py
+++ b/flocks/browser/daemon.py
@@ -3,10 +3,15 @@
 import asyncio
 import json
 import os
+import platform
+import signal
 import socket
 import sys
 import time
+import traceback
+import urllib.parse
 import urllib.request
+import uuid
 from collections import deque
 from pathlib import Path
 
@@ -18,37 +23,7 @@ from .utils import load_env_file
 
 
 AGENT_WORKSPACE = Path(os.environ.get("BH_AGENT_WORKSPACE", DEFAULT_AGENT_WORKSPACE)).expanduser()
-NAME = os.environ.get("BU_NAME", "default")
-SOCK = ipc.sock_addr(NAME)
-LOG = str(ipc.log_path(NAME))
-PID = str(ipc.pid_path(NAME))
 BUF = 500
-PROFILES = [
-    Path.home() / "Library/Application Support/Google/Chrome",
-    Path.home() / "Library/Application Support/Comet",
-    Path.home() / "Library/Application Support/Arc/User Data",
-    Path.home() / "Library/Application Support/Microsoft Edge",
-    Path.home() / "Library/Application Support/Microsoft Edge Beta",
-    Path.home() / "Library/Application Support/Microsoft Edge Dev",
-    Path.home() / "Library/Application Support/Microsoft Edge Canary",
-    Path.home() / "Library/Application Support/BraveSoftware/Brave-Browser",
-    Path.home() / ".config/google-chrome",
-    Path.home() / ".config/chromium",
-    Path.home() / ".config/chromium-browser",
-    Path.home() / ".config/microsoft-edge",
-    Path.home() / ".config/microsoft-edge-beta",
-    Path.home() / ".config/microsoft-edge-dev",
-    Path.home() / ".var/app/org.chromium.Chromium/config/chromium",
-    Path.home() / ".var/app/com.google.Chrome/config/google-chrome",
-    Path.home() / ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
-    Path.home() / ".var/app/com.microsoft.Edge/config/microsoft-edge",
-    Path.home() / "AppData/Local/Google/Chrome/User Data",
-    Path.home() / "AppData/Local/Chromium/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge Beta/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge Dev/User Data",
-    Path.home() / "AppData/Local/Microsoft/Edge SxS/User Data",
-]
 INTERNAL = INTERNAL_URL_PREFIXES
 MARKER = "🟢"
 
@@ -59,11 +34,79 @@ def _load_env() -> None:
             continue
         load_env_file(path)
 
+
 _load_env()
+
+NAME = ipc.runtime_paths().name
+SOCK = ipc.sock_addr(NAME)
+LOG = str(ipc.log_path(NAME))
+PID = str(ipc.pid_path(NAME))
+
+
+def profile_dirs(
+    system: str | None = None,
+    home: Path | None = None,
+    environ: dict[str, str] | None = None,
+) -> list[Path]:
+    """Return only the browser profile directories for the active OS."""
+    system = system or platform.system()
+    home = home or Path.home()
+    environ = os.environ if environ is None else environ
+    if system == "Darwin":
+        support = home / "Library/Application Support"
+        return [
+            support / "Google/Chrome",
+            support / "Google/Chrome Canary",
+            support / "Comet",
+            support / "Arc/User Data",
+            support / "Microsoft Edge",
+            support / "Microsoft Edge Beta",
+            support / "Microsoft Edge Dev",
+            support / "Microsoft Edge Canary",
+            support / "BraveSoftware/Brave-Browser",
+            support / "Chromium",
+        ]
+    if system == "Windows":
+        local = Path(environ.get("LOCALAPPDATA", str(home / "AppData/Local"))).expanduser()
+        return [
+            local / "Google/Chrome/User Data",
+            local / "Google/Chrome Beta/User Data",
+            local / "Google/Chrome Dev/User Data",
+            local / "Google/Chrome SxS/User Data",
+            local / "Chromium/User Data",
+            local / "Microsoft/Edge/User Data",
+            local / "Microsoft/Edge Beta/User Data",
+            local / "Microsoft/Edge Dev/User Data",
+            local / "Microsoft/Edge SxS/User Data",
+            local / "BraveSoftware/Brave-Browser/User Data",
+            local / "BraveSoftware/Brave-Browser-Beta/User Data",
+            local / "BraveSoftware/Brave-Browser-Nightly/User Data",
+        ]
+    return [
+        home / ".config/google-chrome",
+        home / ".config/google-chrome-beta",
+        home / ".config/google-chrome-unstable",
+        home / ".config/chromium",
+        home / ".config/chromium-browser",
+        home / ".config/microsoft-edge",
+        home / ".config/microsoft-edge-beta",
+        home / ".config/microsoft-edge-dev",
+        home / ".config/BraveSoftware/Brave-Browser",
+        home / ".var/app/org.chromium.Chromium/config/chromium",
+        home / ".var/app/com.google.Chrome/config/google-chrome",
+        home / ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
+        home / ".var/app/com.microsoft.Edge/config/microsoft-edge",
+    ]
 
 
 def log(msg: str) -> None:
-    Path(LOG).open("a", encoding="utf-8").write(f"{msg}\n")
+    paths = ipc.runtime_paths(NAME)
+    try:
+        paths.ensure_root()
+        with paths.log.open("a", encoding="utf-8", errors="replace") as handle:
+            handle.write(f"{msg}\n")
+    except OSError:
+        print(msg, file=sys.stderr)
 
 
 async def _silent(coro) -> None:
@@ -71,6 +114,25 @@ async def _silent(coro) -> None:
         await coro
     except Exception:
         pass
+
+
+def _local_cdp_ws_url(port: int) -> str:
+    """Return a validated local browser WebSocket URL discovered over HTTP."""
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1) as response:
+        payload = json.loads(response.read())
+    if not isinstance(payload, dict):
+        raise ValueError("invalid CDP version response")
+    websocket_url = payload.get("webSocketDebuggerUrl")
+    if not isinstance(websocket_url, str):
+        raise ValueError("invalid webSocketDebuggerUrl")
+    parsed = urllib.parse.urlparse(websocket_url)
+    if (
+        parsed.scheme not in {"ws", "wss"}
+        or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        or parsed.port != port
+    ):
+        raise ValueError("invalid webSocketDebuggerUrl")
+    return websocket_url
 
 
 def get_ws_url() -> str:
@@ -90,38 +152,53 @@ def get_ws_url() -> str:
         raise RuntimeError(
             f"BU_CDP_URL={url} unreachable after 30s: {last_err} -- is the dedicated automation browser running?"
         )
-    for base in PROFILES:
+    profiles = profile_dirs()
+    profile_candidates = []
+    profile_errors = []
+    for base in profiles:
         try:
-            port, path = (base / "DevToolsActivePort").read_text().strip().split("\n", 1)
+            port, path = (
+                (base / "DevToolsActivePort").read_text(encoding="utf-8-sig", errors="replace").strip().split("\n", 1)
+            )
         except (FileNotFoundError, NotADirectoryError):
             continue
-        deadline = time.time() + 30
-        while True:
-            probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            probe.settimeout(1)
+        except ValueError:
+            profile_errors.append(f"{base}: invalid DevToolsActivePort")
+            continue
+        try:
+            port_number = int(port.strip())
+            if not 1 <= port_number <= 65535 or not path.strip():
+                raise ValueError
+        except ValueError:
+            profile_errors.append(f"{base}: invalid DevToolsActivePort")
+            continue
+        profile_candidates.append((base, port_number))
+
+    deadline = time.time() + 30
+    while profile_candidates:
+        for base, port in profile_candidates:
             try:
-                probe.connect(("127.0.0.1", int(port.strip())))
-                break
-            except OSError:
-                if time.time() >= deadline:
-                    raise RuntimeError(
-                        "The browser's remote-debugging page is open, but DevTools is not live yet on "
-                        f"127.0.0.1:{port.strip()} — if the browser opened a profile picker, choose your normal "
-                        "profile first, then tick the checkbox and click Allow if shown"
-                    )
-                time.sleep(1)
-            finally:
-                probe.close()
-        return f"ws://127.0.0.1:{port.strip()}{path.strip()}"
+                return _local_cdp_ws_url(port)
+            except (OSError, ValueError, json.JSONDecodeError) as error:
+                profile_errors.append(f"{base}: 127.0.0.1:{port} ({error})")
+        if time.time() >= deadline:
+            break
+        time.sleep(1)
     for probe_port in (9222, 9223):
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{probe_port}/json/version", timeout=1) as response:
-                return json.loads(response.read())["webSocketDebuggerUrl"]
-        except (OSError, KeyError, ValueError):
+            return _local_cdp_ws_url(probe_port)
+        except (OSError, ValueError, json.JSONDecodeError):
             continue
+    if profile_errors:
+        details = "; ".join(dict.fromkeys(profile_errors))
+        raise RuntimeError(
+            "The browser's remote-debugging page is open, but DevTools is not live yet for any detected profile: "
+            f"{details} — if the browser opened a profile picker, choose your normal profile first, then tick the "
+            "checkbox and click Allow if shown"
+        )
     raise RuntimeError(
         "DevToolsActivePort not found in "
-        f"{[str(path) for path in PROFILES]} — enable your browser's remote-debugging page "
+        f"{[str(path) for path in profiles]} — enable your browser's remote-debugging page "
         "(for example chrome://inspect/#remote-debugging or edge://inspect/#remote-debugging), "
         "or set BU_CDP_WS for a remote browser"
     )
@@ -134,14 +211,17 @@ def is_real_page(target: dict) -> bool:
 class Daemon:
     """Long-lived CDP client that serves simple JSON IPC requests."""
 
-    def __init__(self) -> None:
+    def __init__(self, name: str = NAME) -> None:
+        self.name = ipc.runtime_paths(name).name
+        self.instance_id = uuid.uuid4().hex
+        self.browser_kind = "cdp" if os.environ.get("BU_CDP_WS") or os.environ.get("BU_CDP_URL") else "local"
         self.cdp = None
         self.session = None
         self.target_id = None
         self.managed_tabs = {}
         self.events = deque(maxlen=BUF)
         self.dialog = None
-        self.stop = None
+        self.stop = asyncio.Event()
 
     async def _enable_session_domains(self) -> None:
         for domain in ("Page", "DOM", "Runtime", "Network"):
@@ -151,9 +231,9 @@ class Daemon:
                 log(f"enable {domain}: {error}")
 
     async def _attach_target(self, target_id: str) -> dict:
-        self.session = (
-            await self.cdp.send_raw("Target.attachToTarget", {"targetId": target_id, "flatten": True})
-        )["sessionId"]
+        self.session = (await self.cdp.send_raw("Target.attachToTarget", {"targetId": target_id, "flatten": True}))[
+            "sessionId"
+        ]
         self.target_id = target_id
         try:
             info = (await self.cdp.send_raw("Target.getTargetInfo", {"targetId": target_id}))["targetInfo"]
@@ -173,7 +253,6 @@ class Daemon:
         return await self._attach_target(pages[0]["targetId"])
 
     async def start(self) -> None:
-        self.stop = asyncio.Event()
         url = get_ws_url()
         log(f"connecting to {url}")
         self.cdp = CDPClient(url)
@@ -222,6 +301,15 @@ class Daemon:
 
     async def handle(self, req: dict) -> dict:
         meta = req.get("meta")
+        if meta == "ping":
+            return {
+                "pong": True,
+                "protocol_version": ipc.PROTOCOL_VERSION,
+                "name": self.name,
+                "pid": os.getpid(),
+                "instance_id": self.instance_id,
+                "browser_kind": self.browser_kind,
+            }
         if meta == "drain_events":
             output = list(self.events)
             self.events.clear()
@@ -322,27 +410,20 @@ class Daemon:
                     return {"result": await self.cdp.send_raw(method, params, session_id=self.session)}
             return {"error": msg}
 
-
-async def serve(daemon: Daemon) -> None:
-    async def handler(reader, writer):
+    async def close(self) -> None:
+        """Close the CDP client and its background tasks."""
+        if self.cdp is None:
+            return
         try:
-            line = await reader.readline()
-            if not line:
-                return
-            resp = await daemon.handle(json.loads(line))
-            writer.write((json.dumps(resp, default=str) + "\n").encode())
-            await writer.drain()
+            await self.cdp.stop()
         except Exception as error:
-            log(f"conn: {error}")
-            try:
-                writer.write((json.dumps({"error": str(error)}) + "\n").encode())
-                await writer.drain()
-            except Exception:
-                pass
+            log(f"CDP client stop failed: {error}")
         finally:
-            writer.close()
+            self.cdp = None
 
-    serve_task = asyncio.create_task(ipc.serve(NAME, handler))
+
+async def serve(daemon: Daemon, lock: ipc.DaemonLock) -> None:
+    serve_task = asyncio.create_task(ipc.serve(NAME, daemon.handle, lock))
     stop_task = asyncio.create_task(daemon.stop.wait())
     await asyncio.sleep(0.05)
     log(f"listening on {ipc.sock_addr(NAME)} (name={NAME})")
@@ -357,13 +438,24 @@ async def serve(daemon: Daemon) -> None:
                 await task
             except (asyncio.CancelledError, Exception):
                 pass
-        ipc.cleanup_endpoint(NAME)
 
 
-async def main() -> None:
+async def main(lock: ipc.DaemonLock) -> None:
     daemon = Daemon()
-    await daemon.start()
-    await serve(daemon)
+    loop = asyncio.get_running_loop()
+    for signal_number in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(signal_number, daemon.stop.set)
+        except (NotImplementedError, RuntimeError, ValueError):
+            try:
+                signal.signal(signal_number, lambda _signum, _frame: loop.call_soon_threadsafe(daemon.stop.set))
+            except (OSError, RuntimeError, ValueError):
+                pass
+    try:
+        await daemon.start()
+        await serve(daemon, lock)
+    finally:
+        await daemon.close()
 
 
 def already_running() -> bool:
@@ -371,25 +463,57 @@ def already_running() -> bool:
         sock = ipc.connect(NAME, timeout=1.0)
         sock.close()
         return True
-    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
+    except (
+        ipc.EndpointRecordError,
+        FileNotFoundError,
+        ConnectionRefusedError,
+        TimeoutError,
+        socket.timeout,
+        OSError,
+    ):
         return False
 
 
-if __name__ == "__main__":
-    if already_running():
-        print(f"daemon already running on {SOCK}", file=sys.stderr)
-        sys.exit(0)
-    Path(LOG).write_text("", encoding="utf-8")
-    Path(PID).write_text(str(os.getpid()), encoding="utf-8")
+def _configure_stdio() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
+def _remove_own_pid() -> None:
+    path = ipc.pid_path(NAME)
     try:
-        asyncio.run(main())
+        recorded_pid = int(path.read_text(encoding="utf-8", errors="replace").strip())
+    except (FileNotFoundError, ValueError):
+        return
+    if recorded_pid == os.getpid():
+        path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    _configure_stdio()
+    daemon_lock = ipc.DaemonLock(NAME)
+    owns_runtime = False
+    if not daemon_lock.acquire():
+        print(f"daemon startup already in progress for {NAME!r}", file=sys.stderr)
+        sys.exit(ipc.LOCK_BUSY_EXIT_CODE)
+    try:
+        if already_running():
+            print(f"daemon already running on {SOCK}", file=sys.stderr)
+            sys.exit(0)
+        log(f"--- starting browser daemon name={NAME} pid={os.getpid()} ---")
+        ipc.write_pid(NAME, os.getpid())
+        owns_runtime = True
+        asyncio.run(main(daemon_lock))
     except KeyboardInterrupt:
         pass
-    except Exception as error:
-        log(f"fatal: {error}")
+    except Exception:
+        traceback.print_exc()
+        log(f"fatal:\n{traceback.format_exc()}")
         sys.exit(1)
     finally:
-        try:
-            os.unlink(PID)
-        except FileNotFoundError:
-            pass
+        if owns_runtime:
+            _remove_own_pid()
+            ipc.cleanup_endpoint(NAME, daemon_lock)
+        daemon_lock.release()

--- a/flocks/browser/daemon.py
+++ b/flocks/browser/daemon.py
@@ -9,6 +9,7 @@ import socket
 import sys
 import time
 import traceback
+import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
@@ -116,15 +117,20 @@ async def _silent(coro) -> None:
         pass
 
 
-def _local_cdp_ws_url(port: int) -> str:
-    """Return a validated local browser WebSocket URL discovered over HTTP."""
-    with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1) as response:
-        payload = json.loads(response.read())
-    if not isinstance(payload, dict):
-        raise ValueError("invalid CDP version response")
-    websocket_url = payload.get("webSocketDebuggerUrl")
-    if not isinstance(websocket_url, str):
-        raise ValueError("invalid webSocketDebuggerUrl")
+def _local_cdp_ws_url(port: int, devtools_path: str | None = None) -> str:
+    """Return a validated local browser WebSocket URL from profile metadata."""
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1) as response:
+            payload = json.loads(response.read())
+        if not isinstance(payload, dict):
+            raise ValueError("invalid CDP version response")
+        websocket_url = payload.get("webSocketDebuggerUrl")
+        if not isinstance(websocket_url, str):
+            raise ValueError("invalid webSocketDebuggerUrl")
+    except urllib.error.HTTPError:
+        if not devtools_path or not devtools_path.startswith("/"):
+            raise
+        websocket_url = f"ws://127.0.0.1:{port}{devtools_path}"
     parsed = urllib.parse.urlparse(websocket_url)
     if (
         parsed.scheme not in {"ws", "wss"}
@@ -172,13 +178,13 @@ def get_ws_url() -> str:
         except ValueError:
             profile_errors.append(f"{base}: invalid DevToolsActivePort")
             continue
-        profile_candidates.append((base, port_number))
+        profile_candidates.append((base, port_number, path.strip()))
 
     deadline = time.time() + 30
     while profile_candidates:
-        for base, port in profile_candidates:
+        for base, port, devtools_path in profile_candidates:
             try:
-                return _local_cdp_ws_url(port)
+                return _local_cdp_ws_url(port, devtools_path)
             except (OSError, ValueError, json.JSONDecodeError) as error:
                 profile_errors.append(f"{base}: 127.0.0.1:{port} ({error})")
         if time.time() >= deadline:

--- a/flocks/browser/helpers.py
+++ b/flocks/browser/helpers.py
@@ -20,7 +20,6 @@ from .utils import load_env_file
 
 
 AGENT_WORKSPACE = Path(os.environ.get("BH_AGENT_WORKSPACE", DEFAULT_AGENT_WORKSPACE)).expanduser()
-NAME = os.environ.get("BU_NAME", "default")
 INTERNAL = INTERNAL_URL_PREFIXES
 # Legacy compatibility for external imports; cookie export no longer uses site-root guessing.
 _COMMON_SECOND_LEVEL_SUFFIXES = {"ac", "co", "com", "edu", "gov", "mil", "net", "org"}
@@ -48,20 +47,14 @@ def _load_env() -> None:
             continue
         load_env_file(path)
 
+
 _load_env()
+
+NAME = ipc.runtime_paths().name
 
 
 def _send(req: dict) -> dict:
-    sock = ipc.connect(NAME, timeout=5.0)
-    sock.sendall((json.dumps(req) + "\n").encode())
-    data = b""
-    while not data.endswith(b"\n"):
-        chunk = sock.recv(1 << 20)
-        if not chunk:
-            break
-        data += chunk
-    sock.close()
-    response = json.loads(data)
+    response = ipc.request(NAME, req, timeout=5.0)
     if "error" in response:
         raise RuntimeError(response["error"])
     return response
@@ -509,7 +502,7 @@ def click_at_xy(x: int | float, y: int | float, button: str = "left", clicks: in
             from PIL import Image, ImageDraw
 
             dpr = js("window.devicePixelRatio") or 1
-            path = capture_screenshot(str(ipc._TMP / f"debug_click_{_debug_click_counter}.png"))
+            path = capture_screenshot(str(ipc.debug_screenshot_path(_debug_click_counter, NAME)))
             image = Image.open(path)
             draw = ImageDraw.Draw(image)
             px, py = int(x * dpr), int(y * dpr)
@@ -572,7 +565,8 @@ def scroll(x: int | float, y: int | float, dy: int | float = -300, dx: int | flo
 
 def capture_screenshot(path: str | None = None, full: bool = False, max_dim: int | None = None) -> str:
     """Save a PNG of the current viewport."""
-    path = path or str(ipc._TMP / "shot.png")
+    path = path or str(ipc.screenshot_path(NAME))
+    Path(path).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     response = cdp("Page.captureScreenshot", format="png", captureBeyondViewport=full)
     Path(path).write_bytes(base64.b64decode(response["data"]))
     if max_dim:

--- a/flocks/browser/lifecycle.py
+++ b/flocks/browser/lifecycle.py
@@ -1,0 +1,101 @@
+"""Minimal, non-destructive browser daemon lifecycle operations."""
+
+from __future__ import annotations
+
+import socket
+import time
+
+from . import _ipc as ipc
+
+
+def _wait_until(predicate, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.2)
+    return predicate()
+
+
+def _cleanup_stale(name: str, lock_timeout: float = 0.0) -> None:
+    """Clean unreachable runtime artifacts only while holding the session lock."""
+    lock = ipc.DaemonLock(name)
+    deadline = time.monotonic() + lock_timeout
+    acquired = lock.acquire()
+    while not acquired and time.monotonic() < deadline:
+        time.sleep(0.1)
+        acquired = lock.acquire()
+    if not acquired:
+        raise RuntimeError(f"browser daemon {name!r} is locked but not responding; endpoint was preserved")
+    try:
+        if ipc.endpoint_reachable(name, timeout=0.2):
+            raise RuntimeError(f"browser daemon {name!r} became reachable while cleaning stale state")
+        ipc.cleanup_endpoint(name, lock)
+        ipc.pid_path(name).unlink(missing_ok=True)
+    finally:
+        lock.release()
+
+
+def _is_legacy_status(response: dict) -> bool:
+    if response.get("error") in {"not_attached", "cdp_disconnected"}:
+        return True
+    return "target_id" in response and "session_id" in response and "page" in response
+
+
+def _stop_legacy_default(timeout: float) -> None:
+    """Gracefully stop the single legacy endpoint used before named sessions."""
+    try:
+        status = ipc.request("default", {"meta": "connection_status"}, timeout=1.0)
+    except (ipc.EndpointRecordError, ipc.IPCProtocolError, OSError) as error:
+        raise RuntimeError(f"legacy browser daemon could not be confirmed; endpoint was preserved: {error}") from error
+    if not _is_legacy_status(status):
+        raise RuntimeError("legacy browser daemon could not be confirmed; endpoint was preserved")
+    try:
+        ipc.request("default", {"meta": "shutdown"}, timeout=3.0)
+    except (ipc.IPCProtocolError, TimeoutError, socket.timeout, OSError):
+        pass
+    if not _wait_until(lambda: not ipc.endpoint_reachable("default", timeout=0.2), timeout):
+        raise RuntimeError("legacy browser daemon 'default' refused graceful shutdown; endpoint was preserved")
+    _cleanup_stale("default", lock_timeout=min(timeout, 3.0))
+
+
+def stop_daemon(name: str | None = None, timeout: float = 15.0) -> None:
+    """Gracefully stop one daemon without reading or signalling an on-disk PID."""
+    effective_name = ipc.runtime_paths(name).name
+    try:
+        ipc.identify(effective_name, timeout=1.0)
+    except ipc.LegacyProtocolError:
+        if effective_name != "default":
+            raise RuntimeError(f"legacy named daemon {effective_name!r} is unsupported; endpoint was preserved")
+        _stop_legacy_default(timeout)
+        return
+    except ipc.EndpointRecordError:
+        _cleanup_stale(effective_name)
+        return
+    except ipc.IPCProtocolError as error:
+        raise RuntimeError(
+            f"browser daemon {effective_name!r} returned an invalid identity; endpoint was preserved: {error}"
+        ) from error
+    except (FileNotFoundError, ConnectionRefusedError, TimeoutError, socket.timeout, OSError):
+        _cleanup_stale(effective_name)
+        return
+
+    try:
+        ipc.request(effective_name, {"meta": "shutdown"}, timeout=3.0)
+    except (ipc.IPCProtocolError, TimeoutError, socket.timeout, OSError):
+        pass
+    if not _wait_until(lambda: not ipc.endpoint_reachable(effective_name, timeout=0.2), timeout):
+        raise RuntimeError(f"browser daemon {effective_name!r} refused graceful shutdown; endpoint was preserved")
+    _cleanup_stale(effective_name, lock_timeout=min(timeout, 3.0))
+
+
+def stop_all_daemons(timeout: float = 15.0) -> tuple[list[str], dict[str, str]]:
+    """Attempt every visible session and collect failures without stopping early."""
+    names = ipc.discover_names()
+    errors: dict[str, str] = {}
+    for name in names:
+        try:
+            stop_daemon(name, timeout=timeout)
+        except RuntimeError as error:
+            errors[name] = str(error)
+    return names, errors

--- a/flocks/browser/paths.py
+++ b/flocks/browser/paths.py
@@ -1,0 +1,94 @@
+"""Runtime paths for browser daemon sessions."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+_NAME_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
+
+
+def validate_name(name: str) -> str:
+    """Validate and return a browser session name."""
+    if not _NAME_RE.fullmatch(name or ""):
+        raise ValueError(f"invalid BU_NAME {name!r}: must match [A-Za-z0-9_-]{{1,64}}")
+    return name
+
+
+def resolve_name(name: str | None = None, env: Mapping[str, str] | None = None) -> str:
+    """Resolve the effective browser session name."""
+    effective_env = os.environ if env is None else env
+    if name is not None:
+        return validate_name(name)
+    return validate_name(effective_env.get("BU_NAME") or "default")
+
+
+def flocks_root(env: Mapping[str, str] | None = None) -> Path:
+    """Return the configured Flocks data root."""
+    effective_env = os.environ if env is None else env
+    return Path(effective_env.get("FLOCKS_ROOT", str(Path.home() / ".flocks"))).expanduser()
+
+
+def browser_dir(env: Mapping[str, str] | None = None) -> Path:
+    """Return the browser runtime directory without creating it."""
+    return flocks_root(env) / "browser"
+
+
+@dataclass(frozen=True)
+class BrowserRuntimePaths:
+    """All runtime artifacts owned by one browser daemon session."""
+
+    root: Path
+    name: str
+
+    @classmethod
+    def resolve(
+        cls,
+        name: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> BrowserRuntimePaths:
+        return cls(root=browser_dir(env), name=resolve_name(name, env))
+
+    @property
+    def stem(self) -> str:
+        return "bu" if self.name == "default" else f"bu-{self.name}"
+
+    @property
+    def socket(self) -> Path:
+        return self.root / f"{self.stem}.sock"
+
+    @property
+    def port(self) -> Path:
+        return self.root / f"{self.stem}.port"
+
+    @property
+    def pid(self) -> Path:
+        return self.root / f"{self.stem}.pid"
+
+    @property
+    def log(self) -> Path:
+        return self.root / f"{self.stem}.log"
+
+    @property
+    def lock(self) -> Path:
+        return self.root / f"{self.stem}.lock"
+
+    @property
+    def screenshot(self) -> Path:
+        return self.root / f"{self.stem}-shot.png"
+
+    def debug_screenshot(self, sequence: int) -> Path:
+        return self.root / f"{self.stem}-debug-click-{sequence}.png"
+
+    def ensure_root(self) -> Path:
+        """Create the private runtime directory when a write is required."""
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            self.root.chmod(0o700)
+        except OSError:
+            pass
+        return self.root

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -1,23 +1,6 @@
 from flocks.browser import admin
 
 
-class FakeSocket:
-    def __init__(self, response=b'{"target_id":"target-1","session_id":"session-1","page":null}\n'):
-        self.response = response
-        self.closed = False
-        self.sent = b""
-
-    def sendall(self, data):
-        self.sent += data
-
-    def recv(self, _size):
-        output, self.response = self.response, b""
-        return output
-
-    def close(self):
-        self.closed = True
-
-
 def test_local_chrome_mode_is_false_when_env_provides_remote_cdp() -> None:
     assert not admin._is_local_chrome_mode({"BU_CDP_WS": "ws://example.test/devtools/browser/1"})
 
@@ -74,21 +57,21 @@ def test_generic_remote_debugging_message_triggers_prompt() -> None:
     assert admin._needs_chrome_remote_debugging_prompt(msg)
 
 
-def test_daemon_endpoint_names_with_bu_tmp_dir_returns_local_name_when_sock_exists(tmp_path, monkeypatch) -> None:
+def test_daemon_endpoint_names_discovers_default_and_named_sessions(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.ipc, "BU_TMP_DIR", str(tmp_path))
-    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
-    monkeypatch.setattr(admin, "NAME", "session-xyz")
-    (tmp_path / "bu.sock").touch()
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
+    browser_dir = tmp_path / "browser"
+    browser_dir.mkdir()
+    (browser_dir / "bu.sock").touch()
+    (browser_dir / "bu-session-xyz.sock").touch()
+    (browser_dir / "bu-stale.pid").touch()
 
-    assert admin._daemon_endpoint_names() == ["session-xyz"]
+    assert admin._daemon_endpoint_names() == ["default", "session-xyz", "stale"]
 
 
-def test_daemon_endpoint_names_with_bu_tmp_dir_returns_empty_when_sock_missing(tmp_path, monkeypatch) -> None:
+def test_daemon_endpoint_names_returns_empty_when_runtime_dir_is_missing(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
-    monkeypatch.setattr(admin.ipc, "BU_TMP_DIR", str(tmp_path))
-    monkeypatch.setattr(admin.ipc, "_TMP", tmp_path)
-    monkeypatch.setattr(admin, "NAME", "session-xyz")
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
 
     assert admin._daemon_endpoint_names() == []
 
@@ -96,36 +79,43 @@ def test_daemon_endpoint_names_with_bu_tmp_dir_returns_empty_when_sock_missing(t
 def test_active_browser_connections_counts_only_healthy_daemons(monkeypatch) -> None:
     monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default", "stale", "remote"])
 
-    def fake_connect(name, timeout=1.0):
+    def fake_request(name, payload, timeout=1.0):
+        assert payload == {"meta": "connection_status"}
         if name == "stale":
             raise ConnectionRefusedError()
         if name == "remote":
-            return FakeSocket(b'{"error":"no close frame received or sent"}\n')
-        return FakeSocket()
+            return {"error": "no close frame received or sent"}
+        return {"target_id": "target-1", "session_id": "session-1", "page": None}
 
-    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+    monkeypatch.setattr(admin.ipc, "request", fake_request)
     assert admin.active_browser_connections() == 1
 
 
 def test_active_browser_connections_skips_daemons_reporting_cdp_disconnected(monkeypatch) -> None:
     monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default", "stale"])
 
-    def fake_connect(name, timeout=1.0):
+    def fake_request(name, payload, timeout=1.0):
+        assert payload == {"meta": "connection_status"}
         if name == "stale":
-            return FakeSocket(b'{"error":"cdp_disconnected"}\n')
-        return FakeSocket()
+            return {"error": "cdp_disconnected"}
+        return {"target_id": "target-1", "session_id": "session-1", "page": None}
 
-    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+    monkeypatch.setattr(admin.ipc, "request", fake_request)
     assert admin.active_browser_connections() == 1
 
 
 def test_browser_connections_returns_attached_page(monkeypatch) -> None:
     monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default"])
-    response = (
-        b'{"target_id":"target-1","session_id":"session-1",'
-        b'"page":{"targetId":"target-1","title":"Cat - Wikipedia","url":"https://en.wikipedia.org/wiki/Cat"}}\n'
-    )
-    monkeypatch.setattr(admin.ipc, "connect", lambda name, timeout=1.0: FakeSocket(response))
+    response = {
+        "target_id": "target-1",
+        "session_id": "session-1",
+        "page": {
+            "targetId": "target-1",
+            "title": "Cat - Wikipedia",
+            "url": "https://en.wikipedia.org/wiki/Cat",
+        },
+    }
+    monkeypatch.setattr(admin.ipc, "request", lambda name, payload, timeout=1.0: response)
 
     assert admin.browser_connections() == [
         {
@@ -136,32 +126,29 @@ def test_browser_connections_returns_attached_page(monkeypatch) -> None:
 
 
 def test_stop_all_daemons_restarts_every_visible_endpoint(monkeypatch) -> None:
-    monkeypatch.setattr(admin, "_daemon_endpoint_names", lambda: ["default", "remote_1"])
-    restarted = []
-    monkeypatch.setattr(admin, "restart_daemon", lambda name=None: restarted.append(name))
+    monkeypatch.setattr(admin.lifecycle, "stop_all_daemons", lambda: (["default", "remote_1"], {}))
 
     assert admin.stop_all_daemons() == ["default", "remote_1"]
-    assert restarted == ["default", "remote_1"]
 
 
 def test_daemon_protocol_probe_accepts_current_daemon(monkeypatch) -> None:
-    responses = [b'{"result":{"targetInfos":[]}}\n', b'{"tabs":[]}\n']
+    responses = [{"result": {"targetInfos": []}}, {"tabs": []}]
 
-    def fake_connect(name, timeout=3.0):
-        return FakeSocket(responses.pop(0))
+    def fake_request(name, payload, timeout=3.0):
+        return responses.pop(0)
 
-    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+    monkeypatch.setattr(admin.ipc, "request", fake_request)
 
     assert admin._daemon_has_current_protocol()
 
 
 def test_daemon_protocol_probe_rejects_old_managed_tab_protocol(monkeypatch) -> None:
-    responses = [b'{"result":{"targetInfos":[]}}\n', b'{"error":"\'method\'"}\n']
+    responses = [{"result": {"targetInfos": []}}, {"error": "'method'"}]
 
-    def fake_connect(name, timeout=3.0):
-        return FakeSocket(responses.pop(0))
+    def fake_request(name, payload, timeout=3.0):
+        return responses.pop(0)
 
-    monkeypatch.setattr(admin.ipc, "connect", fake_connect)
+    monkeypatch.setattr(admin.ipc, "request", fake_request)
 
     assert not admin._daemon_has_current_protocol()
 
@@ -345,7 +332,9 @@ def test_run_setup_allows_explicit_remote_cdp_without_local_browser(monkeypatch,
 def test_run_setup_restarts_existing_daemon_for_explicit_remote_cdp(monkeypatch, capsys) -> None:
     monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:19222")
     monkeypatch.setattr(admin, "daemon_alive", lambda: True)
-    monkeypatch.setattr(admin, "_chrome_running", lambda: (_ for _ in ()).throw(AssertionError("should not probe browser")))
+    monkeypatch.setattr(
+        admin, "_chrome_running", lambda: (_ for _ in ()).throw(AssertionError("should not probe browser"))
+    )
     restarted = []
     ensure_calls = []
     monkeypatch.setattr(admin, "restart_daemon", lambda name=None: restarted.append(name))
@@ -385,6 +374,7 @@ def test_run_doctor_accepts_explicit_remote_cdp_without_local_browser(monkeypatc
     monkeypatch.setattr(admin, "daemon_alive", lambda: True)
     monkeypatch.setattr(admin, "browser_connections", lambda: [])
     monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_probe_cdp_endpoint", lambda _name, _value: (True, "CDP handshake succeeded"))
 
     assert admin.run_doctor() == 0
 
@@ -392,6 +382,100 @@ def test_run_doctor_accepts_explicit_remote_cdp_without_local_browser(monkeypatc
     assert "[ok  ] browser target — configured via BU_CDP_URL" in out
     assert "[ok  ] daemon alive" in out
     assert "next action       attach; run `flocks browser -c 'print(page_info())'` before setup" in out
+
+
+def test_run_doctor_rejects_unreachable_explicit_remote_cdp(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("BU_CDP_URL", "http://127.0.0.1:19222")
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: False)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: True)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [])
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+    monkeypatch.setattr(
+        admin,
+        "_probe_cdp_endpoint",
+        lambda _name, _value: (False, "connection refused"),
+    )
+
+    assert admin.run_doctor() == 1
+
+    out = capsys.readouterr().out
+    assert "[FAIL] browser target — BU_CDP_URL is unreachable: connection refused" in out
+    assert "next action       fix BU_CDP_URL, then run `flocks browser --setup`" in out
+
+
+def test_probe_cdp_endpoint_rejects_invalid_websocket_url() -> None:
+    assert admin._probe_cdp_endpoint("BU_CDP_WS", "not-a-websocket") == (False, "invalid WebSocket URL")
+
+
+def test_probe_cdp_url_discovers_websocket_and_performs_cdp_handshake(monkeypatch) -> None:
+    sent_messages = []
+
+    class FakeHttpResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b'{"webSocketDebuggerUrl":"ws://browser.test/devtools/browser/1"}'
+
+    class FakeWebSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            pass
+
+        def send(self, message: str) -> None:
+            sent_messages.append(message)
+
+        def recv(self, timeout: float) -> str:
+            assert timeout == 3.0
+            return '{"id":1,"result":{"product":"Chrome/1"}}'
+
+    def fake_urlopen(url: str, timeout: float):
+        assert url == "http://browser.test/json/version"
+        assert timeout == 3.0
+        return FakeHttpResponse()
+
+    def fake_websocket_connect(url: str, **kwargs):
+        assert url == "ws://browser.test/devtools/browser/1"
+        assert kwargs == {"open_timeout": 3.0, "close_timeout": 3.0}
+        return FakeWebSocket()
+
+    monkeypatch.setattr(admin.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(admin, "websocket_connect", fake_websocket_connect)
+
+    assert admin._probe_cdp_endpoint("BU_CDP_URL", "http://browser.test") == (
+        True,
+        "CDP handshake succeeded",
+    )
+    assert sent_messages == ['{"id": 1, "method": "Browser.getVersion"}']
+
+
+def test_probe_cdp_websocket_rejects_non_cdp_response(monkeypatch) -> None:
+    class FakeWebSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            pass
+
+        def send(self, _message: str) -> None:
+            pass
+
+        def recv(self, timeout: float) -> str:
+            return "[]"
+
+    monkeypatch.setattr(admin, "websocket_connect", lambda *_args, **_kwargs: FakeWebSocket())
+
+    assert admin._probe_cdp_endpoint("BU_CDP_WS", "ws://browser.test/devtools/browser/1") == (
+        False,
+        "Browser.getVersion returned an invalid response",
+    )
 
 
 def test_chrome_running_on_windows_handles_non_utf8_tasklist_output(monkeypatch) -> None:

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -153,6 +153,42 @@ def test_daemon_protocol_probe_rejects_old_managed_tab_protocol(monkeypatch) -> 
     assert not admin._daemon_has_current_protocol()
 
 
+def test_ensure_daemon_retries_after_lock_holder_exits_without_endpoint(tmp_path, monkeypatch) -> None:
+    spawned = []
+
+    class FakeProcess:
+        def __init__(self, return_code):
+            self.return_code = return_code
+
+        def poll(self):
+            return self.return_code
+
+    class FakeLock:
+        def __init__(self, name):
+            assert name == "retry-session"
+
+        def acquire(self):
+            return True
+
+        def release(self):
+            pass
+
+    def fake_popen(*args, **kwargs):
+        spawned.append((args, kwargs))
+        return FakeProcess(admin.ipc.LOCK_BUSY_EXIT_CODE if len(spawned) == 1 else None)
+
+    daemon_states = iter([False, True])
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
+    monkeypatch.setattr(admin.ipc, "endpoint_reachable", lambda name: False)
+    monkeypatch.setattr(admin.ipc, "DaemonLock", FakeLock)
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: next(daemon_states))
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    admin.ensure_daemon(wait=1.0, name="retry-session")
+
+    assert len(spawned) == 2
+
+
 def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypatch, capsys) -> None:
     monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
     monkeypatch.setattr(admin, "_install_mode", lambda: "git")

--- a/tests/browser/test_daemon.py
+++ b/tests/browser/test_daemon.py
@@ -1,3 +1,4 @@
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -279,6 +280,26 @@ def test_get_ws_url_skips_open_non_cdp_port_and_uses_next_candidate(tmp_path, mo
     monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
 
     assert daemon.get_ws_url() == "ws://127.0.0.1:2222/devtools/browser/healthy"
+
+
+def test_get_ws_url_uses_devtools_active_port_path_when_version_endpoint_returns_404(tmp_path, monkeypatch) -> None:
+    profile = tmp_path / "chrome"
+    profile.mkdir()
+    (profile / "DevToolsActivePort").write_text(
+        "9222\n/devtools/browser/current\n",
+        encoding="utf-8",
+    )
+
+    def fake_urlopen(url: str, timeout: float):
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setattr(daemon, "profile_dirs", lambda: [profile])
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(daemon.time, "sleep", lambda _seconds: pytest.fail("404 response must not be retried"))
+
+    assert daemon.get_ws_url() == "ws://127.0.0.1:9222/devtools/browser/current"
 
 
 def test_load_env_uses_shared_loader_for_existing_files(tmp_path, monkeypatch) -> None:

--- a/tests/browser/test_daemon.py
+++ b/tests/browser/test_daemon.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 import pytest
 
+from flocks.browser import daemon
 from flocks.browser.daemon import Daemon
 
 
@@ -7,7 +10,9 @@ from flocks.browser.daemon import Daemon
 async def test_daemon_managed_tab_registry_round_trip() -> None:
     daemon = Daemon()
 
-    registered = await daemon.handle({"meta": "register_managed_tab", "target_id": "target-1", "url": "https://example.com"})
+    registered = await daemon.handle(
+        {"meta": "register_managed_tab", "target_id": "target-1", "url": "https://example.com"}
+    )
     assert registered["tab"]["targetId"] == "target-1"
     assert registered["tab"]["url"] == "https://example.com"
     assert registered["tab"]["current_url"] == "https://example.com"
@@ -69,7 +74,81 @@ async def test_daemon_retries_stale_session_on_same_target_before_fallback(monke
     assert response == {"result": {"frameId": "frame-1"}}
     assert daemon.session == "session-2"
     assert daemon.target_id == "target-1"
-from flocks.browser import daemon
+
+
+@pytest.mark.asyncio
+async def test_daemon_ping_reports_strict_session_identity() -> None:
+    browser_daemon = Daemon(name="test-session")
+
+    response = await browser_daemon.handle({"meta": "ping"})
+
+    assert response["pong"] is True
+    assert response["name"] == "test-session"
+    assert type(response["pid"]) is int
+    assert response["instance_id"]
+    assert response["protocol_version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_attach_first_page_does_not_register_automatic_blank_tab() -> None:
+    browser_daemon = Daemon()
+
+    class FakeCDP:
+        async def send_raw(self, method, params=None, session_id=None):
+            if method == "Target.getTargets":
+                return {"targetInfos": []}
+            if method == "Target.createTarget":
+                return {"targetId": "bootstrap-1"}
+            if method == "Target.attachToTarget":
+                return {"sessionId": "session-1"}
+            if method == "Target.getTargetInfo":
+                return {"targetInfo": {"targetId": "bootstrap-1", "url": "about:blank", "type": "page"}}
+            if method.endswith(".enable"):
+                return {}
+            raise AssertionError((method, params, session_id))
+
+    browser_daemon.cdp = FakeCDP()
+    await browser_daemon.attach_first_page()
+
+    assert browser_daemon.managed_tabs == {}
+
+
+@pytest.mark.asyncio
+async def test_daemon_close_stops_cdp_client() -> None:
+    browser_daemon = Daemon()
+
+    class FakeCDP:
+        def __init__(self) -> None:
+            self.stopped = False
+
+        async def stop(self) -> None:
+            self.stopped = True
+
+    fake_cdp = FakeCDP()
+    browser_daemon.cdp = fake_cdp
+
+    await browser_daemon.close()
+
+    assert fake_cdp.stopped is True
+    assert browser_daemon.cdp is None
+
+
+@pytest.mark.asyncio
+async def test_daemon_close_logs_stop_failure_without_hiding_startup_error(monkeypatch) -> None:
+    browser_daemon = Daemon()
+    messages = []
+
+    class FakeCDP:
+        async def stop(self) -> None:
+            raise RuntimeError("stop failed")
+
+    browser_daemon.cdp = FakeCDP()
+    monkeypatch.setattr(daemon, "log", messages.append)
+
+    await browser_daemon.close()
+
+    assert messages == ["CDP client stop failed: stop failed"]
+    assert browser_daemon.cdp is None
 
 
 def test_is_real_page_filters_edge_internal_pages() -> None:
@@ -78,6 +157,128 @@ def test_is_real_page_filters_edge_internal_pages() -> None:
 
 def test_is_real_page_accepts_normal_https_pages() -> None:
     assert daemon.is_real_page({"type": "page", "url": "https://example.com"})
+
+
+def test_profile_dirs_only_returns_paths_for_requested_os() -> None:
+    home = Path.home() / "profile-test-home"
+    local_app_data = home / "AppData/Local"
+
+    mac_profiles = daemon.profile_dirs(system="Darwin", home=home, environ={})
+    linux_profiles = daemon.profile_dirs(system="Linux", home=home, environ={})
+    windows_profiles = daemon.profile_dirs(
+        system="Windows",
+        home=home,
+        environ={"LOCALAPPDATA": str(local_app_data)},
+    )
+
+    assert all("Library" in path.parts and "Application Support" in path.parts for path in mac_profiles)
+    assert all(".config" in path.parts or ".var" in path.parts for path in linux_profiles)
+    assert all(path.is_relative_to(local_app_data) for path in windows_profiles)
+
+
+def test_get_ws_url_skips_unreachable_profile_and_uses_next_candidate(tmp_path, monkeypatch) -> None:
+    stale_profile = tmp_path / "stale"
+    healthy_profile = tmp_path / "healthy"
+    stale_profile.mkdir()
+    healthy_profile.mkdir()
+    (stale_profile / "DevToolsActivePort").write_text(
+        "1111\n/devtools/browser/stale\n",
+        encoding="utf-8",
+    )
+    (healthy_profile / "DevToolsActivePort").write_text(
+        "2222\n/devtools/browser/healthy\n",
+        encoding="utf-8",
+    )
+
+    class FakeHttpResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b'{"webSocketDebuggerUrl":"ws://127.0.0.1:2222/devtools/browser/healthy"}'
+
+    def fake_urlopen(url: str, timeout: float):
+        if ":1111/" in url:
+            raise OSError("connection refused")
+        assert url == "http://127.0.0.1:2222/json/version"
+        return FakeHttpResponse()
+
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setattr(daemon, "profile_dirs", lambda: [stale_profile, healthy_profile])
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
+
+    assert daemon.get_ws_url() == "ws://127.0.0.1:2222/devtools/browser/healthy"
+
+
+def test_get_ws_url_skips_malformed_profile_and_uses_next_candidate(tmp_path, monkeypatch) -> None:
+    malformed_profile = tmp_path / "malformed"
+    healthy_profile = tmp_path / "healthy"
+    malformed_profile.mkdir()
+    healthy_profile.mkdir()
+    (malformed_profile / "DevToolsActivePort").write_text("not-a-port-record\n", encoding="utf-8")
+    (healthy_profile / "DevToolsActivePort").write_text(
+        "2222\n/devtools/browser/healthy\n",
+        encoding="utf-8",
+    )
+
+    class FakeHttpResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b'{"webSocketDebuggerUrl":"ws://127.0.0.1:2222/devtools/browser/healthy"}'
+
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setattr(daemon, "profile_dirs", lambda: [malformed_profile, healthy_profile])
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", lambda _url, timeout: FakeHttpResponse())
+
+    assert daemon.get_ws_url() == "ws://127.0.0.1:2222/devtools/browser/healthy"
+
+
+def test_get_ws_url_skips_open_non_cdp_port_and_uses_next_candidate(tmp_path, monkeypatch) -> None:
+    stale_profile = tmp_path / "stale"
+    healthy_profile = tmp_path / "healthy"
+    stale_profile.mkdir()
+    healthy_profile.mkdir()
+    (stale_profile / "DevToolsActivePort").write_text(
+        "1111\n/devtools/browser/stale\n",
+        encoding="utf-8",
+    )
+    (healthy_profile / "DevToolsActivePort").write_text(
+        "2222\n/devtools/browser/healthy\n",
+        encoding="utf-8",
+    )
+
+    class FakeHttpResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b'{"webSocketDebuggerUrl":"ws://127.0.0.1:2222/devtools/browser/healthy"}'
+
+    def fake_urlopen(url: str, timeout: float):
+        if ":1111/" in url:
+            raise OSError("not a CDP endpoint")
+        assert url == "http://127.0.0.1:2222/json/version"
+        return FakeHttpResponse()
+
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setattr(daemon, "profile_dirs", lambda: [stale_profile, healthy_profile])
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
+
+    assert daemon.get_ws_url() == "ws://127.0.0.1:2222/devtools/browser/healthy"
 
 
 def test_load_env_uses_shared_loader_for_existing_files(tmp_path, monkeypatch) -> None:

--- a/tests/browser/test_helpers.py
+++ b/tests/browser/test_helpers.py
@@ -158,6 +158,31 @@ def test_new_tab_can_attach_in_background() -> None:
     assert {"meta": "register_managed_tab", "target_id": "target-1", "url": "https://example.com"} in sent
 
 
+def test_new_tab_does_not_reuse_bootstrap_tab() -> None:
+    calls = []
+
+    def fake_cdp(method, **kwargs):
+        calls.append((method, kwargs))
+        if method == "Target.createTarget":
+            return {"targetId": "new-1"}
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session-1"}
+        return {}
+
+    with (
+        patch(
+            "flocks.browser.helpers.managed_tabs",
+            return_value=[{"targetId": "bootstrap-1", "url": "about:blank", "bootstrap": True}],
+        ),
+        patch("flocks.browser.helpers.cdp", side_effect=fake_cdp),
+        patch("flocks.browser.helpers._send", return_value={"session_id": "session-1"}),
+    ):
+        assert helpers.new_tab("https://example.com", activate=True) == "new-1"
+
+    assert ("Target.createTarget", {"url": "about:blank"}) in calls
+    assert ("Target.activateTarget", {"targetId": "new-1"}) in calls
+
+
 def test_close_tab_rejects_unmanaged_tabs_by_default() -> None:
     with (
         patch("flocks.browser.helpers._send", return_value={"tabs": []}),

--- a/tests/browser/test_ipc.py
+++ b/tests/browser/test_ipc.py
@@ -1,4 +1,10 @@
+import asyncio
+import json
+import stat
+import tempfile
 from pathlib import Path
+
+import pytest
 
 from flocks.browser import _ipc as ipc
 
@@ -14,3 +20,151 @@ def test_browser_ipc_files_live_under_flocks_browser_dir() -> None:
         assert ipc.sock_addr("default") == "tcp:bu"
     else:
         assert ipc.sock_addr("default") == str(expected_dir / "bu.sock")
+
+
+def test_named_sessions_have_isolated_runtime_artifacts(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
+
+    default = ipc.runtime_paths("default")
+    alpha = ipc.runtime_paths("alpha")
+    beta = ipc.runtime_paths("beta_2")
+
+    assert default.socket == tmp_path / "browser/bu.sock"
+    assert default.lock == tmp_path / "browser/bu.lock"
+    assert alpha.socket == tmp_path / "browser/bu-alpha.sock"
+    assert alpha.pid != beta.pid
+    assert not (tmp_path / "browser").exists()
+
+
+@pytest.mark.parametrize("name", ["", "has space", "../escape", "x" * 65])
+def test_invalid_session_names_are_rejected(name) -> None:
+    with pytest.raises(ValueError, match="invalid BU_NAME"):
+        ipc.runtime_paths(name)
+
+
+def test_runtime_root_honors_flocks_root(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path / "custom"))
+
+    assert ipc.runtime_dir() == tmp_path / "custom/browser"
+
+
+def test_daemon_lock_serializes_same_name_but_not_different_names(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
+    first = ipc.DaemonLock("alpha")
+    same_name = ipc.DaemonLock("alpha")
+    other_name = ipc.DaemonLock("beta")
+    try:
+        assert first.acquire()
+        assert not same_name.acquire()
+        assert other_name.acquire()
+    finally:
+        first.release()
+        same_name.release()
+        other_name.release()
+
+
+def test_identify_rejects_boolean_pid(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ipc,
+        "request",
+        lambda name, payload, timeout=1.0: {
+            "pong": True,
+            "protocol_version": 1,
+            "name": "default",
+            "pid": True,
+            "instance_id": "instance-1",
+            "browser_kind": "local",
+        },
+    )
+
+    with pytest.raises(ipc.IPCProtocolError, match="invalid PID"):
+        ipc.identify("default")
+
+
+def test_identify_classifies_explicit_unknown_ping_as_legacy(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ipc,
+        "request",
+        lambda name, payload, timeout=1.0: {"error": "unknown meta request: ping"},
+    )
+
+    with pytest.raises(ipc.LegacyProtocolError, match="predates"):
+        ipc.identify("default")
+
+
+def test_read_port_record_supports_legacy_and_authenticated_formats(tmp_path) -> None:
+    path = tmp_path / "bu.port"
+    path.write_text("9222", encoding="utf-8")
+    assert ipc._read_port_record(path) == (9222, None)
+
+    path.write_text(json.dumps({"port": 9333, "token": "secret"}), encoding="utf-8")
+    assert ipc._read_port_record(path) == (9333, "secret")
+
+
+def test_read_port_record_rejects_malformed_record(tmp_path) -> None:
+    path = tmp_path / "bu.port"
+    path.write_text('{"port":"9222","token":"secret"}', encoding="utf-8")
+
+    with pytest.raises(ipc.EndpointRecordError, match="invalid browser daemon port record"):
+        ipc._read_port_record(path)
+
+
+def test_request_injects_windows_endpoint_token(monkeypatch) -> None:
+    class FakeSocket:
+        def __init__(self) -> None:
+            self.sent = b""
+            self.response = b'{"ok":true}\n'
+            self.closed = False
+
+        def sendall(self, data) -> None:
+            self.sent += data
+
+        def recv(self, _size) -> bytes:
+            response, self.response = self.response, b""
+            return response
+
+        def close(self) -> None:
+            self.closed = True
+
+    sock = FakeSocket()
+    monkeypatch.setattr(ipc, "_connect_with_token", lambda name, timeout: (sock, "secret"))
+
+    assert ipc.request("default", {"meta": "ping"}) == {"ok": True}
+    assert json.loads(sock.sent) == {"meta": "ping", "_ipc_token": "secret"}
+    assert sock.closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(ipc.IS_WINDOWS, reason="POSIX socket permissions")
+async def test_posix_server_uses_private_socket_and_cleans_it_up(monkeypatch) -> None:
+    with tempfile.TemporaryDirectory(prefix="flocks-ipc-", dir="/tmp") as root:
+        monkeypatch.setenv("FLOCKS_ROOT", root)
+        lock = ipc.DaemonLock("test")
+        assert lock.acquire()
+
+        async def handler(request):
+            return {"echo": request["value"]}
+
+        task = asyncio.create_task(ipc.serve("test", handler, lock))
+        socket_path = ipc.runtime_paths("test").socket
+        try:
+            for _ in range(100):
+                if socket_path.exists() or task.done():
+                    break
+                await asyncio.sleep(0.01)
+            if task.done():
+                try:
+                    await task
+                except PermissionError:
+                    pytest.skip("sandbox does not permit Unix socket binding")
+            assert socket_path.exists()
+            assert stat.S_IMODE(socket_path.stat().st_mode) == 0o600
+            assert await asyncio.to_thread(ipc.request, "test", {"value": "ok"}) == {"echo": "ok"}
+        finally:
+            if not task.done():
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            lock.release()
+
+        assert not socket_path.exists()

--- a/tests/browser/test_lifecycle.py
+++ b/tests/browser/test_lifecycle.py
@@ -1,0 +1,193 @@
+import pytest
+
+from flocks.browser import _ipc as ipc
+from flocks.browser import lifecycle
+
+
+def _identity(pid: int = 1234) -> dict:
+    return {
+        "pong": True,
+        "name": "default",
+        "pid": pid,
+        "instance_id": "instance-1",
+        "browser_kind": "local",
+        "protocol_version": 1,
+    }
+
+
+def test_stale_pid_file_is_never_used_as_process_identity(monkeypatch) -> None:
+    cleaned = []
+    monkeypatch.setattr(ipc, "identify", lambda name, timeout=1.0: (_ for _ in ()).throw(FileNotFoundError()))
+    monkeypatch.setattr(lifecycle, "_cleanup_stale", lambda name, lock_timeout=0.0: cleaned.append(name))
+
+    lifecycle.stop_daemon("default")
+
+    assert cleaned == ["default"]
+
+
+def test_current_daemon_refusal_preserves_endpoint_without_signalling(monkeypatch) -> None:
+    monkeypatch.setattr(ipc, "identify", lambda name, timeout=1.0: _identity())
+    monkeypatch.setattr(ipc, "request", lambda name, payload, timeout=3.0: {"ok": True})
+    monkeypatch.setattr(lifecycle, "_wait_until", lambda predicate, timeout: False)
+    monkeypatch.setattr(
+        lifecycle,
+        "_cleanup_stale",
+        lambda name, lock_timeout=0.0: pytest.fail("live endpoint must be preserved"),
+    )
+    with pytest.raises(RuntimeError, match="refused graceful shutdown"):
+        lifecycle.stop_daemon("default", timeout=0)
+
+
+def test_current_daemon_stops_gracefully_and_cleans_after_lock_release(monkeypatch) -> None:
+    requests = []
+    cleaned = []
+    monkeypatch.setattr(ipc, "identify", lambda name, timeout=1.0: _identity())
+    monkeypatch.setattr(
+        ipc,
+        "request",
+        lambda name, payload, timeout=3.0: requests.append(payload) or {"ok": True},
+    )
+    monkeypatch.setattr(lifecycle, "_wait_until", lambda predicate, timeout: True)
+    monkeypatch.setattr(
+        lifecycle,
+        "_cleanup_stale",
+        lambda name, lock_timeout=0.0: cleaned.append((name, lock_timeout)),
+    )
+
+    lifecycle.stop_daemon("default", timeout=10.0)
+
+    assert requests == [{"meta": "shutdown"}]
+    assert cleaned == [("default", 3.0)]
+
+
+def test_malformed_endpoint_record_is_cleaned_as_stale_state(monkeypatch) -> None:
+    cleaned = []
+    monkeypatch.setattr(
+        ipc,
+        "identify",
+        lambda name, timeout=1.0: (_ for _ in ()).throw(ipc.EndpointRecordError("invalid port record")),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_cleanup_stale",
+        lambda name, lock_timeout=0.0: cleaned.append(name) or True,
+    )
+
+    lifecycle.stop_daemon("default")
+
+    assert cleaned == ["default"]
+
+
+def test_legacy_daemon_only_receives_graceful_shutdown(monkeypatch) -> None:
+    requests = []
+    monkeypatch.setattr(
+        ipc,
+        "identify",
+        lambda name, timeout=1.0: (_ for _ in ()).throw(ipc.LegacyProtocolError("no ping")),
+    )
+
+    def fake_request(name, payload, timeout=1.0):
+        requests.append(payload)
+        if payload == {"meta": "connection_status"}:
+            return {"target_id": "target-1", "session_id": "session-1", "page": None}
+        return {"ok": True}
+
+    monkeypatch.setattr(ipc, "request", fake_request)
+    monkeypatch.setattr(lifecycle, "_wait_until", lambda predicate, timeout: True)
+    monkeypatch.setattr(lifecycle, "_cleanup_stale", lambda name, lock_timeout=0.0: None)
+
+    lifecycle.stop_daemon("default", timeout=0)
+
+    assert requests == [{"meta": "connection_status"}, {"meta": "shutdown"}]
+
+
+def test_legacy_daemon_refusal_preserves_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ipc,
+        "identify",
+        lambda name, timeout=1.0: (_ for _ in ()).throw(ipc.LegacyProtocolError("no ping")),
+    )
+    monkeypatch.setattr(
+        ipc,
+        "request",
+        lambda name, payload, timeout=1.0: {"target_id": "target-1", "session_id": "session-1", "page": None},
+    )
+    monkeypatch.setattr(lifecycle, "_wait_until", lambda predicate, timeout: False)
+    monkeypatch.setattr(
+        lifecycle,
+        "_cleanup_stale",
+        lambda name, lock_timeout=0.0: pytest.fail("live legacy endpoint must be preserved"),
+    )
+
+    with pytest.raises(RuntimeError, match="refused graceful shutdown"):
+        lifecycle.stop_daemon("default", timeout=0)
+
+
+def test_legacy_named_daemon_is_preserved(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ipc,
+        "identify",
+        lambda name, timeout=1.0: (_ for _ in ()).throw(ipc.LegacyProtocolError("no ping")),
+    )
+    monkeypatch.setattr(
+        ipc,
+        "request",
+        lambda name, payload, timeout=1.0: pytest.fail("legacy named daemon must not be stopped"),
+    )
+
+    with pytest.raises(RuntimeError, match="legacy named daemon.*unsupported"):
+        lifecycle.stop_daemon("named")
+
+
+def test_locked_unresponsive_session_is_not_cleaned(monkeypatch) -> None:
+    class FakeLock:
+        def __init__(self, name):
+            self.name = name
+
+        def acquire(self):
+            return False
+
+    monkeypatch.setattr(ipc, "DaemonLock", FakeLock)
+    monkeypatch.setattr(
+        ipc,
+        "cleanup_endpoint",
+        lambda name, lock: pytest.fail("locked endpoint must not be removed"),
+    )
+
+    with pytest.raises(RuntimeError, match="locked but not responding"):
+        lifecycle._cleanup_stale("default")
+
+
+def test_invalid_current_identity_is_not_treated_as_legacy(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ipc,
+        "identify",
+        lambda name, timeout=1.0: (_ for _ in ()).throw(ipc.IPCProtocolError("session mismatch")),
+    )
+    monkeypatch.setattr(
+        ipc,
+        "request",
+        lambda name, payload, timeout=1.0: pytest.fail("invalid identity must not receive legacy shutdown"),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid identity"):
+        lifecycle.stop_daemon("default")
+
+
+def test_stop_all_continues_after_one_session_fails(monkeypatch) -> None:
+    stopped = []
+    monkeypatch.setattr(ipc, "discover_names", lambda: ["default", "broken", "other"])
+
+    def fake_stop(name, timeout=15.0):
+        stopped.append(name)
+        if name == "broken":
+            raise RuntimeError("locked")
+        return None
+
+    monkeypatch.setattr(lifecycle, "stop_daemon", fake_stop)
+
+    names, errors = lifecycle.stop_all_daemons()
+
+    assert names == ["default", "broken", "other"]
+    assert stopped == names
+    assert errors == {"broken": "locked"}

--- a/tests/browser/test_skill_docs.py
+++ b/tests/browser/test_skill_docs.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SKILL_ROOT = _ROOT / ".flocks/plugins/skills/browser-use"
+
+
+def test_browser_skill_documents_isolated_runtime_artifacts_and_safe_cleanup() -> None:
+    skill = (_SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    headless = (_SKILL_ROOT / "references/cdp-headless.md").read_text(encoding="utf-8")
+
+    assert "命名 session 使用 `bu-<BU_NAME>.*`" in skill
+    assert "`flocks browser --reload`" in skill
+    assert 'rm -f "$HOME/.flocks/browser/bu.sock"' not in headless


### PR DESCRIPTION
## Summary

Harden the `flocks browser` daemon runtime so named sessions are isolated, same-session startup is serialized, IPC endpoints can be authenticated and identified, and cleanup never relies on signalling an unverified PID.

The PR also improves CDP discovery and diagnostics, and adds regression coverage for concurrent startup, graceful shutdown, stale artifacts, legacy daemon compatibility, and browser profile probing.

## Key Changes

### Runtime paths and session isolation

- Add `BrowserRuntimePaths` as the single resolver for browser runtime artifacts.
- Honor the existing `FLOCKS_ROOT` environment variable; the default remains `~/.flocks/browser/`.
- Keep the default session on `bu.*` and isolate named `BU_NAME` sessions on `bu-<name>.*`.
- Validate session names before using them in socket, port, PID, log, lock, or screenshot paths.
- Store screenshots and debug-click screenshots per session.

### IPC and daemon identity

- Add a cross-platform advisory lock that is held for the daemon's full lifetime.
- Use private Unix sockets on POSIX and authenticated loopback endpoint records on Windows.
- Write PID and Windows endpoint records atomically with private file permissions.
- Add a versioned `ping` response containing the session name, PID, instance ID, protocol version, and browser kind.
- Strictly validate daemon identity before lifecycle operations.
- Bound IPC response size and normalize malformed or empty responses into protocol errors.

### Lifecycle and concurrent startup

- Replace PID-file signalling with confirmed graceful shutdown through the daemon IPC protocol.
- Remove stale endpoint and PID artifacts only while holding the matching session lock.
- Preserve invalid, mismatched, or locked endpoints instead of deleting or signalling them.
- Support graceful shutdown of the confirmed legacy default daemon while preserving unsupported legacy named endpoints.
- Discover and stop default and named sessions independently, collecting per-session failures.
- Retry daemon startup within the original deadline when a spawned child exits with the lock-busy code and the previous lock holder releases the session without publishing an endpoint.

### CDP connection and diagnostics

- Discover browser profile directories for the active operating system only.
- Validate `DevToolsActivePort` candidates through `/json/version` when available; if Chrome returns an HTTP error, fall back to the WebSocket path from the profile record so the daemon's real CDP handshake can proceed without a 30-second setup stall.
- Make `flocks browser --doctor` perform a real CDP `Browser.getVersion` handshake for explicit `BU_CDP_URL` and `BU_CDP_WS` targets.
- Improve UTF-8 handling for daemon logs, runtime records, process output, and diagnostics.
- Stop the CDP client during daemon shutdown without hiding the original startup failure.
- Keep automatically-created bootstrap `about:blank` targets out of the managed-tab registry, and ensure `new_tab()` creates a distinct managed tab.

### Documentation

- Document `FLOCKS_ROOT`, named-session artifact names, persistent lock files, and safe `--reload` cleanup.
- Replace guidance that manually deletes socket files with the lifecycle-aware reload flow.

## Impact Scope

- **User-visible behavior:** Concurrent commands for the same `BU_NAME` now coordinate through the session lock. `--reload`, setup, service shutdown, diagnostics, logs, and runtime artifact names use the hardened lifecycle behavior. Named sessions no longer share the default daemon artifacts.
- **Compatibility / migration:** No public Python API, CLI flag, or required migration is introduced. The default session keeps the existing `bu.*` filenames. Legacy Windows integer port files remain readable, and a confirmed legacy default daemon can still be stopped gracefully.
- **Configuration / environment:** No new required configuration. Existing `BU_NAME`, `FLOCKS_ROOT`, `BU_CDP_URL`, and `BU_CDP_WS` settings are honored more consistently.
- **Dependencies:** No new third-party dependency is added.
- **Performance / resources:** One small lock file is retained per session. Startup and shutdown add bounded identity/lock checks; `--doctor` performs an explicit CDP handshake when a remote endpoint is configured.
- **Security / permissions:** Windows endpoint records carry a random IPC token; POSIX sockets and runtime records use private permissions. Lifecycle code no longer sends signals based on an unverified on-disk PID.

## Business Logic to Review

- `flocks/browser/_ipc.py`: lock ownership, atomic endpoint publication, Windows token injection, strict ping validation, and the invariant that endpoint cleanup requires the matching acquired lock.
- `flocks/browser/lifecycle.py`: graceful shutdown ordering, preservation of invalid or locked endpoints, legacy-default confirmation, and per-session failure collection.
- `flocks/browser/admin.py::ensure_daemon`: lock-busy retry behavior. After exit code 75, the caller waits for the session lock, releases its probe lock, and respawns within the original deadline; another contender may win the race, in which case the loop continues waiting for the published endpoint.
- `flocks/browser/daemon.py`: the daemon acquires the session lock before publishing PID/endpoint state, holds it through CDP cleanup, and removes only its own PID record.
- CDP discovery: stale, malformed, open-but-non-CDP, and OS-inappropriate profile candidates must not be selected.
- Compatibility boundary: only the legacy default endpoint is eligible for confirmed graceful shutdown; named legacy or identity-mismatched endpoints are intentionally preserved.

## Why This Approach

An on-disk PID is not sufficient process identity because it may be stale or reused. Combining a lifetime session lock with a protocol-level identity makes startup serialization and cleanup deterministic without terminating an unrelated process.

The design keeps existing environment-based session selection and default runtime filenames, while adding isolation and authentication only where required. Legacy support is deliberately narrow so backward compatibility does not weaken the new cleanup invariants.

## Test Plan

- [x] `uv run pytest -q tests/browser` (`106 passed`)
- [x] `uv run pytest -q tests/cli/test_service_manager.py::test_stop_all_uses_supervisor_control_api tests/cli/test_service_manager.py::test_stop_all_reports_when_supervisor_is_down tests/cli/test_service_manager.py::test_stop_all_uses_legacy_runtime_ports_for_orphan_cleanup`
- [x] `uv run ruff check flocks/browser tests/browser`
- [x] `uv run ruff format --check` for the changed Python files, excluding the pre-existing unformatted `tests/browser/test_helpers.py`
- [x] `git diff --check`
- [x] POSIX Unix-socket integration test rerun outside the restricted sandbox

Regression coverage includes named runtime paths, malformed endpoint records, authenticated Windows requests, private POSIX sockets, same-session lock contention, lock-busy startup takeover, strict identity validation, graceful shutdown refusal, legacy compatibility, stale artifact cleanup, CDP client shutdown, OS-specific profiles, `DevToolsActivePort` fallback after metadata HTTP 404, and real CDP probing.

## Compatibility, Migration & Rollback

- No migration is required; the default session continues to use the existing runtime filenames.
- Existing named sessions selected through `BU_NAME` receive isolated artifacts automatically.
- No new secrets, services, feature flags, or deployment steps are required.
- Rolling back the PR restores the previous shared/default runtime behavior; any retained `.lock` files are harmless advisory-lock artifacts and should not be deleted manually.

## Out of Scope

- Changing how inspect pages are opened, including the Windows system-URI / Windows Store behavior.
- Adding a CLI `--name` option; `BU_NAME` remains the session selector.
- Changing AX Tree, JavaScript evaluation, keyboard input, managed-tab policy beyond bootstrap-tab handling, or CI configuration.
