### PR TITLE
fix(tools): synchronize auto-disabled state

### DIFF
--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -1177,9 +1177,32 @@ def _is_api_service_builtin(provider_id: str, tools: Optional[List[Any]] = None)
 
 def _set_api_service_tools_enabled(provider_id: str, enabled: bool) -> int:
     """Synchronize the enabled state of all tools under an API service."""
-    matched_tools = _get_api_service_tool_infos(provider_id)
-    for tool_info in matched_tools:
-        tool_info.enabled = enabled
+    from flocks.tool.registry import ToolRegistry
+
+    ToolRegistry.init()
+    with ToolRegistry._refresh_lock:
+        matched_tools = _get_api_service_tool_infos(provider_id)
+        tool_settings = ConfigWriter.list_tool_settings()
+        previous_states = {
+            tool_info.name: bool(tool_info.enabled)
+            for tool_info in matched_tools
+        }
+        for tool_info in matched_tools:
+            default_enabled = ToolRegistry.get_default_enabled(tool_info.name)
+            effective_enabled = enabled and (
+                default_enabled if default_enabled is not None else True
+            )
+            setting = tool_settings.get(tool_info.name)
+            if isinstance(setting, dict) and "enabled" in setting:
+                effective_enabled = enabled and bool(setting["enabled"])
+            tool_info.enabled = effective_enabled
+            if effective_enabled and not previous_states[tool_info.name]:
+                ToolRegistry._reset_failure_state(tool_info.name)
+        if any(
+            previous_states[tool_info.name] != bool(tool_info.enabled)
+            for tool_info in matched_tools
+        ):
+            ToolRegistry._bump_revision("api_service_tool_state")
     if matched_tools:
         try:
             from flocks.server.routes.tool import _invalidate_tool_summary_cache

