### PR TITLE
chore: bump version to v2026.7.22.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.7.22"
+version = "v2026.7.22.1"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -553,7 +553,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.7.22"
+version = "2026.7.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- bump the project version to v2026.7.22.1
- synchronize the project version in uv.lock

## Validation
- uv lock --check
- git diff --check