### PR TITLE
Fix Windows Chrome debug setup guidance

### DIFF
--- a/.flocks/plugins/skills/browser-use/SKILL.md
+++ b/.flocks/plugins/skills/browser-use/SKILL.md
@@ -61,9 +61,9 @@ flocks browser --doctor
 | 结果 | 触发条件 | 一线修复 | 仍失败兜底 |
 |---|---|---|---|
 | **A** | `next action` 以 `ready` 开头 | 立即确定 `CDP 直连`,阅读 `references/cdp-direct.md`,之后不再切到 `agent-browser` | — |
-| **B** | `next action` 以 `attach` 开头 | 不要先反复 `--setup`；按输出执行 `flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'` 触发一次实际连接/观察 | 如果 `-c` 失败或仍无连接，执行 `flocks browser --reload` 清理旧 daemon，再执行 `flocks browser --setup`；setup 可能需要多次，直到用户完成浏览器 Allow/inspect 授权或错误信息稳定 |
-| **C** | `next action` 以 `setup` 开头 | 先执行 `flocks browser --setup`（不包短超时），再运行 `--doctor` 确认 | 如提示 remote debugging 未启用、`DevToolsActivePort` 缺失、403 handshake 或 not live yet，再提示用户打开对应 inspect 页面并 Allow；用户确认后可多次 `--setup` |
-| **D** | `next action` 提示启动浏览器或提供 endpoint | 明确告知需要先启动 Chrome/Chromium/Edge 或提供 CDP endpoint | **不**擅自降级到 curl/webfetch；坚持告知 skill 边界 |
+| **B** | `next action` 以 `attach` 开头 | 不要先反复 `--setup`；按输出执行 `flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'` 触发一次实际连接/观察 | 如果 `-c` 失败或仍无连接，执行 `flocks browser --reload` 清理旧 daemon，再执行 `flocks browser --setup`；若 setup 输出本地 remote debugging 不可达，按 `references/cdp-setup.md` 的固定端口流程处理 |
+| **C** | `next action` 以 `setup` 开头 | 先执行 `flocks browser --setup`（不包短超时），再运行 `--doctor` 确认 | 如提示 remote debugging 不可达、`DevToolsActivePort` 缺失、403 handshake 或 not live yet，按 `references/cdp-setup.md` 指引使用非默认 `--user-data-dir` 启动 Chromium 系浏览器，再访问 `/json/version` 验证 |
+| **D** | `next action` 提示启动浏览器或提供 endpoint | 明确告知需要先用 remote-debugging 参数启动 Chrome/Chromium/Edge/Brave，或提供 CDP endpoint | **不**擅自降级到 curl/webfetch；坚持告知 skill 边界 |
 
 ### Step 4: 跨模式通用失败
 

