### PR TITLE
fix(docker): align container startup with supervised service

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ macOS / Linux
 ```bash
 docker run -d \
   --name flocks \
-  -p 8000:8000 \
   -p 5173:5173 \
   --shm-size 4gb \
   -v "${HOME}/.flocks:/home/flocks/.flocks" \
@@ -160,14 +159,13 @@ Windows PowerShell
 ```powershell
 docker run -d `
   --name flocks `
-  -p 8000:8000 `
   -p 5173:5173 `
   --shm-size 4gb `
   -v "${env:USERPROFILE}\.flocks:/home/flocks/.flocks" `
   ghcr.io/agentflocks/flocks:latest
 ```
 
-`EXPOSE` in the image only documents container ports. You still need `-p 8000:8000 -p 5173:5173` to access the service from the host browser.
+`EXPOSE` in the image only documents container ports. You still need `-p 5173:5173` to access the service from the host browser.
 
 ## 4. FAQ
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -149,7 +149,6 @@ macOS / Linux
 docker run -d \
   --name flocks \
   -e TZ=Asia/Shanghai \
-  -p 8000:8000 \
   -p 5173:5173 \
   --shm-size 4gb \
   -v "${HOME}/.flocks:/home/flocks/.flocks" \
@@ -161,14 +160,13 @@ Windows PowerShell
 docker run -d `
   --name flocks `
   -e TZ=Asia/Shanghai `
