### PR TITLE
fix: expose extended messaging channels to Rex

### DIFF
--- a/flocks/agent/agents/rex/prompt_builder.py
+++ b/flocks/agent/agents/rex/prompt_builder.py
@@ -432,5 +432,5 @@ Security sub-agents still have dedicated toolsets and should be preferred for no
 def _build_im_send_pointer_section() -> str:
     return """### IM Messaging
 
-When the user wants to send a message to an IM platform, call `im_send_message`.
-When creating a scheduled task that sends to an IM platform later, resolve the target `session_id` with `im_send_message(resolve_only=true)` before calling `schedule_task_create`."""
+When the user wants to send a message to a connected messaging channel (including IM platforms and email), call `im_send_message`.
+When creating a scheduled task that sends to a connected messaging channel later, resolve the target `session_id` with `im_send_message(resolve_only=true)` before calling `schedule_task_create`."""

--- a/flocks/tool/channel/channel_message.py
+++ b/flocks/tool/channel/channel_message.py
@@ -1,8 +1,9 @@
 """
-channel_message tool — sends a message to the IM channel bound to a given session.
+channel_message tool — sends a message to the messaging channel bound to a given session.
 
 Looks up the SessionBinding for the given session_id to automatically resolve
-the target channel (WeCom / Feishu / DingTalk) and chat_id, so the caller
+the target channel (WeCom / Weixin / Feishu / DingTalk / Telegram / WhatsApp / Email)
+and chat_id, so the caller
 does not need to specify them manually.
 
 The optional channel_type parameter selects a specific channel when a session
@@ -25,6 +26,9 @@ _CHANNEL_ALIASES: dict[str, list[str]] = {
     "weixin": ["weixin", "微信", "wechat", "wx"],
     "feishu": ["feishu", "飞书", "lark"],
     "dingtalk": ["dingtalk", "钉钉", "dingding", "dingtalk-connector"],
+    "telegram": ["telegram", "tg", "tele"],
+    "whatsapp": ["whatsapp", "wa"],
+    "email": ["email", "mail", "邮件", "imap", "smtp"],
 }
 
 