--- a/flocks/server/routes/tool.py
+++ b/flocks/server/routes/tool.py
@@ -639,35 +639,39 @@ def _get_effective_tool_enabled(
 
 def _set_global_tool_enabled(tool: Any, desired: bool) -> bool:
     """Persist and apply the global enabled state for a registry tool."""
-    default = _get_default_enabled(tool.info)
-    # Service gate: only matters when the user is trying to enable.
-    # Disabling is always honoured.
-    service_ok = _service_allows_enable(tool.info)
-    new_enabled = desired and service_ok
+    with ToolRegistry._refresh_lock:
+        previous_enabled = bool(tool.info.enabled)
+        default = _get_default_enabled(tool.info)
+        # Service gate: only matters when the user is trying to enable.
+        # Disabling is always honoured.
+        service_ok = _service_allows_enable(tool.info)
+        new_enabled = desired and service_ok
 
-    if desired == default:
-        removed = ConfigWriter.delete_tool_setting(tool.info.name)
-        log.info("tool.updated.reset_to_default", {
-            "name": tool.info.name,
-            "enabled": new_enabled,
-            "default": default,
-            "removed_overlay": removed,
-        })
-    else:
-        ConfigWriter.set_tool_setting(tool.info.name, {"enabled": desired})
-        log.info("tool.updated", {
-            "name": tool.info.name,
-            "enabled": new_enabled,
-            "requested": desired,
-            "blocked_by_service": desired and not service_ok,
-            "native": tool.info.native,
-            "store": "overlay",
-        })
+        if desired == default:
+            removed = ConfigWriter.delete_tool_setting(tool.info.name)
+            log.info("tool.updated.reset_to_default", {
+                "name": tool.info.name,
+                "enabled": new_enabled,
+                "default": default,
+                "removed_overlay": removed,
+            })
+        else:
+            ConfigWriter.set_tool_setting(tool.info.name, {"enabled": desired})
+            log.info("tool.updated", {
+                "name": tool.info.name,
+                "enabled": new_enabled,
+                "requested": desired,
+                "blocked_by_service": desired and not service_ok,
+                "native": tool.info.native,
+                "store": "overlay",
+            })
 
-    tool.info.enabled = new_enabled
-    if new_enabled:
-        ToolRegistry._reset_failure_state(tool.info.name)
-    return new_enabled
+        tool.info.enabled = new_enabled
+        if new_enabled:
+            ToolRegistry._reset_failure_state(tool.info.name)
+        if new_enabled != previous_enabled:
+            ToolRegistry._bump_revision("tool_setting_update")
+        return new_enabled
 
 
 # Routes
@@ -971,10 +975,16 @@ async def reset_tool_setting(tool_name: str, _admin: object = Depends(require_ad
             detail=f"Tool not found: {tool_name}",
         )
 
-    removed = ConfigWriter.delete_tool_setting(tool_name)
-    default = _get_default_enabled(tool.info)
-    new_enabled = default and _service_allows_enable(tool.info)
-    tool.info.enabled = new_enabled
+    with ToolRegistry._refresh_lock:
+        removed = ConfigWriter.delete_tool_setting(tool_name)
+        default = _get_default_enabled(tool.info)
+        new_enabled = default and _service_allows_enable(tool.info)
+        previous_enabled = bool(tool.info.enabled)
+        tool.info.enabled = new_enabled
+        if new_enabled:
+            ToolRegistry._reset_failure_state(tool_name)
+        if new_enabled != previous_enabled:
+            ToolRegistry._bump_revision("tool_setting_reset")
     _invalidate_tool_summary_cache()
 
     log.info("tool.setting.reset", {

--- a/flocks/tool/registry.py
+++ b/flocks/tool/registry.py
@@ -618,6 +618,7 @@ class ToolRegistry:
     # diagnostic only because the plugin loader already isolates each source.
     _plugin_load_errors: List[str] = []
     _revision: int = 0
+    _config_state_token: Optional[tuple[str, int, int, int]] = None
     _failure_state: Dict[str, Dict[str, Any]] = {}
     _failure_disable_threshold: int = 3
     _init_lock = threading.Lock()
@@ -678,22 +679,80 @@ class ToolRegistry:
     def revision(cls) -> int:
         """Return the current registry revision.
 
-        The revision is bumped when plugin or dynamic tools are reloaded so
-        long-lived session caches can detect toolset changes.
+        The revision is bumped when tool membership or enabled state changes
+        so long-lived session caches can detect toolset changes.
         """
+        cls._ensure_initialized()
+        cls._sync_configured_enabled_states()
         with cls._refresh_lock:
             return cls._revision
 
     @classmethod
+    def _current_config_state_token(cls) -> tuple[str, int, int, int]:
+        """Return a cross-process token for the active flocks config file."""
+        from flocks.config.config_writer import ConfigWriter
+
+        path = ConfigWriter._get_config_path()
+        try:
+            stat = path.stat()
+            return str(path), stat.st_ino, stat.st_mtime_ns, stat.st_size
+        except OSError:
+            return str(path), -1, -1, -1
+
+    @classmethod
+    def _sync_configured_enabled_states(cls) -> None:
+        """Apply config changes written by another server worker.
+
+        Registry revisions and ``ToolInfo.enabled`` values are process-local,
+        while ``flocks.json`` is shared.  Rebuild enabled states whenever the
+        atomically replaced config file changes so a request handled by a
+        different worker immediately observes tool/service toggles and
+        repeated-failure auto-disables.
+        """
+        try:
+            token = cls._current_config_state_token()
+        except Exception:
+            return
+
+        with cls._refresh_lock:
+            if token == cls._config_state_token:
+                return
+
+            previous_states = {
+                name: bool(tool.info.enabled)
+                for name, tool in cls._tools.items()
+            }
+            for name, tool in cls._tools.items():
+                default_enabled = cls._enabled_defaults.get(name)
+                if default_enabled is not None:
+                    tool.info.enabled = default_enabled
+            cls._sync_api_service_states()
+            cls._apply_tool_settings()
+            cls._config_state_token = token
+
+            changed_names = [
+                name
+                for name, tool in cls._tools.items()
+                if previous_states[name] != bool(tool.info.enabled)
+            ]
+            for name in changed_names:
+                if cls._tools[name].info.enabled:
+                    cls._reset_failure_state(name)
+            if changed_names:
+                cls._bump_revision("config_enabled_state_sync")
+
+    @classmethod
     def _bump_revision(cls, reason: str) -> None:
         """Advance the registry revision and invalidate agent prompt caches."""
-        cls._revision += 1
+        with cls._refresh_lock:
+            cls._revision += 1
+            revision = cls._revision
         try:
             from flocks.agent.registry import Agent
             Agent.invalidate_cache()
         except Exception as e:
             log.debug("tool.revision.agent_invalidate_failed", {"error": str(e)})
-        log.debug("tool.registry.revision.bumped", {"revision": cls._revision, "reason": reason})
+        log.debug("tool.registry.revision.bumped", {"revision": revision, "reason": reason})
 
     @classmethod
     def register_function(
@@ -766,6 +825,7 @@ class ToolRegistry:
     def get(cls, name: str) -> Optional[Tool]:
         """Get a tool by name"""
         cls._ensure_initialized()
+        cls._sync_configured_enabled_states()
         with cls._refresh_lock:
             return cls._tools.get(name)
 
@@ -773,6 +833,7 @@ class ToolRegistry:
     def list_tools(cls, category: Optional[ToolCategory] = None) -> List[ToolInfo]:
         """List all registered tools, optionally filtered by category"""
         cls._ensure_initialized()
+        cls._sync_configured_enabled_states()
         with cls._refresh_lock:
             tools = list(cls._tools.values())
             if category:
@@ -1017,6 +1078,7 @@ class ToolRegistry:
     def snapshot_identity(cls) -> tuple[int, tuple[str, ...]]:
         """Return a revision/tool-id identity from one consistent registry state."""
         cls._ensure_initialized()
+        cls._sync_configured_enabled_states()
         with cls._refresh_lock:
             return cls._revision, tuple(cls._tools.keys())
 
@@ -1752,7 +1814,7 @@ class ToolRegistry:
     @classmethod
     def _reset_failure_state(cls, tool_name: str) -> None:
         """Reset failure tracking for a tool after success."""
-        if tool_name in cls._failure_state:
+        with cls._refresh_lock:
             cls._failure_state.pop(tool_name, None)
 
     @classmethod
@@ -1817,23 +1879,34 @@ class ToolRegistry:
 
         tool_name = tool.info.name
         key = cls._failure_key(tool_name, params, error)
-        state = cls._failure_state.get(tool_name, {"key": None, "count": 0})
+        with cls._refresh_lock:
+            state = cls._failure_state.get(tool_name, {"key": None, "count": 0})
 
-        if state.get("key") == key:
-            state["count"] = state.get("count", 0) + 1
-        else:
-            state = {"key": key, "count": 1}
+            if state.get("key") == key:
+                state["count"] = state.get("count", 0) + 1
+            else:
+                state = {"key": key, "count": 1}
 
-        cls._failure_state[tool_name] = state
+            cls._failure_state[tool_name] = state
 
-        if state["count"] >= cls._failure_disable_threshold:
-            tool.info.enabled = False
-            log.warn("tool.disabled.repeated_error", {
-                "tool": tool_name,
-                "count": state["count"],
-                "error": error,
-            })
-            return True
+            if state["count"] >= cls._failure_disable_threshold and tool.info.enabled:
+                tool.info.enabled = False
+                try:
+                    from flocks.config.config_writer import ConfigWriter
+
+                    ConfigWriter.set_tool_setting(tool_name, {"enabled": False})
+                except Exception as exc:
+                    log.warn("tool.disabled.repeated_error.persist_failed", {
+                        "tool": tool_name,
+                        "error": str(exc),
+                    })
+                cls._bump_revision("failure_auto_disable")
+                log.warn("tool.disabled.repeated_error", {
+                    "tool": tool_name,
+                    "count": state["count"],
+                    "error": error,
+                })
+                return True
 
         return False
 

--- a/tests/server/routes/test_tool_routes.py
+++ b/tests/server/routes/test_tool_routes.py
@@ -26,6 +26,7 @@ from flocks.tool.registry import (
 def _temporary_tool(tool: Tool) -> Iterator[None]:
     ToolRegistry.init()
     existing = ToolRegistry._tools.get(tool.info.name)
+    existing_default = ToolRegistry._enabled_defaults.get(tool.info.name)
     ToolRegistry.register(tool)
     _clear_tool_summary_cache()
     try:
@@ -36,6 +37,10 @@ def _temporary_tool(tool: Tool) -> Iterator[None]:
             ToolRegistry._tools[tool.info.name] = existing
         else:
             ToolRegistry._tools.pop(tool.info.name, None)
+        if existing_default is not None:
+            ToolRegistry._enabled_defaults[tool.info.name] = existing_default
+        else:
+            ToolRegistry._enabled_defaults.pop(tool.info.name, None)
         _clear_tool_summary_cache()
 
 
@@ -405,6 +410,67 @@ class TestToolRouteSecurity:
 
 
 class TestToolListPageRoute:
+    @pytest.mark.asyncio
+    async def test_auto_disable_syncs_cached_page_across_worker_state(self, client: AsyncClient):
+        from flocks.config.config_writer import ConfigWriter
+
+        async def handler(_ctx, probe_id: str) -> ToolResult:
+            return ToolResult(success=False, error=f"repeated failure for {probe_id}")
+
+        tool = Tool(
+            info=ToolInfo(
+                name="page_auto_disable_cache_tool",
+                description="NeedleAutoDisableCache",
+                category=ToolCategory.CUSTOM,
+                source="plugin_py",
+            ),
+            handler=handler,
+        )
+
+        with _temporary_tool(tool):
+            initial = await client.get(
+                "/api/tools/page",
+                params={"q": "needleautodisablecache", "limit": 25},
+            )
+            for _ in range(ToolRegistry._failure_disable_threshold):
+                result = await client.post(
+                    f"/api/tools/{tool.info.name}/test",
+                    json={"params": {"probe_id": "same-input"}},
+                )
+            setting = ConfigWriter.get_tool_setting(tool.info.name)
+            # Simulate a second worker whose in-memory registry and list cache
+            # still contain the pre-disable state.  The persisted config token
+            # must make the next page request repair both immediately.
+            tool.info.enabled = True
+            refreshed = await client.get(
+                "/api/tools/page",
+                params={"q": "needleautodisablecache", "limit": 25},
+            )
+            disabled_after_refresh = tool.info.enabled
+
+            # The reverse transition must also propagate: another worker can
+            # manually restore the default by deleting the disable overlay.
+            removed = ConfigWriter.delete_tool_setting(tool.info.name)
+            tool.info.enabled = False
+            reenabled = await client.get(
+                "/api/tools/page",
+                params={"q": "needleautodisablecache", "limit": 25},
+            )
+
+        assert initial.status_code == 200, initial.text
+        assert initial.json()["items"][0]["enabled"] is True
+        assert result.status_code == 200, result.text
+        assert result.json()["metadata"]["disabled"] is True
+        assert setting == {"enabled": False}
+        assert disabled_after_refresh is False
+        assert refreshed.status_code == 200, refreshed.text
+        assert refreshed.json()["items"][0]["enabled"] is False
+        assert removed is True
+        assert tool.info.enabled is True
+        assert tool.info.name not in ToolRegistry._failure_state
+        assert reenabled.status_code == 200, reenabled.text
+        assert reenabled.json()["items"][0]["enabled"] is True
+
     @pytest.mark.asyncio
     async def test_list_page_searches_server_side_and_omits_parameter_payload(self, client: AsyncClient):
         async def handler(ctx, text: str) -> ToolResult:

--- a/tests/server/test_tool_setting_routes.py
+++ b/tests/server/test_tool_setting_routes.py
@@ -34,7 +34,10 @@ from flocks.tool.registry import (
 
 # ─── Fixtures ────────────────────────────────────────────────────────────────
 
-def _stub_api_tool(name: str, *, enabled: bool, provider: str = "onesec_api") -> Tool:
+_TEST_SERVICE_ID = "test_api_service"
+
+
+def _stub_api_tool(name: str, *, enabled: bool, provider: str = _TEST_SERVICE_ID) -> Tool:
     async def handler(ctx: ToolContext, value: str = "ok") -> ToolResult:
         return ToolResult(success=True, output=value)
 
@@ -45,6 +48,7 @@ def _stub_api_tool(name: str, *, enabled: bool, provider: str = "onesec_api") ->
             category=ToolCategory.CUSTOM,
             enabled=enabled,
             provider=provider,
+            source="api",
         ),
         handler=handler,
     )
@@ -69,6 +73,8 @@ def tool_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     saved_tools = dict(ToolRegistry._tools)
     saved_defaults = dict(ToolRegistry._enabled_defaults)
     saved_failure_state = dict(ToolRegistry._failure_state)
+    saved_revision = ToolRegistry._revision
+    saved_config_state_token = ToolRegistry._config_state_token
     saved_initialized = ToolRegistry._initialized
 
     enabled_tool = _stub_api_tool("onesec_dns_test", enabled=True)
@@ -103,10 +109,12 @@ def tool_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     ToolRegistry._tools = saved_tools
     ToolRegistry._enabled_defaults = saved_defaults
     ToolRegistry._failure_state = saved_failure_state
+    ToolRegistry._revision = saved_revision
+    ToolRegistry._config_state_token = saved_config_state_token
     ToolRegistry._initialized = saved_initialized
 
 
-def _set_service(*, enabled: bool, sid: str = "onesec_api") -> None:
+def _set_service(*, enabled: bool, sid: str = _TEST_SERVICE_ID) -> None:
     from flocks.config.config_writer import ConfigWriter
     ConfigWriter.set_api_service(sid, {
         "apiKey": "{secret:test_key}",
@@ -198,7 +206,12 @@ class TestUpdateTool:
     def test_manual_reenable_clears_repeated_failure_count(self, tool_client):
         client, enabled_tool, _ = tool_client
         _set_service(enabled=True)
+        revision_before = ToolRegistry.revision()
         enabled_tool.info.enabled = False
+        ToolRegistry._failure_state[enabled_tool.info.name] = {
+            "key": "same-failure",
+            "count": ToolRegistry._failure_disable_threshold,
+        }
         ToolRegistry._failure_state[enabled_tool.info.name] = {
             "key": "same-failure",
             "count": ToolRegistry._failure_disable_threshold,
@@ -212,6 +225,7 @@ class TestUpdateTool:
         assert res.status_code == 200
         assert res.json()["enabled"] is True
         assert enabled_tool.info.name not in ToolRegistry._failure_state
+        assert ToolRegistry.revision() == revision_before + 1
 
     def test_overlay_persisted_when_differs_from_default(self, tool_client):
         client, _, disabled_tool = tool_client
@@ -333,7 +347,75 @@ class TestUpdateTool:
         delete_override.assert_not_awaited()
 
 
+class TestApiServiceToolSync:
+    def test_service_enable_does_not_resurrect_disabled_tool_overlay(
+        self,
+        tool_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        client, enabled_tool, _ = tool_client
+        _set_service(enabled=True)
+        client.patch(f"/api/tools/{enabled_tool.info.name}", json={"enabled": False})
+        assert enabled_tool.info.enabled is False
+
+        from flocks.server.routes import provider as provider_routes
+
+        monkeypatch.setattr(
+            provider_routes,
+            "_get_api_service_tool_infos",
+            lambda _provider_id: [enabled_tool.info, tool_client[2].info],
+        )
+
+        matched = provider_routes._set_api_service_tools_enabled(_TEST_SERVICE_ID, True)
+
+        assert matched == 2
+        assert enabled_tool.info.enabled is False
+        assert _read_settings() == {enabled_tool.info.name: {"enabled": False}}
+
+    def test_service_state_change_bumps_tool_revision(
+        self,
+        tool_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        _, enabled_tool, disabled_tool = tool_client
+        _set_service(enabled=True)
+        revision_before = ToolRegistry.revision()
+        enabled_tool.info.enabled = False
+
+        from flocks.server.routes import provider as provider_routes
+
+        monkeypatch.setattr(
+            provider_routes,
+            "_get_api_service_tool_infos",
+            lambda _provider_id: [enabled_tool.info, disabled_tool.info],
+        )
+
+        provider_routes._set_api_service_tools_enabled(_TEST_SERVICE_ID, True)
+
+        assert enabled_tool.info.enabled is True
+        assert disabled_tool.info.enabled is False
+        assert enabled_tool.info.name not in ToolRegistry._failure_state
+        assert ToolRegistry.revision() == revision_before + 1
+
+
 class TestResetToolSetting:
+    def test_reset_reenable_clears_failure_count_and_bumps_revision(self, tool_client):
+        client, enabled_tool, _ = tool_client
+        _set_service(enabled=True)
+        client.patch(f"/api/tools/{enabled_tool.info.name}", json={"enabled": False})
+        ToolRegistry._failure_state[enabled_tool.info.name] = {
+            "key": "same-failure",
+            "count": ToolRegistry._failure_disable_threshold,
+        }
+        revision_before = ToolRegistry.revision()
+
+        res = client.post(f"/api/tools/{enabled_tool.info.name}/reset")
+
+        assert res.status_code == 200
+        assert res.json()["enabled"] is True
+        assert enabled_tool.info.name not in ToolRegistry._failure_state
+        assert ToolRegistry.revision() == revision_before + 1
+
     def test_reset_restores_default_and_removes_overlay(self, tool_client):
         client, _, disabled_tool = tool_client
         _set_service(enabled=True)

--- a/tests/tool/test_failure_auto_disable_config.py
+++ b/tests/tool/test_failure_auto_disable_config.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
+
 import pytest
 
 from flocks.config.config import Config, ConfigInfo, ToolFailureConfig
+from flocks.config.config_writer import ConfigWriter
 from flocks.tool.registry import (
     Tool,
     ToolCategory,
@@ -34,7 +38,9 @@ def isolated_failure_tracking(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(ToolRegistry, "_initialized", True)
     monkeypatch.setattr(ToolRegistry, "_tools", {tool.info.name: tool})
     monkeypatch.setattr(ToolRegistry, "_failure_state", {})
+    monkeypatch.setattr(ToolRegistry, "_revision", 41)
     monkeypatch.setattr(Config, "_cached_config", ConfigInfo())
+    monkeypatch.setattr(ConfigWriter, "set_tool_setting", lambda _name, _setting: None)
     return tool
 
 
@@ -72,6 +78,33 @@ async def test_repeated_failures_disable_tool_by_default(
         "disabled": True,
         "disabled_reason": "repeated_error",
     }
+    assert ToolRegistry.revision() == 42
+
+
+def test_concurrent_failures_commit_one_disable_transition(
+    isolated_failure_tracking: Tool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = isolated_failure_tracking
+    params = {"query": "same"}
+    error = "synthetic repeated failure"
+    ToolRegistry._failure_state[tool.info.name] = {
+        "key": ToolRegistry._failure_key(tool.info.name, params, error),
+        "count": ToolRegistry._failure_disable_threshold - 1,
+    }
+    persist_setting = Mock()
+    monkeypatch.setattr(ConfigWriter, "set_tool_setting", persist_setting)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        transitions = list(executor.map(
+            lambda _: ToolRegistry._record_failure(tool, params, error),
+            range(8),
+        ))
+
+    assert transitions.count(True) == 1
+    assert tool.info.enabled is False
+    assert ToolRegistry.revision() == 42
+    persist_setting.assert_called_once_with(tool.info.name, {"enabled": False})
 
 
 @pytest.mark.asyncio

--- a/webui/src/hooks/useTools.test.tsx
+++ b/webui/src/hooks/useTools.test.tsx
@@ -414,6 +414,39 @@ describe('useTools', () => {
     expect(listPageMock).toHaveBeenCalledTimes(2);
   });
 
+  it('reloads an auto-disabled tool without refreshing plugins', async () => {
+    listPageMock
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ name: 'tool-alpha', description: 'alpha tool', category: 'custom', source: 'custom', enabled: true }],
+          total: 1,
+          offset: 0,
+          limit: 20,
+          facets: emptyFacets,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ name: 'tool-alpha', description: 'alpha tool', category: 'custom', source: 'custom', enabled: false }],
+          total: 1,
+          offset: 0,
+          limit: 20,
+          facets: emptyFacets,
+        },
+      });
+
+    const { result } = renderHook(() => useToolPage({ offset: 0, limit: 20 }));
+    await waitFor(() => expect(result.current.tools[0]?.enabled).toBe(true));
+
+    await act(async () => {
+      await result.current.reload();
+    });
+
+    expect(result.current.tools[0]?.enabled).toBe(false);
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(listPageMock).toHaveBeenCalledTimes(2);
+  });
+
   it('reports a paged plugin refresh failure after reloading the visible page', async () => {
     listPageMock.mockResolvedValue({
       data: {

--- a/webui/src/hooks/useTools.ts
+++ b/webui/src/hooks/useTools.ts
@@ -111,6 +111,11 @@ function refreshToolPlugins(): Promise<ToolRefreshResponse> {
   return toolRefreshInFlight;
 }
 
+function invalidateToolListResources(): void {
+  toolsResource.invalidate();
+  toolPageResources.forEach((resource) => resource.invalidate());
+}
+
 async function refreshToolsResource(
   fetchVisible: () => Promise<unknown>,
 ): Promise<ToolRefreshResponse> {
@@ -122,8 +127,7 @@ async function refreshToolsResource(
     refreshError = error;
   }
 
-  toolsResource.invalidate();
-  toolPageResources.forEach((resource) => resource.invalidate());
+  invalidateToolListResources();
   let listError: unknown;
   try {
     await fetchVisible();
@@ -220,6 +224,15 @@ export function useToolPage(params: ToolListPageParams) {
     [resource],
   );
 
+  const reload = useCallback(() => {
+    invalidateToolListResources();
+    return resource.fetch({
+      force: true,
+      silent: true,
+      rejectOnError: true,
+    });
+  }, [resource]);
+
   return {
     tools: data.items,
     total: data.total,
@@ -230,5 +243,6 @@ export function useToolPage(params: ToolListPageParams) {
     error,
     initialized,
     refetch,
+    reload,
   };
 }

--- a/webui/src/pages/Tool/ToolPageAutoDisable.test.tsx
+++ b/webui/src/pages/Tool/ToolPageAutoDisable.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ToolPage from './index';
+
+const {
+  getToolMock,
+  listFixturesMock,
+  refetchMock,
+  reloadMock,
+  testToolMock,
+} = vi.hoisted(() => ({
+  getToolMock: vi.fn(),
+  listFixturesMock: vi.fn(),
+  refetchMock: vi.fn(),
+  reloadMock: vi.fn(),
+  testToolMock: vi.fn(),
+}));
+
+const enabledTool = {
+  name: 'failing_custom_tool',
+  description: 'Always fails',
+  source: 'plugin_py',
+  category: 'custom',
+  enabled: true,
+  parameters: [],
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      typeof options?.defaultValue === 'string' ? options.defaultValue : key,
+    i18n: { language: 'zh-CN' },
+  }),
+}));
+
+vi.mock('@/components/common/Toast', () => ({
+  useToast: () => ({
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useTools', () => ({
+  useToolPage: () => ({
+    tools: [enabledTool],
+    total: 1,
+    facets: {
+      category: { custom: 1 },
+      source: { plugin_py: 1 },
+      source_groups: {},
+      source_name: { Flocks: 1 },
+      enabled: { true: 1 },
+    },
+    loading: false,
+    error: null,
+    initialized: true,
+    refetch: refetchMock,
+    reload: reloadMock,
+  }),
+}));
+
+vi.mock('@/api/tool', () => ({
+  canDirectlyTestTool: vi.fn(() => true),
+  toolAPI: {
+    get: getToolMock,
+    listFixtures: listFixturesMock,
+    test: testToolMock,
+  },
+}));
+
+vi.mock('@/api/provider', () => ({
+  providerAPI: {
+    listApiServices: vi.fn(() => Promise.resolve({ data: [] })),
+  },
+}));
+
+describe('ToolPage auto-disable synchronization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getToolMock.mockResolvedValue({ data: enabledTool });
+    listFixturesMock.mockResolvedValue({ data: [] });
+    reloadMock.mockResolvedValue(undefined);
+    testToolMock.mockResolvedValue({
+      data: {
+        success: false,
+        error: 'synthetic repeated failure',
+        metadata: { disabled: true, disabled_reason: 'repeated_error' },
+      },
+    });
+  });
+
+  it('reloads list state without refreshing plugins after an auto-disable result', async () => {
+    render(<ToolPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: enabledTool.name }));
+    await screen.findByText(enabledTool.description);
+    fireEvent.click(screen.getByRole('button', { name: 'toolDetail.tabTest' }));
+    fireEvent.click(screen.getByRole('button', { name: 'toolDetail.runTest' }));
+
+    await waitFor(() => expect(reloadMock).toHaveBeenCalledTimes(1));
+    expect(refetchMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'toolDetail.runTest' })).toBeDisabled();
+  });
+});

--- a/webui/src/pages/Tool/index.tsx
+++ b/webui/src/pages/Tool/index.tsx
@@ -227,6 +227,7 @@ export default function ToolPage() {
     error,
     initialized: toolPageInitialized,
     refetch,
+    reload: reloadToolPage,
   } = useToolPage(toolPageParams);
   const [hasLoadedToolPage, setHasLoadedToolPage] = useState(false);
 
@@ -428,7 +429,12 @@ export default function ToolPage() {
             ? { ...current, enabled: false }
             : current
         ));
-        void refreshToolDataAfterMutation();
+        void reloadToolPage().catch((err: unknown) => {
+          toast.error(
+            t('alert.refreshFailedTitle'),
+            extractErrorMessage(err, t('alert.unknownError')),
+          );
+        });
       }
     } catch (err: any) {
       setTestResult({ success: false, error: err.message });


### PR DESCRIPTION
Persist repeated-failure disables and propagate enabled-state changes across workers and service toggles. Reload the WebUI tool list without refreshing plugins so the disabled state cannot be overwritten.