### PR TITLE
fix(device): create instances from installed templates

### DIFF
--- a/.flocks/plugins/skills/device-integration-guide/SKILL.md
+++ b/.flocks/plugins/skills/device-integration-guide/SKILL.md
@@ -18,67 +18,33 @@ description: 指导 Flocks 新建、添加和接入安全设备。Use when the u
 
 ## 核心原则
 
-- 先确认用户是在**新建设备实例**、**整理配置草稿**，还是**测试连通性**。
+- 先确认用户是在**新建设备实例**、**页面配置**，还是**测试连通性**。
 - 不要要求用户在聊天里粘贴密码、Token、Cookie、API Key 等敏感凭证。
-- 不要在 skill 中优先引导通过工具写入设备配置；设备接入页面表单和 JSON 草稿是配置写入的主路径。
+- 独立会话中，已安装模板的新设备优先通过 `device_manage(action="create")` 创建；只有敏感凭证需要回到设备接入页面填写。
 - 每次修改后，优先用标准连通性测试验证结果。
 - 保持回答简短，给出当前动作、结果和下一步。
 
 ## 决策流程
 
-1. 用户已经在设备列表里有目标设备，并提供了 `device_id`：
+1. 已有 `device_id`：非敏感配置用 `device_manage(action="update")`，测试或排障用 `connectivity_test`；敏感字段回到设备接入页面填写。
+2. 没有 `device_id`：先用 `device_manage(action="list")` 排除已有实例，再调用 `device_manage(action="list_templates")` 查询模板。设备实例为空不代表模板不存在。
+3. 按名称、厂商、`plugin_id`、`service_id`、`storage_key` 和描述匹配模板：
+   - `installed=true`：按 `credential_schema` 整理非敏感字段，然后进入创建流程。
+   - `installed=false`：引导用户在 FlockHub 安装返回的 `plugin_id`，安装后重新查询；不要创建自定义模板。
+   - 没有匹配模板：进入自定义 API、浏览器或 Workflow 接入。
 
-- 如果是配置变更，回到设备接入页面表单或输出页面可回填 JSON 草稿。
-- 如果是测试或排障，先走 `device_manage(action="connectivity_test")`。
+## 使用模板直接创建设备
 
-2. 用户说“添加设备”“接入设备”“新建设备”，但还没有设备实例：
+只有 `list_templates` 已返回匹配模板且 `installed=true` 时，才能调用 `device_manage(action="create")`。`create` 会再次校验模板状态，不能用 `update` 代替创建。
 
-- 如果有已安装模板，引导用户在设备接入页面填写表单。
-- 如果没有合适模板，进入自定义设备接入路径。
-- 如果涉及密钥、密码、Token、Cookie 或浏览器登录态，只说明应该填到页面表单，不要在聊天中收集真实值。
+从模板收集设备名称、机房、SSL 偏好和已声明的非敏感字段；不询问或传递 `storage=secret`、`sensitive=true`、`input_type=password` 的字段。
 
-3. 用户只描述产品、厂商、控制台地址或 API 文档：
+创建成功后：
 