@@ -130,8 +134,9 @@ async def _http_session_send(
 @ToolRegistry.register_function(
     name="channel_message",
     description=(
-        "Send a message to the IM channel bound to a session. "
-        "Channel types: WeCom/企业微信=wecom, Weixin/微信=weixin, Feishu=feishu, DingTalk=dingtalk. "
+        "Send a message to the messaging channel bound to a session. "
+        "Channel types: WeCom/企业微信=wecom, Weixin/微信=weixin, Feishu=feishu, DingTalk=dingtalk, "
+        "Telegram=telegram, WhatsApp=whatsapp, Email/邮件=email. "
         "Resolves the target channel and chat automatically from session_id. "
         "Use channel_type to target a specific channel when the session has multiple bindings."
     ),
@@ -153,9 +158,24 @@ async def _http_session_send(
             name="channel_type",
             type=ParameterType.STRING,
             required=False,
-            enum=["wecom", "weixin", "feishu", "dingtalk", "企微", "企业微信", "微信", "飞书", "钉钉"],
+            enum=[
+                "wecom",
+                "weixin",
+                "feishu",
+                "dingtalk",
+                "telegram",
+                "whatsapp",
+                "email",
+                "企微",
+                "企业微信",
+                "微信",
+                "飞书",
+                "钉钉",
+                "邮件",
+            ],
             description=(
-                "Target channel: wecom=企业微信, weixin=微信, feishu=飞书, or dingtalk=钉钉. "
+                "Target channel: wecom=企业微信, weixin=微信, feishu=飞书, dingtalk=钉钉, "
+                "telegram=Telegram, whatsapp=WhatsApp, or email=邮件. "
                 "Chinese aliases are accepted. "
                 "If omitted and the session has only one binding, that channel is used automatically. "
                 "If omitted and the session has multiple bindings, the message is sent to all of them."

--- a/flocks/tool/channel/im_send_message.py
+++ b/flocks/tool/channel/im_send_message.py
@@ -20,6 +20,9 @@ _CHANNEL_ALIASES: dict[str, list[str]] = {
     "weixin": ["weixin", "微信", "wechat", "wx"],
     "feishu": ["feishu", "飞书", "lark"],
     "dingtalk": ["dingtalk", "钉钉", "dingding", "dingtalk-connector"],
+    "telegram": ["telegram", "tg", "tele"],
+    "whatsapp": ["whatsapp", "wa"],
+    "email": ["email", "mail", "邮件", "imap", "smtp"],
 }
 
 
@@ -200,10 +203,12 @@ async def _resolve_target(
 @ToolRegistry.register_function(
     name="im_send_message",
     description=(
-        "Resolve an IM target session and optionally send a message. "
-        "Use this for WeCom/企业微信, Weixin/微信, Feishu, DingTalk, or custom channel sessions when the user asks to send an IM message. "
-        "Use channel_type=wecom for 企业微信 and channel_type=weixin for 微信. "
-        "If session_id is omitted, it uses the current IM session when available, otherwise asks the user to pick one."
+        "Resolve a messaging channel target session and optionally send a message. "
+        "Use this for WeCom/企业微信, Weixin/微信, Feishu, DingTalk, Telegram, WhatsApp, Email/邮件, "
+        "or custom channel sessions when the user asks to send a message through a connected channel. "
+        "Use channel_type=wecom for 企业微信, channel_type=weixin for 微信, channel_type=telegram for Telegram, "
+        "channel_type=whatsapp for WhatsApp, and channel_type=email for 邮件. "
+        "If session_id is omitted, it uses the current channel session when available, otherwise asks the user to pick one."
     ),
     category=ToolCategory.SYSTEM,
     parameters=[
@@ -225,7 +230,7 @@ async def _resolve_target(
             required=False,
             description=(
                 "Optional channel filter, such as wecom=企业微信, weixin=微信, "
-                "feishu, dingtalk, telegram, or a custom channel id."
+                "feishu, dingtalk, telegram, whatsapp, email=邮件, or a custom channel id."
             ),
         ),
         ToolParameter(

--- a/flocks/tool/task/schedule_task_center.py
+++ b/flocks/tool/task/schedule_task_center.py
@@ -128,12 +128,15 @@ def _normalize_schedule_task_create_inputs(
         "'一次', '这次', specific date like '明天下午3点', '下周五晚上', '2024-01-15 18:00'\n"
         "Queue-only (use type=queued, no schedule): "
         "'等会', '稍后', '待会', '有空时', '不着急'\n\n"
-        "IMPORTANT — IM session resolution before creating:\n"
-        "If the task involves sending a message to an IM platform "
-        "(企业微信/WeCom、微信/Weixin/WeChat、飞书/Feishu、钉钉/DingTalk), "
+        "IMPORTANT — Messaging channel session resolution before creating:\n"
+        "If the task involves sending a message to a connected messaging channel "
+        "(企业微信/WeCom、微信/Weixin/WeChat、飞书/Feishu、钉钉/DingTalk、"
+        "Telegram、WhatsApp、邮件/Email), "
         "you MUST resolve the target session_id and channel_type with im_send_message(resolve_only=true) "
         "BEFORE calling this tool. "
-        "Use channel_type=wecom for 企业微信 and channel_type=weixin for 微信. "
+        "Use channel_type=wecom for 企业微信, channel_type=weixin for 微信, "
+        "channel_type=telegram for Telegram, channel_type=whatsapp for WhatsApp, "
+        "and channel_type=email for 邮件. "
         "Embed both into description and user_prompt. "
         "If the user cannot provide a session_id, do NOT create the task."
     ),
@@ -150,9 +153,12 @@ def _normalize_schedule_task_create_inputs(
             type=ParameterType.STRING,
             description=(
                 "Detailed task description. "
-                "If the task involves sending a message to an IM platform (WeCom/Weixin/Feishu/DingTalk), "
+                "If the task involves sending a message to a connected messaging channel "
+                "(WeCom/Weixin/Feishu/DingTalk/Telegram/WhatsApp/Email), "
                 "MUST include the resolved channel_type and session_id here. "
-                "Use channel_type=wecom for 企业微信 and channel_type=weixin for 微信. "
+                "Use channel_type=wecom for 企业微信, channel_type=weixin for 微信, "
+                "channel_type=telegram for Telegram, channel_type=whatsapp for WhatsApp, "
+                "and channel_type=email for 邮件. "
                 "Example: '每天早上8点向飞书群发送日报 channel_type=feishu session_id=ses_abc123'"
             ),
             required=True,

--- a/tests/tool/test_channel_message.py
+++ b/tests/tool/test_channel_message.py
@@ -26,14 +26,35 @@ def test_channel_message_normalizes_wecom_aliases() -> None:
     assert _normalize_channel_type("wxwork") == "wecom"
 
 
-def test_channel_message_schema_includes_weixin() -> None:
+def test_channel_message_normalizes_telegram_whatsapp_email_aliases() -> None:
+    assert _normalize_channel_type("telegram") == "telegram"
+    assert _normalize_channel_type("tg") == "telegram"
+    assert _normalize_channel_type("tele") == "telegram"
+    assert _normalize_channel_type("whatsapp") == "whatsapp"
+    assert _normalize_channel_type("wa") == "whatsapp"
+    assert _normalize_channel_type("email") == "email"
+    assert _normalize_channel_type("mail") == "email"
+    assert _normalize_channel_type("邮件") == "email"
+
+
+def test_channel_message_schema_includes_builtin_channels() -> None:
     schema = ToolRegistry.get_schema("channel_message")
 
     assert schema is not None
-    assert "wecom" in schema.properties["channel_type"]["enum"]
-    assert "企业微信" in schema.properties["channel_type"]["enum"]
-    assert "weixin" in schema.properties["channel_type"]["enum"]
-    assert "微信" in schema.properties["channel_type"]["enum"]
+    channel_enum = schema.properties["channel_type"]["enum"]
+    for value in (
+        "wecom",
+        "企业微信",
+        "weixin",
+        "微信",
+        "feishu",
+        "dingtalk",
+        "telegram",
+        "whatsapp",
+        "email",
+        "邮件",
+    ):
+        assert value in channel_enum
 
 
 @pytest.mark.asyncio

--- a/tests/tool/test_im_send_message.py
+++ b/tests/tool/test_im_send_message.py
@@ -51,6 +51,28 @@ def test_im_send_message_normalizes_wecom_aliases() -> None:
     assert _normalize_channel_type("wxwork") == "wecom"
 
 
+def test_im_send_message_normalizes_telegram_whatsapp_email_aliases() -> None:
+    assert _normalize_channel_type("telegram") == "telegram"
+    assert _normalize_channel_type("tg") == "telegram"
+    assert _normalize_channel_type("tele") == "telegram"
+    assert _normalize_channel_type("whatsapp") == "whatsapp"
+    assert _normalize_channel_type("wa") == "whatsapp"
+    assert _normalize_channel_type("email") == "email"
+    assert _normalize_channel_type("mail") == "email"
+    assert _normalize_channel_type("邮件") == "email"
+
+
+def test_im_send_message_schema_mentions_extended_builtin_channels() -> None:
+    schema = ToolRegistry.get_schema("im_send_message")
+
+    assert schema is not None
+    channel_description = schema.properties["channel_type"]["description"]
+    tool_description = ToolRegistry.get("im_send_message").info.description
+    for channel in ("telegram", "whatsapp", "email"):
+        assert channel in channel_description.lower()
+        assert channel in tool_description.lower()
+
+
 @pytest.mark.asyncio
 async def test_im_send_message_requires_message_unless_resolve_only() -> None:
     result = await im_send_message(_ctx(), session_id="ses_target")

--- a/tests/tool/test_task_center_compat.py
+++ b/tests/tool/test_task_center_compat.py
@@ -60,6 +60,20 @@ class TestTaskCenterCompatibility:
         assert "action" in schema.properties
         assert "type" not in schema.required
 
+    def test_task_create_schema_mentions_extended_message_channels(self):
+        tool = ToolRegistry.get("schedule_task_create")
+        schema = ToolRegistry.get_schema("schedule_task_create")
+
+        assert tool is not None
+        assert schema is not None
+        text = (
+            tool.info.description
+            + " "
+            + schema.properties["description"]["description"]
+        ).lower()
+        for value in ("telegram", "whatsapp", "email", "channel_type=telegram", "channel_type=whatsapp", "channel_type=email"):
+            assert value in text
+
     def test_task_update_schema_makes_action_optional_and_exposes_trigger_fields(self):
         schema = ToolRegistry.get_schema("schedule_task_update")
 


### PR DESCRIPTION
## 背景

Rex 在创建“定时执行并通过 WhatsApp / Telegram / 邮件回传结果”的任务时，会误判这些通道不可用。实际底层已存在 Telegram、WhatsApp、Email 通道实现，但高层消息发送工具和定时任务提示中没有完整暴露这些通道，导致模型按工具描述错误回复“不支持”。

## 改动

- 为 `im_send_message` 增加 Telegram、WhatsApp、Email 的通道别名归一化：
  - `telegram` / `tg` / `tele`
  - `whatsapp` / `wa`
  - `email` / `mail` / `邮件`
- 更新 `channel_message` 的工具 schema 和描述，显式暴露 `telegram`、`whatsapp`、`email`。
- 更新 `schedule_task_create` 的说明，将定时回传目标从 IM 平台扩展为 connected messaging channel。
- 更新 Rex prompt，明确消息发送可覆盖 IM 平台和 Email。
- 增加单测，防止底层通道已支持但工具描述遗漏的回归。

## 验证

- `uv run python -m pytest tests/tool/test_im_send_message.py tests/tool/test_channel_message.py tests/tool/test_task_center_compat.py::TestTaskCenterCompatibility::test_task_create_schema_mentions_extended_message_channels`
- `uv run python -m ruff check ...`