### PR TITLE
fix(session): retry empty transport stream errors

### DIFF
--- a/flocks/session/lifecycle/retry.py
+++ b/flocks/session/lifecycle/retry.py
@@ -209,6 +209,8 @@ class SessionRetry:
     def is_connection_error(error: Dict[str, Any]) -> bool:
         """Return True for provider/model connection failures."""
         data = error.get("data", {})
+        if data.get("isConnectionError") is True:
+            return True
         message = data.get("message") or error.get("message", "")
         if not isinstance(message, str):
             return False

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -20,6 +20,9 @@ from datetime import datetime
 from typing import Optional, Dict, Any, List, Callable, Awaitable, Tuple
 from dataclasses import dataclass, field
 
+import httpcore
+import httpx
+
 from flocks.utils.log import Log
 from flocks.utils.id import Identifier
 from flocks.session.session import Session, SessionInfo
@@ -107,6 +110,13 @@ LLM_STREAM_FIRST_CHUNK_TIMEOUT_S = 60
 # spurious failures in those cases.
 LLM_STREAM_ONGOING_CHUNK_TIMEOUT_S = 300
 
+_RETRYABLE_TRANSPORT_EXCEPTIONS = (
+    httpx.TransportError,
+    httpcore.NetworkError,
+    httpcore.ProtocolError,
+    httpcore.TimeoutException,
+)
+
 _WORKFLOW_NODE_REF_RE = re.compile(r"^@@node:([^|\n]+)\|([^\n]+)\n?([\s\S]*)$")
 
 
@@ -173,6 +183,18 @@ async def _iter_with_chunk_timeout(
             await aiter.aclose()
         except Exception:
             pass
+
+
+def _find_retryable_transport_exception(exception: Exception) -> Optional[Exception]:
+    """Return a retryable HTTP transport error from an exception chain."""
+    current: Optional[BaseException] = exception
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, _RETRYABLE_TRANSPORT_EXCEPTIONS):
+            return current
+        current = current.__cause__ or current.__context__
+    return None
 
 
 @dataclass
@@ -1341,8 +1363,14 @@ class SessionRunner:
                 
             except Exception as e:
                 error_attempt += 1
