### PR TITLE
fix(tui): select first provider with available models

### DIFF
--- a/tui/flocks/cli/cmd/tui/context/local.tsx
+++ b/tui/flocks/cli/cmd/tui/context/local.tsx
@@ -12,6 +12,7 @@ import { Provider } from "@/provider/provider"
 import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
+import { selectFallbackModel } from "./model-selection"
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -174,16 +175,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
         }
 
-        const provider = sync.data.provider[0]
-        if (!provider) return undefined
-        const defaultModel = sync.data.provider_default[provider.id]
-        const firstModel = Object.values(provider.models)[0]
-        const model = defaultModel ?? firstModel?.id
-        if (!model) return undefined
-        return {
-          providerID: provider.id,
-          modelID: model,
-        }
+        return selectFallbackModel(sync.data.provider, sync.data.provider_default)
       })
 
       const currentModel = createMemo(() => {

--- a/tui/flocks/cli/cmd/tui/context/model-selection.test.ts
+++ b/tui/flocks/cli/cmd/tui/context/model-selection.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { selectFallbackModel } from "./model-selection"
+
+describe("selectFallbackModel", () => {
+  test("skips an empty provider when a later provider has a model", () => {
+    expect(
+      selectFallbackModel(
+        [
+          { id: "openai", models: {} },
+          {
+            id: "threatbook-cn-llm",
+            models: {
+              "minimax-m3": { id: "minimax-m3" },
+            },
+          },
+        ],
+        { "threatbook-cn-llm": "minimax-m3" },
+      ),
+    ).toEqual({
+      providerID: "threatbook-cn-llm",
+      modelID: "minimax-m3",
+    })
+  })
+
+  test("uses the provider default when it is available", () => {
+    expect(
+      selectFallbackModel(
+        [
+          {
+            id: "openai",
+            models: {
+              "gpt-4.1": { id: "gpt-4.1" },
+              "gpt-5": { id: "gpt-5" },
+            },
+          },
+        ],
+        { openai: "gpt-5" },
+      ),
+    ).toEqual({ providerID: "openai", modelID: "gpt-5" })
+  })
+
+  test("uses the first model when the provider default is unavailable", () => {
+    expect(
+      selectFallbackModel(
+        [
+          {
+            id: "openai",
+            models: {
+              "gpt-4.1": { id: "gpt-4.1" },
+            },
+          },
+        ],
+        { openai: "removed-model" },
+      ),
+    ).toEqual({ providerID: "openai", modelID: "gpt-4.1" })
+  })
+
+  test("returns undefined when no provider has a model", () => {
+    expect(selectFallbackModel([{ id: "openai", models: {} }], {})).toBeUndefined()
+  })
+})

--- a/tui/flocks/cli/cmd/tui/context/model-selection.ts
+++ b/tui/flocks/cli/cmd/tui/context/model-selection.ts
@@ -1,0 +1,21 @@
+type Model = {
+  id: string
+}
+
+type Provider = {
+  id: string
+  models: Record<string, Model>
+}
+
+export function selectFallbackModel(providers: Provider[], defaults: Record<string, string>) {
+  const provider = providers.find((item) => Object.keys(item.models).length > 0)
+  if (!provider) return undefined
+  const defaultModel = defaults[provider.id]
+  const firstModel = Object.values(provider.models)[0]
+  const modelID = defaultModel && provider.models[defaultModel] ? defaultModel : firstModel?.id
+  if (!modelID) return undefined
+  return {
+    providerID: provider.id,
+    modelID,
+  }
+}


### PR DESCRIPTION
## Summary

- skip providers with no available models when selecting the TUI fallback model
- prefer a valid provider default and fall back to the provider's first model
- add regression coverage for empty leading providers and invalid defaults

## Root cause

The TUI always used the first provider returned by `/config/providers`. When that provider had no models, fallback model selection returned `undefined` even if a later provider was configured and usable.

## Testing

- `bun test flocks/cli/cmd/tui/context/model-selection.test.ts`
- `bun test`
- `git diff --check`

Full-project `bun run tsc --noEmit` still reports pre-existing type and dependency errors outside this change.