-- 先判断已有模板是否可用。
-- 未安装模板需要先去 FlockHub 安装。
-- 没有合适模板时，按“自定义接入路由”选择 API、浏览器或 Workflow。
-
-## 设备列表与目标确认
-
-如果用户没有给出 `device_id`，先调用：
-
-```python
-device_manage(action="list")
-```
-
-从返回结果里确认目标设备、机房、工具集和 `device_id`。
-
-如果设备不存在，提醒用户前往「设备接入」页面添加设备；不要伪造 `device_id` 或直接调用业务工具。
-
-## 新建设备与页面回填
-
-用户在设备接入页面创建或配置设备时，目标是帮助页面得到清晰的表单信息。
-
-需要收集的信息：
-
-- 设备名称。
-- 已安装模板的 `storage_key`。
-- Base URL、Host、端口、协议、租户或区域等非敏感字段。
-- SSL 证书验证偏好：`verify_ssl=true/false`。
-- 需要填写哪些敏感字段，但不收集真实值。
-
-当信息足够，并且当前任务是在设备接入页面生成配置草稿时，在回复末尾输出 JSON 代码块供页面一键回填：
-
-```json
-{"storage_key":"<storage_key>","device_name":"<设备名称>","fields":{"base_url":"https://example.local"},"verify_ssl":false}
-```
-
-JSON 草稿规则：
-
-- 只包含非敏感字段。
-- 不写真实 API Key、Secret、Token、Cookie、密码。
-- 敏感字段留空或省略，并提示用户稍后在页面表单中填写。
-- 如果没有合适模板，不要输出设备配置 JSON，先进入自定义接入路径。
+- 记录并报告返回的 `device_id`，后续操作始终使用它。
+- 如果返回 `sensitive_fields_to_complete`，告诉用户前往该设备的配置表单填写这些字段，不要在聊天中索要真实值。
+- 用户确认敏感字段已填写后，调用 `device_manage(action="connectivity_test", device_id="<device_id>")`。
+- 同一轮会话已经拿到成功返回的 `device_id` 后，不要因重试或继续对话再次创建。
 
 ## 自定义接入路由
 
@@ -90,9 +56,9 @@ JSON 草稿规则：
 
 如果用户已经明确选择 API、浏览器或 Workflow，不要重复询问接入方式。只有无法判断时，才用一句话澄清。
 
-## 配置草稿与表单更新
+## 页面配置与更新
 
-如果用户要写入或更新设备配置，应根据当前页面上下文整理表单草稿，让设备接入页面负责落库。
+如果用户正在设备接入页面配置设备，帮助确认需要填写的表单字段，让页面负责保存。独立会话中的已有设备非敏感配置更新使用 `device_manage(action="update")`。
 
 可以整理的非敏感字段包括：
 
@@ -104,7 +70,7 @@ JSON 草稿规则：
 - `tenant`
 - `region`
 
-不要在 JSON 草稿或聊天中写入敏感字段：
+不要在聊天中索要或回显敏感字段：
 
 - `api_key`
 - `secret`
@@ -115,11 +81,11 @@ JSON 草稿规则：
 
 如果用户的目标是补填密钥、修改密码、刷新 Token 或重新登录，只说明应该在设备接入页面对应字段中处理。
 
-当需要给页面回填时，使用“新建设备与页面回填”中的 JSON 草稿格式。对于已有设备编辑，也只输出非敏感字段和 `verify_ssl`，并说明敏感字段在页面表单内填写。
+对于已有设备编辑，只处理非敏感字段和 `verify_ssl`，并说明敏感字段应在页面表单内填写。
 
 ## 连通性与冒烟验证
 
