### PR TITLE
Fix Windows legacy upgrade handoff shutdown ordering

### DIFF
--- a/flocks/updater/restart_handoff.py
+++ b/flocks/updater/restart_handoff.py
@@ -591,13 +591,8 @@ def run(argv: Sequence[str] | None = None) -> int:
         f"frontend={args.frontend_host}:{args.frontend_port}"
     )
     legacy_daemon_pid = _legacy_supervisor_pid(args) if args.prepare_handover else None
-
-    if args.parent_pid is not None and not _wait_for_parent_exit(args.parent_pid):
-        _record_handoff_log(f"parent_exit_timeout parent_pid={args.parent_pid}")
-        _cleanup_dir(args.cleanup_dir)
-        return 1
-
     supervisor_stopped = False
+
     if args.prepare_handover:
         supervisor_stopped = _stop_supervisor_before_restart(
             daemon_pid=legacy_daemon_pid,
@@ -609,7 +604,13 @@ def run(argv: Sequence[str] | None = None) -> int:
             _record_handoff_log("legacy_handover_stop_timeout")
             _cleanup_dir(args.cleanup_dir)
             return 1
-    elif args.pro_wheel_path or args.pro_bundle_manifest_path:
+
+    if args.parent_pid is not None and not _wait_for_parent_exit(args.parent_pid):
+        _record_handoff_log(f"parent_exit_timeout parent_pid={args.parent_pid}")
+        _cleanup_dir(args.cleanup_dir)
+        return 1
+
+    if not args.prepare_handover and (args.pro_wheel_path or args.pro_bundle_manifest_path):
         supervisor_stopped = _stop_supervisor_before_restart(
             backend_port=args.backend_port,
             service_ports=(args.frontend_port,),
@@ -622,7 +623,7 @@ def run(argv: Sequence[str] | None = None) -> int:
             _record_handoff_log(f"backend_port_unavailable port={args.backend_port}")
             _cleanup_dir(args.cleanup_dir)
             return 1
-    elif not _ensure_backend_port_free(args.backend_port):
+    elif not args.prepare_handover and not _ensure_backend_port_free(args.backend_port):
         _record_handoff_log(f"backend_port_unavailable port={args.backend_port}")
         _cleanup_dir(args.cleanup_dir)
         return 1

--- a/tests/updater/test_restart_handoff.py
+++ b/tests/updater/test_restart_handoff.py
@@ -736,11 +736,11 @@ def test_v2026_7_15_upgrade_handoff_stops_before_tasks_and_restarts(
 
     assert restart_handoff.run(args) == 0
     assert events == [
-        "wait-parent:1234",
         (
             "stop-supervisor:{'daemon_pid': 2468, 'backend_port': 5173, "
             "'service_ports': (5173,), 'force_daemon_stop': True}"
         ),
+        "wait-parent:1234",
         "install",
         "cleanup-handover",
         f"spawn:{restart_argv}:{tmp_path}:True",


### PR DESCRIPTION
## Summary
- stop the legacy supervisor before waiting for the updater parent process to exit
- prevent the old daemon from auto-restarting the backend during Windows upgrade handoff
- update the v2026.7.15 compatibility regression test to enforce the corrected order

## Root cause
Legacy prepare-handover flows waited for the backend parent to exit before stopping the supervisor. On Windows, the old daemon could observe that exit and synchronously restart the backend, including rebuilding static assets. The handoff then timed out waiting for the daemon and service port to stop, leaving the service down after the daemon eventually exited.

## Validation
- uv run pytest -q tests/updater/test_restart_handoff.py (36 passed)
- uv run ruff check flocks/updater/restart_handoff.py tests/updater/test_restart_handoff.py
- git diff --check