### PR TITLE
fix(cli): handle missing Windows netstat output

### DIFF
--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -838,6 +838,8 @@ def port_is_in_use(port: int, listeners: Sequence[int] | None = None) -> bool:
     current_listeners = list(listeners) if listeners is not None else port_owner_pids(port)
     if current_listeners:
         return True
+    if sys.platform == "win32":
+        return not _bind_port_available(port)
     if _port_owner_lookup_available():
         return False
     return not _bind_port_available(port)
@@ -2169,7 +2171,7 @@ def _run_windows_netstat(port: int) -> str:
         return ""
     target = f":{port}"
     lines = []
-    for line in completed.stdout.splitlines():
+    for line in (completed.stdout or "").splitlines():
         if "LISTENING" not in line.upper():
             continue
         if target not in line:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -512,6 +512,16 @@ def test_parse_windows_netstat_output_extracts_unique_pids() -> None:
     assert service_manager._parse_windows_netstat_output(output) == [1234, 5678]
 
 
+def test_run_windows_netstat_handles_missing_stdout(monkeypatch) -> None:
+    monkeypatch.setattr(
+        service_manager.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout=None),
+    )
+
+    assert service_manager._run_windows_netstat(5173) == ""
+
+
 def test_port_owner_pids_warns_when_no_tool_found(monkeypatch) -> None:
     monkeypatch.setattr(service_manager.sys, "platform", "linux")
     monkeypatch.setattr(service_manager, "which", lambda _name: None)
@@ -527,6 +537,18 @@ def test_port_is_in_use_falls_back_to_bind_when_pid_lookup_unavailable(monkeypat
 
     with pytest.warns(RuntimeWarning, match="退回到 bind 检查"):
         assert service_manager.port_is_in_use(5173) is True
+
+
+@pytest.mark.parametrize(("port_available", "expected"), [(True, False), (False, True)])
+def test_windows_port_is_in_use_confirms_empty_pid_lookup_with_bind(
+    monkeypatch,
+    port_available: bool,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(service_manager.sys, "platform", "win32")
+    monkeypatch.setattr(service_manager, "_bind_port_available", lambda _port: port_available)
+
+    assert service_manager.port_is_in_use(5173, listeners=[]) is expected
 
 
 def test_bind_port_available_checks_all_ipv4_interfaces(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- tolerate missing stdout from the Windows netstat probe
- confirm port availability with a socket bind when no Windows listener PID is detected
- add regression coverage for missing netstat output and the bind fallback

## Root cause
The supervisor queried Windows listener PIDs before starting the backend and called splitlines() on a missing stdout value. This raised an AttributeError before the backend process was spawned and left the service degraded.

## Testing
- .venv/bin/pytest targeted service manager and doctor tests: 13 passed
- .venv/bin/ruff check flocks/cli/service_manager.py tests/cli/test_service_manager.py
- git diff --check

A broader local run completed with 108 passing tests and 4 environment-related failures caused by sandbox restrictions on Unix sockets, ps, and the user log directory.