### PR TITLE
fix(tool): reset and sync auto-disable state

### DIFF
--- a/flocks/server/routes/tool.py
+++ b/flocks/server/routes/tool.py
@@ -665,6 +665,8 @@ def _set_global_tool_enabled(tool: Any, desired: bool) -> bool:
         })
 
     tool.info.enabled = new_enabled
+    if new_enabled:
+        ToolRegistry._reset_failure_state(tool.info.name)
     return new_enabled
 
 

--- a/tests/server/test_tool_setting_routes.py
+++ b/tests/server/test_tool_setting_routes.py
@@ -58,7 +58,7 @@ def tool_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     overlay/service-gate combinations without touching real plugin YAML.
     """
     config_dir = tmp_path / ".flocks" / "config"
-    config_dir.mkdir(parents=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("FLOCKS_CONFIG_DIR", str(config_dir))
 
     from flocks.config.config import Config
@@ -68,6 +68,7 @@ def tool_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     saved_tools = dict(ToolRegistry._tools)
     saved_defaults = dict(ToolRegistry._enabled_defaults)
+    saved_failure_state = dict(ToolRegistry._failure_state)
     saved_initialized = ToolRegistry._initialized
 
     enabled_tool = _stub_api_tool("onesec_dns_test", enabled=True)
@@ -80,6 +81,7 @@ def tool_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         enabled_tool.info.name: True,
         disabled_tool.info.name: False,
     }
+    ToolRegistry._failure_state = {}
     # Skip plugin discovery — our stub registry is enough.
     ToolRegistry._initialized = True
 
@@ -100,6 +102,7 @@ def tool_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     ToolRegistry._tools = saved_tools
     ToolRegistry._enabled_defaults = saved_defaults
+    ToolRegistry._failure_state = saved_failure_state
     ToolRegistry._initialized = saved_initialized
 
 
@@ -192,6 +195,24 @@ class TestToolInfoResponse:
 
 
 class TestUpdateTool:
+    def test_manual_reenable_clears_repeated_failure_count(self, tool_client):
+        client, enabled_tool, _ = tool_client
+        _set_service(enabled=True)
+        enabled_tool.info.enabled = False
+        ToolRegistry._failure_state[enabled_tool.info.name] = {
+            "key": "same-failure",
+            "count": ToolRegistry._failure_disable_threshold,
+        }
+
+        res = client.patch(
+            f"/api/tools/{enabled_tool.info.name}",
+            json={"enabled": True},
+        )
+
+        assert res.status_code == 200
+        assert res.json()["enabled"] is True
+        assert enabled_tool.info.name not in ToolRegistry._failure_state
+
     def test_overlay_persisted_when_differs_from_default(self, tool_client):
         client, _, disabled_tool = tool_client
         _set_service(enabled=True)

--- a/webui/src/pages/Tool/ToolDetailDrawer.test.tsx
+++ b/webui/src/pages/Tool/ToolDetailDrawer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ToolDetailDrawer } from './index';
 
 vi.mock('react-i18next', () => ({
@@ -25,6 +25,7 @@ vi.mock('react-i18next', () => ({
         'toolDetail.no': '否',
         'toolDetail.close': '关闭',
         'toolDetail.testTool': '测试工具',
+        'toolDetail.runTest': '执行测试',
         'toolDetail.enabled': '启用',
         'toolDetail.disabled': '禁用',
       };
@@ -49,6 +50,46 @@ vi.mock('@/api/tool', () => ({
 }));
 
 describe('ToolDetailDrawer', () => {
+  const enabledTool = {
+    name: 'failing_custom_tool',
+    description: 'Always fails',
+    source: 'plugin_py',
+    category: 'custom',
+    enabled: true,
+    parameters: [],
+  } as any;
+
+  const drawerProps = {
+    tool: enabledTool,
+    testParams: '{}',
+    testResult: null,
+    testing: false,
+    onClose: vi.fn(),
+    onTestParamsChange: vi.fn(),
+    onTest: vi.fn(),
+  };
+
+  it('disables test execution as soon as the result reports auto-disable', async () => {
+    const { rerender } = render(<ToolDetailDrawer {...drawerProps} />);
+    fireEvent.click(screen.getByRole('button', { name: '测试' }));
+    expect(screen.getByRole('button', { name: '执行测试' })).toBeEnabled();
+
+    rerender(
+      <ToolDetailDrawer
+        {...drawerProps}
+        testResult={{
+          success: false,
+          error: 'synthetic repeated failure',
+          metadata: { disabled: true, disabled_reason: 'repeated_error' },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '执行测试' })).toBeDisabled();
+    });
+  });
+
   it('wraps long descriptions and parameter text without clipping', () => {
     const longDescription = 'OneSEC DNS grouped tool. dns_search_blocked_queries_by_super_long_keyword_with_no_breaks_and_more_details_to_force_wrapping';
     const longParamDescription = 'DNS 分组动作名 dns_search_blocked_queries_by_super_long_keyword_with_no_breaks_and_more_details_to_force_wrapping';

--- a/webui/src/pages/Tool/index.tsx
+++ b/webui/src/pages/Tool/index.tsx
@@ -420,7 +420,16 @@ export default function ToolPage() {
       setTestResult(null);
       const params = JSON.parse(testParams);
       const response = await toolAPI.test(selectedTool.name, params);
-      setTestResult(response.data);
+      const result = response.data;
+      setTestResult(result);
+      if (result.metadata?.disabled === true) {
+        setSelectedTool((current) => (
+          current?.name === selectedTool.name
+            ? { ...current, enabled: false }
+            : current
+        ));
+        void refreshToolDataAfterMutation();
+      }
     } catch (err: any) {
       setTestResult({ success: false, error: err.message });
     } finally {
@@ -3539,6 +3548,12 @@ export function ToolDetailDrawer({
   }, [tool.enabled, tool.enabled_customized, tool.enabled_default]);
 
   useEffect(() => {
+    if (testResult?.metadata?.disabled === true) {
+      setEnabled(false);
+    }
+  }, [testResult]);
+
+  useEffect(() => {
     setFixturesLoading(true);
     toolAPI.listFixtures(tool.name)
       .then((res) => setFixtures(res.data ?? []))
@@ -3799,14 +3814,14 @@ export function ToolDetailDrawer({
               </div>
               <button
                 onClick={onTest}
-                disabled={testing || !tool.enabled || !canDirectTest}
+                disabled={testing || !enabled || !canDirectTest}
                 className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-slate-700 text-white rounded-lg hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed font-medium text-sm transition-colors"
               >
                 {testing
                   ? <><RefreshCw className="w-4 h-4 animate-spin" />{t('toolDetail.executing')}</>
                   : <><Play className="w-4 h-4" />{t('toolDetail.runTest')}</>}
               </button>
-              {!tool.enabled && (
+              {!enabled && (
                 <p className="text-xs text-amber-600 text-center">{t('toolDetail.disabledNote')}</p>
               )}
               {canDirectTest ? null : (


### PR DESCRIPTION
Clear repeated failure history when a tool is manually re-enabled. Sync the WebUI detail state immediately when a test response reports automatic disablement, and cover both paths with regression tests.