-配置在设备接入页面保存后，除非用户明确不需要，继续调用：
+设备通过 `create` 返回 `device_id`，或在设备接入页面保存后，除非用户明确不需要，继续调用：
 
 ```python
 device_manage(action="connectivity_test", device_id="<device_id>")
@@ -149,6 +115,5 @@ device_manage(action="connectivity_test", device_id="<device_id>")
 
 - 不要在聊天中索要、保存或复述真实密钥。
 - 不要把自定义设备误做成普通 API 服务。
-- 不要对未安装模板输出可回填 JSON。
 - 不要跳过 `device_manage(action="connectivity_test")` 就声称设备已可用。
 - 不要把卡片状态建立在普通业务工具结果上；卡片状态以标准连通性测试写入结果为准。

--- a/.flocks/plugins/skills/device-integration-guide/SKILL.md
+++ b/.flocks/plugins/skills/device-integration-guide/SKILL.md
@@ -77,7 +77,6 @@ description: 指导 Flocks 新建、添加和接入安全设备。Use when the u
 - `password`
 - `token`
 - `cookie`
-- `auth_state`
 
 如果用户的目标是补填密钥、修改密码、刷新 Token 或重新登录，只说明应该在设备接入页面对应字段中处理。
 

--- a/flocks/tool/device/manage_tool.py
+++ b/flocks/tool/device/manage_tool.py
@@ -92,7 +92,7 @@ log = Log.create(service="tool.device.manage_tool")
             description=(
                 "要创建或更新的非敏感设备配置字段，例如 "
                 "{\"base_url\":\"https://device.local\"}。"
-                "禁止传入 api_key、secret、password、token、cookie、auth_state 等敏感字段。"
+                "禁止传入 api_key、secret、password、token、cookie 等敏感字段。"
             ),
             required=False,
         ),
@@ -297,7 +297,6 @@ _SENSITIVE_FIELD_KEYS = frozenset(
         "access_token",
         "refresh_token",
         "cookie",
-        "auth_state",
     }
 )
 
@@ -325,7 +324,7 @@ def _normalize_update_fields(
         return {}, (
             "拒绝通过 device_manage(action='update') 写入敏感字段："
             + ", ".join(f"`{key}`" for key in sorted(rejected))
-            + "。请在设备接入页面的配置表单中填写密钥、密码、Token、Cookie 或 auth_state。"
+            + "。请在设备接入页面的配置表单中填写密钥、密码、Token 或 Cookie。"
         )
 
     return normalized, None

--- a/flocks/tool/device/manage_tool.py
+++ b/flocks/tool/device/manage_tool.py
@@ -1,16 +1,25 @@
 """Built-in device management tool for Rex.
 
-``device_manage`` is the single system-tool entrypoint for device discovery,
-non-secret config updates, and standard connectivity checks. Its
+``device_manage`` is the single system-tool entrypoint for device and template
+discovery, non-secret config updates, and standard connectivity checks. Its
 ``connectivity_test`` action reuses the existing device test path, so card state
 stays consistent with the ``POST /api/devices/{id}/test`` endpoint.
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Optional
 
-from flocks.tool.device.intake import DeviceNotFoundError, test_device, update_device
-from flocks.tool.device.models import DeviceIntegrationUpdate
+from flocks.tool.device.intake import (
+    DeviceNotFoundError,
+    create_device,
+    test_device,
+    update_device,
+)
+from flocks.tool.device.models import (
+    DeviceIntegrationCreate,
+    DeviceIntegrationUpdate,
+)
 from flocks.tool.registry import (
     ParameterType,
     ToolCategory,
@@ -28,6 +37,8 @@ log = Log.create(service="tool.device.manage_tool")
     name="device_manage",
     description=(
         "管理已接入安全设备。action=list 用于列出机房、设备、device_id 和工具集；"
+        "action=list_templates 用于列出已有设备模板、安装状态和配置字段；"
+        "action=create 用于从已安装模板创建设备实例，仅接受非敏感配置；"
         "action=update 用于写入/更新已有设备实例的非敏感配置字段；"
         "action=connectivity_test 用于测试指定设备连通性并更新设备卡片状态。"
     ),
@@ -37,9 +48,37 @@ log = Log.create(service="tool.device.manage_tool")
         ToolParameter(
             name="action",
             type=ParameterType.STRING,
-            description="操作类型：list 列出设备；update 更新已有设备非敏感配置；connectivity_test 测试设备连通性。",
+            description=(
+                "操作类型：list 列出设备实例；list_templates 列出已有设备模板；"
+                "create 从已安装模板创建设备实例；update 更新已有设备非敏感配置；"
+                "connectivity_test 测试设备连通性。"
+            ),
             required=True,
-            enum=["list", "update", "connectivity_test"],
+            enum=[
+                "list",
+                "list_templates",
+                "create",
+                "update",
+                "connectivity_test",
+            ],
+        ),
+        ToolParameter(
+            name="storage_key",
+            type=ParameterType.STRING,
+            description="已安装设备模板的 storage_key。action=create 时必填。",
+            required=False,
+        ),
+        ToolParameter(
+            name="device_name",
+            type=ParameterType.STRING,
+            description="新设备实例名称。action=create 时必填。",
+            required=False,
+        ),
+        ToolParameter(
+            name="group_id",
+            type=ParameterType.STRING,
+            description="目标机房 ID。action=create 时可选，默认使用默认机房。",
+            required=False,
         ),
         ToolParameter(
             name="device_id",
@@ -51,7 +90,8 @@ log = Log.create(service="tool.device.manage_tool")
             name="fields",
             type=ParameterType.OBJECT,
             description=(
-                "要更新的非敏感设备配置字段，例如 {\"base_url\":\"https://device.local\"}。"
+                "要创建或更新的非敏感设备配置字段，例如 "
+                "{\"base_url\":\"https://device.local\"}。"
                 "禁止传入 api_key、secret、password、token、cookie、auth_state 等敏感字段。"
             ),
             required=False,
@@ -59,7 +99,7 @@ log = Log.create(service="tool.device.manage_tool")
         ToolParameter(
             name="verify_ssl",
             type=ParameterType.BOOLEAN,
-            description="是否开启 SSL 证书验证。仅 action=update 时使用。",
+            description="是否开启 SSL 证书验证。action=create 或 update 时使用。",
             required=False,
         ),
     ],
@@ -67,21 +107,37 @@ log = Log.create(service="tool.device.manage_tool")
 async def device_manage(
     ctx: ToolContext,
     action: str,
+    storage_key: Optional[str] = None,
+    device_name: Optional[str] = None,
+    group_id: Optional[str] = None,
     device_id: Optional[str] = None,
     fields: Optional[dict[str, Any]] = None,
     verify_ssl: Optional[bool] = None,
 ) -> ToolResult:
-    """List devices, update non-secret config, or run a standard probe."""
+    """List devices/templates, update non-secret config, or run a probe."""
     normalized_action = (action or "").strip()
     if normalized_action == "list":
         return await _list_devices()
+    if normalized_action == "list_templates":
+        return await _list_device_templates()
+    if normalized_action == "create":
+        return await _create_device_from_template(
+            storage_key,
+            device_name,
+            group_id,
+            fields,
+            verify_ssl,
+        )
     if normalized_action == "update":
         return await _update_device_config(ctx, device_id, fields, verify_ssl)
     if normalized_action == "connectivity_test":
         return await _connectivity_test(ctx, device_id)
     return ToolResult(
         success=False,
-        error="未知 action，请使用 list、update 或 connectivity_test。",
+        error=(
+            "未知 action，请使用 list、list_templates、create、update 或 "
+            "connectivity_test。"
+        ),
     )
 
 
@@ -102,6 +158,131 @@ async def _list_devices() -> ToolResult:
     except Exception as exc:
         log.warn("tool.device_manage.list_failed", {"error": str(exc)})
         return ToolResult(success=False, error=f"查询设备列表失败: {exc}")
+
+
+async def _list_device_templates() -> ToolResult:
+    """Return the same device template index consumed by the access page."""
+    try:
+        from flocks.tool.device.plugin_index import list_device_templates
+
+        templates = await asyncio.to_thread(list_device_templates, refresh=False)
+        return ToolResult(
+            success=True,
+            output=[template.model_dump(mode="json") for template in templates],
+            metadata={
+                "template_count": len(templates),
+                "installed_count": sum(template.installed for template in templates),
+            },
+            title="设备模板列表",
+        )
+    except Exception as exc:
+        log.warn("tool.device_manage.list_templates_failed", {"error": str(exc)})
+        return ToolResult(success=False, error=f"查询设备模板失败: {exc}")
+
+
+async def _create_device_from_template(
+    storage_key: Optional[str],
+    device_name: Optional[str],
+    group_id: Optional[str],
+    fields: Optional[dict[str, Any]],
+    verify_ssl: Optional[bool],
+) -> ToolResult:
+    target_storage_key = (storage_key or "").strip()
+    name = (device_name or "").strip()
+    if not target_storage_key:
+        return ToolResult(success=False, error="action=create 时 storage_key 不能为空。")
+    if not name:
+        return ToolResult(success=False, error="action=create 时 device_name 不能为空。")
+
+    try:
+        from flocks.tool.device.plugin_index import list_device_templates
+
+        templates = await asyncio.to_thread(list_device_templates, refresh=False)
+        template = next(
+            (item for item in templates if item.storage_key == target_storage_key),
+            None,
+        )
+    except Exception as exc:
+        log.warn("tool.device_manage.create_template_lookup_failed", {"error": str(exc)})
+        return ToolResult(success=False, error=f"查询设备模板失败: {exc}")
+
+    if template is None:
+        return ToolResult(
+            success=False,
+            error=(
+                f"未找到 storage_key={target_storage_key!r} 的设备模板，"
+                "请先调用 device_manage(action='list_templates')。"
+            ),
+        )
+    if not template.installed:
+        return ToolResult(
+            success=False,
+            error=(
+                f"模板 {template.name!r} 尚未安装。请先在 FlockHub 安装 "
+                f"plugin_id={template.plugin_id!r}，然后重新查询模板。"
+            ),
+        )
+
+    schema = {
+        str(field.get("key") or "").strip(): field
+        for field in template.credential_schema
+        if str(field.get("key") or "").strip()
+    }
+    normalized_fields = {
+        str(key).strip(): "" if value is None else str(value)
+        for key, value in (fields or {}).items()
+    }
+    unknown = sorted(set(normalized_fields).difference(schema))
+    if unknown:
+        return ToolResult(
+            success=False,
+            error="模板未声明字段：" + ", ".join(f"`{key}`" for key in unknown),
+        )
+
+    sensitive_fields = sorted(
+        key
+        for key, field in schema.items()
+        if field.get("storage") == "secret"
+        or field.get("sensitive") is True
+        or field.get("input_type") == "password"
+        or key.lower() in _SENSITIVE_FIELD_KEYS
+    )
+    rejected = sorted(set(normalized_fields).intersection(sensitive_fields))
+    if rejected:
+        return ToolResult(
+            success=False,
+            error=(
+                "拒绝写入敏感字段："
+                + ", ".join(f"`{key}`" for key in rejected)
+                + "。请创建设备后在设备接入页面填写。"
+            ),
+        )
+
+    body = DeviceIntegrationCreate(
+        name=name,
+        storage_key=template.storage_key,
+        service_id=template.service_id,
+        group_id=(group_id or "").strip() or None,
+        verify_ssl=bool(verify_ssl) if verify_ssl is not None else False,
+        fields=normalized_fields,
+    )
+    try:
+        created = await create_device(body)
+    except ValueError as exc:
+        return ToolResult(success=False, error=f"创建设备失败: {exc}")
+    except Exception as exc:
+        log.warn("tool.device_manage.create_failed", {"error": str(exc)})
+        return ToolResult(success=False, error=f"创建设备失败: {exc}")
+
+    output = created.model_dump(mode="json")
+    output["device_id"] = created.id
+    output["sensitive_fields_to_complete"] = sensitive_fields
+    return ToolResult(
+        success=True,
+        output=output,
+        metadata={"device_id": created.id, "sensitive_fields": sensitive_fields},
+        title="设备已创建",
+    )
 
 
 _SENSITIVE_FIELD_KEYS = frozenset(

--- a/tests/skill/test_device_integration_guide_skill.py
+++ b/tests/skill/test_device_integration_guide_skill.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SKILL_FILE = (
+    PROJECT_ROOT
+    / ".flocks"
+    / "plugins"
+    / "skills"
+    / "device-integration-guide"
+    / "SKILL.md"
+)
+
+
+def test_device_integration_guide_queries_templates_before_custom_creation() -> None:
+    content = SKILL_FILE.read_text(encoding="utf-8")
+
+    assert 'device_manage(action="list_templates")' in content
+    assert "设备实例为空不代表模板不存在" in content
+    assert "没有匹配模板：进入自定义" in content
+
+
+def test_device_integration_guide_routes_uninstalled_template_to_flockhub() -> None:
+    content = SKILL_FILE.read_text(encoding="utf-8")
+
+    assert "installed=false" in content
+    assert "FlockHub 安装返回的 `plugin_id`" in content
+    assert "不要创建自定义模板" in content
+
+
+def test_device_integration_guide_creates_from_installed_template() -> None:
+    content = SKILL_FILE.read_text(encoding="utf-8")
+
+    assert 'device_manage(action="create")' in content
+    assert 'device_manage(\n    action="create"' not in content
+    assert "不能用 `update` 代替创建" in content
+    assert "只有 `list_templates` 已返回匹配模板且 `installed=true`" in content
+    assert "sensitive_fields_to_complete" in content
+    assert "同一轮会话已经拿到成功返回的 `device_id`" in content
+
+
+def test_device_integration_guide_does_not_embed_page_json_protocol() -> None:
+    content = SKILL_FILE.read_text(encoding="utf-8")
+
+    assert "```json" not in content
+    assert '"storage_key":"<storage_key>"' not in content
+    assert "一键回填" not in content