-  -p 8000:8000 `
   -p 5173:5173 `
   --shm-size 4gb `
   -v "${env:USERPROFILE}\.flocks:/home/flocks/.flocks" `
   ghcr.io/agentflocks/flocks:latest
 ```
 
-镜像中的 `EXPOSE` 仅用于声明容器端口；要从宿主机浏览器访问服务，仍需使用 `-p 8000:8000 -p 5173:5173` 映射端口。
+镜像中的 `EXPOSE` 仅用于声明容器端口；要从宿主机浏览器访问服务，仍需使用 `-p 5173:5173` 映射端口。
 
 ## 4. 常见问题
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,8 @@ ARG VITE_APP_VERSION=docker
 
 ENV DEBIAN_FRONTEND=noninteractive \
     FLOCKS_DEPLOY_MODE=docker \
-    FLOCKS_BACKEND_HOST=0.0.0.0 \
-    FLOCKS_FRONTEND_HOST=0.0.0.0 \
+    FLOCKS_HOST=0.0.0.0 \
+    FLOCKS_PORT=5173 \
     FLOCKS_FRONTEND_DIST_DIR=/opt/flocks/webui/dist \
     FLOCKS_ROOT=/home/flocks/.flocks \
     FLOCKS_CONFIG_DIR=/home/flocks/.flocks/config \
@@ -88,9 +88,9 @@ RUN sed -i 's/^# *zh_CN.UTF-8 UTF-8/zh_CN.UTF-8 UTF-8/' /etc/locale.gen \
 RUN mkdir -p "$HOME/.flocks" "$HOME/.flocks/config" "$HOME/.agent-browser" \
     && chown -R flocks:flocks /opt/flocks "$HOME"
 
-EXPOSE 8000 5173
+EXPOSE 5173
 
 USER flocks
 
-ENTRYPOINT ["/usr/bin/tini", "--"]
+ENTRYPOINT ["/usr/bin/tini", "-g", "--"]
 CMD ["bash", "./scripts/container-start.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,8 @@ ARG VITE_APP_VERSION=docker
 
 ENV DEBIAN_FRONTEND=noninteractive \
     FLOCKS_DEPLOY_MODE=docker \
-    FLOCKS_HOST=0.0.0.0 \
-    FLOCKS_PORT=5173 \
+    FLOCKS_BACKEND_HOST=0.0.0.0 \
+    FLOCKS_BACKEND_PORT=5173 \
     FLOCKS_FRONTEND_DIST_DIR=/opt/flocks/webui/dist \
     FLOCKS_ROOT=/home/flocks/.flocks \
     FLOCKS_CONFIG_DIR=/home/flocks/.flocks/config \

--- a/scripts/container-start.sh
+++ b/scripts/container-start.sh
@@ -5,86 +5,18 @@
 set -euo pipefail
 
 ROOT_DIR="${ROOT_DIR:-/opt/flocks}"
-BACKEND_HOST="${FLOCKS_BACKEND_HOST:-0.0.0.0}"
-BACKEND_PORT="${FLOCKS_BACKEND_PORT:-8000}"
-FRONTEND_HOST="${FLOCKS_FRONTEND_HOST:-0.0.0.0}"
-FRONTEND_PORT="${FLOCKS_FRONTEND_PORT:-5173}"
-FRONTEND_DIST_DIR="${FLOCKS_FRONTEND_DIST_DIR:-$ROOT_DIR/webui/dist}"
-FRONTEND_PROXY_TARGET="${FLOCKS_FRONTEND_PROXY_TARGET:-http://127.0.0.1:${BACKEND_PORT}}"
-
-backend_pid=""
-frontend_pid=""
-ready_hint_pid=""
+service_started=false
 
 cleanup() {
-  local pid
-  for pid in "$backend_pid" "$frontend_pid" "$ready_hint_pid"; do
-    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-      kill -TERM "$pid" 2>/dev/null || true
-    fi
-  done
-
-  for pid in "$backend_pid" "$frontend_pid" "$ready_hint_pid"; do
-    if [[ -n "$pid" ]]; then
-      wait "$pid" 2>/dev/null || true
-    fi
-  done
+  trap - EXIT INT TERM
+  if [[ "$service_started" == true ]]; then
+    flocks stop || true
+  fi
 }
 
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
 cd "$ROOT_DIR"
-[[ -f "$FRONTEND_DIST_DIR/index.html" ]] || {
-  printf '[flocks] error: WebUI 构建产物不存在: %s\n' "$FRONTEND_DIST_DIR/index.html" >&2
-  exit 1
-}
-[[ -f "$ROOT_DIR/scripts/serve_webui.py" ]] || {
-  printf '[flocks] error: 缺少前端静态服务脚本: %s\n' "$ROOT_DIR/scripts/serve_webui.py" >&2
-  exit 1
-}
-
-printf '[flocks] publish ports to access from host: -p %s:%s -p %s:%s\n' \
-  "$BACKEND_PORT" "$BACKEND_PORT" "$FRONTEND_PORT" "$FRONTEND_PORT"
-
-printf '[flocks] starting backend on %s:%s\n' "$BACKEND_HOST" "$BACKEND_PORT"
-python -m uvicorn flocks.server.app:app \
-  --host "$BACKEND_HOST" \
-  --port "$BACKEND_PORT" &
-backend_pid=$!
-
-printf '[flocks] starting frontend on %s:%s (proxy -> %s)\n' \
-  "$FRONTEND_HOST" "$FRONTEND_PORT" "$FRONTEND_PROXY_TARGET"
-( exec python "$ROOT_DIR/scripts/serve_webui.py" \
-    --directory "$FRONTEND_DIST_DIR" \
-    --host "$FRONTEND_HOST" \
-    --port "$FRONTEND_PORT" \
-    --proxy-target "$FRONTEND_PROXY_TARGET" ) &
-frontend_pid=$!
-
-(
-  while kill -0 "$backend_pid" 2>/dev/null && kill -0 "$frontend_pid" 2>/dev/null; do
-    if python - "$BACKEND_PORT" <<'PY'
-import sys
-import urllib.request
-
-port = sys.argv[1]
-url = f"http://127.0.0.1:{port}/api/health"
-
-try:
-    with urllib.request.urlopen(url, timeout=1) as response:
-        sys.exit(0 if response.status == 200 else 1)
-except Exception:
-    sys.exit(1)
-PY
-    then
-      printf '[flocks] open WebUI in your browser: http://127.0.0.1:%s\n' "$FRONTEND_PORT"
-      exit 0
-    fi
-
-    sleep 1
-  done
-) &
-ready_hint_pid=$!
-
-wait -n "$backend_pid" "$frontend_pid"
-exit $?
+flocks start --no-browser --skip-webui-build
+service_started=true
+flocks logs --follow

--- a/tests/docker/test_container_start.py
+++ b/tests/docker/test_container_start.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTAINER_START = REPO_ROOT / "scripts" / "container-start.sh"
+
+
+def test_container_start_uses_supervised_service_commands(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    call_log = tmp_path / "calls.log"
+    flocks = bin_dir / "flocks"
+    flocks.write_text(
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$CALL_LOG"\n',
+        encoding="utf-8",
+    )
+    flocks.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "CALL_LOG": str(call_log),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "ROOT_DIR": str(tmp_path),
+        }
+    )
+
+    completed = subprocess.run(
+        ["bash", str(CONTAINER_START)],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        "start --no-browser --skip-webui-build",
+        "logs --follow",
+        "stop",
+    ]

--- a/tests/docker/test_dockerfile_runtime_requirements.py
+++ b/tests/docker/test_dockerfile_runtime_requirements.py
@@ -1,8 +1,42 @@
+import re
 from pathlib import Path
+
+import pytest
+
+from flocks.cli.service_config import build_service_config
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
+PORT_ENV_NAMES = (
+    "FLOCKS_PORT",
+    "FLOCKS_PUBLIC_PORT",
+    "FLOCKS_WEBUI_PORT",
+    "FLOCKS_FRONTEND_PORT",
+    "FLOCKS_SERVER_PORT",
+    "FLOCKS_BACKEND_PORT",
+)
+
+
+def _docker_port_env() -> dict[str, str]:
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    values = {}
+    for name in PORT_ENV_NAMES:
+        match = re.search(rf"\b{re.escape(name)}=([^\s\\]+)", dockerfile)
+        if match:
+            values[name] = match.group(1)
+    return values
+
+
+def _resolve_docker_port(monkeypatch: pytest.MonkeyPatch, runtime_env: dict[str, str]) -> int:
+    for name in PORT_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    for name, value in _docker_port_env().items():
+        monkeypatch.setenv(name, value)
+    for name, value in runtime_env.items():
+        monkeypatch.setenv(name, value)
+    config = build_service_config(default_server_host="127.0.0.1", default_server_port=8000)
+    return config.backend_port
 
 
 def test_runtime_image_no_longer_bundles_system_chromium() -> None:
@@ -15,8 +49,27 @@ def test_runtime_image_no_longer_bundles_system_chromium() -> None:
 def test_runtime_image_uses_unified_supervised_service_port() -> None:
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
 
-    assert "FLOCKS_HOST=0.0.0.0" in dockerfile
-    assert "FLOCKS_PORT=5173" in dockerfile
+    assert "FLOCKS_BACKEND_HOST=0.0.0.0" in dockerfile
+    assert "FLOCKS_BACKEND_PORT=5173" in dockerfile
+    assert "FLOCKS_HOST=0.0.0.0" not in dockerfile
+    assert "FLOCKS_PORT=5173" not in dockerfile
     assert "EXPOSE 5173" in dockerfile
     assert "EXPOSE 8000" not in dockerfile
     assert 'ENTRYPOINT ["/usr/bin/tini", "-g", "--"]' in dockerfile
+
+
+@pytest.mark.parametrize(
+    ("runtime_env", "expected_port"),
+    [
+        ({}, 5173),
+        ({"FLOCKS_BACKEND_PORT": "6184"}, 6184),
+        ({"FLOCKS_FRONTEND_PORT": "6184"}, 6184),
+        ({"FLOCKS_PORT": "6184"}, 6184),
+    ],
+)
+def test_runtime_port_overrides_remain_backward_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_env: dict[str, str],
+    expected_port: int,
+) -> None:
+    assert _resolve_docker_port(monkeypatch, runtime_env) == expected_port

--- a/tests/docker/test_dockerfile_runtime_requirements.py
+++ b/tests/docker/test_dockerfile_runtime_requirements.py
@@ -10,3 +10,13 @@ def test_runtime_image_no_longer_bundles_system_chromium() -> None:
 
     assert "AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium" not in dockerfile
     assert "    chromium \\" not in dockerfile
+
+
+def test_runtime_image_uses_unified_supervised_service_port() -> None:
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "FLOCKS_HOST=0.0.0.0" in dockerfile
+    assert "FLOCKS_PORT=5173" in dockerfile
+    assert "EXPOSE 5173" in dockerfile
+    assert "EXPOSE 8000" not in dockerfile
+    assert 'ENTRYPOINT ["/usr/bin/tini", "-g", "--"]' in dockerfile


### PR DESCRIPTION
## Summary
- replace the legacy Docker uvicorn and standalone WebUI startup with the source-managed Flocks daemon lifecycle
- use the unified public service port while preserving legacy FLOCKS_BACKEND_PORT and FLOCKS_FRONTEND_PORT overrides
- forward container signals through tini, update Docker usage documentation, and add regression coverage

## Root cause
The Docker entrypoint still launched the backend and WebUI independently after the source runtime had moved to a daemon-supervised server that serves the static WebUI. In addition, setting FLOCKS_PORT=5173 in the image took precedence over legacy runtime port variables, so upgraded containers with custom ports silently listened on 5173 instead.

## Tests
- bash -n scripts/container-start.sh
- .venv/bin/ruff check tests/docker/test_container_start.py tests/docker/test_dockerfile_runtime_requirements.py
- .venv/bin/pytest -q tests/docker/test_container_start.py tests/docker/test_dockerfile_runtime_requirements.py
- git diff --check

## Notes
An end-to-end image build was not run because the local Docker daemon was unavailable.