### PR TITLE
fix(question): prevent remote prompt loss

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -2973,6 +2973,37 @@ describe('streaming activity helpers', () => {
 });
 
 describe('SessionChat fallback polling', () => {
+  it('reconciles pending questions while the session is busy', async () => {
+    vi.useFakeTimers();
+    try {
+      render(React.createElement(SessionChat, {
+        sessionId: 'sess-1',
+        live: true,
+      }));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      pendingQuestionsHookMock.fetchPendingQuestions.mockClear();
+
+      act(() => {
+        useSSEOptionsRef.current.onEvent({
+          type: 'session.status',
+          properties: { sessionID: 'sess-1', status: { type: 'busy' } },
+        });
+      });
+      pendingQuestionsHookMock.fetchPendingQuestions.mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+
+      expect(pendingQuestionsHookMock.fetchPendingQuestions).toHaveBeenCalledWith('sess-1');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not finish streaming while fetched messages still contain a running tool', async () => {
     vi.useFakeTimers();
     const refetch = vi.fn();

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -1087,6 +1087,7 @@ export function getUserAvatarSpacerClassName(_compact: boolean): string {
 const ABORT_SSE_SETTLE_DELAY = 2000;
 const SCROLL_BOTTOM_THRESHOLD_PX = 80;
 const FALLBACK_POLL_MS = 5_000;
+const PENDING_QUESTION_RECONCILE_MS = 2_000;
 const WORKSPACE_UPLOAD_DEST = 'uploads';
 const FILE_INPUT_ACCEPT_DOCS = '.txt,.md,.json,.yaml,.yml,.xml,.csv,.pdf,.doc,.docx,.html,.htm,.ppt,.pptx,.xls,.xlsx';
 const FILE_INPUT_ACCEPT_ALL = `${FILE_INPUT_ACCEPT_DOCS},${FILE_INPUT_ACCEPT_IMAGES}`;
@@ -2122,6 +2123,19 @@ export default function SessionChat({
     checkStatus();
   }, [sessionId, loading, messages, fetchPendingQuestions]);
 
+  // A remote proxy or a reconnect boundary can delay or lose the one-shot
+  // question.asked event. Reconcile only while the session is active; the
+  // hook ignores responses made stale by a newer SSE update.
+  useEffect(() => {
+    if (!sessionId || (!isStreaming && !sending)) return;
+    const timer = setInterval(() => {
+      fetchPendingQuestions(sessionId).catch((err) => {
+        console.warn('[SessionChat] Failed to reconcile pending questions:', err);
+      });
+    }, PENDING_QUESTION_RECONCILE_MS);
+    return () => clearInterval(timer);
+  }, [sessionId, isStreaming, sending, fetchPendingQuestions]);
+
   // Refetch when page becomes visible again
   useEffect(() => {
     if (!sessionId) return;
@@ -2129,11 +2143,14 @@ export default function SessionChat({
       if (document.visibilityState === 'visible') {
         refetch();
         fetchPromptQueue();
+        fetchPendingQuestions(sessionId).catch((err) => {
+          console.warn('[SessionChat] Failed to recover pending questions after visibility change:', err);
+        });
       }
     };
     document.addEventListener('visibilitychange', handler);
     return () => document.removeEventListener('visibilitychange', handler);
-  }, [sessionId, refetch, fetchPromptQueue]);
+  }, [sessionId, refetch, fetchPromptQueue, fetchPendingQuestions]);
 
   // Backup refetch when compaction ends — covers SSE reconnect scenarios
   // where the session.status event may have been missed.

--- a/webui/src/features/session-chat/usePendingQuestions.ts
+++ b/webui/src/features/session-chat/usePendingQuestions.ts
@@ -5,7 +5,7 @@
  * cleanup so SessionChat does not need to own question runtime state.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import client from '@/api/client';
 import type { QuestionItem } from '@/components/common/QuestionTool';
@@ -34,8 +34,11 @@ function isNotFoundError(error: unknown): boolean {
 
 export function usePendingQuestions() {
   const [pendingQuestions, setPendingQuestions] = useState<Record<string, PendingQuestion>>({});
+  const stateVersionRef = useRef(0);
+  const fetchSequenceRef = useRef(0);
 
   const removeByCallId = useCallback((callID: string) => {
+    stateVersionRef.current += 1;
     setPendingQuestions(prev => {
       const next = { ...prev };
       delete next[callID];
@@ -45,6 +48,7 @@ export function usePendingQuestions() {
 
   const handleQuestionAsked = useCallback(
     (callID: string, requestId: string, questions: QuestionItem[]) => {
+      stateVersionRef.current += 1;
       setPendingQuestions(prev => ({
         ...prev,
         [callID]: { requestId, questions },
@@ -78,6 +82,7 @@ export function usePendingQuestions() {
   );
 
   const removeByRequestId = useCallback((requestId: string) => {
+    stateVersionRef.current += 1;
     setPendingQuestions(prev => {
       const next = { ...prev };
       for (const [callID, pending] of Object.entries(prev)) {
@@ -90,7 +95,15 @@ export function usePendingQuestions() {
   }, []);
 
   const fetchPendingQuestions = useCallback(async (sessionId: string) => {
+    const fetchSequence = ++fetchSequenceRef.current;
+    const stateVersion = stateVersionRef.current;
     const response = await client.get<PendingQuestionApiResponse[]>(`/api/question/session/${sessionId}/pending`);
+    if (
+      fetchSequence !== fetchSequenceRef.current
+      || stateVersion !== stateVersionRef.current
+    ) {
+      return;
+    }
     const next: Record<string, PendingQuestion> = {};
     for (const item of response.data || []) {
       const callID = item.tool?.callID;
@@ -105,6 +118,7 @@ export function usePendingQuestions() {
   }, []);
 
   const clearAll = useCallback(() => {
+    stateVersionRef.current += 1;
     setPendingQuestions({});
   }, []);
 

--- a/webui/src/hooks/usePendingQuestions.test.ts
+++ b/webui/src/hooks/usePendingQuestions.test.ts
@@ -63,4 +63,29 @@ describe('usePendingQuestions', () => {
     await expect(result.current.submitAnswer('call-1', 'req-1', [['yes']])).rejects.toBe(error);
     expect(result.current.pendingQuestions['call-1']).toBeDefined();
   });
+
+  it('does not let stale hydration clear a newer SSE question', async () => {
+    let resolvePendingRequest: ((value: { data: [] }) => void) | undefined;
+    clientGetMock.mockReturnValueOnce(new Promise((resolve) => {
+      resolvePendingRequest = resolve;
+    }));
+    const { result } = renderHook(() => usePendingQuestions());
+
+    let hydration: Promise<void> | undefined;
+    act(() => {
+      hydration = result.current.fetchPendingQuestions('sess-1');
+    });
+    act(() => {
+      result.current.handleQuestionAsked('call-1', 'req-1', [{ question: 'Continue?' }]);
+    });
+    await act(async () => {
+      resolvePendingRequest?.({ data: [] });
+      await hydration;
+    });
+
+    expect(result.current.pendingQuestions['call-1']).toEqual({
+      requestId: 'req-1',
+      questions: [{ question: 'Continue?' }],
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- prevent stale pending-question REST hydration from overwriting a newer question.asked SSE update
- ignore superseded and out-of-order pending-question fetches
- reconcile pending questions while a session is active and when the page becomes visible, recovering one-shot prompts delayed or missed across remote SSE connections

## Root cause
Standard flocks start launches one Uvicorn worker, so cross-worker state was not the cause. The failure is a frontend ordering race amplified by remote latency: a pending-question GET can start before the question exists, question.asked then adds the prompt through SSE, and the older empty GET response can arrive last and clear the prompt again.

## Why this approach
The pending-question hook now tracks both local state revisions and request sequence numbers. A REST response is applied only when no newer SSE/local mutation or newer fetch has superseded it. The backend remains on its existing single-process in-memory question state; no shared-storage protocol or multi-worker fallback is added.

## Impact scope
- active generating sessions perform one lightweight pending-question reconciliation request every two seconds
- no API, storage, configuration, or migration changes
- reply and reject behavior remains unchanged

## Similar-risk review
- prompt queue hydration already invalidates in-flight requests when SSE updates arrive
- context usage and goal hydration already guard stale responses
- SSE queue handling preserves question and permission control events and reconnects after a dropped-event marker
- permission.request is not rendered in SessionChat today; that is a separate interaction UX gap rather than this regression
- message-not-found 404 responses come from message edit/regenerate/tool-context routes and are separate from question submission

## Testing
- npm test -- --run src/hooks/usePendingQuestions.test.ts src/hooks/useSSE.test.tsx src/features/session-chat/sseActions.test.ts src/features/session-chat/useSessionPromptQueue.test.ts src/features/session-chat/useSessionContextUsage.test.ts src/components/common/SessionChat.test.ts
- .venv/bin/pytest -q tests/server/routes/test_event_routes.py tests/server/routes/test_interaction_access_routes.py tests/tool/test_question_handler.py
- npm exec eslint -- src/features/session-chat/usePendingQuestions.ts src/hooks/usePendingQuestions.test.ts src/components/common/SessionChat.tsx src/components/common/SessionChat.test.ts
- npm run build
- git diff --check