### PR TITLE
fix(webui): restore Pro product name fallback

### DIFF
--- a/webui/src/components/layout/Layout.test.tsx
+++ b/webui/src/components/layout/Layout.test.tsx
@@ -481,7 +481,7 @@ describe('Layout onboarding entry', () => {
 
     expect(await screen.findByText('admin.roleMember')).toBeInTheDocument();
     expect(await screen.findByText('v2026.6.21')).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Flocks' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Flocks Pro' })).not.toBeInTheDocument();
     await waitFor(() => expect(checkUpdate).toHaveBeenCalledWith('zh-CN', 'flockspro'));
 
     const sidebarShell = container.querySelector('aside > div');
@@ -537,7 +537,7 @@ describe('Layout onboarding entry', () => {
 
     await user.click(screen.getByRole('button', { name: 'admin settings' }));
 
-    expect(screen.getByRole('link', { name: 'Flocks' })).toHaveAttribute('href', '/settings/flockspro');
+    expect(screen.getByRole('link', { name: 'Flocks Pro' })).toHaveAttribute('href', '/settings/flockspro');
     expect(screen.getByRole('button', { name: 'checkUpdate' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'settings' })).toHaveAttribute('href', '/settings/preferences');
 
@@ -608,7 +608,7 @@ describe('Layout onboarding entry', () => {
 
     await user.click(screen.getByRole('button', { name: 'admin settings' }));
 
-    expect(screen.getByRole('link', { name: 'Flocks' })).toHaveAttribute('href', '/settings/flockspro');
+    expect(screen.getByRole('link', { name: 'Flocks Pro' })).toHaveAttribute('href', '/settings/flockspro');
     expect(screen.getByRole('link', { name: 'settings' })).toHaveAttribute('href', '/settings/preferences');
 
     await user.click(screen.getByRole('button', { name: 'logout' }));

--- a/webui/src/components/layout/Layout.tsx
+++ b/webui/src/components/layout/Layout.tsx
@@ -198,7 +198,7 @@ export default function Layout() {
   const { t: tWebUIContractPage } = useTranslation('webuiContractPage');
   const { t: tAuth } = useTranslation('auth');
   const toast = useToast();
-  const { productName } = useProductName();
+  const { productName, proProductName } = useProductName();
   const [hasUpdate, setHasUpdate] = useState(false);
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [currentVersion, setCurrentVersion] = useState<string | null>(null);
@@ -914,7 +914,7 @@ export default function Layout() {
                     className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 hover:text-zinc-950 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
                   >
                     <ArrowUpCircle className="h-4 w-4 text-zinc-400" />
-                    {productName}
+                    {proProductName}
                   </Link>
                 )}
                 <button

--- a/webui/src/contexts/ProductNameContext.test.tsx
+++ b/webui/src/contexts/ProductNameContext.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProductNameProvider, useProductName } from "./ProductNameContext";
+
+const { uiConfigApi } = vi.hoisted(() => ({
+  uiConfigApi: {
+    getDisplay: vi.fn(),
+    resetFavicon: vi.fn(),
+    update: vi.fn(),
+    uploadFavicon: vi.fn(),
+  },
+}));
+
+vi.mock("@/api/uiConfig", () => ({
+  uiConfigApi,
+}));
+
+function ProductNames() {
+  const { productName, proProductName } = useProductName();
+  return (
+    <div>
+      <span data-testid="product-name">{productName}</span>
+      <span data-testid="pro-product-name">{proProductName}</span>
+    </div>
+  );
+}
+
+describe("ProductNameProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses Flocks Pro for Pro surfaces when no custom display name is configured", async () => {
+    uiConfigApi.getDisplay.mockResolvedValue({
+      displayName: "Flocks",
+      configuredDisplayName: null,
+      faviconUrl: null,
+    });
+
+    render(
+      <ProductNameProvider>
+        <ProductNames />
+      </ProductNameProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("product-name")).toHaveTextContent("Flocks"),
+    );
+    expect(screen.getByTestId("pro-product-name")).toHaveTextContent(
+      "Flocks Pro",
+    );
+  });
+
+  it("uses the configured display name for Pro surfaces", async () => {
+    uiConfigApi.getDisplay.mockResolvedValue({
+      displayName: "Acme SOC",
+      configuredDisplayName: "Acme SOC",
+      faviconUrl: null,
+    });
+
+    render(
+      <ProductNameProvider>
+        <ProductNames />
+      </ProductNameProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("product-name")).toHaveTextContent("Acme SOC"),
+    );
+    expect(screen.getByTestId("pro-product-name")).toHaveTextContent(
+      "Acme SOC",
+    );
+  });
+});

--- a/webui/src/contexts/ProductNameContext.tsx
+++ b/webui/src/contexts/ProductNameContext.tsx
@@ -3,10 +3,12 @@ import type { ReactNode } from 'react';
 import { uiConfigApi, type UIDisplayConfig } from '@/api/uiConfig';
 
 const DEFAULT_PRODUCT_NAME = (import.meta.env.VITE_APP_NAME || 'Flocks').trim() || 'Flocks';