--- a/.flocks/plugins/skills/browser-use/references/cdp-direct.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-direct.md
@@ -350,11 +350,11 @@ print({"cookies": [c["name"] for c in cookies], "localStorage": js("Object.keys(
 
 1. 先运行 `flocks browser --doctor` 看版本、安装模式、daemon 和浏览器状态；不要只看退出码，优先读 `next action`，再看 `browser running`、`daemon alive`、`active browser connections`。
 2. `next action` 为 `attach`，或 `daemon alive` ok 但 `active browser connections` 为 0 时，不要先反复 `--setup`。先用一次实际命令触发连接/观察：`flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'`。
-3. 如果上一步失败或仍无连接，再执行 `flocks browser --reload` 清旧 daemon，然后执行 `flocks browser --setup`；setup 可能需要多次，因为用户可能需要完成浏览器 inspect/Allow 授权，或浏览器需要时间写入 remote debugging 状态。
+3. 如果上一步失败或仍无连接，再执行 `flocks browser --reload` 清旧 daemon，然后执行 `flocks browser --setup`。若 setup 输出本地 remote debugging 不可达，按 `references/cdp-setup.md` 的固定端口流程处理。
 4. 首次安装、冷启动、daemon 不存在/不通，且浏览器已经运行或配置了 `BU_CDP_URL` / `BU_CDP_WS` 时，优先运行 `flocks browser --setup`。
-5. Chrome / Chromium / Edge 未运行且没有显式 CDP endpoint 时，只提示用户启动浏览器或提供 endpoint；不要直接让用户改设置。
-6. 只有在明确提示 remote debugging 未启用、`DevToolsActivePort` 缺失、403 handshake、remote-debugging page 或 not live yet 时，才让用户打开对应浏览器的 inspect 页面（例如 `chrome://inspect/#remote-debugging` 或 `edge://inspect/#remote-debugging`）并勾选 Allow remote debugging。
-7. 用户刚开启 remote debugging 时，不要立刻再次运行 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 daemon attach，再用 `--doctor` 做只读确认。
+5. Chrome / Chromium / Edge / Brave 未运行且没有显式 CDP endpoint 时，按 `references/cdp-setup.md` 提供对应平台的 remote-debugging 启动命令。
+6. 只有在明确提示 remote debugging 不可达、`DevToolsActivePort` 缺失、403 handshake、remote-debugging page 或 not live yet 时，才让用户使用非默认 `--user-data-dir` 和 `--remote-debugging-port=9222` 启动 Chromium 系浏览器，并访问 `http://127.0.0.1:9222/json/version` 验证。
+7. 用户刚按固定端口流程启动浏览器时，不要立刻再次运行 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 daemon attach，再用 `--doctor` 做只读确认。
 8. `connection refused`、`DevTools not live yet`、`/json/version` 404 通常是浏览器正在启动，轮询等待，不要重启。
 9. stale websocket / stale socket 时执行一次：
 

--- a/.flocks/plugins/skills/browser-use/references/cdp-setup.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-setup.md
@@ -1,6 +1,6 @@
 # Flocks browser setup
 
-浏览器已运行，但 daemon 不存在/不通，或 active browser connection 不可用
+本地固定端口 CDP 设置：daemon 不存在/不通，active browser connection 不可用，或浏览器尚未以 remote debugging 参数启动。
 
 先区分两种情况：
 
@@ -11,15 +11,44 @@
 2. daemon 不存在/不通，且浏览器已运行或配置了 `BU_CDP_URL` / `BU_CDP_WS`：
    - 执行 `flocks browser --setup` 触发 attach，不要用短超时包装该命令。
 
-只有在错误明确指向 remote debugging 未启用、`DevToolsActivePort` 缺失、403 handshake 或 not live yet 时，才提示用户：
+只有在错误明确指向 remote debugging 不可达、`DevToolsActivePort` 缺失、403 handshake 或 not live yet 时，才提示用户走本地固定端口流程：
 
 ```text
-browser: not connected — 请确保 Chrome / Chromium / Edge 已打开，然后访问对应浏览器的 inspect 页面（例如 chrome://inspect/#remote-debugging 或 edge://inspect/#remote-debugging）并勾选 Allow remote debugging
+不要从 chrome://inspect 查找 webSocketDebuggerUrl。关闭对应 Chromium 系浏览器后，使用非默认 --user-data-dir 和 --remote-debugging-port=9222 启动浏览器，再访问 http://127.0.0.1:9222/json/version 验证。
 ```
 
-然后等待用户进一步指示，不要直接操作。
+候选命令按平台选择一个即可；如果浏览器安装路径不同，替换可执行文件路径：
 
-当用户确认已开启remote-debugging后:
-1. 执行 `flocks browser --setup` 触发交互式 attach，不要用短超时包装该命令
+Windows PowerShell：
+
+```powershell
+& "$env:ProgramFiles\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\.flocks\chrome-debug-profile"
+& "${env:ProgramFiles(x86)}\Microsoft\Edge\Application\msedge.exe" --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\.flocks\edge-debug-profile"
+chromium.exe --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\.flocks\chromium-debug-profile"
+& "$env:ProgramFiles\BraveSoftware\Brave-Browser\Application\brave.exe" --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\.flocks\brave-debug-profile"
+```
+
+macOS：
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/chrome-debug-profile"
+/Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/edge-debug-profile"
+/Applications/Chromium.app/Contents/MacOS/Chromium --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/chromium-debug-profile"
+/Applications/Brave\ Browser.app/Contents/MacOS/Brave\ Browser --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/brave-debug-profile"
+```
+
+Linux：
+
+```bash
+google-chrome --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/chrome-debug-profile"
+microsoft-edge --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/edge-debug-profile"
+chromium --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/chromium-debug-profile"
+brave-browser --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/brave-debug-profile"
+```
+
+输出命令后等待用户进一步指示，不要占用当前终端盲目重试。
+
+当用户确认 `http://127.0.0.1:9222/json/version` 已可访问后:
+1. 执行 `flocks browser --setup` 触发 attach，不要用短超时包装该命令
 2. 再运行 `flocks browser --doctor` 做只读确认。
-3. 如果还失败，先执行 `flocks browser --reload` 清理旧 daemon，再重新执行 `flocks browser --setup`，避免因为残留 daemon 造成干扰。setup 可能需要多次，直到用户完成浏览器 Allow/inspect 授权或错误信息稳定。
+3. 如果还失败，先执行 `flocks browser --reload` 清理旧 daemon，再重新执行 `flocks browser --setup`，避免因为残留 daemon 造成干扰。

--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -20,7 +20,7 @@ from .utils import load_env_file
 VERSION_CACHE = Path(tempfile.gettempdir()) / "flocks-browser-version-cache.json"
 VERSION_CACHE_TTL = 24 * 3600
 DOCTOR_TEXT_LIMIT = 140
-# run_setup: at most two daemon/CDP attach attempts to avoid repeated Allow prompts.
+# run_setup retries transient attach failures once, but exits after manual setup guidance.
 _SETUP_ATTACH_WAIT = 20.0
 _SETUP_RETRY_WAIT = 30.0
 
@@ -54,6 +54,7 @@ def _needs_chrome_remote_debugging_prompt(msg: str | None) -> bool:
     return (
         "devtoolsactiveport not found" in lower
         or "chrome remote debugging is not reachable" in lower
+        or "chromium-based browser remote debugging is not reachable" in lower
         or "remote-debugging page" in lower
         or "inspect/#remote-debugging" in lower
         or "not live yet" in lower
@@ -62,38 +63,49 @@ def _needs_chrome_remote_debugging_prompt(msg: str | None) -> bool:
 
 
 def _local_debugging_setup_lines(system: str | None = None) -> list[str]:
-    """Return concise manual setup guidance for local Chrome debugging."""
+    """Return concise manual setup guidance for local Chromium-based debugging."""
     import platform
 
     system = system or platform.system()
     lines = [
         "Do not look for webSocketDebuggerUrl in chrome://inspect; that page does not reliably show it.",
+        "Close the matching Chromium-based browser if it is already open, then run one command below.",
     ]
     if system == "Windows":
         lines.extend(
             [
-                "On Windows, close Chrome and run this in PowerShell:",
+                "On Windows PowerShell:",
                 '& "$env:ProgramFiles\\Google\\Chrome\\Application\\chrome.exe" --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\\.flocks\\chrome-debug-profile"',
-                "If Chrome is installed elsewhere, replace the chrome.exe path.",
+                '& "${env:ProgramFiles(x86)}\\Microsoft\\Edge\\Application\\msedge.exe" --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\\.flocks\\edge-debug-profile"',
+                'chromium.exe --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\\.flocks\\chromium-debug-profile"',
+                '& "$env:ProgramFiles\\BraveSoftware\\Brave-Browser\\Application\\brave.exe" --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\\.flocks\\brave-debug-profile"',
+                "If your browser is installed elsewhere, replace the executable path.",
             ]
         )
     elif system == "Darwin":
         lines.extend(
             [
-                "On macOS, close Chrome and run:",
+                "On macOS:",
                 "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/chrome-debug-profile\"",
+                "/Applications/Microsoft\\ Edge.app/Contents/MacOS/Microsoft\\ Edge --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/edge-debug-profile\"",
+                "/Applications/Chromium.app/Contents/MacOS/Chromium --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/chromium-debug-profile\"",
+                "/Applications/Brave\\ Browser.app/Contents/MacOS/Brave\\ Browser --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/brave-debug-profile\"",
             ]
         )
     else:
         lines.extend(
             [
-                "On Linux, close Chrome and run:",
+                "On Linux:",
                 "google-chrome --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/chrome-debug-profile\"",
+                "microsoft-edge --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/edge-debug-profile\"",
+                "chromium --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/chromium-debug-profile\"",
+                "brave-browser --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/brave-debug-profile\"",
             ]
         )
     lines.extend(
         [
             "Then verify http://127.0.0.1:9222/json/version; Flocks reads the WebSocket URL from that endpoint.",
+            "After the endpoint responds, rerun `flocks browser --setup`.",
         ]
     )
     return lines
@@ -263,7 +275,7 @@ def _doctor_short_text(value, limit: int | None = None) -> str:
 
 
 def ensure_daemon(
-    wait: float = 60.0, name: str | None = None, env: dict | None = None, _open_inspect: bool = True
+    wait: float = 60.0, name: str | None = None, env: dict | None = None, _show_debugging_guidance: bool = True
 ) -> None:
     """Ensure a healthy daemon is running, restarting stale sessions when needed."""
     effective_name = ipc.runtime_paths(name or NAME).name
@@ -316,13 +328,10 @@ def ensure_daemon(
         msg = _log_tail(effective_name) or ""
         if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
             restart_daemon(effective_name)
-            if not _open_inspect:
-                raise RuntimeError(
-                    msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}"
-                )
-            print(f"{BROWSER_LABEL}: local Chrome remote debugging is not reachable.", file=sys.stderr)
-            _print_local_debugging_setup(sys.stderr)
-            continue
+            if _show_debugging_guidance:
+                print(f"{BROWSER_LABEL}: local Chromium-based browser remote debugging is not reachable.", file=sys.stderr)
+                _print_local_debugging_setup(sys.stderr)
+            raise RuntimeError(msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}")
         raise RuntimeError(msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}")
 
 
@@ -419,10 +428,10 @@ def _chrome_running() -> bool:
     try:
         if system == "Windows":
             output = subprocess.check_output(["tasklist"], timeout=5)
-            names = ("chrome.exe", "chromium.exe", "msedge.exe")
+            names = ("chrome.exe", "chromium.exe", "msedge.exe", "brave.exe")
         else:
             output = subprocess.check_output(["ps", "-A", "-o", "comm="], text=True, timeout=5)
-            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge")
+            names = ("Google Chrome", "chrome", "chromium", "Microsoft Edge", "msedge", "Brave Browser", "brave")
         return _output_contains_process_names(output, names)
     except Exception:
         return False
@@ -448,25 +457,28 @@ def run_setup() -> int:
             print("daemon already running but browser connection is stale; restarting.")
             restart_daemon()
     if not endpoint_name and not _chrome_running():
-        print("no Chrome/Chromium/Edge process detected. please start your browser and rerun `flocks browser --setup`.")
+        print("no Chrome/Chromium/Edge/Brave process detected.")
+        print("start a Chromium-based browser with remote debugging, then rerun `flocks browser --setup`.")
+        _print_local_debugging_setup(sys.stdout)
         return 1
     try:
-        ensure_daemon(wait=_SETUP_ATTACH_WAIT, _open_inspect=False)
+        ensure_daemon(wait=_SETUP_ATTACH_WAIT, _show_debugging_guidance=False)
         print("daemon is up.")
         return 0
     except RuntimeError as error:
         first_err = str(error)
 
-    needs_inspect = _is_local_chrome_mode() and _needs_chrome_remote_debugging_prompt(first_err)
-    if needs_inspect:
-        print("browser remote debugging is not reachable for the current profile.")
+    needs_manual_debugging_setup = _is_local_chrome_mode() and _needs_chrome_remote_debugging_prompt(first_err)
+    if needs_manual_debugging_setup:
+        print("Chromium-based browser remote debugging is not reachable for the current profile.")
         _print_local_debugging_setup(sys.stdout)
+        return 1
     else:
         print(f"attach failed: {first_err}")
         print("retrying once (the browser may still be starting up)...")
 
     try:
-        ensure_daemon(wait=_SETUP_RETRY_WAIT, _open_inspect=False)
+        ensure_daemon(wait=_SETUP_RETRY_WAIT, _show_debugging_guidance=False)
         print("daemon is up.")
         return 0
     except RuntimeError as error:
@@ -509,7 +521,10 @@ def run_doctor() -> int:
     elif target_available:
         next_action = "setup; run `flocks browser --setup`"
     else:
-        next_action = "start Chrome/Chromium/Edge or provide BU_CDP_URL/BU_CDP_WS, then run `flocks browser --setup`"
+        next_action = (
+            "start Chrome/Chromium/Edge/Brave or provide BU_CDP_URL/BU_CDP_WS, "
+            "then run `flocks browser --setup`"
+        )
 
     print(f"{BROWSER_LABEL} doctor")
     print(f"  platform          {platform.system()} {platform.release()}")
@@ -528,7 +543,7 @@ def run_doctor() -> int:
         row(
             "browser running",
             browser_running,
-            "" if browser_running else "start Chrome, Chromium, or Edge and rerun `flocks browser --setup`",
+            "" if browser_running else "start Chrome, Chromium, Edge, or Brave and rerun `flocks browser --setup`",
         )
     row(
         "daemon alive",

--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -49,15 +49,62 @@ def _log_tail(name: str | None):
 
 
 def _needs_chrome_remote_debugging_prompt(msg: str | None) -> bool:
-    """Return True when a local browser needs the inspect-page permission flow."""
+    """Return True when a local browser needs remote-debugging setup guidance."""
     lower = (msg or "").lower()
     return (
         "devtoolsactiveport not found" in lower
+        or "chrome remote debugging is not reachable" in lower
         or "remote-debugging page" in lower
         or "inspect/#remote-debugging" in lower
         or "not live yet" in lower
         or ("ws handshake failed" in lower and "403" in lower)
     )
+
+
+def _local_debugging_setup_lines(system: str | None = None) -> list[str]:
+    """Return concise manual setup guidance for local Chrome debugging."""
+    import platform
+
+    system = system or platform.system()
+    lines = [
+        "Do not look for webSocketDebuggerUrl in chrome://inspect; that page does not reliably show it.",
+    ]
+    if system == "Windows":
+        lines.extend(
+            [
+                "On Windows, close Chrome and run this in PowerShell:",
+                '& "$env:ProgramFiles\\Google\\Chrome\\Application\\chrome.exe" --remote-debugging-port=9222 --user-data-dir="$env:USERPROFILE\\.flocks\\chrome-debug-profile"',
+                "If Chrome is installed elsewhere, replace the chrome.exe path.",
+            ]
+        )
+    elif system == "Darwin":
+        lines.extend(
+            [
+                "On macOS, close Chrome and run:",
+                "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/chrome-debug-profile\"",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "On Linux, close Chrome and run:",
+                "google-chrome --remote-debugging-port=9222 --user-data-dir=\"$HOME/.flocks/chrome-debug-profile\"",
+            ]
+        )
+    lines.extend(
+        [
+            "Then verify http://127.0.0.1:9222/json/version; Flocks reads the WebSocket URL from that endpoint.",
+        ]
+    )
+    return lines
+
+
+def _print_local_debugging_setup(out=None) -> None:
+    import sys
+
+    out = out or sys.stderr
+    for line in _local_debugging_setup_lines():
+        print(line, file=out)
 
 
 def _configured_cdp_endpoint(env: dict | None = None) -> tuple[str | None, str | None]:
@@ -273,12 +320,8 @@ def ensure_daemon(
                 raise RuntimeError(
                     msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}"
                 )
-            _open_browser_inspect()
-            print(
-                f"{BROWSER_LABEL}: click Allow on your browser's inspect page "
-                "(for example chrome://inspect or edge://inspect), and tick the checkbox if shown",
-                file=sys.stderr,
-            )
+            print(f"{BROWSER_LABEL}: local Chrome remote debugging is not reachable.", file=sys.stderr)
+            _print_local_debugging_setup(sys.stderr)
             continue
         raise RuntimeError(msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}")
 
@@ -385,40 +428,6 @@ def _chrome_running() -> bool:
         return False
 
 
-def _open_browser_inspect() -> None:
-    import platform
-    import subprocess
-    import webbrowser
-
-    inspect_targets = [
-        ("Google Chrome", "chrome://inspect/#remote-debugging"),
-        ("Microsoft Edge", "edge://inspect/#remote-debugging"),
-    ]
-    if platform.system() == "Darwin":
-        for app_name, url in inspect_targets:
-            try:
-                subprocess.run(
-                    [
-                        "osascript",
-                        "-e",
-                        f'tell application "{app_name}" to activate',
-                        "-e",
-                        f'tell application "{app_name}" to open location "{url}"',
-                    ],
-                    timeout=5,
-                    check=False,
-                )
-                return
-            except Exception:
-                continue
-    for _app_name, url in inspect_targets:
-        try:
-            if webbrowser.open(url, new=2):
-                return
-        except Exception:
-            continue
-
-
 def run_setup() -> int:
     """Interactively attach to the running browser."""
     import sys
@@ -450,11 +459,8 @@ def run_setup() -> int:
 
     needs_inspect = _is_local_chrome_mode() and _needs_chrome_remote_debugging_prompt(first_err)
     if needs_inspect:
-        print("browser remote debugging is not enabled on the current profile.")
-        print("opening your browser's inspect page -- in the tab that opens:")
-        print("  1. if the browser shows the profile picker, pick your normal profile;")
-        print("  2. tick 'Discover network targets' and click Allow if prompted.")
-        _open_browser_inspect()
+        print("browser remote debugging is not reachable for the current profile.")
+        _print_local_debugging_setup(sys.stdout)
     else:
         print(f"attach failed: {first_err}")
         print("retrying once (the browser may still be starting up)...")
@@ -529,7 +535,7 @@ def run_doctor() -> int:
         daemon,
         ""
         if daemon
-        else "not running; run `flocks browser --setup` to attach; if setup reports remote debugging is disabled, follow its inspect-page prompt",
+        else "not running; run `flocks browser --setup` to attach; if setup reports remote debugging is not reachable, follow its debug-browser instructions",
     )
     row("active browser connections", bool(connections), str(len(connections)))
     for conn in connections:

--- a/flocks/browser/daemon.py
+++ b/flocks/browser/daemon.py
@@ -53,9 +53,11 @@ def profile_dirs(
     system = system or platform.system()
     home = home or Path.home()
     environ = os.environ if environ is None else environ
+    flocks_debug_profile = home / ".flocks/chrome-debug-profile"
     if system == "Darwin":
         support = home / "Library/Application Support"
         return [
+            flocks_debug_profile,
             support / "Google/Chrome",
             support / "Google/Chrome Canary",
             support / "Comet",
@@ -70,6 +72,7 @@ def profile_dirs(
     if system == "Windows":
         local = Path(environ.get("LOCALAPPDATA", str(home / "AppData/Local"))).expanduser()
         return [
+            flocks_debug_profile,
             local / "Google/Chrome/User Data",
             local / "Google/Chrome Beta/User Data",
             local / "Google/Chrome Dev/User Data",
@@ -84,6 +87,7 @@ def profile_dirs(
             local / "BraveSoftware/Brave-Browser-Nightly/User Data",
         ]
     return [
+        flocks_debug_profile,
         home / ".config/google-chrome",
         home / ".config/google-chrome-beta",
         home / ".config/google-chrome-unstable",
@@ -125,7 +129,9 @@ def _local_cdp_ws_url(port: int, devtools_path: str | None = None) -> str:
         if not isinstance(payload, dict):
             raise ValueError("invalid CDP version response")
         websocket_url = payload.get("webSocketDebuggerUrl")
-        if not isinstance(websocket_url, str):
+        if not isinstance(websocket_url, str) and devtools_path and devtools_path.startswith("/"):
+            websocket_url = f"ws://127.0.0.1:{port}{devtools_path}"
+        elif not isinstance(websocket_url, str):
             raise ValueError("invalid webSocketDebuggerUrl")
     except urllib.error.HTTPError:
         if not devtools_path or not devtools_path.startswith("/"):
@@ -198,15 +204,14 @@ def get_ws_url() -> str:
     if profile_errors:
         details = "; ".join(dict.fromkeys(profile_errors))
         raise RuntimeError(
-            "The browser's remote-debugging page is open, but DevTools is not live yet for any detected profile: "
-            f"{details} — if the browser opened a profile picker, choose your normal profile first, then tick the "
-            "checkbox and click Allow if shown"
+            "Chrome remote debugging is not reachable for any detected profile: "
+            f"{details} — for manual setup, start Chrome with --remote-debugging-port and a non-default "
+            "--user-data-dir, then verify http://127.0.0.1:9222/json/version"
         )
     raise RuntimeError(
         "DevToolsActivePort not found in "
-        f"{[str(path) for path in profiles]} — enable your browser's remote-debugging page "
-        "(for example chrome://inspect/#remote-debugging or edge://inspect/#remote-debugging), "
-        "or set BU_CDP_WS for a remote browser"
+        f"{[str(path) for path in profiles]} — start Chrome with --remote-debugging-port and a non-default "
+        "--user-data-dir, or set BU_CDP_WS for a remote browser"
     )
 
 

--- a/flocks/browser/daemon.py
+++ b/flocks/browser/daemon.py
@@ -23,6 +23,12 @@ from . import _ipc as ipc
 from .utils import load_env_file
 
 
+FLOCKS_DEBUG_PROFILE_NAMES = (
+    "chrome-debug-profile",
+    "edge-debug-profile",
+    "chromium-debug-profile",
+    "brave-debug-profile",
+)
 AGENT_WORKSPACE = Path(os.environ.get("BH_AGENT_WORKSPACE", DEFAULT_AGENT_WORKSPACE)).expanduser()
 BUF = 500
 INTERNAL = INTERNAL_URL_PREFIXES
@@ -53,11 +59,11 @@ def profile_dirs(
     system = system or platform.system()
     home = home or Path.home()
     environ = os.environ if environ is None else environ
-    flocks_debug_profile = home / ".flocks/chrome-debug-profile"
+    flocks_debug_profiles = [home / ".flocks" / name for name in FLOCKS_DEBUG_PROFILE_NAMES]
     if system == "Darwin":
         support = home / "Library/Application Support"
         return [
-            flocks_debug_profile,
+            *flocks_debug_profiles,
             support / "Google/Chrome",
             support / "Google/Chrome Canary",
             support / "Comet",
@@ -72,7 +78,7 @@ def profile_dirs(
     if system == "Windows":
         local = Path(environ.get("LOCALAPPDATA", str(home / "AppData/Local"))).expanduser()
         return [
-            flocks_debug_profile,
+            *flocks_debug_profiles,
             local / "Google/Chrome/User Data",
             local / "Google/Chrome Beta/User Data",
             local / "Google/Chrome Dev/User Data",
@@ -87,7 +93,7 @@ def profile_dirs(
             local / "BraveSoftware/Brave-Browser-Nightly/User Data",
         ]
     return [
-        flocks_debug_profile,
+        *flocks_debug_profiles,
         home / ".config/google-chrome",
         home / ".config/google-chrome-beta",
         home / ".config/google-chrome-unstable",
@@ -204,13 +210,13 @@ def get_ws_url() -> str:
     if profile_errors:
         details = "; ".join(dict.fromkeys(profile_errors))
         raise RuntimeError(
-            "Chrome remote debugging is not reachable for any detected profile: "
-            f"{details} — for manual setup, start Chrome with --remote-debugging-port and a non-default "
+            "Chromium-based browser remote debugging is not reachable for any detected profile: "
+            f"{details} — for manual setup, start the browser with --remote-debugging-port and a non-default "
             "--user-data-dir, then verify http://127.0.0.1:9222/json/version"
         )
     raise RuntimeError(
         "DevToolsActivePort not found in "
-        f"{[str(path) for path in profiles]} — start Chrome with --remote-debugging-port and a non-default "
+        f"{[str(path) for path in profiles]} — start a Chromium-based browser with --remote-debugging-port and a non-default "
         "--user-data-dir, or set BU_CDP_WS for a remote browser"
     )
 
@@ -285,7 +291,9 @@ class Daemon:
                     f"{hint}"
                 ) from error
             raise RuntimeError(
-                f"CDP WS handshake failed: {error} -- click Allow in your browser if prompted, then retry"
+                f"CDP WS handshake failed: {error} -- restart your Chromium-based browser with "
+                "--remote-debugging-port and a non-default --user-data-dir, then verify "
+                "http://127.0.0.1:9222/json/version"
             )
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pytest
+
 from flocks.browser import admin
 
 
@@ -59,9 +63,9 @@ def test_generic_remote_debugging_message_triggers_prompt() -> None:
 
 def test_current_remote_debugging_unreachable_message_triggers_prompt() -> None:
     msg = (
-        "Chrome remote debugging is not reachable for any detected profile: "
+        "Chromium-based browser remote debugging is not reachable for any detected profile: "
         "/tmp/chrome: 127.0.0.1:9222 (connection refused) — for manual setup, "
-        "start Chrome with --remote-debugging-port and a non-default --user-data-dir"
+        "start the browser with --remote-debugging-port and a non-default --user-data-dir"
     )
     assert admin._needs_chrome_remote_debugging_prompt(msg)
 
@@ -73,7 +77,38 @@ def test_local_debugging_setup_lines_use_windows_user_data_dir() -> None:
     assert "does not reliably show it" in lines
     assert "--remote-debugging-port=9222" in lines
     assert '--user-data-dir="$env:USERPROFILE\\.flocks\\chrome-debug-profile"' in lines
+    assert "msedge.exe" in lines
+    assert '--user-data-dir="$env:USERPROFILE\\.flocks\\edge-debug-profile"' in lines
+    assert "chromium.exe" in lines
+    assert "brave.exe" in lines
     assert "http://127.0.0.1:9222/json/version" in lines
+    assert "rerun `flocks browser --setup`" in lines
+
+
+def test_local_debugging_setup_lines_list_chromium_browser_candidates() -> None:
+    mac_lines = "\n".join(admin._local_debugging_setup_lines("Darwin"))
+    linux_lines = "\n".join(admin._local_debugging_setup_lines("Linux"))
+
+    assert "Microsoft\\ Edge.app" in mac_lines
+    assert "Chromium.app" in mac_lines
+    assert "Brave\\ Browser.app" in mac_lines
+    assert "microsoft-edge" in linux_lines
+    assert "chromium" in linux_lines
+    assert "brave-browser" in linux_lines
+
+
+def test_browser_skill_docs_do_not_reintroduce_inspect_allow_setup_flow() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    docs = [
+        repo_root / ".flocks/plugins/skills/browser-use/SKILL.md",
+        repo_root / ".flocks/plugins/skills/browser-use/references/cdp-direct.md",
+        repo_root / ".flocks/plugins/skills/browser-use/references/cdp-setup.md",
+    ]
+    text = "\n".join(path.read_text(encoding="utf-8") for path in docs)
+
+    assert "chrome://inspect/#remote-debugging" not in text
+    assert "edge://inspect/#remote-debugging" not in text
+    assert "Allow remote debugging" not in text
 
 
 def test_daemon_endpoint_names_discovers_default_and_named_sessions(tmp_path, monkeypatch) -> None:
@@ -208,6 +243,40 @@ def test_ensure_daemon_retries_after_lock_holder_exits_without_endpoint(tmp_path
     assert len(spawned) == 2
 
 
+def test_ensure_daemon_prints_manual_guidance_without_blind_retry(tmp_path, monkeypatch, capsys) -> None:
+    spawned = []
+    restarted = []
+
+    class FakeProcess:
+        def poll(self):
+            return 1
+
+    def fake_popen(*args, **kwargs):
+        spawned.append((args, kwargs))
+        return FakeProcess()
+
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
+    monkeypatch.setattr(admin.ipc, "endpoint_reachable", lambda name: False)
+    monkeypatch.setattr(admin, "daemon_alive", lambda name: False)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        admin,
+        "_log_tail",
+        lambda name: "Chromium-based browser remote debugging is not reachable for any detected profile",
+    )
+    monkeypatch.setattr(admin, "restart_daemon", lambda name=None: restarted.append(name))
+    monkeypatch.setattr(admin, "_local_debugging_setup_lines", lambda: ["debug browser instructions"])
+
+    with pytest.raises(RuntimeError):
+        admin.ensure_daemon(wait=1.0, name="manual-session")
+
+    err = capsys.readouterr().err
+    assert "local Chromium-based browser remote debugging is not reachable" in err
+    assert "debug browser instructions" in err
+    assert len(spawned) == 1
+    assert restarted == ["manual-session"]
+
+
 def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypatch, capsys) -> None:
     monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
     monkeypatch.setattr(admin, "_install_mode", lambda: "git")
@@ -294,14 +363,17 @@ def test_run_doctor_suggests_setup_when_target_exists_but_daemon_missing(monkeyp
 def test_run_setup_uses_generic_missing_browser_wording(monkeypatch, capsys) -> None:
     monkeypatch.setattr(admin, "daemon_alive", lambda: False)
     monkeypatch.setattr(admin, "_chrome_running", lambda: False)
+    monkeypatch.setattr(admin, "_local_debugging_setup_lines", lambda: ["debug browser instructions"])
 
     assert admin.run_setup() == 1
 
     out = capsys.readouterr().out
-    assert "no Chrome/Chromium/Edge process detected" in out
+    assert "no Chrome/Chromium/Edge/Brave process detected" in out
+    assert "start a Chromium-based browser with remote debugging" in out
+    assert "debug browser instructions" in out
 
 
-def test_run_setup_uses_generic_remote_debugging_wording(monkeypatch, capsys) -> None:
+def test_run_setup_prints_remote_debugging_guidance_without_blind_retry(monkeypatch, capsys) -> None:
     monkeypatch.setattr(admin, "daemon_alive", lambda: False)
     monkeypatch.setattr(admin, "_chrome_running", lambda: True)
     monkeypatch.setattr(admin, "_is_local_chrome_mode", lambda env=None: True)
@@ -319,12 +391,13 @@ def test_run_setup_uses_generic_remote_debugging_wording(monkeypatch, capsys) ->
 
     monkeypatch.setattr(admin, "ensure_daemon", fake_ensure_daemon)
 
-    assert admin.run_setup() == 0
+    assert admin.run_setup() == 1
 
     out = capsys.readouterr().out
-    assert "browser remote debugging is not reachable for the current profile." in out
+    assert "Chromium-based browser remote debugging is not reachable for the current profile." in out
     assert "debug browser instructions" in out
     assert "opening your browser's inspect page" not in out
+    assert calls["count"] == 1
 
 
 def test_run_setup_restarts_stale_existing_local_daemon(monkeypatch, capsys) -> None:
@@ -342,7 +415,7 @@ def test_run_setup_restarts_stale_existing_local_daemon(monkeypatch, capsys) -> 
     assert "browser connection is stale; restarting" in out
     assert "daemon is up." in out
     assert restarted == [None]
-    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False}]
+    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_show_debugging_guidance": False}]
 
 
 def test_run_setup_retries_at_most_once(monkeypatch, capsys) -> None:
@@ -362,8 +435,8 @@ def test_run_setup_retries_at_most_once(monkeypatch, capsys) -> None:
     out = capsys.readouterr()
     assert "retrying once" in out.out
     assert ensure_calls == [
-        {"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False},
-        {"wait": admin._SETUP_RETRY_WAIT, "_open_inspect": False},
+        {"wait": admin._SETUP_ATTACH_WAIT, "_show_debugging_guidance": False},
+        {"wait": admin._SETUP_RETRY_WAIT, "_show_debugging_guidance": False},
     ]
 
 
@@ -379,7 +452,7 @@ def test_run_setup_allows_explicit_remote_cdp_without_local_browser(monkeypatch,
     out = capsys.readouterr().out
     assert "attaching via BU_CDP_WS" in out
     assert "daemon is up." in out
-    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False}]
+    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_show_debugging_guidance": False}]
 
 
 def test_run_setup_restarts_existing_daemon_for_explicit_remote_cdp(monkeypatch, capsys) -> None:
@@ -400,7 +473,7 @@ def test_run_setup_restarts_existing_daemon_for_explicit_remote_cdp(monkeypatch,
     assert "restarting to attach via BU_CDP_URL" in out
     assert "daemon is up." in out
     assert restarted == [None]
-    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False}]
+    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_show_debugging_guidance": False}]
 
 
 def test_run_doctor_uses_generic_browser_wording_when_missing(monkeypatch, capsys) -> None:
@@ -415,8 +488,8 @@ def test_run_doctor_uses_generic_browser_wording_when_missing(monkeypatch, capsy
 
     out = capsys.readouterr().out
     assert "[FAIL] browser running" in out
-    assert "start Chrome, Chromium, or Edge and rerun `flocks browser --setup`" in out
-    assert "next action       start Chrome/Chromium/Edge or provide BU_CDP_URL/BU_CDP_WS" in out
+    assert "start Chrome, Chromium, Edge, or Brave and rerun `flocks browser --setup`" in out
+    assert "next action       start Chrome/Chromium/Edge/Brave or provide BU_CDP_URL/BU_CDP_WS" in out
 
 
 def test_run_doctor_points_to_debug_browser_instructions_when_daemon_missing(monkeypatch, capsys) -> None:
@@ -563,8 +636,22 @@ def test_chrome_running_on_windows_detects_chromium_process(monkeypatch) -> None
     assert admin._chrome_running()
 
 
+def test_chrome_running_on_windows_detects_brave_process(monkeypatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Windows")
+    monkeypatch.setattr("subprocess.check_output", lambda *args, **kwargs: b"brave.exe\r\n")
+
+    assert admin._chrome_running()
+
+
 def test_chrome_running_on_non_windows_matches_text_output(monkeypatch) -> None:
     monkeypatch.setattr("platform.system", lambda: "Darwin")
     monkeypatch.setattr("subprocess.check_output", lambda *args, **kwargs: "Google Chrome\n")
+
+    assert admin._chrome_running()
+
+
+def test_chrome_running_on_non_windows_detects_brave_process(monkeypatch) -> None:
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("subprocess.check_output", lambda *args, **kwargs: "Brave Browser\n")
 
     assert admin._chrome_running()

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -57,6 +57,25 @@ def test_generic_remote_debugging_message_triggers_prompt() -> None:
     assert admin._needs_chrome_remote_debugging_prompt(msg)
 
 
+def test_current_remote_debugging_unreachable_message_triggers_prompt() -> None:
+    msg = (
+        "Chrome remote debugging is not reachable for any detected profile: "
+        "/tmp/chrome: 127.0.0.1:9222 (connection refused) — for manual setup, "
+        "start Chrome with --remote-debugging-port and a non-default --user-data-dir"
+    )
+    assert admin._needs_chrome_remote_debugging_prompt(msg)
+
+
+def test_local_debugging_setup_lines_use_windows_user_data_dir() -> None:
+    lines = "\n".join(admin._local_debugging_setup_lines("Windows"))
+
+    assert "chrome://inspect" in lines
+    assert "does not reliably show it" in lines
+    assert "--remote-debugging-port=9222" in lines
+    assert '--user-data-dir="$env:USERPROFILE\\.flocks\\chrome-debug-profile"' in lines
+    assert "http://127.0.0.1:9222/json/version" in lines
+
+
 def test_daemon_endpoint_names_discovers_default_and_named_sessions(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(admin.ipc, "IS_WINDOWS", False)
     monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path))
@@ -286,8 +305,7 @@ def test_run_setup_uses_generic_remote_debugging_wording(monkeypatch, capsys) ->
     monkeypatch.setattr(admin, "daemon_alive", lambda: False)
     monkeypatch.setattr(admin, "_chrome_running", lambda: True)
     monkeypatch.setattr(admin, "_is_local_chrome_mode", lambda env=None: True)
-    open_calls = []
-    monkeypatch.setattr(admin, "_open_browser_inspect", lambda: open_calls.append(True))
+    monkeypatch.setattr(admin, "_local_debugging_setup_lines", lambda: ["debug browser instructions"])
 
     calls = {"count": 0}
 
@@ -304,10 +322,9 @@ def test_run_setup_uses_generic_remote_debugging_wording(monkeypatch, capsys) ->
     assert admin.run_setup() == 0
 
     out = capsys.readouterr().out
-    assert "browser remote debugging is not enabled on the current profile." in out
-    assert "opening your browser's inspect page" in out
-    assert "if the browser shows the profile picker" in out
-    assert open_calls == [True]
+    assert "browser remote debugging is not reachable for the current profile." in out
+    assert "debug browser instructions" in out
+    assert "opening your browser's inspect page" not in out
 
 
 def test_run_setup_restarts_stale_existing_local_daemon(monkeypatch, capsys) -> None:
@@ -400,6 +417,22 @@ def test_run_doctor_uses_generic_browser_wording_when_missing(monkeypatch, capsy
     assert "[FAIL] browser running" in out
     assert "start Chrome, Chromium, or Edge and rerun `flocks browser --setup`" in out
     assert "next action       start Chrome/Chromium/Edge or provide BU_CDP_URL/BU_CDP_WS" in out
+
+
+def test_run_doctor_points_to_debug_browser_instructions_when_daemon_missing(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
+    monkeypatch.setattr(admin, "_install_mode", lambda: "git")
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "daemon_alive", lambda: False)
+    monkeypatch.setattr(admin, "browser_connections", lambda: [])
+    monkeypatch.setattr(admin, "_latest_release_tag", lambda: "0.1.0")
+
+    assert admin.run_doctor() == 1
+
+    out = capsys.readouterr().out
+    assert "follow its debug-browser instructions" in out
+    assert "remote debugging is not reachable" in out
+    assert "inspect-page prompt" not in out
 
 
 def test_run_doctor_accepts_explicit_remote_cdp_without_local_browser(monkeypatch, capsys) -> None:

--- a/tests/browser/test_daemon.py
+++ b/tests/browser/test_daemon.py
@@ -163,7 +163,12 @@ def test_is_real_page_accepts_normal_https_pages() -> None:
 def test_profile_dirs_only_returns_paths_for_requested_os() -> None:
     home = Path.home() / "profile-test-home"
     local_app_data = home / "AppData/Local"
-    flocks_debug_profile = home / ".flocks/chrome-debug-profile"
+    flocks_debug_profiles = [
+        home / ".flocks/chrome-debug-profile",
+        home / ".flocks/edge-debug-profile",
+        home / ".flocks/chromium-debug-profile",
+        home / ".flocks/brave-debug-profile",
+    ]
 
     mac_profiles = daemon.profile_dirs(system="Darwin", home=home, environ={})
     linux_profiles = daemon.profile_dirs(system="Linux", home=home, environ={})
@@ -173,12 +178,12 @@ def test_profile_dirs_only_returns_paths_for_requested_os() -> None:
         environ={"LOCALAPPDATA": str(local_app_data)},
     )
 
-    assert mac_profiles[0] == flocks_debug_profile
-    assert linux_profiles[0] == flocks_debug_profile
-    assert windows_profiles[0] == flocks_debug_profile
-    assert all("Library" in path.parts and "Application Support" in path.parts for path in mac_profiles[1:])
-    assert all(".config" in path.parts or ".var" in path.parts for path in linux_profiles[1:])
-    assert all(path.is_relative_to(local_app_data) for path in windows_profiles[1:])
+    assert mac_profiles[:4] == flocks_debug_profiles
+    assert linux_profiles[:4] == flocks_debug_profiles
+    assert windows_profiles[:4] == flocks_debug_profiles
+    assert all("Library" in path.parts and "Application Support" in path.parts for path in mac_profiles[4:])
+    assert all(".config" in path.parts or ".var" in path.parts for path in linux_profiles[4:])
+    assert all(path.is_relative_to(local_app_data) for path in windows_profiles[4:])
 
 
 def test_get_ws_url_skips_unreachable_profile_and_uses_next_candidate(tmp_path, monkeypatch) -> None:

--- a/tests/browser/test_daemon.py
+++ b/tests/browser/test_daemon.py
@@ -163,6 +163,7 @@ def test_is_real_page_accepts_normal_https_pages() -> None:
 def test_profile_dirs_only_returns_paths_for_requested_os() -> None:
     home = Path.home() / "profile-test-home"
     local_app_data = home / "AppData/Local"
+    flocks_debug_profile = home / ".flocks/chrome-debug-profile"
 
     mac_profiles = daemon.profile_dirs(system="Darwin", home=home, environ={})
     linux_profiles = daemon.profile_dirs(system="Linux", home=home, environ={})
@@ -172,9 +173,12 @@ def test_profile_dirs_only_returns_paths_for_requested_os() -> None:
         environ={"LOCALAPPDATA": str(local_app_data)},
     )
 
-    assert all("Library" in path.parts and "Application Support" in path.parts for path in mac_profiles)
-    assert all(".config" in path.parts or ".var" in path.parts for path in linux_profiles)
-    assert all(path.is_relative_to(local_app_data) for path in windows_profiles)
+    assert mac_profiles[0] == flocks_debug_profile
+    assert linux_profiles[0] == flocks_debug_profile
+    assert windows_profiles[0] == flocks_debug_profile
+    assert all("Library" in path.parts and "Application Support" in path.parts for path in mac_profiles[1:])
+    assert all(".config" in path.parts or ".var" in path.parts for path in linux_profiles[1:])
+    assert all(path.is_relative_to(local_app_data) for path in windows_profiles[1:])
 
 
 def test_get_ws_url_skips_unreachable_profile_and_uses_next_candidate(tmp_path, monkeypatch) -> None:
@@ -298,6 +302,35 @@ def test_get_ws_url_uses_devtools_active_port_path_when_version_endpoint_returns
     monkeypatch.setattr(daemon, "profile_dirs", lambda: [profile])
     monkeypatch.setattr(daemon.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr(daemon.time, "sleep", lambda _seconds: pytest.fail("404 response must not be retried"))
+
+    assert daemon.get_ws_url() == "ws://127.0.0.1:9222/devtools/browser/current"
+
+
+def test_get_ws_url_uses_devtools_active_port_path_when_version_omits_websocket_url(
+    tmp_path, monkeypatch
+) -> None:
+    profile = tmp_path / "chrome"
+    profile.mkdir()
+    (profile / "DevToolsActivePort").write_text(
+        "9222\n/devtools/browser/current\n",
+        encoding="utf-8",
+    )
+
+    class FakeHttpResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            pass
+
+        def read(self) -> bytes:
+            return b'{"Browser":"Chrome/126.0","Protocol-Version":"1.3"}'
+
+    monkeypatch.delenv("BU_CDP_WS", raising=False)
+    monkeypatch.delenv("BU_CDP_URL", raising=False)
+    monkeypatch.setattr(daemon, "profile_dirs", lambda: [profile])
+    monkeypatch.setattr(daemon.urllib.request, "urlopen", lambda _url, timeout: FakeHttpResponse())
+    monkeypatch.setattr(daemon.time, "sleep", lambda _seconds: pytest.fail("missing field must not be retried"))
 
     assert daemon.get_ws_url() == "ws://127.0.0.1:9222/devtools/browser/current"
 


### PR DESCRIPTION
## 背景

Windows Chrome 远程调试配置指引存在误导：原先提示用户到 `chrome://inspect` 查找 `webSocketDebuggerUrl`，但该页面并不可靠。Chrome 136+ 还要求 `--remote-debugging-port` 配合非默认 `--user-data-dir` 使用。

## 修改内容

- 将本地 Chrome 调试指引改为访问 `http://127.0.0.1:9222/json/version` 获取 `webSocketDebuggerUrl`
- Windows/macOS/Linux 启动命令均补充非默认 `--user-data-dir`
- 移除自动打开 `chrome://inspect/#remote-debugging` 的恢复路径
- 当 `/json/version` 缺少 `webSocketDebuggerUrl` 时，允许使用 `DevToolsActivePort` 中的 browser WebSocket path 兜底
- 将 Flocks 建议的 `~/.flocks/chrome-debug-profile` 纳入本地 profile 扫描
- 增加相关回归测试

## 验证

- `.venv/bin/python -m pytest tests/browser/test_daemon.py tests/browser/test_admin.py`
- `.venv/bin/python -m ruff check flocks/browser/admin.py flocks/browser/daemon.py tests/browser/test_admin.py tests/browser/test_daemon.py`