### PR TITLE
fix(webui): recover missed questions without duplicate messages

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -3033,6 +3033,91 @@ describe('SessionChat fallback polling', () => {
     }
   });
 
+  it('refetches when polling finds a running question missing from local messages', async () => {
+    vi.useFakeTimers();
+    const refetch = vi.fn();
+    const onStreamingDone = vi.fn();
+    try {
+      useSessionMessagesMock.mockReturnValue({
+        messages: [
+          makeMessage({
+            id: 'assistant-1',
+            parts: [],
+          }),
+        ],
+        loading: false,
+        refetch,
+        addMessage: vi.fn(),
+        updateMessage: vi.fn(),
+        updateMessagePart: vi.fn(),
+        replaceMessageText: vi.fn(),
+        truncateAfterMessage: vi.fn(),
+      });
+      clientGetMock.mockImplementation((url: string) => {
+        if (url === '/api/session/sess-1/message') {
+          return Promise.resolve({
+            data: {
+              items: [
+                {
+                  info: {
+                    id: 'assistant-1',
+                    sessionID: 'sess-1',
+                    role: 'assistant',
+                    finish: null,
+                  },
+                  parts: [
+                    {
+                      id: 'question-tool-1',
+                      messageID: 'assistant-1',
+                      sessionID: 'sess-1',
+                      type: 'tool',
+                      tool: 'question',
+                      callID: 'call-question-1',
+                      state: {
+                        status: 'running',
+                        input: { questions: [{ question: 'Continue?' }] },
+                      },
+                    },
+                  ],
+                },
+              ],
+              hasMore: false,
+              nextBefore: null,
+            },
+          });
+        }
+        if (url === '/api/session/status') {
+          return Promise.resolve({ data: { 'sess-1': { type: 'busy' } } });
+        }
+        return Promise.resolve({ data: {} });
+      });
+
+      render(React.createElement(SessionChat, {
+        sessionId: 'sess-1',
+        live: true,
+        onStreamingDone,
+      }));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      act(() => {
+        useSSEOptionsRef.current.onEvent({
+          type: 'session.status',
+          properties: { sessionID: 'sess-1', status: { type: 'busy' } },
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(onStreamingDone).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not finish streaming while fetched messages still contain a running tool', async () => {
     vi.useFakeTimers();
     const refetch = vi.fn();
@@ -3056,24 +3141,32 @@ describe('SessionChat fallback polling', () => {
         replaceMessageText: vi.fn(),
         truncateAfterMessage: vi.fn(),
       });
-      clientGetMock.mockResolvedValueOnce({
-        data: {
-          items: [
-            {
-              info: {
-                id: 'assistant-1',
-                sessionID: 'sess-1',
-                role: 'assistant',
-                finish: 'tool-calls',
-              },
-              parts: [
-                { id: 'tool-1', type: 'tool', state: { status: 'running' } },
+      clientGetMock.mockImplementation((url: string) => {
+        if (url === '/api/session/sess-1/message') {
+          return Promise.resolve({
+            data: {
+              items: [
+                {
+                  info: {
+                    id: 'assistant-1',
+                    sessionID: 'sess-1',
+                    role: 'assistant',
+                    finish: 'tool-calls',
+                  },
+                  parts: [
+                    { id: 'tool-1', type: 'tool', state: { status: 'running' } },
+                  ],
+                },
               ],
+              hasMore: false,
+              nextBefore: null,
             },
-          ],
-          hasMore: false,
-          nextBefore: null,
-        },
+          });
+        }
+        if (url === '/api/session/status') {
+          return Promise.resolve({ data: { 'sess-1': { type: 'busy' } } });
+        }
+        return Promise.resolve({ data: {} });
       });
 
       render(React.createElement(SessionChat, {
@@ -3081,6 +3174,9 @@ describe('SessionChat fallback polling', () => {
         live: true,
         onStreamingDone,
       }));
+      await act(async () => {
+        await Promise.resolve();
+      });
       act(() => {
         useSSEOptionsRef.current.onEvent({
           type: 'session.status',
@@ -3088,7 +3184,9 @@ describe('SessionChat fallback polling', () => {
         });
       });
 
-      await vi.advanceTimersByTimeAsync(5_000);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
 
       expect(refetch).not.toHaveBeenCalled();
       expect(onStreamingDone).not.toHaveBeenCalled();

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -271,6 +271,83 @@ function makeMessage(overrides: Partial<Message> & { id: string }): Message {
   } as Message;
 }
 
+type FetchedMessageFixture = {
+  info: {
+    id: string;
+    sessionID: string;
+    role: 'user' | 'assistant';
+    parentID?: string;
+    finish?: string | null;
+  };
+  parts: Message['parts'];
+};
+
+function makeFetchedMessage(
+  info: Omit<FetchedMessageFixture['info'], 'sessionID'>,
+  parts: Message['parts'] = [],
+): FetchedMessageFixture {
+  return {
+    info: { sessionID: 'sess-1', ...info },
+    parts,
+  };
+}
+
+function mockFallbackPolling({
+  localMessages,
+  fetchedMessages,
+  refetch,
+  status = { 'sess-1': { type: 'busy' } },
+}: {
+  localMessages: Message[];
+  fetchedMessages: FetchedMessageFixture[];
+  refetch: () => unknown;
+  status?: Record<string, { type: string }>;
+}) {
+  useSessionMessagesMock.mockReturnValue({
+    messages: localMessages,
+    loading: false,
+    refetch,
+    addMessage: vi.fn(),
+    updateMessage: vi.fn(),
+    updateMessagePart: vi.fn(),
+    replaceMessageText: vi.fn(),
+    truncateAfterMessage: vi.fn(),
+  });
+  clientGetMock.mockImplementation((url: string) => {
+    if (url === '/api/session/sess-1/message') {
+      return Promise.resolve({
+        data: {
+          items: fetchedMessages,
+          hasMore: false,
+          nextBefore: null,
+        },
+      });
+    }
+    if (url === '/api/session/status') {
+      return Promise.resolve({ data: status });
+    }
+    return Promise.resolve({ data: {} });
+  });
+}
+
+async function startFallbackPolling(onStreamingDone: () => void) {
+  render(React.createElement(SessionChat, {
+    sessionId: 'sess-1',
+    live: true,
+    onStreamingDone,
+  }));
+  await act(async () => {
+    await Promise.resolve();
+  });
+  clientGetMock.mockClear();
+  act(() => {
+    useSSEOptionsRef.current.onEvent({
+      type: 'session.status',
+      properties: { sessionID: 'sess-1', status: { type: 'busy' } },
+    });
+  });
+}
+
 function mockStatefulSessionMessages() {
   useSessionMessagesMock.mockImplementation(() => {
     const [messages, setMessages] = React.useState<Message[]>([]);
@@ -3033,79 +3110,46 @@ describe('SessionChat fallback polling', () => {
     }
   });
 
-  it('refetches when polling finds a running question missing from local messages', async () => {
+  it('refetches when polling finds a pending question missing from local messages', async () => {
     vi.useFakeTimers();
-    const refetch = vi.fn();
+    let resolveRefetch: (() => void) | undefined;
+    const refetch = vi.fn(() => new Promise<void>((resolve) => {
+      resolveRefetch = resolve;
+    }));
     const onStreamingDone = vi.fn();
     try {
-      useSessionMessagesMock.mockReturnValue({
-        messages: [
-          makeMessage({
-            id: 'assistant-1',
-            parts: [],
-          }),
+      pendingQuestionsHookMock.pendingQuestions = {
+        'call-question-1': {
+          requestId: 'request-question-1',
+          questions: [{ question: 'Continue?' }],
+        },
+      };
+      mockFallbackPolling({
+        localMessages: [
+          makeMessage({ id: 'user-1', role: 'user' }),
+          makeMessage({ id: 'assistant-1', parentID: 'user-1' }),
         ],
-        loading: false,
+        fetchedMessages: [
+          makeFetchedMessage({ id: 'user-1', role: 'user' }),
+          makeFetchedMessage(
+            { id: 'assistant-1', role: 'assistant', parentID: 'user-1', finish: 'tool-calls' },
+            [{
+              id: 'question-tool-1',
+              messageID: 'assistant-1',
+              sessionID: 'sess-1',
+              type: 'tool',
+              tool: 'question',
+              callID: 'call-question-1',
+              state: {
+                status: 'completed',
+                input: { questions: [{ question: 'Continue?' }] },
+              },
+            } as Message['parts'][number]],
+          ),
+        ],
         refetch,
-        addMessage: vi.fn(),
-        updateMessage: vi.fn(),
-        updateMessagePart: vi.fn(),
-        replaceMessageText: vi.fn(),
-        truncateAfterMessage: vi.fn(),
       });
-      clientGetMock.mockImplementation((url: string) => {
-        if (url === '/api/session/sess-1/message') {
-          return Promise.resolve({
-            data: {
-              items: [
-                {
-                  info: {
-                    id: 'assistant-1',
-                    sessionID: 'sess-1',
-                    role: 'assistant',
-                    finish: null,
-                  },
-                  parts: [
-                    {
-                      id: 'question-tool-1',
-                      messageID: 'assistant-1',
-                      sessionID: 'sess-1',
-                      type: 'tool',
-                      tool: 'question',
-                      callID: 'call-question-1',
-                      state: {
-                        status: 'running',
-                        input: { questions: [{ question: 'Continue?' }] },
-                      },
-                    },
-                  ],
-                },
-              ],
-              hasMore: false,
-              nextBefore: null,
-            },
-          });
-        }
-        if (url === '/api/session/status') {
-          return Promise.resolve({ data: { 'sess-1': { type: 'busy' } } });
-        }
-        return Promise.resolve({ data: {} });
-      });
-
-      render(React.createElement(SessionChat, {
-        sessionId: 'sess-1',
-        live: true,
-        onStreamingDone,
-      }));
-      await act(async () => {
-        await Promise.resolve();
-      });
-      act(() => {
-        useSSEOptionsRef.current.onEvent({
-          type: 'session.status',
-          properties: { sessionID: 'sess-1', status: { type: 'busy' } },
-        });
-      });
+      await startFallbackPolling(onStreamingDone);
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5_000);
@@ -3113,76 +3157,173 @@ describe('SessionChat fallback polling', () => {
 
       expect(refetch).toHaveBeenCalledTimes(1);
       expect(onStreamingDone).not.toHaveBeenCalled();
+      expect(clientGetMock).not.toHaveBeenCalledWith('/api/session/status');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(clientGetMock.mock.calls.filter(
+        ([url]) => url === '/api/session/sess-1/message',
+      )).toHaveLength(2);
+
+      await act(async () => {
+        resolveRefetch?.();
+        await Promise.resolve();
+      });
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('does not finish streaming while fetched messages still contain a running tool', async () => {
+  it('ignores a missing running question from a historical turn while the session is busy', async () => {
     vi.useFakeTimers();
     const refetch = vi.fn();
     const onStreamingDone = vi.fn();
     try {
-      useSessionMessagesMock.mockReturnValue({
-        messages: [
-          makeMessage({
-            id: 'assistant-1',
-            finish: 'tool-calls',
-            parts: [
-              { id: 'tool-1', type: 'tool', state: { status: 'running' } } as Message['parts'][number],
-            ],
+      const localMessages = [
+        makeMessage({ id: 'old-user', role: 'user' }),
+        makeMessage({ id: 'old-assistant', parentID: 'old-user', finish: 'tool-calls' }),
+        makeMessage({ id: 'current-user', role: 'user' }),
+        makeMessage({ id: 'current-assistant', parentID: 'current-user' }),
+      ];
+      mockFallbackPolling({
+        localMessages,
+        fetchedMessages: [
+          makeFetchedMessage({ id: 'old-user', role: 'user' }),
+          makeFetchedMessage(
+            {
+              id: 'old-assistant',
+              role: 'assistant',
+              parentID: 'old-user',
+              finish: 'tool-calls',
+            },
+            [{
+              id: 'old-tool',
+              type: 'tool',
+              tool: 'question',
+              state: { status: 'running' },
+            } as Message['parts'][number]],
+          ),
+          makeFetchedMessage({ id: 'current-user', role: 'user' }),
+          makeFetchedMessage({
+            id: 'current-assistant',
+            role: 'assistant',
+            parentID: 'current-user',
+            finish: null,
           }),
         ],
-        loading: false,
         refetch,
-        addMessage: vi.fn(),
-        updateMessage: vi.fn(),
-        updateMessagePart: vi.fn(),
-        replaceMessageText: vi.fn(),
-        truncateAfterMessage: vi.fn(),
       });
-      clientGetMock.mockImplementation((url: string) => {
-        if (url === '/api/session/sess-1/message') {
-          return Promise.resolve({
-            data: {
-              items: [
-                {
-                  info: {
-                    id: 'assistant-1',
-                    sessionID: 'sess-1',
-                    role: 'assistant',
-                    finish: 'tool-calls',
-                  },
-                  parts: [
-                    { id: 'tool-1', type: 'tool', state: { status: 'running' } },
-                  ],
-                },
-              ],
-              hasMore: false,
-              nextBefore: null,
-            },
-          });
-        }
-        if (url === '/api/session/status') {
-          return Promise.resolve({ data: { 'sess-1': { type: 'busy' } } });
-        }
-        return Promise.resolve({ data: {} });
+      await startFallbackPolling(onStreamingDone);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
       });
 
-      render(React.createElement(SessionChat, {
-        sessionId: 'sess-1',
-        live: true,
-        onStreamingDone,
-      }));
+      expect(clientGetMock).toHaveBeenCalledWith('/api/session/sess-1/message', {
+        params: { page: true, limit: 50, include_archived: true },
+      });
+      expect(clientGetMock).not.toHaveBeenCalledWith('/api/session/status');
+      expect(refetch).not.toHaveBeenCalled();
+      expect(onStreamingDone).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('finishes streaming when only a historical turn has a running question', async () => {
+    vi.useFakeTimers();
+    const refetch = vi.fn();
+    const onStreamingDone = vi.fn();
+    try {
+      const localMessages = [
+        makeMessage({ id: 'old-user', role: 'user' }),
+        makeMessage({ id: 'old-assistant', parentID: 'old-user', finish: 'tool-calls' }),
+        makeMessage({ id: 'current-user', role: 'user' }),
+        makeMessage({ id: 'current-assistant', parentID: 'current-user', finish: 'stop' }),
+      ];
+      mockFallbackPolling({
+        localMessages,
+        fetchedMessages: [
+          makeFetchedMessage({ id: 'old-user', role: 'user' }),
+          makeFetchedMessage(
+            {
+              id: 'old-assistant',
+              role: 'assistant',
+              parentID: 'old-user',
+              finish: 'tool-calls',
+            },
+            [{
+              id: 'old-tool',
+              type: 'tool',
+              tool: 'question',
+              state: { status: 'running' },
+            } as Message['parts'][number]],
+          ),
+          makeFetchedMessage({ id: 'current-user', role: 'user' }),
+          makeFetchedMessage(
+            {
+              id: 'current-assistant',
+              role: 'assistant',
+              parentID: 'current-user',
+              finish: 'stop',
+            },
+            [{ id: 'current-text', type: 'text', text: 'done' } as Message['parts'][number]],
+          ),
+        ],
+        refetch,
+        status: {},
+      });
+      await startFallbackPolling(onStreamingDone);
+
       await act(async () => {
-        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(5_000);
       });
-      act(() => {
-        useSSEOptionsRef.current.onEvent({
-          type: 'session.status',
-          properties: { sessionID: 'sess-1', status: { type: 'busy' } },
-        });
+
+      expect(clientGetMock).toHaveBeenCalledWith('/api/session/status');
+      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(onStreamingDone).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
       });
+      expect(refetch).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not refetch a missing non-question tool while it is still running', async () => {
+    vi.useFakeTimers();
+    const refetch = vi.fn();
+    const onStreamingDone = vi.fn();
+    try {
+      mockFallbackPolling({
+        localMessages: [
+          makeMessage({ id: 'user-1', role: 'user' }),
+          makeMessage({ id: 'assistant-1', parentID: 'user-1', finish: 'tool-calls' }),
+        ],
+        fetchedMessages: [
+          makeFetchedMessage({ id: 'user-1', role: 'user' }),
+          makeFetchedMessage(
+            {
+              id: 'assistant-1',
+              role: 'assistant',
+              parentID: 'user-1',
+              finish: 'tool-calls',
+            },
+            [{
+              id: 'tool-1',
+              type: 'tool',
+              tool: 'bash',
+              state: { status: 'running' },
+            } as Message['parts'][number]],
+          ),
+        ],
+        refetch,
+      });
+      await startFallbackPolling(onStreamingDone);
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(5_000);
@@ -3190,6 +3331,7 @@ describe('SessionChat fallback polling', () => {
 
       expect(refetch).not.toHaveBeenCalled();
       expect(onStreamingDone).not.toHaveBeenCalled();
+      expect(clientGetMock).not.toHaveBeenCalledWith('/api/session/status');
       expect(clientGetMock).toHaveBeenCalledWith('/api/session/sess-1/message', {
         params: { page: true, limit: 50, include_archived: true },
       });

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -2226,6 +2226,82 @@ describe('SessionChat intermediate process collapse', () => {
   });
 });
 
+describe('SessionChat optimistic message identity', () => {
+  it('uses the optimistic user message ID for the persisted prompt', async () => {
+    const user = userEvent.setup();
+    const addMessage = vi.fn();
+    useSessionMessagesMock.mockReturnValue({
+      messages: [],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage,
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    await user.type(screen.getByPlaceholderText('请输入消息'), '测试 question 工具{enter}');
+
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledWith(
+        '/api/session/sess-1/prompt_async',
+        expect.objectContaining({ messageID: expect.stringMatching(/^msg_/) }),
+      );
+    });
+
+    expect(addMessage).toHaveBeenCalledTimes(1);
+    expect(clientPostMock.mock.calls.filter(
+      ([url]) => url === '/api/session/sess-1/prompt_async',
+    )).toHaveLength(1);
+    const optimisticMessage = addMessage.mock.calls[0][0] as Message;
+    const promptCall = clientPostMock.mock.calls.find(
+      ([url]) => url === '/api/session/sess-1/prompt_async',
+    );
+    const payload = promptCall?.[1] as { messageID?: string } | undefined;
+    expect(payload?.messageID).toBe(optimisticMessage.id);
+  });
+
+  it('uses the optimistic user message ID for slash commands', async () => {
+    const user = userEvent.setup();
+    const addMessage = vi.fn();
+    useSessionMessagesMock.mockReturnValue({
+      messages: [],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage,
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    await user.type(screen.getByPlaceholderText('请输入消息'), '/tools{enter}');
+
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledWith(
+        '/api/session/sess-1/command',
+        expect.objectContaining({ messageID: expect.stringMatching(/^msg_/) }),
+      );
+    });
+
+    expect(addMessage).toHaveBeenCalledTimes(1);
+    expect(clientPostMock.mock.calls.filter(
+      ([url]) => url === '/api/session/sess-1/command',
+    )).toHaveLength(1);
+    const optimisticMessage = addMessage.mock.calls[0][0] as Message;
+    const commandCall = clientPostMock.mock.calls.find(
+      ([url]) => url === '/api/session/sess-1/command',
+    );
+    const payload = commandCall?.[1] as { messageID?: string } | undefined;
+    expect(payload?.messageID).toBe(optimisticMessage.id);
+  });
+});
+
 describe('SessionChat agent mentions', () => {
   const mentionAgents = [
     {

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -2871,11 +2871,30 @@ export default function SessionChat({
         });
         const msgs: any[] = Array.isArray(res.data) ? res.data : (res.data?.items || []);
         const lastMsg = msgs[msgs.length - 1];
-        if (lastMsg?.info?.role === 'assistant' && (lastMsg.info.finish || lastMsg.info.time?.completed)) {
-          const hasFetchedActiveTool = msgs.some((msg) => hasActiveToolPart(msg.parts));
-          if (hasFetchedActiveTool) {
-            return;
+        const hasFetchedActiveTool = msgs.some((msg) => hasActiveToolPart(msg.parts));
+        if (hasFetchedActiveTool) {
+          const localActiveToolPartIds = new Set<string>();
+          const localActiveToolCallIds = new Set<string>();
+          for (const message of messagesRef.current) {
+            for (const part of message.parts || []) {
+              if (!isActiveToolPart(part)) continue;
+              if (part.id) localActiveToolPartIds.add(part.id);
+              if (part.callID) localActiveToolCallIds.add(part.callID);
+            }
           }
+          const hasMissingFetchedActiveTool = msgs.some((msg) => (
+            (msg.parts || []).some((part: MessagePart) => (
+              isActiveToolPart(part)
+              && !(
+                (part.id && localActiveToolPartIds.has(part.id))
+                || (part.callID && localActiveToolCallIds.has(part.callID))
+              )
+            ))
+          ));
+          if (hasMissingFetchedActiveTool) refetch();
+          return;
+        }
+        if (lastMsg?.info?.role === 'assistant' && (lastMsg.info.finish || lastMsg.info.time?.completed)) {
           activeToolPartIdsRef.current.clear();
           const statusRes = await client.get('/api/session/status');
           const status = statusRes.data?.[sessionId];

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -39,6 +39,7 @@ import { workspaceAPI } from '@/api/workspace';
 import { formatSmartTime } from '@/utils/time';
 import { getAgentDisplayDescription } from '@/utils/agentDisplay';
 import { copyText } from '@/utils/clipboard';
+import { createMessageId } from '@/utils/messageId';
 import {
   FILE_INPUT_ACCEPT_IMAGES,
   batchCompressOptions,
@@ -2472,12 +2473,12 @@ export default function SessionChat({
     setIsStreaming(true);
 
     const displayText = args ? `/${command} ${args}` : `/${command}`;
-    const tempId = `temp-${Date.now()}`;
+    const messageId = createMessageId();
     addMessage({
-      id: tempId,
+      id: messageId,
       sessionID: sessionId,
       role: 'user',
-      parts: [{ id: `${tempId}-part`, type: 'text', text: displayText }],
+      parts: [{ id: `temp-${messageId}-part`, type: 'text', text: displayText }],
       timestamp: Date.now(),
     } as Message);
 
@@ -2486,6 +2487,7 @@ export default function SessionChat({
         command,
         arguments: args,
         agent: agentName,
+        messageID: messageId,
       });
       if (command === 'goal' && args.trim()) {
         goalHydrationVersionRef.current += 1;
@@ -2527,18 +2529,18 @@ export default function SessionChat({
     setIsStreaming(true);
     setPendingAgentName(effectiveAgent || 'rex');
 
-    const tempId = `temp-${Date.now()}`;
+    const messageId = createMessageId();
     const tempParts: MessagePart[] = [];
-    if (visibleText) tempParts.push({ id: `${tempId}-text`, type: 'text', text: visibleText });
+    if (visibleText) tempParts.push({ id: `temp-${messageId}-text`, type: 'text', text: visibleText });
     imageParts.forEach((img, i) => {
-      tempParts.push({ id: `${tempId}-img-${i}`, type: 'file', url: img.url, mime: img.mime, filename: img.filename });
+      tempParts.push({ id: `temp-${messageId}-img-${i}`, type: 'file', url: img.url, mime: img.mime, filename: img.filename });
     });
 
     addMessage({
-      id: tempId,
+      id: messageId,
       sessionID: sessionId,
       role: 'user',
-      parts: tempParts.length > 0 ? tempParts : [{ id: `${tempId}-part`, type: 'text', text: visibleText }],
+      parts: tempParts.length > 0 ? tempParts : [{ id: `temp-${messageId}-part`, type: 'text', text: visibleText }],
       timestamp: Date.now(),
       agent: effectiveAgent,
     } as Message);
@@ -2546,6 +2548,7 @@ export default function SessionChat({
     try {
       const payload: Record<string, unknown> = {
         parts: buildPromptParts(text, imageParts),
+        messageID: messageId,
       };
       if (effectiveAgent) payload.agent = effectiveAgent;
       if (model) payload.model = model;

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -901,6 +901,54 @@ export function hasActiveToolPart(parts?: Array<Pick<MessagePart, 'type' | 'stat
   return parts?.some(isActiveToolPart) ?? false;
 }
 
+type FetchedMessageWithParts = {
+  info?: {
+    id?: string;
+    role?: string;
+    parentID?: string | null;
+    finish?: string | null;
+    time?: { completed?: number | null };
+  };
+  parts?: MessagePart[];
+};
+
+function getCurrentTurnAssistantMessages(
+  messages: FetchedMessageWithParts[],
+): FetchedMessageWithParts[] | null {
+  let latestUserIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.info?.role === 'user') {
+      latestUserIndex = index;
+      break;
+    }
+  }
+
+  let turnParentID = latestUserIndex >= 0
+    ? messages[latestUserIndex]?.info?.id
+    : undefined;
+  let turnStartIndex = latestUserIndex + 1;
+
+  // A single tool-heavy turn can exceed the latest-message page. If its user
+  // message is outside the page, recover the turn from the newest assistant's
+  // parent instead of falling back to every historical tool in the page.
+  if (!turnParentID) {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const info = messages[index]?.info;
+      if (info?.role === 'assistant' && info.parentID) {
+        turnParentID = info.parentID;
+        turnStartIndex = 0;
+        break;
+      }
+    }
+  }
+
+  if (!turnParentID) return null;
+  return messages.slice(turnStartIndex).filter((message) => (
+    message.info?.role === 'assistant'
+    && message.info.parentID === turnParentID
+  ));
+}
+
 export function isActiveSessionStatus(status?: { type?: string } | null): boolean {
   return status?.type === 'busy' || status?.type === 'compacting' || status?.type === 'retry';
 }
@@ -1725,6 +1773,8 @@ export default function SessionChat({
   // Keep a ref to latest messages so handleAbort can read it without stale closure
   const messagesRef = useRef(messages);
   useEffect(() => { messagesRef.current = messages; }, [messages]);
+  const pendingQuestionsRef = useRef(pendingQuestions);
+  useEffect(() => { pendingQuestionsRef.current = pendingQuestions; }, [pendingQuestions]);
 
   const hasUserMessage = useMemo(() => messages.some((m) => m.role === 'user'), [messages]);
 
@@ -2864,43 +2914,81 @@ export default function SessionChat({
   // Fallback polling to detect completion when SSE events are missed
   useEffect(() => {
     if (!isStreaming || !sessionId) return;
+    let questionRecoveryInFlight = false;
     const timer = setInterval(async () => {
       try {
         const res = await client.get(`/api/session/${sessionId}/message`, {
           params: { page: true, limit: 50, include_archived: true },
         });
-        const msgs: any[] = Array.isArray(res.data) ? res.data : (res.data?.items || []);
-        const lastMsg = msgs[msgs.length - 1];
-        const hasFetchedActiveTool = msgs.some((msg) => hasActiveToolPart(msg.parts));
-        if (hasFetchedActiveTool) {
-          const localActiveToolPartIds = new Set<string>();
-          const localActiveToolCallIds = new Set<string>();
+        const msgs: FetchedMessageWithParts[] = Array.isArray(res.data)
+          ? res.data
+          : (res.data?.items || []);
+        const currentTurnAssistantMessages = getCurrentTurnAssistantMessages(msgs);
+        const shouldRecoverQuestionPart = (part: MessagePart) => (
+          isQuestionToolName(part.tool || '')
+          && (
+            isActiveToolPart(part)
+            || !!(part.callID && pendingQuestionsRef.current[part.callID])
+          )
+        );
+        const hasFetchedPendingQuestion = currentTurnAssistantMessages?.some((message) => (
+          (message.parts || []).some((part) => (
+            shouldRecoverQuestionPart(part)
+          ))
+        )) ?? false;
+        if (currentTurnAssistantMessages && hasFetchedPendingQuestion) {
+          const localQuestionPartIds = new Set<string>();
+          const localQuestionCallIds = new Set<string>();
           for (const message of messagesRef.current) {
             for (const part of message.parts || []) {
-              if (!isActiveToolPart(part)) continue;
-              if (part.id) localActiveToolPartIds.add(part.id);
-              if (part.callID) localActiveToolCallIds.add(part.callID);
+              if (
+                (part.type !== 'tool' && part.type !== 'toolCall')
+                || !isQuestionToolName(part.tool || '')
+              ) continue;
+              if (part.id) localQuestionPartIds.add(part.id);
+              if (part.callID) localQuestionCallIds.add(part.callID);
             }
           }
-          const hasMissingFetchedActiveTool = msgs.some((msg) => (
+          const hasMissingFetchedQuestion = currentTurnAssistantMessages.some((msg) => (
             (msg.parts || []).some((part: MessagePart) => (
-              isActiveToolPart(part)
+              shouldRecoverQuestionPart(part)
               && !(
-                (part.id && localActiveToolPartIds.has(part.id))
-                || (part.callID && localActiveToolCallIds.has(part.callID))
+                (part.id && localQuestionPartIds.has(part.id))
+                || (part.callID && localQuestionCallIds.has(part.callID))
               )
             ))
           ));
-          if (hasMissingFetchedActiveTool) refetch();
-          return;
+          if (hasMissingFetchedQuestion && !questionRecoveryInFlight) {
+            questionRecoveryInFlight = true;
+            try {
+              await refetch();
+            } finally {
+              questionRecoveryInFlight = false;
+            }
+          }
         }
+
+        const lastMsg = msgs[msgs.length - 1];
         if (lastMsg?.info?.role === 'assistant' && (lastMsg.info.finish || lastMsg.info.time?.completed)) {
+          const currentTurnMessages = currentTurnAssistantMessages
+            ? new Set(currentTurnAssistantMessages)
+            : null;
+          const hasFetchedActiveTool = msgs.some((msg) => (
+            (msg.parts || []).some((part: MessagePart) => {
+              if (!isQuestionToolName(part.tool || '')) return isActiveToolPart(part);
+              const isPendingQuestion = isActiveToolPart(part)
+                || !!(part.callID && pendingQuestionsRef.current[part.callID]);
+              if (!isPendingQuestion) return false;
+              return currentTurnMessages === null || currentTurnMessages.has(msg);
+            })
+          ));
+          if (hasFetchedActiveTool) return;
+
           activeToolPartIdsRef.current.clear();
           const statusRes = await client.get('/api/session/status');
           const status = statusRes.data?.[sessionId];
-          if (isActiveSessionStatus(status)) {
-            return;
-          }
+          if (isActiveSessionStatus(status)) return;
+
           refetch();
           setIsStreaming(false);
         }

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -714,6 +714,88 @@ describe('updateMessagePart scheduling', () => {
     expect((result.current.messages[1].parts as any[])[0].text).toBe('new reply');
   });
 
+  it('keeps one user message when refetch and delayed SSE reconcile its optimistic ID', async () => {
+    const optimisticId = 'msg_000000000001abcdefghijklmn';
+    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.addMessage(makeMsg({
+        id: optimisticId,
+        role: 'user',
+        timestamp: 100,
+        parts: [{
+          id: `temp-${optimisticId}-text`,
+          type: 'text',
+          text: '测试 question 工具',
+        }] as Message['parts'],
+      }));
+    });
+
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            info: {
+              id: optimisticId,
+              sessionID: 'sess-1',
+              role: 'user',
+              time: { created: 200 },
+            },
+            parts: [{
+              id: 'user-real-text',
+              messageID: optimisticId,
+              sessionID: 'sess-1',
+              type: 'text',
+              text: '测试 question 工具',
+            }],
+          },
+          {
+            info: {
+              id: 'assistant-question',
+              sessionID: 'sess-1',
+              role: 'assistant',
+              parentID: optimisticId,
+              time: { created: 201 },
+            },
+            parts: [{
+              id: 'question-part',
+              messageID: 'assistant-question',
+              sessionID: 'sess-1',
+              type: 'tool',
+              tool: 'question',
+              callID: 'question-call',
+              state: { status: 'running' },
+            }],
+          },
+        ],
+        hasMore: false,
+        nextBefore: null,
+      },
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+      result.current.updateMessage({
+        id: optimisticId,
+        sessionID: 'sess-1',
+        role: 'user',
+        time: { created: 200 },
+      });
+    });
+
+    expect(result.current.messages.filter((message) => message.role === 'user'))
+      .toHaveLength(1);
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      optimisticId,
+      'assistant-question',
+    ]);
+    expect(result.current.messages[0].parts.map((part) => part.id)).toEqual([
+      'user-real-text',
+    ]);
+  });
+
   it('truncateAfterMessage keeps the target by default', async () => {
     const { result } = renderHook(() => useSessionMessages('sess-1'));
     await act(async () => {});

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -674,6 +674,58 @@ describe('updateMessagePart scheduling', () => {
     expect((result.current.messages[2].parts as any[])[0].text).toBe('new reply');
   });
 
+  it('moves a late assistant process beside its parent when metadata arrives', async () => {
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.addMessage(makeMsg({
+        id: 'old-user',
+        role: 'user',
+        timestamp: 100,
+      }));
+      result.current.addMessage(makeMsg({
+        id: 'current-user',
+        role: 'user',
+        timestamp: 300,
+      }));
+      result.current.addMessage(makeMsg({
+        id: 'current-assistant',
+        role: 'assistant',
+        parentID: 'current-user',
+        timestamp: 400,
+        finish: 'stop',
+      }));
+
+      // A tool/reasoning part can arrive before its message metadata. The
+      // placeholder is initially appended after the current conversation.
+      result.current.updateMessagePart({
+        id: 'old-tool',
+        messageID: 'old-assistant',
+        sessionID: 'sess-1',
+        type: 'tool',
+        tool: 'question',
+        state: { status: 'completed' },
+      });
+      result.current.updateMessage({
+        id: 'old-assistant',
+        sessionID: 'sess-1',
+        role: 'assistant',
+        parentID: 'old-user',
+        time: { created: 200 },
+        finish: 'tool-calls',
+      });
+    });
+
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      'old-user',
+      'old-assistant',
+      'current-user',
+      'current-assistant',
+    ]);
+    expect((result.current.messages[1].parts as any[])[0].id).toBe('old-tool');
+  });
+
   it('moves a replaced temp user before an already streamed assistant child', async () => {
     const { result } = renderHook(() => useSessionMessages('sess-1'));
     await act(async () => {});

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -674,58 +674,6 @@ describe('updateMessagePart scheduling', () => {
     expect((result.current.messages[2].parts as any[])[0].text).toBe('new reply');
   });
 
-  it('moves a late assistant process beside its parent when metadata arrives', async () => {
-    const { result } = renderHook(() => useSessionMessages('sess-1'));
-    await act(async () => {});
-
-    await act(async () => {
-      result.current.addMessage(makeMsg({
-        id: 'old-user',
-        role: 'user',
-        timestamp: 100,
-      }));
-      result.current.addMessage(makeMsg({
-        id: 'current-user',
-        role: 'user',
-        timestamp: 300,
-      }));
-      result.current.addMessage(makeMsg({
-        id: 'current-assistant',
-        role: 'assistant',
-        parentID: 'current-user',
-        timestamp: 400,
-        finish: 'stop',
-      }));
-
-      // A tool/reasoning part can arrive before its message metadata. The
-      // placeholder is initially appended after the current conversation.
-      result.current.updateMessagePart({
-        id: 'old-tool',
-        messageID: 'old-assistant',
-        sessionID: 'sess-1',
-        type: 'tool',
-        tool: 'question',
-        state: { status: 'completed' },
-      });
-      result.current.updateMessage({
-        id: 'old-assistant',
-        sessionID: 'sess-1',
-        role: 'assistant',
-        parentID: 'old-user',
-        time: { created: 200 },
-        finish: 'tool-calls',
-      });
-    });
-
-    expect(result.current.messages.map((message) => message.id)).toEqual([
-      'old-user',
-      'old-assistant',
-      'current-user',
-      'current-assistant',
-    ]);
-    expect((result.current.messages[1].parts as any[])[0].id).toBe('old-tool');
-  });
-
   it('moves a replaced temp user before an already streamed assistant child', async () => {
     const { result } = renderHook(() => useSessionMessages('sess-1'));
     await act(async () => {});

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -613,7 +613,11 @@ export function useSessionMessages(sessionId?: string) {
             providerID: messageInfo.providerID ?? existing.providerID,
             cost: messageInfo.cost ?? existing.cost,
           };
-          return updated;
+          // Part events can create an assistant placeholder before its
+          // message metadata arrives. Once parentID is known, move that
+          // placeholder beside its user message instead of leaving an old
+          // reasoning/tool process at the end of the conversation.
+          return normalizeMessageOrder(updated);
         }
 
         // If a user SSE message arrives and there's a temp placeholder, replace it

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -613,11 +613,7 @@ export function useSessionMessages(sessionId?: string) {
             providerID: messageInfo.providerID ?? existing.providerID,
             cost: messageInfo.cost ?? existing.cost,
           };
-          // Part events can create an assistant placeholder before its
-          // message metadata arrives. Once parentID is known, move that
-          // placeholder beside its user message instead of leaving an old
-          // reasoning/tool process at the end of the conversation.
-          return normalizeMessageOrder(updated);
+          return updated;
         }
 
         // If a user SSE message arrives and there's a temp placeholder, replace it

--- a/webui/src/utils/messageId.test.ts
+++ b/webui/src/utils/messageId.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMessageId } from './messageId';
+
+describe('createMessageId', () => {
+  it('creates a canonical message ID with its timestamp bits encoded', () => {
+    const timestamp = 1_700_000_000_000;
+    const id = createMessageId(timestamp);
+
+    expect(id).toMatch(/^msg_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
+    const encodedTime = BigInt(`0x${id.slice(4, 16)}`);
+    expect(encodedTime >> 12n).toBe(BigInt(timestamp) & ((1n << 36n) - 1n));
+  });
+
+  it('keeps IDs unique and ordered within the same millisecond', () => {
+    const timestamp = 1_700_000_000_001;
+    const first = createMessageId(timestamp);
+    const second = createMessageId(timestamp);
+
+    expect(second).not.toBe(first);
+    expect(second > first).toBe(true);
+  });
+});

--- a/webui/src/utils/messageId.ts
+++ b/webui/src/utils/messageId.ts
@@ -1,0 +1,24 @@
+const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const RANDOM_SUFFIX_LENGTH = 14;
+
+let lastTimestamp = 0;
+let counter = 0;
+
+export function createMessageId(timestamp = Date.now()): string {
+  if (timestamp !== lastTimestamp) {
+    lastTimestamp = timestamp;
+    counter = 0;
+  }
+  counter += 1;
+
+  const encodedTime = BigInt(timestamp) * 0x1000n + BigInt(counter);
+  const timeHex = encodedTime.toString(16).slice(-12).padStart(12, '0');
+  const randomBytes = new Uint8Array(RANDOM_SUFFIX_LENGTH);
+  globalThis.crypto.getRandomValues(randomBytes);
+  const randomSuffix = Array.from(
+    randomBytes,
+    (byte) => BASE62[byte % BASE62.length],
+  ).join('');
+
+  return `msg_${timeHex}${randomSuffix}`;
+}


### PR DESCRIPTION
## Summary

- Recover a pending question prompt when the message stream misses its tool-part update.
- Limit question recovery and completion blocking to assistant messages in the current user turn.
- Use the same canonical message ID for optimistic user bubbles and persisted prompts or slash commands.
- Prevent overlapping question recovery refetches on slow remote connections.
- Ignore stale historical question state without changing non-question tool behavior.

## Root cause

A missed or delayed SSE update could leave pending-question state ahead of the local message list. The recovery refetch then exposed an existing optimistic-state race: the local `temp-*` user message and the persisted user message had different IDs, so both remained visible until a page reload.

The WebUI now supplies the optimistic message ID through the existing backend `messageID` contract. SSE updates and refetch snapshots therefore reconcile the same message by ID.

## Performance and regression safety

- Keep normal fallback polling at one message request per interval.
- Query session status only on the existing terminal-message path.
- Add no new network requests, message scans, or heuristic text matching.
- Generate one fixed-size ID per user send and keep temporary part replacement behavior unchanged.
- Remove the unrelated late-message ordering change from this PR.

## Testing

- `npm run test:run` — 109 files, 731 tests passed
- `npm run lint -- --no-cache`
- `npm run build`
- `git diff --check`