+const DEFAULT_PRO_PRODUCT_NAME = 'Flocks Pro';
 const DEFAULT_FAVICON_URL = '/favicon.svg';
 
 interface ProductNameContextValue {
   productName: string;
+  proProductName: string;
   configuredDisplayName: string | null;
   faviconUrl: string;
   hasCustomFavicon: boolean;
@@ -19,6 +21,7 @@ interface ProductNameContextValue {
 
 const ProductNameContext = createContext<ProductNameContextValue>({
   productName: DEFAULT_PRODUCT_NAME,
+  proProductName: DEFAULT_PRO_PRODUCT_NAME,
   configuredDisplayName: null,
   faviconUrl: DEFAULT_FAVICON_URL,
   hasCustomFavicon: false,
@@ -112,6 +115,7 @@ export function ProductNameProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo<ProductNameContextValue>(() => ({
     productName: displayConfig.displayName,
+    proProductName: displayConfig.configuredDisplayName || DEFAULT_PRO_PRODUCT_NAME,
     configuredDisplayName: displayConfig.configuredDisplayName ?? null,
     faviconUrl: displayConfig.faviconUrl || DEFAULT_FAVICON_URL,
     hasCustomFavicon: Boolean(displayConfig.faviconUrl),

--- a/webui/src/pages/FlocksproUpgrade/index.test.tsx
+++ b/webui/src/pages/FlocksproUpgrade/index.test.tsx
@@ -43,7 +43,10 @@ vi.mock('react-i18next', () => ({
         return options.defaultValue;
       }
       if (key === 'upgrade.installedTitle') {
-        return `Flocks Pro ${options?.version || ''}`;
+        return `${options?.productName || ''} ${options?.version || ''}`;
+      }
+      if (key === 'upgrade.title') {
+        return `Upgrade to ${options?.productName || ''}`;
       }
       return key;
     },
@@ -107,6 +110,25 @@ describe('FlocksproUpgradePage', () => {
 
     await waitFor(() => expect(consoleUpgradeApi.getProPackageStatus).toHaveBeenCalled());
     expect(await screen.findByRole('button', { name: 'upgrade.startUpgrade' })).toBeInTheDocument();
+  });
+
+  it('uses the Pro product name when no custom display name is configured', async () => {
+    consoleUpgradeApi.listRequests.mockResolvedValue([]);
+    consoleUpgradeApi.getProPackageStatus.mockResolvedValue({
+      installed: false,
+      runtime_importable: false,
+      install_marker_present: false,
+      pro_enabled: false,
+      license_status: 'uninstalled',
+    });
+
+    render(
+      <MemoryRouter>
+        <FlocksproUpgradePage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Upgrade to Flocks Pro')).toBeInTheDocument();
   });
 
   it('shows the installed bundle version instead of the Pro component version', async () => {

--- a/webui/src/pages/FlocksproUpgrade/index.tsx
+++ b/webui/src/pages/FlocksproUpgrade/index.tsx
@@ -303,7 +303,7 @@ function requestDurationDays(item: UpgradeRequestStatus): number | null {
 
 export default function FlocksproUpgradePage() {
   const { t } = useTranslation('flockspro');
-  const { productName } = useProductName();
+  const { proProductName } = useProductName();
   const [searchParams, setSearchParams] = useSearchParams();
   const [consoleLoginStatus, setConsoleLoginStatus] = useState<ConsoleLoginSessionStatus | null>(null);
   const [consoleLoginLoading, setConsoleLoginLoading] = useState(false);
@@ -993,8 +993,8 @@ export default function FlocksproUpgradePage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title={t('title', { productName })}
-        description={t('description', { productName })}
+        title={t('title', { productName: proProductName })}
+        description={t('description', { productName: proProductName })}
         icon={<ArrowUpCircle className="w-8 h-8" />}
       />
 
@@ -1052,13 +1052,13 @@ export default function FlocksproUpgradePage() {
           <div>
             <h2 className="text-lg font-semibold text-gray-900">
               {isProLoaded
-                ? t('upgrade.installedTitle', { productName, version: proVersion })
-                : t('upgrade.title', { productName })}
+                ? t('upgrade.installedTitle', { productName: proProductName, version: proVersion })
+                : t('upgrade.title', { productName: proProductName })}
             </h2>
             <p className="text-sm text-gray-500 mt-1">
               {isProLoaded
-                ? t('upgrade.installedDescription', { productName })
-                : t('upgrade.description', { productName })}
+                ? t('upgrade.installedDescription', { productName: proProductName })
+                : t('upgrade.description', { productName: proProductName })}
             </p>
           </div>
           {isProLoaded ? (
@@ -1231,7 +1231,7 @@ export default function FlocksproUpgradePage() {
           >
             {currentLicenseInvalid && (
               <div className="mb-3 rounded-lg border border-red-200 bg-white/70 px-3 py-2 text-sm text-red-800">
-                {t('upgrade.revokedOrExpiredHint', { productName })}
+                {t('upgrade.revokedOrExpiredHint', { productName: proProductName })}
               </div>
             )}
             <div className={`flex flex-wrap items-center justify-between gap-3 border-b pb-3 ${
@@ -1393,12 +1393,12 @@ export default function FlocksproUpgradePage() {
       {showApplyDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4">
           <div className="w-full max-w-lg rounded-xl bg-white border border-gray-200 shadow-xl p-6 space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">{t('upgrade.applyDialogTitle', { productName })}</h3>
+            <h3 className="text-lg font-semibold text-gray-900">{t('upgrade.applyDialogTitle', { productName: proProductName })}</h3>
             <div className="space-y-3">
               <div className="space-y-1">
                 <div className="text-sm text-gray-600">{t('upgrade.productLabel')}</div>
                 <input
-                  value={productName}
+                  value={proProductName}
                   readOnly
                   className="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700"
                 />
@@ -1492,7 +1492,7 @@ export default function FlocksproUpgradePage() {
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-gray-900">{t('upgrade.downgradeDialogTitle')}</h3>
-                <p className="mt-1 text-sm text-gray-600">{t('upgrade.downgradeDialogDescription', { productName })}</p>
+                <p className="mt-1 text-sm text-gray-600">{t('upgrade.downgradeDialogDescription', { productName: proProductName })}</p>
               </div>
             </div>
             <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
@@ -1543,8 +1543,8 @@ export default function FlocksproUpgradePage() {
                   ? t('upgrade.waitingDowngradeRestart')
                   : t('upgrade.waitingRestart')
                 : updateMode === 'downgrade'
-                ? t('upgrade.downgradingHint', { productName })
-                : t('upgrade.installingHint', { productName })}
+                ? t('upgrade.downgradingHint', { productName: proProductName })
+                : t('upgrade.installingHint', { productName: proProductName })}
             </div>
             {upgradeSteps.length > 0 && (
               <div className="space-y-2">
@@ -1564,7 +1564,7 @@ export default function FlocksproUpgradePage() {
                       )}
                       <div className="min-w-0">
                         <div className={isError ? 'font-medium text-red-700' : 'font-medium text-gray-800'}>
-                          {t(`upgrade.stageLabels.${step.stage}`, { defaultValue: step.stage, productName })}
+                          {t(`upgrade.stageLabels.${step.stage}`, { defaultValue: step.stage, productName: proProductName })}
                         </div>
                         <div className={isError ? 'text-xs text-red-600' : 'text-xs text-gray-500'}>
                           {step.message}

--- a/webui/src/pages/Settings/index.test.tsx
+++ b/webui/src/pages/Settings/index.test.tsx
@@ -196,7 +196,7 @@ describe('SettingsPage', () => {
     renderSettings('/settings/flockspro');
 
     expect(await screen.findByRole('heading', { name: 'settingsPreferences' })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Flocks' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Flocks Pro' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'auditLogs' })).not.toBeInTheDocument();
   });
 });

--- a/webui/src/pages/Settings/index.tsx
+++ b/webui/src/pages/Settings/index.tsx
@@ -395,7 +395,7 @@ export default function SettingsPage() {
   const navigate = useNavigate();
   const { t } = useTranslation('nav');
   const { user } = useAuth();
-  const { productName } = useProductName();
+  const { proProductName } = useProductName();
   const isAdmin = user?.role === 'admin';
   const sectionId = params.sectionId;
   const [flocksproCapabilityReady, setFlocksproCapabilityReady] = useState(false);
@@ -455,11 +455,11 @@ export default function SettingsPage() {
           { id: 'account', name: t('accountManagement'), icon: UserCog },
           { id: 'system-logs', name: t('systemLog'), icon: ScrollText },
           { id: 'audit-logs', name: t('auditLogs'), icon: ShieldCheck, adminOnly: true, requiresFlockspro: true },
-          { id: 'flockspro', name: productName, icon: ArrowUpCircle, adminOnly: true },
+          { id: 'flockspro', name: proProductName, icon: ArrowUpCircle, adminOnly: true },
         ],
       },
     ],
-    [productName, t],
+    [proProductName, t],
   );
 
   const visibleGroups = groups


### PR DESCRIPTION
## Summary
- add a dedicated Pro display name that falls back to Flocks Pro
- preserve configured custom display names across Pro navigation and upgrade surfaces
- keep the fixed authorization product value unchanged
- add regression coverage for default and configured display names

## Root cause
The custom UI branding change reused the standard product name on Pro-specific surfaces. Unconfigured OSS installations therefore rendered Flocks instead of Flocks Pro.

## Verification
- npm test -- --run src/contexts/ProductNameContext.test.tsx src/pages/FlocksproUpgrade/index.test.tsx src/pages/Settings/index.test.tsx src/components/layout/Layout.test.tsx
- npm run build
- targeted ESLint checks
- git diff --check