### PR TITLE
Fix MCP calls hanging after connection owner exits

### DIFF
--- a/flocks/mcp/client.py
+++ b/flocks/mcp/client.py
@@ -781,10 +781,15 @@ class McpClient:
         command = _ClientCommand(action=action, payload=payload, response=response)
         await self._command_queue.put(command)
 
-        done, _ = await asyncio.wait(
-            {response, owner_task},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        try:
+            done, _ = await asyncio.wait(
+                {response, owner_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        except asyncio.CancelledError:
+            response.cancel()
+            raise
+
         if response in done:
             return await response
 

--- a/flocks/mcp/client.py
+++ b/flocks/mcp/client.py
@@ -781,11 +781,25 @@ class McpClient:
         command = _ClientCommand(action=action, payload=payload, response=response)
         await self._command_queue.put(command)
 
-        if owner_task.done() and not response.done():
-            owner_error = self._owner_error or RuntimeError(f"Client not connected: {self.name}")
-            response.set_exception(owner_error)
+        done, _ = await asyncio.wait(
+            {response, owner_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if response in done:
+            return await response
 
-        return await response
+        response.cancel()
+        try:
+            owner_error = owner_task.exception()
+        except asyncio.CancelledError:
+            owner_error = None
+
+        if owner_error is not None:
+            raise RuntimeError(
+                f"Connection lost: {self.name}: {_extract_root_cause(owner_error)}"
+            ) from owner_error
+
+        raise RuntimeError(f"Connection lost: {self.name}")
 
     async def _await_task(self, task: asyncio.Task[Any]) -> None:
         """Await a task safely from the owner loop or another loop."""

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -295,3 +295,30 @@ class TestMcpClientCrossLoopSubmission:
         assert cancelled.is_set() is True
         assert client._owner_task is None
         assert client._command_queue is None
+
+
+class TestMcpClientOwnerFailure:
+    @pytest.mark.asyncio
+    async def test_call_tool_fails_when_owner_exits_during_request(self):
+        client = McpClient(
+            name="demo",
+            server_type="remote",
+            url="https://example.com/mcp",
+        )
+        client._connected = True
+        client._owner_loop = asyncio.get_running_loop()
+        client._command_queue = asyncio.Queue()
+
+        async def failing_owner() -> None:
+            await client._command_queue.get()
+            raise RuntimeError("HTTP 504 from https://example.com/mcp")
+
+        owner_task = asyncio.create_task(failing_owner())
+        owner_task.add_done_callback(client._handle_owner_task_done)
+        client._owner_task = owner_task
+
+        with pytest.raises(RuntimeError, match="HTTP 504"):
+            await asyncio.wait_for(
+                client.call_tool("demo_tool", {"value": "x"}),
+                timeout=1.0,
+            )

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -322,3 +322,38 @@ class TestMcpClientOwnerFailure:
                 client.call_tool("demo_tool", {"value": "x"}),
                 timeout=1.0,
             )
+
+    @pytest.mark.asyncio
+    async def test_call_tool_cancels_response_when_caller_is_cancelled(self):
+        client = McpClient(
+            name="demo",
+            server_type="remote",
+            url="https://example.com/mcp",
+        )
+        client._connected = True
+        client._owner_loop = asyncio.get_running_loop()
+        client._command_queue = asyncio.Queue()
+        command_seen = asyncio.get_running_loop().create_future()
+
+        async def blocked_owner() -> None:
+            command = await client._command_queue.get()
+            command_seen.set_result(command)
+            await asyncio.Future()
+
+        owner_task = asyncio.create_task(blocked_owner())
+        client._owner_task = owner_task
+
+        try:
+            call_task = asyncio.create_task(client.call_tool("demo_tool", {}))
+            command = await asyncio.wait_for(command_seen, timeout=1.0)
+            call_task.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await call_task
+
+            assert command.response is not None
+            assert command.response.cancelled() is True
+        finally:
+            owner_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await owner_task


### PR DESCRIPTION
## Summary
- wait for either the MCP command response or the connection owner task
- fail immediately with the connection root cause when the owner exits first
- cancel the pending response future when the caller is interrupted
- add regression coverage for HTTP 504 owner failures and caller cancellation

## Testing
- uv run pytest -q tests/mcp tests/tool/test_delegate_task_compat.py tests/session/test_session_abort_inject.py::TestAbortPropagation::test_session_loop_run_publishes_busy_and_idle_status_events (147 passed)
- uv run ruff check flocks/mcp/client.py tests/mcp/test_mcp_client.py