### PR TITLE
fix: show visible error when model is unavailable

### DIFF
--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -26,7 +26,7 @@ import httpx
 from flocks.utils.log import Log
 from flocks.utils.id import Identifier
 from flocks.session.session import Session, SessionInfo
-from flocks.session.message import Message, MessageInfo, MessageRole
+from flocks.session.message import Message, MessageInfo, MessageRole, TextPart
 from flocks.session.prompt import SessionPrompt
 from flocks.session.core.status import SessionStatus, SessionStatusRetry, SessionStatusBusy
 from flocks.session.core.defaults import (
@@ -319,6 +319,139 @@ class SessionRunner:
             "with the same arguments and kept producing a tool-only turn. Change strategy, "
             "summarize the blocker, or answer directly instead of repeating the exact same call."
         )
+
+    @staticmethod
+    def _build_session_error_dict(
+        message: str,
+        *,
+        name: str = "SessionError",
+        display_message: Optional[str] = None,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        error_data = {"message": message}
+        if data:
+            error_data.update(data)
+        if display_message:
+            error_data["displayMessage"] = display_message
+        return {
+            "name": name,
+            "message": message,
+            "data": error_data,
+        }
+
+    async def _publish_assistant_error_message(
+        self,
+        assistant_msg: MessageInfo,
+        *,
+        agent_name: str,
+        parent_id: str,
+        error_dict: Dict[str, Any],
+        text_part: Optional[TextPart] = None,
+    ) -> None:
+        if not self.callbacks.event_publish_callback:
+            return
+        now_ms = int(time.time() * 1000)
+        await self.callbacks.event_publish_callback("message.updated", {
+            "info": {
+                "id": assistant_msg.id,
+                "sessionID": self.session.id,
+                "role": "assistant",
+                "time": {"created": now_ms, "completed": now_ms},
+                "parentID": parent_id,
+                "modelID": self.model_id,
+                "providerID": self.provider_id,
+                "agent": agent_name,
+                "mode": agent_name,
+                "finish": "error",
+                "error": error_dict,
+                "tokens": {"input": 0, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+            }
+        })
+        if text_part is not None:
+            await self.callbacks.event_publish_callback("message.part.updated", {
+                "part": {
+                    "id": text_part.id,
+                    "messageID": text_part.messageID,
+                    "sessionID": text_part.sessionID,
+                    "type": "text",
+                    "text": text_part.text,
+                }
+            })
+
+    async def _create_error_assistant_message(
+        self,
+        *,
+        last_user: MessageInfo,
+        agent: AgentInfo,
+        error_message: str,
+        error_dict: Dict[str, Any],
+        visible_text: Optional[str] = None,
+    ) -> MessageInfo:
+        text = visible_text or error_message
+        part_id = Identifier.ascending("part")
+        now_ms = int(time.time() * 1000)
+        assistant_msg = await Message.create(
+            session_id=self.session.id,
+            role=MessageRole.ASSISTANT,
+            content=text,
+            agent=agent.name,
+            model_id=self.model_id,
+            provider_id=self.provider_id,
+            parent_id=last_user.id,
+            finish="error",
+            error=error_dict,
+            time={"created": now_ms, "completed": now_ms},
+            part_id=part_id,
+        )
+        parts = await Message.parts(assistant_msg.id, self.session.id)
+        text_part = next(
+            (
+                part for part in parts
+                if isinstance(part, TextPart) and part.id == part_id
+            ),
+            TextPart(
+                id=part_id,
+                sessionID=self.session.id,
+                messageID=assistant_msg.id,
+                type="text",
+                text=text,
+            ),
+        )
+        await self._publish_assistant_error_message(
+            assistant_msg,
+            agent_name=agent.name,
+            parent_id=last_user.id,
+            error_dict=error_dict,
+            text_part=text_part,
+        )
+        return assistant_msg
+
+    async def _ensure_visible_error_text(
+        self,
+        assistant_msg: MessageInfo,
+        error_message: str,
+    ) -> Optional[TextPart]:
+        if not error_message:
+            return None
+
+        parts = await Message.parts(assistant_msg.id, self.session.id)
+        for part in parts:
+            if getattr(part, "type", None) == "text" and str(getattr(part, "text", "") or "").strip():
+                return None
+
+        text_part = next((part for part in parts if getattr(part, "type", None) == "text"), None)
+        if isinstance(text_part, TextPart):
+            text_part.text = error_message
+        else:
+            text_part = TextPart(
+                id=Identifier.ascending("part"),
+                sessionID=self.session.id,
+                messageID=assistant_msg.id,
+                type="text",
+                text=error_message,
+            )
+        stored = await Message.store_part(self.session.id, assistant_msg.id, text_part)
+        return stored if isinstance(stored, TextPart) else text_part
 
     def _update_tool_loop_guard(
         self,
@@ -1004,9 +1137,22 @@ class SessionRunner:
         provider = Provider.get(self.provider_id)
         if not provider:
             error = f"Provider {self.provider_id} not found"
+            error_dict = self._build_session_error_dict(
+                error,
+                name="ProviderUnavailableError",
+                display_message="Model is unavailable. Please check the provider connection and model configuration.",
+                data={"providerID": self.provider_id, "modelID": self.model_id},
+            )
+            await self._create_error_assistant_message(
+                last_user=last_user,
+                agent=agent,
+                error_message=error,
+                error_dict=error_dict,
+                visible_text=error_dict["data"]["displayMessage"],
+            )
             if self.callbacks.on_error:
-                await self.callbacks.on_error(error)
-            return StepResult(action="stop", error=error)
+                await self.callbacks.on_error(error_dict["data"]["displayMessage"])
+            return StepResult(action="stop", error=error_dict["data"]["displayMessage"])
 
         # Apply config-based provider options (api_key/base_url)
         try:
@@ -1019,9 +1165,22 @@ class SessionRunner:
         
         if not provider.is_configured():
             error = f"Provider {self.provider_id} not configured"
+            error_dict = self._build_session_error_dict(
+                error,
+                name="ProviderConfigurationError",
+                display_message="Model is unavailable. Please check the provider connection and model configuration.",
+                data={"providerID": self.provider_id, "modelID": self.model_id},
+            )
+            await self._create_error_assistant_message(
+                last_user=last_user,
+                agent=agent,
+                error_message=error,
+                error_dict=error_dict,
+                visible_text=error_dict["data"]["displayMessage"],
+            )
             if self.callbacks.on_error:
-                await self.callbacks.on_error(error)
-            return StepResult(action="stop", error=error)
+                await self.callbacks.on_error(error_dict["data"]["displayMessage"])
+            return StepResult(action="stop", error=error_dict["data"]["displayMessage"])
         
         # Build prompts and tools
         tools_started_at = time.perf_counter()
@@ -1323,6 +1482,14 @@ class SessionRunner:
                             error=empty_error_dict,
                             finish="error",
                         )
+                        text_part = await self._ensure_visible_error_text(assistant_msg, empty_error_msg)
+                        await self._publish_assistant_error_message(
+                            assistant_msg,
+                            agent_name=agent.name,
+                            parent_id=last_user.id,
+                            error_dict=empty_error_dict,
+                            text_part=text_part,
+                        )
                         return StepResult(action="stop", error=empty_error_msg)
 
                 tool_loop_guard = self._update_tool_loop_guard(
@@ -1437,6 +1604,14 @@ class SessionRunner:
                         assistant_msg.id,
                         error=error_dict,
                         finish="error",
+                    )
+                    text_part = await self._ensure_visible_error_text(assistant_msg, final_error_message)
+                    await self._publish_assistant_error_message(
+                        assistant_msg,
+                        agent_name=agent.name,
+                        parent_id=last_user.id,
+                        error_dict=error_dict,
+                        text_part=text_part,
                     )
                     
                     return StepResult(action="stop", error=final_error_message)

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -2486,6 +2486,167 @@ async def test_call_llm_skips_llm_hook_payload_preparation_without_handlers(monk
 
 
 @pytest.mark.asyncio
+async def test_process_step_persists_visible_error_when_provider_missing(monkeypatch):
+    runner = _make_runner("ses_runner_missing_provider_error")
+    user = await Message.create(
+        runner.session.id,
+        MessageRole.USER,
+        "hello",
+        agent="rex",
+        model={"providerID": "missing-provider", "modelID": "missing-model"},
+    )
+    messages = await Message.list(runner.session.id)
+    agent = SimpleNamespace(name="rex", tools=[], steps=5, prompt=None)
+    events = []
+    callback_errors = []
+
+    async def publish_event(event_name, payload):
+        events.append((event_name, payload))
+
+    async def on_error(error):
+        callback_errors.append(error)
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", staticmethod(lambda _provider_id: None))
+
+    runner.provider_id = "missing-provider"
+    runner.model_id = "missing-model"
+    runner.callbacks = RunnerCallbacks(
+        on_error=on_error,
+        event_publish_callback=publish_event,
+    )
+
+    result = await runner._process_step(messages, user)
+    messages_with_parts = await Message.list_with_parts(runner.session.id)
+    assistant = next(item for item in messages_with_parts if item.info.role == MessageRole.ASSISTANT)
+    visible_text_parts = [
+        part for part in assistant.parts
+        if getattr(part, "type", None) == "text" and getattr(part, "text", "").strip()
+    ]
+
+    assert result.action == "stop"
+    assert result.error == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
+    assert callback_errors == [runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE]
+    assert assistant.info.finish == "error"
+    assert assistant.info.error["name"] == "ProviderUnavailableError"
+    assert visible_text_parts
+    assert visible_text_parts[0].text == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
+    assert any(event_name == "message.part.updated" for event_name, _payload in events)
+
+
+@pytest.mark.asyncio
+async def test_process_step_persists_visible_error_when_provider_not_configured(monkeypatch):
+    runner = _make_runner("ses_runner_unconfigured_provider_error")
+    user = await Message.create(
+        runner.session.id,
+        MessageRole.USER,
+        "hello",
+        agent="rex",
+        model={"providerID": "unconfigured-provider", "modelID": "unconfigured-model"},
+    )
+    messages = await Message.list(runner.session.id)
+    agent = SimpleNamespace(name="rex", tools=[], steps=5, prompt=None)
+    events = []
+    callback_errors = []
+
+    class UnconfiguredProvider:
+        def is_configured(self):
+            return False
+
+    async def publish_event(event_name, payload):
+        events.append((event_name, payload))
+
+    async def on_error(error):
+        callback_errors.append(error)
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", staticmethod(lambda _provider_id: UnconfiguredProvider()))
+    monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
+
+    runner.provider_id = "unconfigured-provider"
+    runner.model_id = "unconfigured-model"
+    runner.callbacks = RunnerCallbacks(
+        on_error=on_error,
+        event_publish_callback=publish_event,
+    )
+
+    result = await runner._process_step(messages, user)
+    messages_with_parts = await Message.list_with_parts(runner.session.id)
+    assistant = next(item for item in messages_with_parts if item.info.role == MessageRole.ASSISTANT)
+    visible_text_parts = [
+        part for part in assistant.parts
+        if getattr(part, "type", None) == "text" and getattr(part, "text", "").strip()
+    ]
+
+    assert result.action == "stop"
+    assert result.error == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
+    assert callback_errors == [runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE]
+    assert assistant.info.finish == "error"
+    assert assistant.info.error["name"] == "ProviderConfigurationError"
+    assert visible_text_parts
+    assert visible_text_parts[0].text == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
+    assert any(event_name == "message.part.updated" for event_name, _payload in events)
+
+
+@pytest.mark.asyncio
+async def test_process_step_persists_visible_error_when_model_returns_empty_stream(monkeypatch):
+    runner = _make_runner("ses_runner_empty_stream_error")
+    user = await Message.create(
+        runner.session.id,
+        MessageRole.USER,
+        "hello",
+        agent="rex",
+        model={"providerID": "empty-provider", "modelID": "empty-model"},
+    )
+    messages = await Message.list(runner.session.id)
+    agent = SimpleNamespace(name="rex", tools=[], steps=5, prompt=None, model=None)
+    events = []
+
+    class EmptyProvider:
+        def is_configured(self):
+            return True
+
+        async def chat_stream(self, **kwargs):
+            del kwargs
+            if False:
+                yield None
+
+    async def publish_event(event_name, payload):
+        events.append((event_name, payload))
+
+    monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
+    monkeypatch.setattr(runner_mod.Provider, "get", staticmethod(lambda _provider_id: EmptyProvider()))
+    monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(SessionRunner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionRetry, "sleep", AsyncMock(return_value=None))
+
+    runner.provider_id = "empty-provider"
+    runner.model_id = "empty-model"
+    runner.callbacks = RunnerCallbacks(event_publish_callback=publish_event)
+
+    result = await runner._process_step(messages, user)
+    messages_with_parts = await Message.list_with_parts(runner.session.id)
+    assistant = next(item for item in messages_with_parts if item.info.role == MessageRole.ASSISTANT)
+    visible_text = "\n".join(
+        getattr(part, "text", "")
+        for part in assistant.parts
+        if getattr(part, "type", None) == "text" and getattr(part, "text", "").strip()
+    )
+
+    assert result.action == "stop"
+    assert "returned an empty response" in result.error
+    assert assistant.info.finish == "error"
+    assert assistant.info.error["name"] == "EmptyResponseError"
+    assert "returned an empty response" in visible_text
+    assert any(
+        event_name == "message.part.updated"
+        and "returned an empty response" in _payload["part"]["text"]
+        for event_name, _payload in events
+    )
+
+
+@pytest.mark.asyncio
 async def test_process_step_uses_loaded_tool_schema_names_for_prompt_guidance(monkeypatch):
     runner = _make_runner("ses_runner_prompt_guidance_tool_names")
     runner.callbacks = RunnerCallbacks(on_error=AsyncMock())

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -1363,6 +1363,35 @@ describe('SessionChat error rendering', () => {
     expect(screen.getByText('Connection error.')).toBeInTheDocument();
     expect(container.querySelectorAll('.animate-bounce')).toHaveLength(0);
   });
+
+  it('renders assistant error messages when the only part is blank text', () => {
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'assistant-error-with-blank-text',
+          role: 'assistant',
+          parts: [{ id: 'blank-text', type: 'text', text: '' }] as Message['parts'],
+          finish: 'error',
+          error: {
+            name: 'EmptyResponseError',
+            data: { message: 'Model returned an empty response.' },
+          } as any,
+        }),
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    const { container } = render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    expect(screen.getByText('Model returned an empty response.')).toBeInTheDocument();
+    expect(container.querySelectorAll('.animate-bounce')).toHaveLength(0);
+  });
 });
 
 describe('SessionChat intermediate process collapse', () => {

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -3884,6 +3884,12 @@ function ChatMessageBubbleInner({
   const iconButtonClass = 'group/action relative inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200/80 bg-white/80 text-gray-400 transition-colors duration-150 hover:border-gray-300 hover:text-gray-700 disabled:opacity-40 disabled:cursor-not-allowed dark:border-zinc-800 dark:bg-zinc-900/80 dark:text-zinc-500 dark:hover:border-zinc-700 dark:hover:text-zinc-200';
   const tooltipClass = 'pointer-events-none absolute bottom-full left-1/2 z-10 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-[11px] font-medium text-white opacity-0 shadow-sm transition-opacity duration-150 group-hover/action:opacity-100';
   const messageErrorText = isUser ? '' : getMessageErrorText(message);
+  const hasOnlyBlankTextParts = parts.length > 0 && parts.every((part) =>
+    part.type === 'text' && !String(part.text || '').trim()
+  );
+  const shouldRenderAssistantErrorState = !isUser && !!messageErrorText && (
+    parts.length === 0 || hasOnlyBlankTextParts
+  );
 
   const avatarSize = compact ? 'w-7 h-7 text-xs' : 'w-8 h-8 text-sm';
   const avatar = isUser ? (
@@ -3901,7 +3907,7 @@ function ChatMessageBubbleInner({
     <div className={`${bubbleClass} relative`} style={{ overflowWrap: 'anywhere' }}>
 
       {/* Empty / loading state */}
-      {parts.length === 0 && (
+      {(parts.length === 0 || shouldRenderAssistantErrorState) && (
         isUser ? (
           <div className="flex items-center gap-2 opacity-60">
             <div className="w-1.5 h-1.5 rounded-full bg-current animate-pulse" />


### PR DESCRIPTION
## 背景

测试反馈「偶发：模型不回复，如果是模型不可用需要返回信息」。排查发现模型不可用、provider 未配置、模型返回空流等场景下，后端可能没有生成可见 assistant 回复，或前端把空 text part 渲染为空白。

## 修改

- provider 不存在或未配置时，创建带可见错误文案的 assistant 消息。
- 模型空响应或异常耗尽重试后，为 assistant 消息补充可见错误文本并发布更新事件。
- 前端支持 `message.error` 存在但 text part 为空时渲染错误态。
- 增加后端和前端回归测试覆盖上述场景。

## 验证

- `uv run pytest tests/session/test_runner_step.py::test_process_step_persists_visible_error_when_provider_missing tests/session/test_runner_step.py::test_process_step_persists_visible_error_when_provider_not_configured tests/session/test_runner_step.py::test_process_step_persists_visible_error_when_model_returns_empty_stream -q`
- `uv run ruff check flocks/session/runner.py tests/session/test_runner_step.py`
- `cd webui && npm run test:run -- src/components/common/SessionChat.test.ts -t "SessionChat error rendering|getMessageErrorText"`