--- a/tests/tool/test_device_manage_tool.py
+++ b/tests/tool/test_device_manage_tool.py
@@ -154,6 +154,12 @@ async def test_device_manage_create_uses_installed_template_identity():
                 "required": False,
             },
             {
+                "key": "auth_state",
+                "label": "Auth State",
+                "storage": "config",
+                "required": False,
+            },
+            {
                 "key": "password",
                 "label": "Password",
                 "storage": "secret",
@@ -184,7 +190,10 @@ async def test_device_manage_create_uses_installed_template_identity():
             action="create",
             storage_key="360_waf_v5_5",
             device_name="360 WAF",
-            fields={"base_url": "https://192.168.1.100"},
+            fields={
+                "base_url": "https://192.168.1.100",
+                "auth_state": "ready",
+            },
             verify_ssl=False,
         )
 
@@ -193,7 +202,10 @@ async def test_device_manage_create_uses_installed_template_identity():
     assert body.name == "360 WAF"
     assert body.storage_key == "360_waf_v5_5"
     assert body.service_id == "360_waf"
-    assert body.fields == {"base_url": "https://192.168.1.100"}
+    assert body.fields == {
+        "base_url": "https://192.168.1.100",
+        "auth_state": "ready",
+    }
     assert result.success is True
     assert result.output["device_id"] == "dev-360"
     assert result.metadata["sensitive_fields"] == ["password"]