-                log.error("runner.step.error", {
+                error_log_context = {
                     "error": str(e),
+                    "error_type": type(e).__name__,
+                    "error_module": type(e).__module__,
+                    "error_repr": repr(e)[:1000],
+                }
+                log.error("runner.step.error", {
+                    **error_log_context,
                     "attempt": error_attempt,
                 })
                 
@@ -1388,12 +1416,12 @@ class SessionRunner:
                     # Error is not retryable, or retry budget exhausted
                     if retry_message is not None:
                         log.error("runner.step.max_retries_exceeded", {
-                            "error": str(e),
+                            **error_log_context,
                             "attempt": error_attempt,
                             "max_retries": MAX_ERROR_RETRIES,
                         })
                     else:
-                        log.error("runner.step.not_retryable", {"error": str(e)})
+                        log.error("runner.step.not_retryable", error_log_context)
 
                     final_error_message = str(e)
                     if SessionRetry.is_connection_error(error_dict):
@@ -1796,8 +1824,23 @@ class SessionRunner:
             "message": str(exception),
             "data": {
                 "message": str(exception),
+                "exceptionType": type(exception).__name__,
+                "exceptionModule": type(exception).__module__,
             }
         }
+
+        transport_exception = _find_retryable_transport_exception(exception)
+        if transport_exception is not None:
+            transport_type = type(transport_exception).__name__
+            error_dict["name"] = "APIError"
+            error_dict["data"].update({
+                "message": str(exception) or f"Transport connection error ({transport_type})",
+                "isRetryable": True,
+                "isConnectionError": True,
+                "displayMessage": CONNECTION_ERROR_DISPLAY_MESSAGE,
+                "transportExceptionType": transport_type,
+                "transportExceptionModule": type(transport_exception).__module__,
+            })
         
         # Check if it's an API error with specific attributes
         if hasattr(exception, 'status_code'):

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -10,6 +10,8 @@ Covers:
 - SessionRunner construction and abort behavior (from existing tests)
 """
 
+import httpcore
+import httpx
 import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -269,6 +271,51 @@ class TestExceptionToErrorDict:
         assert result["name"] == "APIError"
         assert result["data"]["isRetryable"] is True
         assert result["data"]["displayMessage"] == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ReadError("", request=httpx.Request("GET", "https://example.test")),
+            httpx.RemoteProtocolError(
+                "",
+                request=httpx.Request("GET", "https://example.test"),
+            ),
+            httpcore.ReadError(),
+            httpcore.RemoteProtocolError(),
+        ],
+    )
+    def test_empty_transport_exception_is_retryable_connection_error(self, exc):
+        runner = _make_runner()
+
+        result = runner._exception_to_error_dict(exc)
+
+        assert result["name"] == "APIError"
+        assert result["data"]["isRetryable"] is True
+        assert result["data"]["isConnectionError"] is True
+        assert result["data"]["displayMessage"] == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
+        assert result["data"]["exceptionType"] == type(exc).__name__
+
+    def test_wrapped_transport_exception_is_retryable_connection_error(self):
+        runner = _make_runner()
+        transport_error = httpcore.ReadError()
+        exc = RuntimeError("stream failed")
+        exc.__cause__ = transport_error
+
+        result = runner._exception_to_error_dict(exc)
+
+        assert result["name"] == "APIError"
+        assert result["data"]["isRetryable"] is True
+        assert result["data"]["isConnectionError"] is True
+        assert result["data"]["exceptionType"] == "RuntimeError"
+        assert result["data"]["transportExceptionType"] == "ReadError"
+
+    def test_empty_non_transport_exception_is_not_retryable(self):
+        runner = _make_runner()
+
+        result = runner._exception_to_error_dict(RuntimeError())
+
+        assert result["name"] == "RuntimeError"
+        assert result["data"].get("isRetryable") is not True
 
     def test_exception_with_status_code_429(self):
         runner = _make_runner()
@@ -2632,6 +2679,55 @@ async def test_process_step_empty_retry_records_usage_per_attempt(monkeypatch):
     assert record_mock.await_count == 2
     record_mock.assert_any_await(first_usage, message_id=assistant_msg.id)
     record_mock.assert_any_await(second_usage, message_id=assistant_msg.id)
+
+
+@pytest.mark.asyncio
+async def test_process_step_retries_empty_transport_exception(monkeypatch):
+    runner = _make_runner("ses_runner_transport_retry")
+    runner.callbacks = RunnerCallbacks(on_error=AsyncMock())
+
+    last_user = UserMessageInfo(
+        id="msg_user_transport_retry",
+        sessionID=runner.session.id,
+        role="user",
+        time={"created": 1_000},
+        agent="rex",
+        model={"providerID": "openai", "modelID": "gpt-5"},
+    )
+    agent = SimpleNamespace(name="rex", steps=None, mode="primary", prompt="", tools=[])
+    provider = MagicMock()
+    provider.is_configured.return_value = True
+    assistant_msg = SimpleNamespace(id="msg_assistant_transport_retry")
+    call_llm_mock = AsyncMock(
+        side_effect=[
+            httpcore.ReadError(),
+            StepResult(action="stop", content="recovered"),
+        ]
+    )
+    sleep_mock = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
+    monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        runner,
+        "_to_chat_messages",
+        AsyncMock(return_value=[SimpleNamespace(role="user", content="hi")]),
+    )
+    monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="hi"))
+    monkeypatch.setattr(runner_mod.Message, "create", AsyncMock(return_value=assistant_msg))
+    monkeypatch.setattr(runner_mod.Message, "update", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner, "_call_llm", call_llm_mock)
+    monkeypatch.setattr(runner_mod.SessionRetry, "sleep", sleep_mock)
+
+    result = await runner._process_step([last_user], last_user)
+
+    assert result.content == "recovered"
+    assert call_llm_mock.await_count == 2
+    sleep_mock.assert_awaited_once()
+    runner.callbacks.on_error.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- classify empty httpx and httpcore transport failures as retryable connection errors
- preserve exception type, module, and repr in runner error logs
- detect wrapped transport errors through exception chains
- keep non-transport and non-retryable failures unchanged

## Root cause
Some transport exceptions stringify to an empty message. Retry classification relied on the exception message, so these transient stream failures were marked as non-retryable and stopped the session loop after partial output.

## Testing
- .venv/bin/python -m pytest tests/session/test_runner_step.py tests/session/test_retry.py -q (129 passed)
- .venv/bin/ruff check flocks/session/runner.py flocks/session/lifecycle/retry.py tests/session/test_runner_step.py
- git diff --check