### PR TITLE
Clarify project session hierarchy in the sidebar

### DIFF
--- a/flocks/project/project.py
+++ b/flocks/project/project.py
@@ -126,6 +126,10 @@ class ProjectInfo(BaseModel):
     session_count: int = Field(0, alias="sessionCount")
     matched_session_count: int = Field(0, alias="matchedSessionCount")
     last_activity_at: Optional[int] = Field(None, alias="lastActivityAt")
+    owner_user_id: Optional[str] = Field(None, alias="ownerUserID")
+    can_write: bool = Field(True, alias="canWrite")
+    can_delete: bool = Field(True, alias="canDelete")
+    is_shared: bool = Field(False, alias="isShared")
 
 
 class ProjectRegistryEntry(BaseModel):
@@ -138,6 +142,8 @@ class ProjectRegistryEntry(BaseModel):
     worktree: str
     created_at: int = Field(alias="createdAt")
     updated_at: int = Field(alias="updatedAt")
+    owner_user_id: Optional[str] = Field(None, alias="ownerUserID")
+    shared_local: bool = Field(False, alias="sharedLocal")
 
 
 class ProjectRegistry(BaseModel):
@@ -375,7 +381,12 @@ class Project:
             raise
 
     @classmethod
-    def _entry_to_info(cls, entry: ProjectRegistryEntry) -> ProjectInfo:
+    def _entry_to_info(
+        cls,
+        entry: ProjectRegistryEntry,
+        *,
+        can_write: bool = True,
+    ) -> ProjectInfo:
         return ProjectInfo(
             id=entry.id,
             worktree=entry.worktree,
@@ -383,6 +394,10 @@ class Project:
             vcs="git" if (Path(entry.worktree) / ".git").exists() else None,
             time=ProjectTime(created=entry.created_at, updated=entry.updated_at),
             pathStatus=cls._path_status(entry.worktree),
+            ownerUserID=entry.owner_user_id,
+            canWrite=can_write,
+            canDelete=can_write,
+            isShared=entry.shared_local,
         )
 
     @classmethod
@@ -396,6 +411,7 @@ class Project:
             time=ProjectTime(created=now, updated=now),
             isDefault=True,
             pathStatus=cls._path_status(registry.default_worktree),
+            canDelete=False,
         )
 
     @classmethod
@@ -457,6 +473,7 @@ class Project:
                     worktree=normalized_worktree,
                     createdAt=now,
                     updatedAt=now,
+                    ownerUserID=owner_id,
                 )
                 registry.projects.append(entry)
                 cls._write_registry(owner_id, registry)
@@ -475,6 +492,89 @@ class Project:
         projects = [cls._entry_to_info(entry) for entry in registry.projects]
         projects.sort(key=lambda item: item.time.updated, reverse=True)
         return [cls._default_to_info(registry), *projects]