@@ -316,7 +328,11 @@ async def test_device_manage_update_updates_existing_device_non_secret_config():
             make_ctx(),
             action="update",
             device_id="dev-1",
-            fields={"base_url": "https://device.local", "port": 443},
+            fields={
+                "base_url": "https://device.local",
+                "port": 443,
+                "auth_state": "ready",
+            },
             verify_ssl=True,
         )
 
@@ -326,11 +342,12 @@ async def test_device_manage_update_updates_existing_device_non_secret_config():
     assert update_body.fields == {
         "base_url": "https://device.local",
         "port": "443",
+        "auth_state": "ready",
     }
     assert update_body.verify_ssl is True
     assert result.success is True
     assert result.output["device_id"] == "dev-1"
-    assert result.output["updated_fields"] == ["base_url", "port"]
+    assert result.output["updated_fields"] == ["auth_state", "base_url", "port"]
     assert result.metadata["verify_ssl"] is True
 
 

--- a/tests/tool/test_device_manage_tool.py
+++ b/tests/tool/test_device_manage_tool.py
@@ -7,7 +7,7 @@ import pytest
 
 from flocks.tool.device.intake import DeviceNotFoundError
 from flocks.tool.device.manage_tool import device_manage
-from flocks.tool.device.models import DeviceIntegration, DeviceTestResult
+from flocks.tool.device.models import DeviceIntegration, DeviceTemplate, DeviceTestResult
 from flocks.tool.registry import ToolContext, ToolRegistry
 
 
