### PR TITLE
fix(skyeye): encode alarm list IP filters

### DIFF
--- a/.flocks/plugins/tools/device/skyeye_v4_0_14_0_SP2/skyeye.handler.py
+++ b/.flocks/plugins/tools/device/skyeye_v4_0_14_0_SP2/skyeye.handler.py
@@ -1,4 +1,5 @@
 import base64
+import gzip
 import hashlib
 import json
 import random
@@ -187,6 +188,12 @@ def _clean_params(params: dict[str, Any]) -> dict[str, Any]:
             continue
         cleaned[key] = value
     return cleaned
+
+
+def _encode_ip_param(value: str | None) -> str | None:
+    if value is None or not value.strip() or value.startswith("H4sI"):
+        return value
+    return base64.b64encode(gzip.compress(value.encode("utf-8"))).decode("ascii")
 
 
 def _payload_error(payload: Any) -> str | None:
@@ -498,8 +505,8 @@ async def alarm_list(
             "status": status,
             "serial_num": serial_num,
             "data_source": data_source,
-            "alarm_sip": alarm_sip,
-            "attack_sip": attack_sip,
+            "alarm_sip": _encode_ip_param(alarm_sip),
+            "attack_sip": _encode_ip_param(attack_sip),
             "ioc": ioc,
             "threat_name": threat_name,
             "host": host,

--- a/tests/tool/test_skyeye_api_tools.py
+++ b/tests/tool/test_skyeye_api_tools.py
@@ -1,3 +1,5 @@
+import base64
+import gzip
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -205,6 +207,45 @@ async def test_skyeye_alarm_list_accepts_legacy_threat_level_alias():
     assert request_url == "https://skyeye.local/skyeye/api/v1/alarm/alarm/list"
     assert request_kwargs["params"]["hazard_level"] == "3"
     assert "threat_level" not in request_kwargs["params"]
+
+
+@pytest.mark.asyncio
+async def test_skyeye_alarm_list_encodes_ip_filters_without_affecting_other_params():
+    tool = _load_tool("skyeye_alarm_list.yaml")
+    mock_secret_manager = MagicMock()
+    mock_secret_manager.get.side_effect = lambda key: {
+        "skyeye_api_key": "login-key-123",
+    }.get(key)
+    fake_session = _FakeSession([
+        _FakeResponse(json_payload={"access_token": "token-123", "status": 200}),
+        _FakeResponse(text_payload='<html><meta name="csrf-token" content="abcdef1234567890"></html>'),
+        _FakeResponse(json_payload={"data": {"items": [], "total": 0}, "status": 1000, "message": "ok"}),
+    ])
+
+    with (
+        patch("flocks.security.get_secret_manager", return_value=mock_secret_manager),
+        patch(
+            "flocks.config.config_writer.ConfigWriter.get_api_service_raw",
+            return_value={
+                "apiKey": "{secret:skyeye_api_key}",
+                "base_url": "https://skyeye.local",
+            },
+        ),
+        patch("aiohttp.ClientSession", return_value=fake_session),
+    ):
+        result = await tool.handler(
+            ToolContext(session_id="test", message_id="test"),
+            alarm_sip="10.105.249.255",
+            attack_sip="10.61.116.134",
+            limit=3,
+        )
+
+    assert result.success is True
+    _, _, request_kwargs = fake_session.calls[2]
+    params = request_kwargs["params"]
+    assert gzip.decompress(base64.b64decode(params["alarm_sip"])).decode() == "10.105.249.255"
+    assert gzip.decompress(base64.b64decode(params["attack_sip"])).decode() == "10.61.116.134"
+    assert params["limit"] == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- gzip and base64 encode `alarm_sip` and `attack_sip` for `skyeye_alarm_list`
- preserve already encoded values and empty filters
- keep SkyEye download endpoints unchanged
- add regression coverage that decodes the transmitted values back to the original IPs

## Testing

- `.venv/bin/python -m pytest tests/tool/test_skyeye_api_tools.py tests/tool/test_skyeye_skill_cli.py -q`
- `.venv/bin/ruff check .flocks/plugins/tools/device/skyeye_v4_0_14_0_SP2/skyeye.handler.py tests/tool/test_skyeye_api_tools.py`
- `git diff --check`