### PR TITLE
fix(tdp): remove default incident duration cap

### DIFF
--- a/.flocks/plugins/tools/device/tdp_v3_3_10/tdp.handler.py
+++ b/.flocks/plugins/tools/device/tdp_v3_3_10/tdp.handler.py
@@ -479,7 +479,7 @@ def _condition_time_body(body: dict[str, Any]) -> dict[str, Any]:
 def _incident_search_body(body: dict[str, Any]) -> dict[str, Any]:
     defaults = _body_with_condition_time(
         {
-            "condition": {"duration": {"begin_duration": 0, "end_duration": 24}},
+            "condition": {"duration": {"begin_duration": 0}},
             "page": {"cur_page": 1, "page_size": 20, "sort": [{"sort_by": "last_time", "sort_order": "desc"}]},
         }
     )

--- a/tests/tool/test_tdp_api_tools.py
+++ b/tests/tool/test_tdp_api_tools.py
@@ -212,7 +212,7 @@ async def test_tdp_threat_intelligent_aggregation_can_use_secret_manager_credent
     assert method == "POST"
     assert request_url == "https://tdp.internal/api/v1/incident/search"
     condition = request_kwargs["json"]["condition"]
-    assert condition["duration"] == {"begin_duration": 0, "end_duration": 24}
+    assert condition["duration"] == {"begin_duration": 0}
     assert condition["time_from"] < condition["time_to"]
 
 


### PR DESCRIPTION
Summary: Remove the implicit 24-hour maximum duration filter from TDP intelligent aggregation incident searches while retaining the required zero-hour lower bound. Update the request contract test to ensure long-running incidents are not excluded by default. Testing: uv run pytest -q tests/tool/test_tdp_api_tools.py tests/tool/test_tdp_skyeye_api_plugins.py (66 passed); uv run ruff check on the modified Python files.