@@ -41,19 +41,43 @@ def make_device(**overrides) -> DeviceIntegration:
     return DeviceIntegration(**data)
 
 
+def make_template(**overrides) -> DeviceTemplate:
+    data = {
+        "plugin_id": "360-waf",
+        "storage_key": "360_waf_v5_5",
+        "service_id": "360_waf",
+        "name": "360 WAF",
+        "credential_schema": [],
+        "installed": True,
+        "state": "installed",
+        "source": "project",
+    }
+    data.update(overrides)
+    return DeviceTemplate(**data)
+
+
 def test_device_manage_is_registered():
     tools = {tool.name for tool in ToolRegistry.list_tools()}
     assert "device_manage" in tools
 
 
-def test_device_manage_schema_includes_update_action():
+def test_device_manage_schema_includes_template_discovery_action():
     tool = ToolRegistry.get("device_manage")
     assert tool is not None
 
     action_param = next(param for param in tool.info.parameters if param.name == "action")
-    assert action_param.enum == ["list", "update", "connectivity_test"]
+    assert action_param.enum == [
+        "list",
+        "list_templates",
+        "create",
+        "update",
+        "connectivity_test",
+    ]
     assert {param.name for param in tool.info.parameters} >= {
         "device_id",
+        "device_name",
+        "storage_key",
+        "group_id",
         "fields",
         "verify_ssl",
     }
