### PR TITLE
fix(webui): sync workflow chat model selection

### DIFF
--- a/webui/src/pages/WorkflowDetail/tabs/ChatTab.test.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/ChatTab.test.tsx
@@ -7,11 +7,13 @@ import type { ComponentProps } from 'react';
 import ChatTab from './ChatTab';
 import { workflowAPI } from '@/api/workflow';
 import { setStoredSessions } from '../sessionStorage';
+import { __resetChatModelOptionsResourcesForTesting } from '@/components/common/ChatPromptSelectors';
 
 const {
   capturedSessionChatProps,
   capturedSessionOptions,
   mockClientGet,
+  mockClientPatch,
   mockCreate,
   mockCreateAndSend,
   mockReset,
@@ -24,6 +26,7 @@ const {
   capturedSessionChatProps: [] as any[],
   capturedSessionOptions: [] as any[],
   mockClientGet: vi.fn(),
+  mockClientPatch: vi.fn(),
   mockCreate: vi.fn(),
   mockCreateAndSend: vi.fn(),
   mockReset: vi.fn(),
@@ -53,7 +56,7 @@ vi.mock('@/hooks/useSessionChat', () => ({
 }));
 
 vi.mock('@/api/client', () => ({
-  default: { get: mockClientGet },
+  default: { get: mockClientGet, patch: mockClientPatch },
 }));
 
 vi.mock('@/api/workflow', () => ({
@@ -266,10 +269,12 @@ function renderChatTab(props: Partial<ComponentProps<typeof ChatTab>> = {}) {
 describe('WorkflowDetail ChatTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetChatModelOptionsResourcesForTesting();
     capturedSessionChatProps.length = 0;
     capturedSessionOptions.length = 0;
     localStorage.clear();
     mockClientGet.mockResolvedValue({ data: {} });
+    mockClientPatch.mockResolvedValue({ data: {} });
     mockCreateAndSend.mockResolvedValue(undefined);
     mockUseAgents.mockReturnValue({
       agents: [
@@ -563,6 +568,152 @@ describe('WorkflowDetail ChatTab', () => {
     expect(screen.getAllByText(/Rex/i).length).toBeGreaterThan(0);
     expect(screen.queryByRole('button', { name: /Rex/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Explore/i })).not.toBeInTheDocument();
+  });
+
+  it('hydrates the workflow workbench model picker from the active session pinned model', async () => {
+    setStoredSessions(workflow.id, [
+      { id: 'workflow-session-kimi', title: 'Existing', createdAt: Date.now() },
+    ]);
+    mockUseProviders.mockReturnValue({
+      providers: [{ id: 'moonshot', name: 'Moonshot', configured: true }],
+      connectedIds: ['moonshot'],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockModelListDefinitions.mockResolvedValue({
+      data: {
+        models: [{
+          provider_id: 'moonshot',
+          id: 'kimi-k2.6',
+          name: 'kimi-k2.6',
+          model_type: 'chat',
+          capabilities: { supports_vision: false },
+          limits: { context_window: 128000 },
+        }],
+      },
+    });
+    mockClientGet.mockResolvedValue({
+      data: {
+        id: 'workflow-session-kimi',
+        provider: 'moonshot',
+        model: 'kimi-k2.6',
+        model_pinned: true,
+      },
+    });
+
+    renderChatTab();
+
+    await waitFor(() => {
+      const latestProps = capturedSessionChatProps[capturedSessionChatProps.length - 1];
+      expect(latestProps.sessionId).toBe('workflow-session-kimi');
+      expect(latestProps.model).toEqual({ providerID: 'moonshot', modelID: 'kimi-k2.6' });
+    });
+    expect(await screen.findByText('kimi-k2.6')).toBeInTheDocument();
+  });
+
+  it('falls back consistently when the active session pinned model is no longer available', async () => {
+    setStoredSessions(workflow.id, [
+      { id: 'workflow-session-stale-model', title: 'Existing', createdAt: Date.now() },
+    ]);
+    mockUseProviders.mockReturnValue({
+      providers: [{ id: 'minimax', name: 'MiniMax', configured: true }],
+      connectedIds: ['minimax'],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockModelListDefinitions.mockResolvedValue({
+      data: {
+        models: [{
+          provider_id: 'minimax',
+          id: 'minimax-m3',
+          name: 'minimax-m3',
+          model_type: 'chat',
+          capabilities: { supports_vision: false },
+          limits: { context_window: 64000 },
+        }],
+      },
+    });
+    mockClientGet.mockResolvedValue({
+      data: {
+        id: 'workflow-session-stale-model',
+        provider: 'moonshot',
+        model: 'kimi-k2.6',
+        model_pinned: true,
+      },
+    });
+
+    renderChatTab();
+
+    await waitFor(() => {
+      const latestProps = capturedSessionChatProps[capturedSessionChatProps.length - 1];
+      expect(latestProps.sessionId).toBe('workflow-session-stale-model');
+      expect(latestProps.model).toEqual({ providerID: 'minimax', modelID: 'minimax-m3' });
+    });
+    expect(await screen.findByText('minimax-m3')).toBeInTheDocument();
+  });
+
+  it('pins model picker changes back to the active workflow chat session', async () => {
+    const user = userEvent.setup();
+    setStoredSessions(workflow.id, [
+      { id: 'workflow-session-model-switch', title: 'Existing', createdAt: Date.now() },
+    ]);
+    mockUseProviders.mockReturnValue({
+      providers: [
+        { id: 'minimax', name: 'MiniMax', configured: true },
+        { id: 'moonshot', name: 'Moonshot', configured: true },
+      ],
+      connectedIds: ['minimax', 'moonshot'],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockModelListDefinitions.mockResolvedValue({
+      data: {
+        models: [
+          {
+            provider_id: 'moonshot',
+            id: 'kimi-k2.6',
+            name: 'kimi-k2.6',
+            model_type: 'chat',
+            capabilities: { supports_vision: false },
+            limits: { context_window: 128000 },
+          },
+          {
+            provider_id: 'minimax',
+            id: 'minimax-m3',
+            name: 'minimax-m3',
+            model_type: 'chat',
+            capabilities: { supports_vision: false },
+            limits: { context_window: 64000 },
+          },
+        ],
+      },
+    });
+    mockClientGet.mockResolvedValue({
+      data: {
+        id: 'workflow-session-model-switch',
+        provider: 'moonshot',
+        model: 'kimi-k2.6',
+        model_pinned: true,
+      },
+    });
+
+    renderChatTab();
+
+    await user.click(await screen.findByRole('button', { name: /kimi-k2\.6/i }));
+    await user.click(await screen.findByRole('button', { name: /minimax-m3/i }));
+
+    expect(mockClientPatch).toHaveBeenCalledWith('/api/session/workflow-session-model-switch', {
+      provider: 'minimax',
+      model: 'minimax-m3',
+      model_pinned: true,
+    });
+    await waitFor(() => {
+      const latestProps = capturedSessionChatProps[capturedSessionChatProps.length - 1];
+      expect(latestProps.model).toEqual({ providerID: 'minimax', modelID: 'minimax-m3' });
+    });
   });
 
   it('keeps the workflow composer compact enough for guide shortcuts above it', () => {

--- a/webui/src/pages/WorkflowDetail/tabs/ChatTab.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/ChatTab.tsx
@@ -53,6 +53,8 @@ type WorkflowPromptParams = Record<string, unknown> & {
   backendConfigAccessGuide: string;
 };
 
+type PromptModel = { providerID: string; modelID: string };
+
 function withBackendConfigAccessGuide(
   t: TranslateFn,
   params: Record<string, unknown>,
@@ -109,17 +111,46 @@ export default function ChatTab({
   const workflowIdRef = useRef<string>(workflow.id);
   workflowIdRef.current = workflow.id;
   const historyBtnRef = useRef<HTMLDivElement>(null);
+  const sessionModelHydrationRef = useRef(0);
+  const [sessionPinnedModel, setSessionPinnedModel] = useState<PromptModel | null>(null);
   const { agents: workflowChatAgents } = useChatAgentOptions({
     allowedAgentNames: WORKFLOW_CHAT_AGENT_NAMES,
   });
   const {
     groupedOptions: groupedChatModelOptions,
     loading: loadingChatModels,
+    options: chatModelOptions,
     selectedModelOption,
     selectedPromptModel,
     setSelectedModelKey,
   } = useChatModelOptions();
+  const sessionPinnedModelKey = sessionPinnedModel
+    ? `${sessionPinnedModel.providerID}::${sessionPinnedModel.modelID}`
+    : null;
+  const hasSessionPinnedModelOption = Boolean(
+    sessionPinnedModelKey && chatModelOptions.some((option) => option.key === sessionPinnedModelKey),
+  );
+  const effectiveSessionPinnedModel = hasSessionPinnedModelOption ? sessionPinnedModel : null;
   const effectiveSupportsVision = selectedModelOption?.supportsVision ?? defaultSupportsVision;
+
+  const applySessionModel = useCallback((session: unknown) => {
+    const data = session as {
+      provider?: unknown;
+      model?: unknown;
+      model_pinned?: unknown;
+    } | null;
+    const providerID = typeof data?.provider === 'string' ? data.provider : '';
+    const modelID = typeof data?.model === 'string' ? data.model : '';
+
+    if (data?.model_pinned && providerID && modelID) {
+      setSessionPinnedModel({ providerID, modelID });
+      setSelectedModelKey(`${providerID}::${modelID}`);
+      return;
+    }
+
+    setSessionPinnedModel(null);
+    setSelectedModelKey(null);
+  }, [setSelectedModelKey]);
 
   useEffect(() => {
     workflowRevisionRef.current = workflowRevisionKey(workflow);
@@ -170,6 +201,39 @@ export default function ChatTab({
   useEffect(() => {
     onSessionChange?.(sessionId ?? null);
   }, [onSessionChange, sessionId]);
+
+  useEffect(() => {
+    if (!sessionPinnedModelKey) return;
+    if (!chatModelOptions.some((option) => option.key === sessionPinnedModelKey)) return;
+    setSelectedModelKey(sessionPinnedModelKey);
+  }, [chatModelOptions, sessionPinnedModelKey, setSelectedModelKey]);
+
+  useEffect(() => {
+    sessionModelHydrationRef.current += 1;
+    const hydrationId = sessionModelHydrationRef.current;
+
+    if (!sessionId) {
+      setSessionPinnedModel(null);
+      setSelectedModelKey(null);
+      return;
+    }
+
+    let cancelled = false;
+    client.get(`/api/session/${sessionId}`)
+      .then((res) => {
+        if (cancelled || hydrationId !== sessionModelHydrationRef.current) return;
+        applySessionModel(res.data);
+      })
+      .catch(() => {
+        if (cancelled || hydrationId !== sessionModelHydrationRef.current) return;
+        setSessionPinnedModel(null);
+        setSelectedModelKey(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [applySessionModel, sessionId]);
 
   // Load stored sessions and validate only the active one (lightweight check)
   useEffect(() => {
@@ -312,6 +376,27 @@ export default function ChatTab({
     setShowHistory(false);
     hasCreatedRef.current = true;
   }, []);
+
+  const handleSelectModel = useCallback((option: {
+    key: string;
+    providerID: string;
+    modelID: string;
+  }) => {
+    sessionModelHydrationRef.current += 1;
+    const nextModel = { providerID: option.providerID, modelID: option.modelID };
+    setSessionPinnedModel(nextModel);
+    setSelectedModelKey(option.key);
+
+    if (!sessionId) return;
+
+    client.patch(`/api/session/${sessionId}`, {
+      provider: option.providerID,
+      model: option.modelID,
+      model_pinned: true,
+    }).catch((err) => {
+      console.warn('[WorkflowDetail] failed to pin workflow chat model', err);
+    });
+  }, [sessionId, setSelectedModelKey]);
 
   // Helper: fetch fresh workflow and notify parent if updated
   const checkWorkflowUpdate = useCallback(async () => {
@@ -477,7 +562,7 @@ export default function ChatTab({
           onSSEEvent={handleSSEEvent}
           supportsVision={effectiveSupportsVision}
           contextWindowTokens={selectedModelOption?.contextWindowTokens ?? null}
-          model={selectedPromptModel}
+          model={effectiveSessionPinnedModel ?? selectedPromptModel}
           onCreateAndSend={!sessionId ? handleCreateAndSend : undefined}
           composerTextareaMinHeight={48}
           composerTextareaMaxHeight={120}
@@ -492,7 +577,7 @@ export default function ChatTab({
               groupedOptions={groupedChatModelOptions}
               loading={loadingChatModels}
               selectedModelOption={selectedModelOption}
-              onSelectModel={(option) => setSelectedModelKey(option.key)}
+              onSelectModel={handleSelectModel}
             />
           }
           conversationBottomSlot={({ sendPrompt, sending, streaming }) => (


### PR DESCRIPTION
## 背景

修复工作流详情工作台中模型选择态与当前 session 不一致的问题。此前工作台只使用本地默认模型选择，没有复用 session 的 pinned model，可能出现 Session 页显示一个模型、工作台显示/发送另一个模型的情况。

## 修改

- 工作流工作台加载当前 session 时同步 `provider/model/model_pinned`
- 模型仍可用时复用 session pinned model；不可用时与 UI 一起回退到默认/首个可用模型
- 工作台切换模型后写回 session pinned state
- 补充 pinned model hydrate、不可用 fallback、切换写回的回归测试

## 验证

- `npm test -- --run src/pages/WorkflowDetail/tabs/ChatTab.test.tsx`
- `npm run build`