### PR TITLE
fix(browser): reuse connected daemon for state save

### DIFF
--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -151,6 +151,12 @@ def _daemon_browser_connection(name: str):
         return None
 
 
+def daemon_browser_connected(name: str | None = None) -> bool:
+    """Return whether the selected daemon still has a live browser connection."""
+    effective_name = ipc.runtime_paths(name or NAME).name
+    return _daemon_browser_connection(effective_name) is not None
+
+
 def browser_connections() -> list[dict]:
     """Return live daemons with healthy browser connections."""
     output = []

--- a/flocks/browser/run.py
+++ b/flocks/browser/run.py
@@ -8,6 +8,7 @@ import sys
 
 from .admin import (
     _version,
+    daemon_browser_connected,
     ensure_daemon,
     print_update_banner,
     restart_daemon,
@@ -100,10 +101,12 @@ def _run_state_command(args: list[str]) -> None:
     url, no_reload = _parse_state_options(rest, allow_no_reload=action == "load")
 
     print_update_banner()
-    ensure_daemon()
     if action == "save":
+        if not daemon_browser_connected():
+            ensure_daemon()
         result = save_state(path, url=url)
     else:
+        ensure_daemon()
         result = load_state(path, url=url, reload=not no_reload)
     print(json.dumps(result, ensure_ascii=False, indent=2))
 

--- a/tests/browser/test_run.py
+++ b/tests/browser/test_run.py
@@ -46,10 +46,11 @@ def test_state_show_prints_summary_without_daemon() -> None:
     mock_daemon.assert_not_called()
 
 
-def test_state_save_ensures_daemon_and_prints_result() -> None:
+def test_state_save_reuses_connected_daemon_and_prints_result() -> None:
     stdout = StringIO()
     with (
         patch("flocks.browser.run.save_state", return_value={"path": "/tmp/auth-state.json", "cookies": 2}),
+        patch("flocks.browser.run.daemon_browser_connected", return_value=True),
         patch("flocks.browser.run.ensure_daemon") as mock_daemon,
         patch("flocks.browser.run.print_update_banner") as mock_banner,
         patch("sys.stdout", stdout),
@@ -58,6 +59,18 @@ def test_state_save_ensures_daemon_and_prints_result() -> None:
 
     assert '"cookies": 2' in stdout.getvalue()
     mock_banner.assert_called_once()
+    mock_daemon.assert_not_called()
+
+
+def test_state_save_ensures_daemon_when_browser_is_disconnected() -> None:
+    with (
+        patch("flocks.browser.run.save_state", return_value={"path": "/tmp/auth-state.json"}),
+        patch("flocks.browser.run.daemon_browser_connected", return_value=False),
+        patch("flocks.browser.run.ensure_daemon") as mock_daemon,
+        patch("flocks.browser.run.print_update_banner"),
+    ):
+        run.main(["state", "save", "/tmp/auth-state.json"])
+
     mock_daemon.assert_called_once()
 
 
@@ -65,7 +78,7 @@ def test_state_load_passes_optional_flags() -> None:
     stdout = StringIO()
     with (
         patch("flocks.browser.run.load_state", return_value={"finalUrl": "https://example.com"}) as mock_load,
-        patch("flocks.browser.run.ensure_daemon"),
+        patch("flocks.browser.run.ensure_daemon") as mock_daemon,
         patch("flocks.browser.run.print_update_banner"),
         patch("sys.stdout", stdout),
     ):
@@ -85,6 +98,7 @@ def test_state_load_passes_optional_flags() -> None:
         url="https://example.com/dashboard",
         reload=False,
     )
+    mock_daemon.assert_called_once()
     assert '"finalUrl": "https://example.com"' in stdout.getvalue()
 
 


### PR DESCRIPTION
## Summary
- reuse an existing daemon when it still has a live browser connection before saving state
- fall back to the existing strict daemon health check when the browser connection is unavailable
- keep state load behavior unchanged

## Root cause
State save unconditionally ran the full daemon protocol check, including managed-tabs support. A failed optional compatibility probe could restart a daemon that was still connected to Chrome, and the replacement daemon could then fail to reconnect before state persistence began.

## Testing
- uv run pytest tests/browser -q (107 passed)
- uv run ruff check flocks/browser/admin.py flocks/browser/run.py tests/browser/test_run.py
- git diff --check