### PR TITLE
fix(session): make TUI sessions manageable in WebUI

### DIFF
--- a/flocks/server/auth.py
+++ b/flocks/server/auth.py
@@ -18,6 +18,7 @@ from flocks.security import get_secret_manager
 
 SESSION_COOKIE_NAME = "flocks_session"
 API_TOKEN_SECRET_ID = "server_api_token"
+API_TOKEN_SERVICE_USER_ID = "api-token-service"
 
 # Paths that never require auth. Everything else is protected by default.
 PUBLIC_PATHS = frozenset({
@@ -228,8 +229,8 @@ def _is_valid_api_token(token: Optional[str]) -> bool:
 def _build_api_token_user() -> AuthUser:
     """Synthetic service identity for API token clients."""
     return AuthUser(
-        id="api-token-service",
-        username="api-token-service",
+        id=API_TOKEN_SERVICE_USER_ID,
+        username=API_TOKEN_SERVICE_USER_ID,
         role="admin",
         status="active",
         must_reset_password=False,

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -28,7 +28,7 @@ from flocks.session.policy import SessionPolicy
 from flocks.utils.log import Log
 from flocks.utils.json_repair import parse_json_robust, repair_truncated_json
 from flocks.utils.monitor import get_monitor
-from flocks.server.auth import require_user
+from flocks.server.auth import API_TOKEN_SERVICE_USER_ID, require_user
 
 router = APIRouter()
 log = Log.create(service="session-routes")
@@ -584,6 +584,8 @@ async def create_session(http_request: Request, request: Optional[SessionCreateR
             )
             for p in request.permission
         ]
+
+    is_api_token_client = current_user.id == API_TOKEN_SERVICE_USER_ID
     
     session = await Session.create(
         project_id=project_id,
@@ -591,7 +593,8 @@ async def create_session(http_request: Request, request: Optional[SessionCreateR
         title=request.title,
         parent_id=request.parentID,
         permission=permission,
-        owner_user_id=current_user.id,
+        owner_user_id=None if is_api_token_client else current_user.id,
+        owner_username=None if is_api_token_client else current_user.username,
         **({"category": request.category} if request.category else {}),
     )
 
@@ -606,7 +609,7 @@ async def create_session(http_request: Request, request: Optional[SessionCreateR
                 "user_name": current_user.username,
                 "username": current_user.username,
                 "session_id": session.id,
-                "owner_user_id": current_user.id,
+                "owner_user_id": session.owner_user_id,
                 "project_id": session.project_id,
             },
         )

--- a/tests/server/routes/test_session_routes.py
+++ b/tests/server/routes/test_session_routes.py
@@ -66,6 +66,80 @@ class TestSessionCRUD:
         assert resp.json()["category"] == "workflow"
 
     @pytest.mark.asyncio
+    async def test_create_session_with_api_token_is_ownerless(self, client: AsyncClient):
+        """Sessions created by API-token clients remain manageable by WebUI admins."""
+        resp = await client.post("/api/session", json={"title": "TUI Session"})
+
+        assert resp.status_code == status.HTTP_200_OK
+        session = await Session.get_by_id(resp.json()["id"])
+        assert session is not None
+        assert session.owner_user_id is None
+        assert session.owner_username is None
+
+    @pytest.mark.asyncio
+    async def test_create_session_with_local_user_keeps_owner(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Browser-authenticated sessions remain private to their local user."""
+        from flocks.server.routes import session as session_routes
+
+        user = AuthUser(id="usr_admin", username="admin", role="admin", status="active")
+        monkeypatch.setattr(session_routes, "require_user", lambda _request: user)
+
+        resp = await client.post("/api/session", json={"title": "WebUI Session"})
+
+        assert resp.status_code == status.HTTP_200_OK
+        session = await Session.get_by_id(resp.json()["id"])
+        assert session is not None
+        assert session.owner_user_id == user.id
+        assert session.owner_username == user.username
+
+    @pytest.mark.asyncio
+    async def test_webui_admin_can_manage_api_token_session(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A WebUI admin can list, continue, rename, and delete a TUI session."""
+        from flocks.server.routes import session as session_routes
+
+        create_resp = await client.post("/api/session", json={"title": "TUI Session"})
+        assert create_resp.status_code == status.HTTP_200_OK
+        session_id = create_resp.json()["id"]
+
+        admin = AuthUser(id="usr_admin", username="admin", role="admin", status="active")
+        monkeypatch.setattr(session_routes, "require_user", lambda _request: admin)
+
+        list_resp = await client.get(
+            "/api/session",
+            params={"view": "list", "manager": "true", "roots": "true"},
+        )
+        assert list_resp.status_code == status.HTTP_200_OK
+        assert session_id in {session["id"] for session in list_resp.json()}
+
+        message_resp = await client.post(
+            f"/api/session/{session_id}/message",
+            json={
+                "parts": [{"type": "text", "text": "Continue from WebUI"}],
+                "noReply": True,
+            },
+        )
+        assert message_resp.status_code == status.HTTP_200_OK
+
+        rename_resp = await client.patch(
+            f"/api/session/{session_id}",
+            json={"title": "Renamed in WebUI"},
+        )
+        assert rename_resp.status_code == status.HTTP_200_OK
+        assert rename_resp.json()["title"] == "Renamed in WebUI"
+
+        delete_resp = await client.delete(f"/api/session/{session_id}")
+        assert delete_resp.status_code == status.HTTP_200_OK
+        assert delete_resp.json() is True
+
+    @pytest.mark.asyncio
     async def test_get_session_includes_persisted_goal(self, client: AsyncClient):
         """GET /api/session/{id} hydrates persisted goal state for the WebUI."""
         from flocks.session.goal import GoalManager


### PR DESCRIPTION
## Summary
- store sessions created by API-token clients as ownerless
- preserve ownership for browser-authenticated local users
- allow WebUI admins to list, continue, rename, and delete TUI sessions through the existing ownerless-session policy
- record the persisted owner in session creation audit events

## Testing
- uv run pytest -q tests/server/routes/test_session_routes.py -k 'create_session_with_api_token_is_ownerless or create_session_with_local_user_keeps_owner or webui_admin_can_manage_api_token_session' tests/session/test_session_policy.py --disable-warnings --maxfail=1
- uv run pytest -q tests/session/test_session_policy.py tests/server/test_auth_compat.py --disable-warnings --maxfail=1
- uv run ruff check flocks/server/auth.py flocks/server/routes/session.py tests/server/routes/test_session_routes.py tests/session/test_session_policy.py
- git diff --check