@@ -69,6 +93,216 @@ async def test_device_manage_list_returns_device_inventory():
 
     assert result.success is True
     assert "dev-1" in result.output
+
+
+@pytest.mark.asyncio
+async def test_device_manage_list_templates_returns_existing_template_metadata():
+    templates = [
+        make_template(
+            plugin_id="tdp",
+            storage_key="tdp_v3_3_10",
+            service_id="tdp",
+            name="TDP",
+            version="3.3.10",
+            vendor="threatbook",
+            credential_schema=[
+                {
+                    "key": "base_url",
+                    "label": "Base URL",
+                    "required": True,
+                    "secret": False,
+                },
+                {
+                    "key": "api_key",
+                    "label": "API Key",
+                    "required": True,
+                    "secret": True,
+                },
+            ],
+            tool_count=2,
+        )
+    ]
+    with patch(
+        "flocks.tool.device.plugin_index.list_device_templates",
+        return_value=templates,
+    ) as mocked_list:
+        result = await device_manage(make_ctx(), action="list_templates")
+
+    mocked_list.assert_called_once_with(refresh=False)
+    assert result.success is True
+    assert result.output == [templates[0].model_dump(mode="json")]
+    assert result.metadata == {
+        "template_count": 1,
+        "installed_count": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_device_manage_create_uses_installed_template_identity():
+    template = make_template(
+        credential_schema=[
+            {
+                "key": "base_url",
+                "label": "Base URL",
+                "storage": "config",
+                "required": True,
+            },
+            {
+                "key": "username",
+                "label": "Username",
+                "storage": "config",
+                "required": False,
+            },
+            {
+                "key": "password",
+                "label": "Password",
+                "storage": "secret",
+                "required": True,
+            },
+        ],
+    )
+    created = make_device(
+        id="dev-360",
+        name="360 WAF",
+        storage_key=template.storage_key,
+        service_id=template.service_id,
+        fields={"base_url": "https://192.168.1.100"},
+        fields_set={"base_url": True},
+    )
+    with (
+        patch(
+            "flocks.tool.device.plugin_index.list_device_templates",
+            return_value=[template],
+        ),
+        patch(
+            "flocks.tool.device.manage_tool.create_device",
+            AsyncMock(return_value=created),
+        ) as mocked_create,
+    ):
+        result = await device_manage(
+            make_ctx(),
+            action="create",
+            storage_key="360_waf_v5_5",
+            device_name="360 WAF",
+            fields={"base_url": "https://192.168.1.100"},
+            verify_ssl=False,
+        )
+
+    mocked_create.assert_awaited_once()
+    body = mocked_create.await_args.args[0]
+    assert body.name == "360 WAF"
+    assert body.storage_key == "360_waf_v5_5"
+    assert body.service_id == "360_waf"
+    assert body.fields == {"base_url": "https://192.168.1.100"}
+    assert result.success is True
+    assert result.output["device_id"] == "dev-360"
+    assert result.metadata["sensitive_fields"] == ["password"]
+
+
+@pytest.mark.asyncio
+async def test_device_manage_create_rejects_uninstalled_template():
+    template = make_template(
+        installed=False,
+        state="available",
+        source="bundled",
+    )
+    with patch(
+        "flocks.tool.device.plugin_index.list_device_templates",
+        return_value=[template],
+    ):
+        result = await device_manage(
+            make_ctx(),
+            action="create",
+            storage_key=template.storage_key,
+            device_name="360 WAF",
+        )
+
+    assert result.success is False
+    assert "尚未安装" in (result.error or "")
+    assert "360-waf" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_device_manage_create_rejects_secret_and_unknown_fields():
+    template = make_template(
+        credential_schema=[
+            {"key": "base_url", "storage": "config", "required": True},
+            {"key": "password", "storage": "secret", "required": True},
+        ],
+    )
+    with patch(
+        "flocks.tool.device.plugin_index.list_device_templates",
+        return_value=[template],
+    ):
+        secret_result = await device_manage(
+            make_ctx(),
+            action="create",
+            storage_key=template.storage_key,
+            device_name="360 WAF",
+            fields={
+                "base_url": "https://192.168.1.100",
+                "password": "do-not-store",
+            },
+        )
+        unknown_result = await device_manage(
+            make_ctx(),
+            action="create",
+            storage_key=template.storage_key,
+            device_name="360 WAF",
+            fields={
+                "base_url": "https://192.168.1.100",
+                "account": "admin",
+            },
+        )
+
+    assert secret_result.success is False
+    assert "敏感字段" in (secret_result.error or "")
+    assert "password" in (secret_result.error or "")
+    assert unknown_result.success is False
+    assert "模板未声明字段" in (unknown_result.error or "")
+    assert "account" in (unknown_result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_device_manage_create_leaves_missing_fields_for_page_completion():
+    template = make_template(
+        credential_schema=[
+            {
+                "key": "base_url",
+                "storage": "config",
+                "required": True,
+                "default_value": "https://default.local",
+            },
+            {"key": "password", "storage": "secret", "required": True},
+        ],
+    )
+    created = make_device(
+        name="360 WAF",
+        storage_key=template.storage_key,
+        service_id=template.service_id,
+        fields={},
+        fields_set={},
+    )
+    with (
+        patch(
+            "flocks.tool.device.plugin_index.list_device_templates",
+            return_value=[template],
+        ),
+        patch(
+            "flocks.tool.device.manage_tool.create_device",
+            AsyncMock(return_value=created),
+        ) as mocked_create,
+    ):
+        result = await device_manage(
+            make_ctx(),
+            action="create",
+            storage_key=template.storage_key,
+            device_name="360 WAF",
+        )
+
+    assert result.success is True
+    assert mocked_create.await_args.args[0].fields == {}
+    assert result.output["sensitive_fields_to_complete"] == ["password"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose installed device templates through device_manage
- create device instances only after template discovery and tool-side installed-template validation
- reject undeclared or sensitive fields while allowing auth_state configuration
- simplify device integration skill guidance and keep page-specific JSON protocols out of the skill

## Tests
- uv run pytest tests/tool/test_device_manage_tool.py tests/tool/test_device_plugin_index.py tests/tool/test_device_manage_prompt.py tests/server/routes/test_device_routes.py tests/skill/test_device_integration_guide_skill.py -q
- uv run ruff check flocks/tool/device/manage_tool.py tests/tool/test_device_manage_tool.py tests/skill/test_device_integration_guide_skill.py
- git diff --check