+
+    @classmethod
+    def _all_registry_entries(cls) -> List[ProjectRegistryEntry]:
+        """Return valid entries across local user registries."""
+
+        registry_dir = cls._flocks_root() / "projects"
+        if not registry_dir.is_dir():
+            return []
+        entries: List[ProjectRegistryEntry] = []
+        for path in registry_dir.glob("*.json"):
+            registry = cls._read_registry_file(path)
+            if registry is not None:
+                entries.extend(registry.projects)
+        return entries
+
+    @classmethod
+    def shared_project_ids(cls) -> set[str]:
+        """Return IDs of all projects shared to local accounts."""
+
+        return {entry.id for entry in cls._all_registry_entries() if entry.shared_local}
+
+    @classmethod
+    async def list_visible(
+        cls,
+        *,
+        owner_id: str,
+        default_worktree: Optional[str] = None,
+    ) -> List[ProjectInfo]:
+        """List owned projects plus projects shared by other local users."""
+
+        owned = await cls.list(owner_id=owner_id, default_worktree=default_worktree)
+        owned_ids = {project.id for project in owned}
+        shared = [
+            cls._entry_to_info(entry, can_write=False)
+            for entry in cls._all_registry_entries()
+            if entry.shared_local and entry.owner_user_id != owner_id and entry.id not in owned_ids
+        ]
+        shared.sort(key=lambda item: item.time.updated, reverse=True)
+        return [*owned, *shared]
+
+    @classmethod
+    def visible_project_ids(cls, owner_id: str) -> set[str]:
+        """Return project IDs visible to a local user."""
+
+        return cls.registered_project_ids(owner_id) | cls.shared_project_ids()
+
+    @classmethod
+    def is_local_shared(cls, owner_id: Optional[str], project_id: Optional[str]) -> bool:
+        """Return whether an owner's registered project is locally shared."""
+
+        if not owner_id or not project_id or project_id == DEFAULT_PROJECT_ID:
+            return False
+        registry = cls._read_registry(owner_id)
+        return any(entry.id == project_id and entry.shared_local for entry in registry.projects)
+
+    @classmethod
+    async def set_local_shared(
+        cls,
+        project_id: str,
+        *,
+        owner_id: str,
+        shared: bool,
+    ) -> ProjectInfo:
+        """Share or unshare an owned project with all local accounts."""
+
+        if project_id == DEFAULT_PROJECT_ID:
+            raise ProjectDeletionError("The default project cannot be shared")
+        async with cls._lock:
+            with _registry_cross_process_lock(cls.registry_path(owner_id)):
+                registry = cls._read_registry(owner_id)
+                entry = next((item for item in registry.projects if item.id == project_id), None)
+                if entry is None:
+                    raise ValueError(f"Project {project_id} not found")
+                entry.owner_user_id = owner_id
+                entry.shared_local = shared
+                entry.updated_at = cls._now_ms()
+                cls._write_registry(owner_id, registry)
+            cls.invalidate_session_stats()
+            log.info(
+                "project.sharing.updated",
+                {"id": project_id, "owner": cls._owner_hash(owner_id), "shared": shared},
+            )
+            return cls._entry_to_info(entry)
 
     @classmethod
     async def get(
@@ -546,7 +646,7 @@ class Project:
 
     @classmethod
     def effective_project_id(cls, owner_id: str, stored_project_id: Optional[str]) -> str:
-        if stored_project_id and stored_project_id in cls.registered_project_ids(owner_id):
+        if stored_project_id and stored_project_id in cls.visible_project_ids(owner_id):
             return stored_project_id
         return DEFAULT_PROJECT_ID
 

--- a/flocks/server/routes/project.py
+++ b/flocks/server/routes/project.py
@@ -60,10 +60,11 @@ class FolderBrowserResponse(BaseModel):
 
 async def _list_project_summaries(user: AuthUser, search: Optional[str]) -> List[ProjectInfo]:
     owner_id = user.id
-    projects = await Project.list(
+    projects = await Project.list_visible(
         owner_id=owner_id,
         default_worktree=Project.default_worktree_candidate(),
     )
+    shared_project_ids = Project.shared_project_ids()
     term = search.strip().casefold() if search else None
     stats = Project.get_session_stats_cache(owner_id, term or "")
     if stats is None:
@@ -73,7 +74,11 @@ async def _list_project_summaries(user: AuthUser, search: Optional[str]) -> List
         last_activity: dict[str, int] = {}
 
         for session in await Session.list_all_unfiltered():
-            if not SessionPolicy.can_read(session, user):
+            if not SessionPolicy.can_read(
+                session,
+                user,
+                shared_project_ids=shared_project_ids,
+            ):
                 continue
             metadata = session.metadata if isinstance(session.metadata, dict) else {}
             if metadata.get("hideFromSessionManager"):
@@ -249,6 +254,48 @@ async def update_project(project_id: str, payload: ProjectUpdateRequest, request
         return await Project.update(project_id, owner_id=user.id, name=payload.name)
     except ProjectNameConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ProjectDeletionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post(
+    "/{project_id}/share-local",
+    response_model=ProjectInfo,
+    summary="Share project locally",
+)
+async def share_project_local(project_id: str, request: Request):
+    """Share a project and all of its sessions as read-only."""
+
+    user = require_user(request)
+    try:
+        return await Project.set_local_shared(
+            project_id,
+            owner_id=user.id,
+            shared=True,
+        )
+    except ProjectDeletionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post(
+    "/{project_id}/unshare-local",
+    response_model=ProjectInfo,
+    summary="Unshare project locally",
+)
+async def unshare_project_local(project_id: str, request: Request):
+    """Cancel local sharing for a project and all of its sessions."""
+
+    user = require_user(request)
+    try:
+        return await Project.set_local_shared(
+            project_id,
+            owner_id=user.id,
+            shared=False,
+        )
     except ProjectDeletionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:

--- a/flocks/server/routes/project.py
+++ b/flocks/server/routes/project.py
@@ -189,7 +189,15 @@ async def browse_project_folders(request: Request, path: Optional[str] = Query(N
         raise HTTPException(status_code=400, detail="No project roots are available")
 
     try:
-        current = Path(path).expanduser().resolve(strict=True) if path else Path(default_project.worktree).resolve(strict=True)
+        if path:
+            current = Path(path).expanduser().resolve(strict=True)
+        else:
+            home = Path.home().resolve(strict=True)
+            current = (
+                home
+                if any(home == root or home.is_relative_to(root) for root in roots)
+                else roots[0]
+            )
     except (OSError, RuntimeError) as exc:
         raise HTTPException(status_code=400, detail="Directory does not exist") from exc
     if not current.is_dir():

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -222,6 +222,7 @@ class SessionListItem(BaseModel):
 def _session_to_response(
     session: SessionModel,
     effective_project_id: Optional[str] = None,
+    shared_project_ids: Optional[set[str]] = None,
 ) -> SessionResponse:
     """
     Convert SessionModel to SessionResponse
@@ -229,7 +230,7 @@ def _session_to_response(
     current_user = get_current_auth_user()
     can_write = SessionPolicy.can_write(session, current_user)
     can_delete = SessionPolicy.can_delete(session, current_user)
-    is_shared = SessionPolicy.is_shared(session)
+    is_shared = SessionPolicy.is_shared(session, shared_project_ids)
     from flocks.project.project import Project
 
     if effective_project_id is None:
@@ -271,6 +272,7 @@ def _session_to_response(
 def _session_to_list_item(
     session: SessionModel,
     effective_project_id: Optional[str] = None,
+    shared_project_ids: Optional[set[str]] = None,
 ) -> SessionListItem:
     """Convert a session to the lightweight manager-list response shape."""
     current_user = get_current_auth_user()
@@ -300,16 +302,17 @@ def _session_to_list_item(
         model_pinned=session.model_pinned,
         canWrite=SessionPolicy.can_write(session, current_user),
         canDelete=SessionPolicy.can_delete(session, current_user),
-        isShared=SessionPolicy.is_shared(session),
+        isShared=SessionPolicy.is_shared(session, shared_project_ids),
     )
 
 
 async def _session_to_response_with_goal(
     session: SessionModel,
     effective_project_id: Optional[str] = None,
+    shared_project_ids: Optional[set[str]] = None,
 ) -> SessionResponse:
     """Convert SessionModel to SessionResponse and attach persisted goal state."""
-    response = _session_to_response(session, effective_project_id)
+    response = _session_to_response(session, effective_project_id, shared_project_ids)
     try:
         from flocks.session.goal import GoalManager
 
@@ -539,7 +542,8 @@ async def list_sessions(
     list_started_at = time.perf_counter()
     all_sessions = await Session.list_all_unfiltered()
     list_elapsed_ms = (time.perf_counter() - list_started_at) * 1000
-    registered_project_ids = Project.registered_project_ids(current_user.id)
+    visible_project_ids = Project.visible_project_ids(current_user.id)
+    shared_project_ids = Project.shared_project_ids()
     
     filtered = []
     effective_project_ids: Dict[str, str] = {}
@@ -548,7 +552,11 @@ async def list_sessions(
     skip_remaining = offset or 0
     
     for session in all_sessions:
-        if not SessionPolicy.can_read(session, current_user):
+        if not SessionPolicy.can_read(
+            session,
+            current_user,
+            shared_project_ids=shared_project_ids,
+        ):
             continue
         if _is_hidden_from_session_manager(session):
             continue
@@ -556,7 +564,7 @@ async def list_sessions(
             continue
         effective_project_id = (
             session.project_id
-            if session.project_id in registered_project_ids
+            if session.project_id in visible_project_ids
             else DEFAULT_PROJECT_ID
         )
         if projectID is not None and effective_project_id != projectID:
@@ -589,7 +597,7 @@ async def list_sessions(
 
     if view == "list":
         response = [
-            _session_to_list_item(s, effective_project_ids[s.id])
+            _session_to_list_item(s, effective_project_ids[s.id], shared_project_ids)
             for s in filtered
         ]
         log_route_timing(log, "session.list.light.complete", started_at=started_at, extra={
@@ -607,7 +615,11 @@ async def list_sessions(
         return response
 
     response = [
-        await _session_to_response_with_goal(s, effective_project_ids[s.id])
+        await _session_to_response_with_goal(
+            s,
+            effective_project_ids[s.id],
+            shared_project_ids,
+        )
         for s in filtered
     ]
     log_route_timing(log, "session.list.complete", started_at=started_at, extra={

--- a/flocks/session/policy.py
+++ b/flocks/session/policy.py
@@ -56,13 +56,36 @@ class SessionPolicy:
         return not session.owner_user_id and not session.owner_username
 
     @classmethod
-    def is_shared(cls, session: "SessionInfo") -> bool:
+    def is_shared(
+        cls,
+        session: "SessionInfo",
+        shared_project_ids: Optional[set[str]] = None,
+    ) -> bool:
         """Whether the session is explicitly shared to all local users.
 
         Ownerless sessions are a legacy / unauthenticated compatibility state,
         not a sharing state. The UI badge should only reflect explicit sharing.
         """
-        return cls.is_local_shared(session)
+        return cls.is_local_shared(session) or cls.is_project_shared(
+            session,
+            shared_project_ids,
+        )
+
+    @staticmethod
+    def is_project_shared(
+        session: "SessionInfo",
+        shared_project_ids: Optional[set[str]] = None,
+    ) -> bool:
+        """Whether the session belongs to a locally shared project."""
+
+        if shared_project_ids is not None:
+            return session.project_id in shared_project_ids
+        try:
+            from flocks.project.project import Project
+
+            return Project.is_local_shared(session.owner_user_id, session.project_id)
+        except Exception:
+            return False
 
     @staticmethod
     def _shared_read_user_ids(session: "SessionInfo") -> set[str]:
@@ -75,17 +98,31 @@ class SessionPolicy:
         return {str(item) for item in raw if item}
 
     @classmethod
-    def is_shared_read_only(cls, session: "SessionInfo", user: Optional["AuthUser"]) -> bool:
+    def is_shared_read_only(
+        cls,
+        session: "SessionInfo",
+        user: Optional["AuthUser"],
+        shared_project_ids: Optional[set[str]] = None,
+    ) -> bool:
         if user is None:
             return False
         if cls.is_owner(session, user):
             return False
-        if cls.is_local_shared(session):
+        if cls.is_local_shared(session) or cls.is_project_shared(
+            session,
+            shared_project_ids,
+        ):
             return True
         return user.id in cls._shared_read_user_ids(session)
 
     @classmethod
-    def can_read(cls, session: "SessionInfo", user: Optional["AuthUser"] = None) -> bool:
+    def can_read(
+        cls,
+        session: "SessionInfo",
+        user: Optional["AuthUser"] = None,
+        *,
+        shared_project_ids: Optional[set[str]] = None,
+    ) -> bool:
         """
         Whether the session should be visible in listings / fetch.
 
@@ -100,7 +137,7 @@ class SessionPolicy:
             return True
         if cls._has_no_owner(session) and cls.is_admin(resolved):
             return True
-        return cls.is_shared_read_only(session, resolved)
+        return cls.is_shared_read_only(session, resolved, shared_project_ids)
 
     @classmethod
     def can_write(cls, session: "SessionInfo", user: Optional["AuthUser"] = None) -> bool:

--- a/tests/server/routes/test_project_routes.py
+++ b/tests/server/routes/test_project_routes.py
@@ -87,6 +87,20 @@ async def test_duplicate_project_directory_returns_existing_project(
 
 
 @pytest.mark.asyncio
+async def test_folder_browser_starts_at_home_when_path_is_omitted(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    home = Path.home().resolve()
+    monkeypatch.setenv("FLOCKS_PROJECT_ROOTS", str(home))
+
+    response = await client.get("/api/project/folders")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["path"] == str(home)
+
+
+@pytest.mark.asyncio
 async def test_folder_browser_lists_directories_and_blocks_outside_root(
     client: AsyncClient,
     tmp_path: Path,

--- a/tests/server/routes/test_project_routes.py
+++ b/tests/server/routes/test_project_routes.py
@@ -5,6 +5,8 @@ from fastapi import status
 from httpx import AsyncClient
 
 from flocks.auth.context import AuthUser
+from flocks.project.project import Project
+from flocks.session.session import Session
 from flocks.storage.storage import Storage
 
 
@@ -126,6 +128,84 @@ async def test_folder_browser_lists_directories_and_blocks_outside_root(
         params={"path": str(escape_link)},
     )
     assert escaped_listing.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_project_local_sharing_includes_existing_and_future_sessions(
+    client: AsyncClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from flocks.server.routes import project as project_routes
+    from flocks.server.routes import session as session_routes
+
+    owner = AuthUser(id="usr_owner", username="owner", role="member", status="active")
+    viewer = AuthUser(id="usr_viewer", username="viewer", role="member", status="active")
+    worktree = tmp_path / "shared-project"
+    worktree.mkdir()
+    project = await Project.create(
+        owner_id=owner.id,
+        name="Shared Project",
+        worktree=str(worktree),
+    )
+    existing = await Session.create(
+        project_id=project.id,
+        directory=str(worktree),
+        title="Existing session",
+        owner_user_id=owner.id,
+        owner_username=owner.username,
+    )
+
+    monkeypatch.setattr(project_routes, "require_user", lambda _request: owner)
+    share_response = await client.post(f"/api/project/{project.id}/share-local")
+
+    assert share_response.status_code == status.HTTP_200_OK
+    assert share_response.json()["isShared"] is True
+
+    future = await Session.create(
+        project_id=project.id,
+        directory=str(worktree),
+        title="Future session",
+        owner_user_id=owner.id,
+        owner_username=owner.username,
+    )
+
+    monkeypatch.setattr(project_routes, "require_user", lambda _request: viewer)
+    project_list = (await client.get("/api/project")).json()
+    shared_project = next(item for item in project_list if item["id"] == project.id)
+    assert shared_project["isShared"] is True
+    assert shared_project["canWrite"] is False
+    assert shared_project["canDelete"] is False
+
+    non_owner_share = await client.post(f"/api/project/{project.id}/share-local")
+    assert non_owner_share.status_code == status.HTTP_404_NOT_FOUND
+
+    monkeypatch.setattr(session_routes, "require_user", lambda _request: viewer)
+    session_list = (
+        await client.get(
+            "/api/session",
+            params={"view": "list", "manager": True, "projectID": project.id},
+        )
+    ).json()
+    assert {item["id"] for item in session_list} == {existing.id, future.id}
+    assert all(item["effectiveProjectID"] == project.id for item in session_list)
+    assert all(item["isShared"] is True for item in session_list)
+    assert all(item["canWrite"] is False for item in session_list)
+
+    monkeypatch.setattr(project_routes, "require_user", lambda _request: owner)
+    unshare_response = await client.post(f"/api/project/{project.id}/unshare-local")
+    assert unshare_response.status_code == status.HTTP_200_OK
+    assert unshare_response.json()["isShared"] is False
+
+    monkeypatch.setattr(project_routes, "require_user", lambda _request: viewer)
+    assert project.id not in {item["id"] for item in (await client.get("/api/project")).json()}
+    monkeypatch.setattr(session_routes, "require_user", lambda _request: viewer)
+    assert (
+        await client.get(
+            "/api/session",
+            params={"view": "list", "manager": True, "projectID": project.id},
+        )
+    ).json() == []
 
 
 @pytest.mark.asyncio

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -296,7 +296,6 @@
     "folderLabel": "Project folder",
     "folderPlaceholder": "Enter an absolute project folder path",
     "folderEmpty": "Choose a project folder",
-    "defaultFolder": "Default: {{path}}",
     "chooseFolder": "Choose",
     "parentFolder": "Parent folder",
     "selectCurrentFolder": "Select this folder",

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -268,7 +268,6 @@
   "toggleTasks": "Expand or collapse tasks",
   "selectTasks": "Select tasks",
   "createTaskSession": "New task",
-  "toggleProject": "Expand or collapse project {{project}}",
   "selectProject": "Select project {{project}}",
   "createSessionInProject": "New session in project {{project}}",
   "projectActions": "Project actions",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -268,7 +268,6 @@
   "toggleTasks": "展开或收起任务",
   "selectTasks": "选择任务",
   "createTaskSession": "新建任务",
-  "toggleProject": "展开或收起项目 {{project}}",
   "selectProject": "选择项目 {{project}}",
   "createSessionInProject": "在项目 {{project}} 中新建会话",
   "projectActions": "项目操作",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -296,7 +296,6 @@
     "folderLabel": "项目文件夹",
     "folderPlaceholder": "输入项目文件夹的绝对路径",
     "folderEmpty": "请选择项目文件夹",
-    "defaultFolder": "默认：{{path}}",
     "chooseFolder": "选择",
     "parentFolder": "上一级目录",
     "selectCurrentFolder": "选择此文件夹",

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -637,6 +637,35 @@ describe('SessionPage session actions menu', () => {
     });
   });
 
+  it('does not submit when Enter is pressed before choosing a project folder', async () => {
+    const user = userEvent.setup();
+    client.post.mockResolvedValue({
+      data: { id: 'prj_labs', name: 'Labs', worktree: '/tmp/labs' },
+    });
+    renderSessionPage();
+
+    await user.click(await screen.findByRole('button', { name: 'projectDialog.createTitle' }));
+    const nameInput = screen.getByLabelText('projectDialog.nameLabel');
+    await user.type(nameInput, 'Labs');
+    fireEvent.keyDown(nameInput, { key: 'Enter' });
+
+    expect(client.post).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+
+    const folderInput = screen.getByLabelText('projectDialog.folderLabel');
+    await user.type(folderInput, '/tmp/labs');
+    fireEvent.keyDown(nameInput, { key: 'Enter', isComposing: true });
+    expect(client.post).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(nameInput, { key: 'Enter' });
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledWith('/api/project', {
+        name: 'Labs',
+        worktree: '/tmp/labs',
+      });
+    });
+  });
+
   it('shows the backend detail when project creation fails', async () => {
     const user = userEvent.setup();
     client.post.mockRejectedValue({

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -519,6 +519,37 @@ describe('SessionPage session actions menu', () => {
     expect(screen.queryByText('Original Session')).not.toBeInTheDocument();
   });
 
+  it('renders project sessions with the same card outline as task sessions', async () => {
+    client.get.mockResolvedValue({
+      data: [
+        { id: 'default', worktree: '/tmp/project', name: '默认', isDefault: true },
+        { id: 'prj_labs', worktree: '/tmp/labs', name: 'Labs', isDefault: false },
+      ],
+    });
+    useSessions.mockReturnValue({
+      sessions: [{
+        ...session,
+        projectID: 'prj_labs',
+        effectiveProjectID: 'prj_labs',
+        directory: '/tmp/labs',
+      }],
+      loading: false,
+      error: null,
+      refetch: refetchSessions,
+      updateSessionTitle,
+      removeSession,
+      removeSessions,
+      addSession,
+    });
+
+    renderSessionPage();
+
+    const sessionTitle = await screen.findByText('Original Session');
+    const sessionCard = sessionTitle.closest('[class*="cursor-pointer"]');
+    expect(sessionCard).not.toBeNull();
+    expect(sessionCard).toHaveClass('border-gray-100');
+  });
+
   it('groups legacy sessions by the effective project returned by the backend', async () => {
     client.get.mockResolvedValue({
       data: [{
@@ -786,6 +817,76 @@ describe('SessionPage session actions menu', () => {
     });
     const renamedProject = await screen.findByText('Renamed Project');
     expect(renamedProject.closest('[class*="group/project"]')).toHaveTextContent('8');
+  });
+
+  it('shares and unshares a project from the sidebar', async () => {
+    const user = userEvent.setup();
+    const defaultProject = { id: 'default', worktree: '/tmp/project', name: '默认', isDefault: true };
+    let projectRows = [
+      defaultProject,
+      {
+        id: 'prj_project2', worktree: '/tmp/labs', name: 'Labs',
+        canWrite: true, canDelete: true, isShared: false,
+      },
+    ];
+    client.get.mockImplementation(() => Promise.resolve({ data: projectRows }));
+    client.post.mockImplementation((url: string) => {
+      if (url === '/api/project/prj_project2/share-local') {
+        projectRows = projectRows.map((project) => (
+          project.id === 'prj_project2' ? { ...project, isShared: true } : project
+        ));
+      }
+      if (url === '/api/project/prj_project2/unshare-local') {
+        projectRows = projectRows.map((project) => (
+          project.id === 'prj_project2' ? { ...project, isShared: false } : project
+        ));
+      }
+      return Promise.resolve({ data: true });
+    });
+
+    renderSessionPage();
+
+    let projectRow = (await screen.findByText('Labs')).closest('[class*="group/project"]');
+    expect(projectRow).not.toBeNull();
+    await user.click(within(projectRow as HTMLElement).getByRole('button', { name: 'projectActions' }));
+    await user.click(within(projectRow as HTMLElement).getByRole('menuitem', { name: 'shareAction' }));
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledWith('/api/project/prj_project2/share-local');
+      expect(screen.getByText('sharedTag')).toBeInTheDocument();
+    });
+
+    projectRow = screen.getByText('Labs').closest('[class*="group/project"]');
+    await user.click(within(projectRow as HTMLElement).getByRole('button', { name: 'projectActions' }));
+    await user.click(within(projectRow as HTMLElement).getByRole('menuitem', { name: 'unshareAction' }));
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledWith('/api/project/prj_project2/unshare-local');
+      expect(screen.queryByText('sharedTag')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps a shared project read-only for non-owners', async () => {
+    const user = userEvent.setup();
+    client.get.mockResolvedValue({
+      data: [
+        { id: 'default', worktree: '/tmp/project', name: '默认', isDefault: true },
+        {
+          id: 'prj_shared', worktree: '/tmp/shared', name: 'Shared Labs',
+          canWrite: false, canDelete: false, isShared: true,
+        },
+      ],
+    });
+
+    renderSessionPage();
+
+    const projectRow = (await screen.findByText('Shared Labs')).closest('[class*="group/project"]');
+    expect(projectRow).not.toBeNull();
+    expect(within(projectRow as HTMLElement).getByRole('button', { name: 'createSessionInProject' })).toBeDisabled();
+    await user.click(within(projectRow as HTMLElement).getByRole('button', { name: 'projectActions' }));
+    expect(within(projectRow as HTMLElement).getByRole('menuitem', { name: 'projectDialog.copyPathAction' })).toBeInTheDocument();
+    expect(within(projectRow as HTMLElement).queryByRole('menuitem', { name: 'shareAction' })).not.toBeInTheDocument();
+    expect(within(projectRow as HTMLElement).queryByRole('menuitem', { name: 'unshareAction' })).not.toBeInTheDocument();
+    expect(within(projectRow as HTMLElement).queryByRole('menuitem', { name: 'projectDialog.renameAction' })).not.toBeInTheDocument();
+    expect(within(projectRow as HTMLElement).queryByRole('menuitem', { name: 'projectDialog.deleteAction' })).not.toBeInTheDocument();
   });
 
   it('ignores stale project results after the search changes', async () => {

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -601,8 +601,8 @@ describe('SessionPage session actions menu', () => {
     client.get.mockImplementation((url: string) => Promise.resolve({
       data: url === '/api/project/folders'
         ? {
-            path: '/tmp/project/child',
-            parent: '/tmp/project',
+            path: '/home/test-user',
+            parent: null,
             roots: [],
             entries: [],
           }
@@ -612,13 +612,19 @@ describe('SessionPage session actions menu', () => {
     renderSessionPage();
 
     await user.click(await screen.findByRole('button', { name: 'projectDialog.createTitle' }));
-    expect(screen.getByLabelText('projectDialog.folderLabel')).toHaveValue('/tmp/project');
+    expect(screen.getByLabelText('projectDialog.nameLabel')).toHaveValue('');
+    expect(screen.getByLabelText('projectDialog.folderLabel')).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'cancel' })).toBeEnabled();
 
     await user.click(screen.getByRole('button', { name: 'projectDialog.chooseFolder' }));
 
-    expect(await screen.findByText('/tmp/project/child')).toBeInTheDocument();
+    expect(await screen.findByText('/home/test-user')).toBeInTheDocument();
+    expect(client.get).toHaveBeenCalledWith('/api/project/folders', {
+      params: { path: undefined },
+    });
     expect(screen.queryByLabelText('projectDialog.folderLabel')).not.toBeInTheDocument();
   });
+
   it('shows the backend detail when project creation fails', async () => {
     const user = userEvent.setup();
     client.post.mockRejectedValue({

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -590,7 +590,7 @@ describe('SessionPage session actions menu', () => {
     });
   });
 
-  it('shows only the browser path while choosing a project folder', async () => {
+  it('uses the current browser path when saving without selecting the folder', async () => {
     const user = userEvent.setup();
     const defaultProject = {
       id: 'default',
@@ -608,6 +608,9 @@ describe('SessionPage session actions menu', () => {
           }
         : [defaultProject],
     }));
+    client.post.mockResolvedValue({
+      data: { id: 'prj_home', name: 'test-user', worktree: '/home/test-user' },
+    });
 
     renderSessionPage();
 
@@ -623,6 +626,15 @@ describe('SessionPage session actions menu', () => {
       params: { path: undefined },
     });
     expect(screen.queryByLabelText('projectDialog.folderLabel')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'save' }));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledWith('/api/project', {
+        name: 'test-user',
+        worktree: '/home/test-user',
+      });
+    });
   });
 
   it('shows the backend detail when project creation fails', async () => {

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -668,7 +668,7 @@ describe('SessionPage session actions menu', () => {
     });
   });
 
-  it('updates the folder input while navigating the folder browser', async () => {
+  it('keeps the folder input and folder browser in sync', async () => {
     const user = userEvent.setup();
     client.get.mockImplementation((url: string, config?: { params?: { path?: string } }) => {
       if (url !== '/api/project/folders') {
@@ -699,8 +699,14 @@ describe('SessionPage session actions menu', () => {
     await user.click(screen.getByRole('button', { name: 'projectDialog.chooseFolder' }));
     await waitFor(() => expect(folderInput).toHaveValue('/home/test-user'));
 
-    await user.click(screen.getByRole('button', { name: 'labs' }));
-    await waitFor(() => expect(folderInput).toHaveValue('/home/test-user/labs'));
+    await user.clear(folderInput);
+    await user.type(folderInput, '/home/test-user/labs');
+    await waitFor(() => {
+      expect(client.get).toHaveBeenCalledWith('/api/project/folders', {
+        params: { path: '/home/test-user/labs' },
+      });
+      expect(screen.getByText('/home/test-user/labs')).toBeInTheDocument();
+    });
   });
 
   it('does not submit when Enter is pressed before choosing a project folder', async () => {

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -656,7 +656,7 @@ describe('SessionPage session actions menu', () => {
     expect(client.get).toHaveBeenCalledWith('/api/project/folders', {
       params: { path: undefined },
     });
-    expect(screen.queryByLabelText('projectDialog.folderLabel')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('projectDialog.folderLabel')).toHaveValue('/home/test-user');
 
     await user.click(screen.getByRole('button', { name: 'save' }));
 
@@ -666,6 +666,41 @@ describe('SessionPage session actions menu', () => {
         worktree: '/home/test-user',
       });
     });
+  });
+
+  it('updates the folder input while navigating the folder browser', async () => {
+    const user = userEvent.setup();
+    client.get.mockImplementation((url: string, config?: { params?: { path?: string } }) => {
+      if (url !== '/api/project/folders') {
+        return Promise.resolve({
+          data: [{ id: 'default', worktree: '/tmp/project', name: '默认', isDefault: true }],
+        });
+      }
+      const path = config?.params?.path;
+      if (path === '/home/test-user/labs') {
+        return Promise.resolve({
+          data: { path, parent: '/home/test-user', roots: [], entries: [] },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          path: '/home/test-user',
+          parent: null,
+          roots: [],
+          entries: [{ name: 'labs', path: '/home/test-user/labs' }],
+        },
+      });
+    });
+
+    renderSessionPage();
+
+    await user.click(await screen.findByRole('button', { name: 'projectDialog.createTitle' }));
+    const folderInput = screen.getByLabelText('projectDialog.folderLabel');
+    await user.click(screen.getByRole('button', { name: 'projectDialog.chooseFolder' }));
+    await waitFor(() => expect(folderInput).toHaveValue('/home/test-user'));
+
+    await user.click(screen.getByRole('button', { name: 'labs' }));
+    await waitFor(() => expect(folderInput).toHaveValue('/home/test-user/labs'));
   });
 
   it('does not submit when Enter is pressed before choosing a project folder', async () => {

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -699,6 +699,14 @@ describe('SessionPage session actions menu', () => {
     await user.click(screen.getByRole('button', { name: 'projectDialog.chooseFolder' }));
     await waitFor(() => expect(folderInput).toHaveValue('/home/test-user'));
 
+    await user.type(folderInput, '/');
+    await waitFor(() => {
+      expect(client.get).toHaveBeenCalledWith('/api/project/folders', {
+        params: { path: '/home/test-user/' },
+      });
+    });
+    expect(folderInput).toHaveValue('/home/test-user/');
+
     await user.clear(folderInput);
     await user.type(folderInput, '/home/test-user/labs');
     await waitFor(() => {

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -435,7 +435,7 @@ describe('SessionPage session actions menu', () => {
     const firstRender = renderSessionPage();
 
     await screen.findByText('Labs');
-    await user.click(screen.getByRole('button', { name: 'toggleProject' }));
+    await user.click(screen.getByRole('button', { name: 'selectProject' }));
     expect(screen.queryByText('Original Session')).not.toBeInTheDocument();
 
     firstRender.unmount();
@@ -503,14 +503,17 @@ describe('SessionPage session actions menu', () => {
     renderSessionPage();
 
     await screen.findByText('Labs');
-    const toggle = screen.getByRole('button', { name: 'toggleProject' });
     const projectRow = screen.getByRole('button', { name: 'selectProject' });
+    expect(screen.queryByRole('button', { name: 'toggleProject' })).not.toBeInTheDocument();
+    expect(projectRow).toHaveAttribute('aria-expanded', 'true');
 
-    await user.click(toggle);
+    await user.click(projectRow);
     expect(screen.queryByText('Original Session')).not.toBeInTheDocument();
+    expect(projectRow).toHaveAttribute('aria-expanded', 'false');
 
     await user.click(projectRow);
     expect(screen.getByText('Original Session')).toBeInTheDocument();
+    expect(projectRow).toHaveAttribute('aria-expanded', 'true');
 
     await user.click(projectRow);
     expect(screen.queryByText('Original Session')).not.toBeInTheDocument();
@@ -587,6 +590,35 @@ describe('SessionPage session actions menu', () => {
     });
   });
 
+  it('shows only the browser path while choosing a project folder', async () => {
+    const user = userEvent.setup();
+    const defaultProject = {
+      id: 'default',
+      worktree: '/tmp/project',
+      name: '默认',
+      isDefault: true,
+    };
+    client.get.mockImplementation((url: string) => Promise.resolve({
+      data: url === '/api/project/folders'
+        ? {
+            path: '/tmp/project/child',
+            parent: '/tmp/project',
+            roots: [],
+            entries: [],
+          }
+        : [defaultProject],
+    }));
+
+    renderSessionPage();
+
+    await user.click(await screen.findByRole('button', { name: 'projectDialog.createTitle' }));
+    expect(screen.getByLabelText('projectDialog.folderLabel')).toHaveValue('/tmp/project');
+
+    await user.click(screen.getByRole('button', { name: 'projectDialog.chooseFolder' }));
+
+    expect(await screen.findByText('/tmp/project/child')).toBeInTheDocument();
+    expect(screen.queryByLabelText('projectDialog.folderLabel')).not.toBeInTheDocument();
+  });
   it('shows the backend detail when project creation fails', async () => {
     const user = userEvent.setup();
     client.post.mockRejectedValue({

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -1015,6 +1015,9 @@ describe('SessionPage session actions menu', () => {
     await screen.findByText('Original Session');
     await user.click(screen.getByRole('button', { name: 'moreActions' }));
 
+    const menu = document.querySelector('[data-session-menu-portal]');
+    expect(menu).toHaveClass('min-w-28', 'rounded-md', 'p-1');
+    expect(menu).not.toHaveClass('w-36', 'rounded-lg');
     expect(screen.getByRole('button', { name: 'rename' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'downloadJson' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'deleteAction' })).toBeInTheDocument();

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -1195,12 +1195,17 @@ export default function SessionPage() {
 
   const handleSubmitProject = useCallback(async () => {
     if (!projectDialogMode || projectSubmitInFlightRef.current) return;
-    const nextName = projectNameValue.trim();
+    const nextWorktree = projectWorktreeValue.trim() || folderBrowser?.path.trim() || '';
+    const nextName = projectNameValue.trim() || (
+      projectDialogMode === 'create' && !projectNameManuallyEdited && nextWorktree
+        ? getPathBasename(nextWorktree)
+        : ''
+    );
     if (!nextName) {
       toast.error(t('projectDialog.saveFailed'), t('projectDialog.nameEmpty'));
       return;
     }
-    if (projectDialogMode === 'create' && !projectWorktreeValue.trim()) {
+    if (projectDialogMode === 'create' && !nextWorktree) {
       toast.error(t('projectDialog.saveFailed'), t('projectDialog.folderEmpty'));
       return;
     }
@@ -1211,7 +1216,7 @@ export default function SessionPage() {
       if (projectDialogMode === 'create') {
         const response = await client.post('/api/project', {
           name: nextName,
-          worktree: projectWorktreeValue.trim(),
+          worktree: nextWorktree,
         });
         const createdProject = response.data as ProjectSummary;
         setProjects(prev => (
@@ -1246,7 +1251,7 @@ export default function SessionPage() {
       projectSubmitInFlightRef.current = false;
       setProjectSubmitting(false);
     }
-  }, [editingProjectId, fetchProjects, projectDialogMode, projectNameValue, projectWorktreeValue, t, toast]);
+  }, [editingProjectId, fetchProjects, folderBrowser?.path, projectDialogMode, projectNameManuallyEdited, projectNameValue, projectWorktreeValue, t, toast]);
 
   const handleDownloadSession = useCallback(async (sessionId: string, title: string) => {
     setOpenMenuSessionId(null);

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -59,6 +59,10 @@ type ProjectSummary = {
   sessionCount?: number;
   matchedSessionCount?: number;
   lastActivityAt?: number | null;
+  ownerUserID?: string | null;
+  canWrite?: boolean;
+  canDelete?: boolean;
+  isShared?: boolean;
 };
 type ProjectDialogMode = 'create' | 'rename';
 type ProjectSessionGroup = {
@@ -69,6 +73,9 @@ type ProjectSessionGroup = {
   sessionCount: number;
   isDefault: boolean;
   pathStatus: 'available' | 'missing' | 'unreadable';
+  canWrite: boolean;
+  canDelete: boolean;
+  isShared: boolean;
 };
 type FolderEntry = { name: string; path: string };
 type FolderBrowserResponse = {
@@ -218,7 +225,7 @@ function SessionSidebarItemInner({
           : selectMode && checked
           ? 'bg-blue-50 border-blue-200 dark:border-blue-500/40 dark:bg-blue-950/30'
           : nested
-            ? 'border-transparent hover:bg-gray-50 dark:hover:bg-zinc-900'
+            ? 'border-gray-100 hover:border-gray-200 hover:bg-gray-50 dark:border-zinc-800 dark:hover:bg-zinc-900'
             : 'border-gray-100 hover:border-gray-200 hover:bg-gray-50 hover:shadow-sm dark:border-transparent dark:hover:border-zinc-800 dark:hover:bg-zinc-900 dark:hover:shadow-none'
       }`}
     >
@@ -581,6 +588,9 @@ export default function SessionPage() {
           : project.sessionCount ?? projectSessions.length,
         isDefault,
         pathStatus: project.pathStatus ?? 'available',
+        canWrite: project.canWrite ?? true,
+        canDelete: project.canDelete ?? true,
+        isShared: project.isShared ?? false,
       };
     })
       .filter((group) => {
@@ -1160,6 +1170,24 @@ export default function SessionPage() {
     }
   }, [t, toast]);
 
+  const handleShareProject = useCallback(async (
+    project: ProjectSessionGroup,
+    nextShared: boolean,
+  ) => {
+    setOpenProjectMenuId(null);
+    try {
+      const action = nextShared ? 'share-local' : 'unshare-local';
+      await client.post(`/api/project/${project.id}/${action}`);
+      toast.success(t(nextShared ? 'shareEnabled' : 'shareDisabled'));
+      await Promise.all([
+        fetchProjects(undefined, searchQuery),
+        refetchSessions(),
+      ]);
+    } catch (err: any) {
+      toast.error(t('shareUpdateFailed'), err.message);
+    }
+  }, [fetchProjects, refetchSessions, searchQuery, t, toast]);
+
   const handleOpenDeleteProject = useCallback((project: ProjectSessionGroup) => {
     setOpenProjectMenuId(null);
     setProjectPendingDelete(project);
@@ -1574,6 +1602,11 @@ export default function SessionPage() {
                         >
                           <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-gray-500 dark:text-zinc-500" />
                           <span className="min-w-0 flex-1 truncate font-medium">{group.label}</span>
+                          {group.isShared && (
+                            <span className="inline-flex shrink-0 items-center rounded-full border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:border-blue-500/30 dark:bg-blue-950/30 dark:text-blue-300">
+                              {t('sharedTag')}
+                            </span>
+                          )}
                           {group.pathStatus !== 'available' && (
                             <AlertTriangle
                               className="h-3.5 w-3.5 shrink-0 text-amber-500"
@@ -1587,7 +1620,7 @@ export default function SessionPage() {
                             event.stopPropagation();
                             handleCreateSessionInProject(group.id);
                           }}
-                          disabled={creating || group.pathStatus !== 'available'}
+                          disabled={creating || !group.canWrite || group.pathStatus !== 'available'}
                           className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
                           title={t('createSessionInProject', { project: group.label })}
                           aria-label={t('createSessionInProject', { project: group.label })}
@@ -1628,7 +1661,18 @@ export default function SessionPage() {
                             <Copy className="h-3.5 w-3.5" />
                             {t('projectDialog.copyPathAction')}
                           </button>
-                          {!isDefaultProject && (
+                          {!isDefaultProject && group.canWrite && (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            onClick={() => void handleShareProject(group, !group.isShared)}
+                            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-zinc-700 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                          >
+                            <Share2 className="h-3.5 w-3.5" />
+                            {t(group.isShared ? 'unshareAction' : 'shareAction')}
+                          </button>
+                          )}
+                          {!isDefaultProject && group.canWrite && (
                           <button
                             type="button"
                             role="menuitem"
@@ -1639,10 +1683,10 @@ export default function SessionPage() {
                             {t('projectDialog.renameAction')}
                           </button>
                           )}
-                          {!isDefaultProject && (
+                          {!isDefaultProject && group.canDelete && (
                           <div className="mx-2 my-1 border-t border-zinc-100 dark:border-zinc-800" />
                           )}
-                          {!isDefaultProject && (
+                          {!isDefaultProject && group.canDelete && (
                           <button
                             type="button"
                             role="menuitem"

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -387,6 +387,7 @@ export default function SessionPage() {
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameSubmitInFlightRef = useRef(false);
   const projectSubmitInFlightRef = useRef(false);
+  const folderBrowserRequestIdRef = useRef(0);
   const sessionUpdateRefetchTimerRef = useRef<number | null>(null);
   const projectListRequestSeqRef = useRef(0);
   const toast = useToast();
@@ -1138,21 +1139,41 @@ export default function SessionPage() {
     setFolderBrowser(null);
   }, [projectSubmitting]);
 
-  const loadFolderBrowser = useCallback(async (path?: string) => {
+  const loadFolderBrowser = useCallback(async (
+    path?: string,
+    options?: { silent?: boolean },
+  ) => {
+    const requestId = ++folderBrowserRequestIdRef.current;
     setFolderBrowserLoading(true);
     try {
       const response = await client.get('/api/project/folders', {
         params: { path: path?.trim() || undefined },
       });
+      if (requestId !== folderBrowserRequestIdRef.current) return;
       const browser = response.data as FolderBrowserResponse;
       setFolderBrowser(browser);
       setProjectWorktreeValue(browser.path);
     } catch (err: any) {
-      toast.error(t('projectDialog.folderBrowseFailed'), err.message);
+      if (requestId === folderBrowserRequestIdRef.current && !options?.silent) {
+        toast.error(t('projectDialog.folderBrowseFailed'), err.message);
+      }
     } finally {
-      setFolderBrowserLoading(false);
+      if (requestId === folderBrowserRequestIdRef.current) {
+        setFolderBrowserLoading(false);
+      }
     }
   }, [t, toast]);
+
+  useEffect(() => {
+    if (!folderBrowser) return undefined;
+    const path = projectWorktreeValue.trim();
+    if (!path || path === folderBrowser.path) return undefined;
+
+    const timer = window.setTimeout(() => {
+      void loadFolderBrowser(path, { silent: true });
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [folderBrowser, loadFolderBrowser, projectWorktreeValue]);
 
   const handleSelectProjectFolder = useCallback((path: string) => {
     setProjectWorktreeValue(path);
@@ -2215,6 +2236,8 @@ export default function SessionPage() {
                       id="session-project-worktree"
                       value={projectWorktreeValue}
                       onChange={(event) => {
+                        folderBrowserRequestIdRef.current += 1;
+                        setFolderBrowserLoading(false);
                         setProjectWorktreeValue(event.target.value);
                         if (!projectNameManuallyEdited) {
                           setProjectNameValue(getPathBasename(event.target.value));

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -1097,15 +1097,13 @@ export default function SessionPage() {
   }, [renameValue, sessions, t, toast, updateSessionTitle]);
 
   const handleOpenCreateProject = useCallback(() => {
-    const defaultProject = projects.find((project) => project.isDefault)
-      ?? projects.find((project) => project.id === defaultProjectId);
     setProjectDialogMode('create');
     setEditingProjectId(null);
-    setProjectWorktreeValue(defaultProject?.worktree ?? '');
-    setProjectNameValue(defaultProject?.worktree ? getPathBasename(defaultProject.worktree) : '');
+    setProjectWorktreeValue('');
+    setProjectNameValue('');
     setProjectNameManuallyEdited(false);
     setFolderBrowser(null);
-  }, [defaultProjectId, projects]);
+  }, []);
 
   const handleOpenRenameProject = useCallback((project: ProjectSessionGroup) => {
     const persistedName = projects.find((item) => item.id === project.id)?.name?.trim();
@@ -2152,37 +2150,30 @@ export default function SessionPage() {
                 <>
                   {!folderBrowser && (
                     <>
-                      <div className="flex items-center justify-between pt-1">
-                    <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400" htmlFor="session-project-worktree">
-                      {t('projectDialog.folderLabel')}
-                    </label>
-                    <span className="max-w-64 truncate text-[11px] text-zinc-400 dark:text-zinc-600" title={projects.find((project) => project.isDefault)?.worktree}>
-                      {t('projectDialog.defaultFolder', {
-                        path: projects.find((project) => project.isDefault)?.worktree ?? '',
-                      })}
-                    </span>
-                  </div>
-                  <div className="flex gap-2">
-                    <input
-                      id="session-project-worktree"
-                      value={projectWorktreeValue}
-                      onChange={(event) => {
-                        setProjectWorktreeValue(event.target.value);
-                        if (!projectNameManuallyEdited) {
-                          setProjectNameValue(getPathBasename(event.target.value));
-                        }
-                      }}
-                      disabled={projectSubmitting}
-                      placeholder={t('projectDialog.folderPlaceholder')}
-                      className="min-w-0 flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 font-mono text-xs text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-blue-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-600 dark:focus:border-blue-500"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => void loadFolderBrowser(projectWorktreeValue)}
-                      disabled={projectSubmitting || folderBrowserLoading}
-                      className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-zinc-200 px-3 text-xs font-medium text-zinc-600 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
-                    >
-                      {folderBrowserLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FolderOpen className="h-3.5 w-3.5" />}
+                      <label className="block pt-1 text-xs font-medium text-zinc-500 dark:text-zinc-400" htmlFor="session-project-worktree">
+                        {t('projectDialog.folderLabel')}
+                      </label>
+                      <div className="flex gap-2">
+                        <input
+                          id="session-project-worktree"
+                          value={projectWorktreeValue}
+                          onChange={(event) => {
+                            setProjectWorktreeValue(event.target.value);
+                            if (!projectNameManuallyEdited) {
+                              setProjectNameValue(getPathBasename(event.target.value));
+                            }
+                          }}
+                          disabled={projectSubmitting}
+                          placeholder={t('projectDialog.folderPlaceholder')}
+                          className="min-w-0 flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 font-mono text-xs text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-blue-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-600 dark:focus:border-blue-500"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => void loadFolderBrowser(projectWorktreeValue)}
+                          disabled={projectSubmitting || folderBrowserLoading}
+                          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-zinc-200 px-3 text-xs font-medium text-zinc-600 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
+                        >
+                          {folderBrowserLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FolderOpen className="h-3.5 w-3.5" />}
                           {t('projectDialog.chooseFolder')}
                         </button>
                       </div>
@@ -2252,7 +2243,7 @@ export default function SessionPage() {
               <button
                 type="button"
                 onClick={handleCloseProjectDialog}
-                disabled={projectSubmitting || (projectDialogMode === 'create' && !projectWorktreeValue.trim())}
+                disabled={projectSubmitting}
                 className="rounded-lg px-3 py-1.5 text-sm text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-900 dark:hover:text-zinc-100"
               >
                 {t('cancel')}

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -170,6 +170,7 @@ function getProjectLabel(project?: ProjectSummary, fallbackDirectory?: string): 
 
 interface SessionSidebarItemProps {
   session: Session;
+  nested?: boolean;
   selected: boolean;
   selectMode: boolean;
   checked: boolean;
@@ -189,6 +190,7 @@ interface SessionSidebarItemProps {
 
 function SessionSidebarItemInner({
   session,
+  nested = false,
   selected,
   selectMode,
   checked,
@@ -208,12 +210,16 @@ function SessionSidebarItemInner({
   return (
     <div
       onClick={() => onSelect(session.id)}
-      className={`group relative mx-2 mb-1 px-3 py-2.5 rounded-xl border cursor-pointer transition-all duration-150 ${
+      className={`group relative mb-1 cursor-pointer border px-3 transition-all duration-150 ${
+        nested ? 'ml-7 mr-2 rounded-lg py-2' : 'mx-2 rounded-xl py-2.5'
+      } ${
         !selectMode && selected
-          ? 'bg-gray-100 border-gray-300 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none'
+          ? 'border-gray-300 bg-gray-100 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-none'
           : selectMode && checked
           ? 'bg-blue-50 border-blue-200 dark:border-blue-500/40 dark:bg-blue-950/30'
-          : 'border-gray-100 hover:border-gray-200 hover:bg-gray-50 hover:shadow-sm dark:border-transparent dark:hover:border-zinc-800 dark:hover:bg-zinc-900 dark:hover:shadow-none'
+          : nested
+            ? 'border-transparent hover:bg-gray-50 dark:hover:bg-zinc-900'
+            : 'border-gray-100 hover:border-gray-200 hover:bg-gray-50 hover:shadow-sm dark:border-transparent dark:hover:border-zinc-800 dark:hover:bg-zinc-900 dark:hover:shadow-none'
       }`}
     >
       <div className="flex items-center gap-1.5 min-w-0 pr-7">
@@ -293,6 +299,7 @@ function SessionSidebarItemInner({
 
 const SessionSidebarItem = memo(SessionSidebarItemInner, (prev, next) => (
   prev.session.id === next.session.id &&
+  prev.nested === next.nested &&
   prev.session.title === next.session.title &&
   prev.session.category === next.session.category &&
   prev.session.isShared === next.session.isShared &&
@@ -1533,7 +1540,7 @@ export default function SessionPage() {
                   </button>
                 </div>
                 {!projectsSectionCollapsed && (
-                  <div className="space-y-1">
+                  <div className="space-y-2">
                 {managedProjectSessionGroups.map((group) => {
                   const collapsed = collapsedProjectIds.has(group.id);
                   const isDefaultProject = group.isDefault;
@@ -1554,23 +1561,13 @@ export default function SessionPage() {
                       >
                         <button
                           type="button"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            toggleProjectCollapsed(group.id);
-                          }}
-                          className="rounded p-0.5 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
-                          aria-label={t('toggleProject', { project: group.label })}
-                        >
-                          {collapsed ? <ChevronRight className="h-3.5 w-3.5 shrink-0" /> : <ChevronDown className="h-3.5 w-3.5 shrink-0" />}
-                        </button>
-                        <button
-                          type="button"
                           onClick={() => {
                             setSelectedProjectId(group.id);
                             toggleProjectCollapsed(group.id);
                           }}
                           className="flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-0.5 text-left"
                           aria-label={t('selectProject', { project: group.label })}
+                          aria-expanded={!collapsed}
                         >
                           <FolderGit2 className="h-3.5 w-3.5 shrink-0 text-gray-500 dark:text-zinc-500" />
                           <span className="min-w-0 flex-1 truncate font-medium">{group.label}</span>
@@ -1609,7 +1606,7 @@ export default function SessionPage() {
                             <MoreHorizontal className="h-3.5 w-3.5" />
                           </button>
                         )}
-                        <span className="w-5 shrink-0 text-right text-xs tabular-nums text-gray-400 dark:text-zinc-600">
+                        <span className="inline-flex min-w-5 shrink-0 items-center justify-center rounded-full bg-white/80 px-1.5 py-0.5 text-[10px] tabular-nums text-gray-400 dark:bg-zinc-800 dark:text-zinc-500">
                           {group.sessionCount}
                         </span>
                       </div>
@@ -1656,12 +1653,13 @@ export default function SessionPage() {
                         </div>
                       )}
                       {!collapsed && (
-                        <div className="mt-1">
+                        <div className="mt-1.5">
                           {group.sessions.length > 0 ? (
                             group.sessions.map((session) => (
                               <SessionSidebarItem
                                 key={session.id}
                                 session={session}
+                                nested
                                 selected={selectedSessionId === session.id}
                                 selectMode={selectMode}
                                 checked={checkedIds.has(session.id)}
@@ -1680,12 +1678,12 @@ export default function SessionPage() {
                               />
                             ))
                           ) : (
-                            <div className="mx-4 py-1 text-xs text-gray-400 dark:text-zinc-600">
+                            <div className="ml-7 mr-2 rounded-lg px-3 py-2 text-xs text-gray-400 dark:text-zinc-600">
                               {t('noProjectSessions')}
                             </div>
                           )}
                           {hasMoreProjectSessions && (
-                            <div className="mx-4 py-1">
+                            <div className="ml-7 mr-2 py-1">
                               <button
                                 type="button"
                                 onClick={() => void loadMoreSessions(group.id)}
@@ -2152,7 +2150,9 @@ export default function SessionPage() {
               />
               {projectDialogMode === 'create' && (
                 <>
-                  <div className="flex items-center justify-between pt-1">
+                  {!folderBrowser && (
+                    <>
+                      <div className="flex items-center justify-between pt-1">
                     <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400" htmlFor="session-project-worktree">
                       {t('projectDialog.folderLabel')}
                     </label>
@@ -2183,9 +2183,11 @@ export default function SessionPage() {
                       className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-zinc-200 px-3 text-xs font-medium text-zinc-600 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
                     >
                       {folderBrowserLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FolderOpen className="h-3.5 w-3.5" />}
-                      {t('projectDialog.chooseFolder')}
-                    </button>
-                  </div>
+                          {t('projectDialog.chooseFolder')}
+                        </button>
+                      </div>
+                    </>
+                  )}
                   {folderBrowser && (
                     <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
                       <div className="flex items-center gap-1 border-b border-zinc-100 bg-zinc-50 px-2 py-1.5 dark:border-zinc-800 dark:bg-zinc-900">

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -2382,14 +2382,14 @@ export default function SessionPage() {
         if (!session) return null;
         return (
           <div
-            className="fixed z-50 w-36 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-zinc-800 dark:bg-zinc-900"
+            className="fixed z-50 min-w-28 rounded-md border border-zinc-200 bg-white p-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-900"
             style={{ top: menuAnchor.top, right: menuAnchor.right }}
             data-session-menu-portal
             onClick={(e) => e.stopPropagation()}
           >
             <button
               onClick={(e) => { e.stopPropagation(); handleStartRename(session.id, session.title); setOpenMenuSessionId(null); setMenuAnchor(null); }}
-              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors dark:text-zinc-200 dark:hover:bg-zinc-800"
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-zinc-700 transition-colors hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-800"
             >
               <PencilLine className="w-3.5 h-3.5" />
               <span>{t('rename')}</span>
@@ -2397,7 +2397,7 @@ export default function SessionPage() {
             <button
               onClick={(e) => { e.stopPropagation(); void handleDownloadSession(session.id, session.title); setOpenMenuSessionId(null); setMenuAnchor(null); }}
               disabled={downloadingSessionId === session.id}
-              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-zinc-700 transition-colors hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-200 dark:hover:bg-zinc-800"
             >
               <Download className="w-3.5 h-3.5" />
               <span>{t('downloadJson')}</span>
@@ -2405,16 +2405,16 @@ export default function SessionPage() {
             <button
               onClick={(e) => { e.stopPropagation(); setOpenMenuSessionId(null); setMenuAnchor(null); void handleShareSession(session.id, !session.isShared); }}
               disabled={session.canWrite === false}
-              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-zinc-700 transition-colors hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-200 dark:hover:bg-zinc-800"
             >
               <Share2 className="w-3.5 h-3.5" />
               <span>{session.isShared ? t('unshareAction') : t('shareAction')}</span>
             </button>
-            <div className="mx-2.5 my-1 border-t border-gray-100 dark:border-zinc-800" />
+            <div className="mx-2 my-1 border-t border-zinc-100 dark:border-zinc-800" />
             <button
               onClick={(e) => { e.stopPropagation(); setOpenMenuSessionId(null); setMenuAnchor(null); void handleDeleteSession(session.id); }}
               disabled={session.canDelete === false}
-              className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-sm text-red-600 hover:bg-red-50 transition-colors disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-300 dark:hover:bg-red-950/40"
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-300 dark:hover:bg-red-950/40"
             >
               <Trash2 className="w-3.5 h-3.5" />
               <span>{t('deleteAction')}</span>

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -1144,7 +1144,9 @@ export default function SessionPage() {
       const response = await client.get('/api/project/folders', {
         params: { path: path?.trim() || undefined },
       });
-      setFolderBrowser(response.data as FolderBrowserResponse);
+      const browser = response.data as FolderBrowserResponse;
+      setFolderBrowser(browser);
+      setProjectWorktreeValue(browser.path);
     } catch (err: any) {
       toast.error(t('projectDialog.folderBrowseFailed'), err.message);
     } finally {
@@ -2205,37 +2207,33 @@ export default function SessionPage() {
               />
               {projectDialogMode === 'create' && (
                 <>
-                  {!folderBrowser && (
-                    <>
-                      <label className="block pt-1 text-xs font-medium text-zinc-500 dark:text-zinc-400" htmlFor="session-project-worktree">
-                        {t('projectDialog.folderLabel')}
-                      </label>
-                      <div className="flex gap-2">
-                        <input
-                          id="session-project-worktree"
-                          value={projectWorktreeValue}
-                          onChange={(event) => {
-                            setProjectWorktreeValue(event.target.value);
-                            if (!projectNameManuallyEdited) {
-                              setProjectNameValue(getPathBasename(event.target.value));
-                            }
-                          }}
-                          disabled={projectSubmitting}
-                          placeholder={t('projectDialog.folderPlaceholder')}
-                          className="min-w-0 flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 font-mono text-xs text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-blue-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-600 dark:focus:border-blue-500"
-                        />
-                        <button
-                          type="button"
-                          onClick={() => void loadFolderBrowser(projectWorktreeValue)}
-                          disabled={projectSubmitting || folderBrowserLoading}
-                          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-zinc-200 px-3 text-xs font-medium text-zinc-600 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
-                        >
-                          {folderBrowserLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FolderOpen className="h-3.5 w-3.5" />}
-                          {t('projectDialog.chooseFolder')}
-                        </button>
-                      </div>
-                    </>
-                  )}
+                  <label className="block pt-1 text-xs font-medium text-zinc-500 dark:text-zinc-400" htmlFor="session-project-worktree">
+                    {t('projectDialog.folderLabel')}
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      id="session-project-worktree"
+                      value={projectWorktreeValue}
+                      onChange={(event) => {
+                        setProjectWorktreeValue(event.target.value);
+                        if (!projectNameManuallyEdited) {
+                          setProjectNameValue(getPathBasename(event.target.value));
+                        }
+                      }}
+                      disabled={projectSubmitting}
+                      placeholder={t('projectDialog.folderPlaceholder')}
+                      className="min-w-0 flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 font-mono text-xs text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-blue-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-600 dark:focus:border-blue-500"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void loadFolderBrowser(projectWorktreeValue)}
+                      disabled={projectSubmitting || folderBrowserLoading}
+                      className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-zinc-200 px-3 text-xs font-medium text-zinc-600 hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
+                    >
+                      {folderBrowserLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FolderOpen className="h-3.5 w-3.5" />}
+                      {t('projectDialog.chooseFolder')}
+                    </button>
+                  </div>
                   {folderBrowser && (
                     <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800">
                       <div className="flex items-center gap-1 border-b border-zinc-100 bg-zinc-50 px-2 py-1.5 dark:border-zinc-800 dark:bg-zinc-900">

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -388,6 +388,7 @@ export default function SessionPage() {
   const renameSubmitInFlightRef = useRef(false);
   const projectSubmitInFlightRef = useRef(false);
   const folderBrowserRequestIdRef = useRef(0);
+  const folderBrowserInputPathRef = useRef<string | null>(null);
   const sessionUpdateRefetchTimerRef = useRef<number | null>(null);
   const projectListRequestSeqRef = useRef(0);
   const toast = useToast();
@@ -1141,7 +1142,7 @@ export default function SessionPage() {
 
   const loadFolderBrowser = useCallback(async (
     path?: string,
-    options?: { silent?: boolean },
+    options?: { preserveInput?: boolean; silent?: boolean },
   ) => {
     const requestId = ++folderBrowserRequestIdRef.current;
     setFolderBrowserLoading(true);
@@ -1152,7 +1153,12 @@ export default function SessionPage() {
       if (requestId !== folderBrowserRequestIdRef.current) return;
       const browser = response.data as FolderBrowserResponse;
       setFolderBrowser(browser);
-      setProjectWorktreeValue(browser.path);
+      if (options?.preserveInput) {
+        folderBrowserInputPathRef.current = path?.trim() || browser.path;
+      } else {
+        folderBrowserInputPathRef.current = browser.path;
+        setProjectWorktreeValue(browser.path);
+      }
     } catch (err: any) {
       if (requestId === folderBrowserRequestIdRef.current && !options?.silent) {
         toast.error(t('projectDialog.folderBrowseFailed'), err.message);
@@ -1167,10 +1173,14 @@ export default function SessionPage() {
   useEffect(() => {
     if (!folderBrowser) return undefined;
     const path = projectWorktreeValue.trim();
-    if (!path || path === folderBrowser.path) return undefined;
+    if (
+      !path
+      || path === folderBrowser.path
+      || path === folderBrowserInputPathRef.current
+    ) return undefined;
 
     const timer = window.setTimeout(() => {
-      void loadFolderBrowser(path, { silent: true });
+      void loadFolderBrowser(path, { preserveInput: true, silent: true });
     }, 300);
     return () => window.clearTimeout(timer);
   }, [folderBrowser, loadFolderBrowser, projectWorktreeValue]);
@@ -2237,6 +2247,7 @@ export default function SessionPage() {
                       value={projectWorktreeValue}
                       onChange={(event) => {
                         folderBrowserRequestIdRef.current += 1;
+                        folderBrowserInputPathRef.current = null;
                         setFolderBrowserLoading(false);
                         setProjectWorktreeValue(event.target.value);
                         if (!projectNameManuallyEdited) {

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -2139,6 +2139,14 @@ export default function SessionPage() {
                 onKeyDown={(event) => {
                   if (event.key === 'Enter') {
                     event.preventDefault();
+                    if (
+                      event.nativeEvent.isComposing
+                      || (projectDialogMode === 'create'
+                        && !projectWorktreeValue.trim()
+                        && !folderBrowser?.path.trim())
+                    ) {
+                      return;
+                    }
                     void handleSubmitProject();
                   }
                   if (event.key === 'Escape') {


### PR DESCRIPTION
## Summary
- visually nest project sessions with the same outlined card treatment used by task sessions
- remove per-project disclosure icons and keep project-row expand/collapse behavior accessible
- add local project sharing that exposes the project and all existing or future sessions as read-only to other local users
- allow project owners to share or unshare from the project menu while hiding write actions for viewers
- start new projects with an empty folder field and open the folder browser from the user home directory
- save directly with the current browsed folder when the explicit folder-selection button was not clicked
- prevent Enter in the project name field from submitting before a folder is available, including IME composition
- avoid duplicate project folder paths while the folder browser is open

## Validation
- `.venv/bin/python -m pytest tests/project/test_project.py tests/server/routes/test_project_routes.py tests/server/routes/test_session_routes.py -q` (81 passed)
- `npm test -- --run src/pages/Session/index.test.tsx` (47 passed)
- `npx eslint src/pages/Session/index.tsx src/pages/Session/index.test.tsx --report-unused-disable-directives --max-warnings 0`
- `npm run build`
- `.venv/bin/ruff check flocks/project/project.py flocks/server/routes/project.py flocks/server/routes/session.py flocks/session/policy.py tests/server/routes/test_project_routes.py`
- `git diff --check`
