### PR TITLE
fix(updater): pause legacy supervisor during handoff

### DIFF
--- a/flocks/updater/restart_handoff.py
+++ b/flocks/updater/restart_handoff.py
@@ -19,6 +19,7 @@ DEFAULT_PARENT_TIMEOUT_SECONDS = 20.0
 DEFAULT_PORT_TIMEOUT_SECONDS = 10.0
 POST_STOP_PORT_TIMEOUT_SECONDS = 20.0
 SUPERVISOR_STOP_TIMEOUT_SECONDS = 20.0
+LEGACY_SUPERVISOR_PREPARE_TIMEOUT_SECONDS = 300.0
 DEFAULT_POLL_INTERVAL_SECONDS = 0.25
 
 
@@ -102,19 +103,89 @@ def _stop_supervisor_before_restart(
                 _record_handoff_log(f"supervisor_force_stop_failed error={terminate_exc}")
                 return False
 
+    def stopped() -> bool:
+        return (
+            not service_control.supervisor_is_running(paths)
+            and not service_manager.pid_is_running(daemon_pid)
+            and all(not _backend_port_in_use(port) for port in ports)
+        )
+
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
-        control_stopped = not service_control.supervisor_is_running(paths)
-        daemon_stopped = not service_manager.pid_is_running(daemon_pid)
-        ports_stopped = all(not _backend_port_in_use(port) for port in ports)
-        if control_stopped and daemon_stopped and ports_stopped:
+        if stopped():
             return True
         time.sleep(poll_interval_seconds)
-    return (
-        not service_control.supervisor_is_running(paths)
-        and not service_manager.pid_is_running(daemon_pid)
-        and all(not _backend_port_in_use(port) for port in ports)
-    )
+    if stopped():
+        return True
+
+    if force_daemon_stop and daemon_pid is not None and service_manager.pid_is_running(daemon_pid):
+        try:
+            _record_handoff_log(f"supervisor_force_stop_after_timeout pid={daemon_pid}")
+            service_manager._terminate_orphan_pid(daemon_pid, "daemon", _NullConsole())
+        except Exception as exc:
+            _record_handoff_log(f"supervisor_force_stop_failed error={exc}")
+            return False
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if stopped():
+                return True
+            time.sleep(poll_interval_seconds)
+    return stopped()
+
+
+def _prepare_legacy_supervisor_for_upgrade(
+    *,
+    daemon_pid: int | None,
+    service_ports: Sequence[int],
+    timeout_seconds: float = LEGACY_SUPERVISOR_PREPARE_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
+) -> bool:
+    """Pause a v2026.7.15 supervisor after its updater parent exits."""
+    from flocks.cli import service_control
+
+    paths = service_manager.runtime_paths()
+    ports = set(service_ports)
+
+    def paused() -> bool:
+        try:
+            status = service_control.read_supervisor_status(paths=paths, timeout=1.0)
+        except Exception:
+            return False
+        return status.backend.paused and status.webui.paused and all(not _backend_port_in_use(port) for port in ports)
+
+    deadline = time.monotonic() + timeout_seconds
+    try:
+        response = service_control.control_api_request(
+            "POST",
+            "/upgrade/prepare",
+            paths=paths,
+            timeout=timeout_seconds,
+            json={},
+        )
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError("legacy supervisor returned an invalid upgrade prepare response")
+        status = service_control.parse_supervisor_status(payload)
+        if status.backend.paused and status.webui.paused and all(not _backend_port_in_use(port) for port in ports):
+            return True
+    except Exception as exc:
+        _record_handoff_log(f"legacy_handover_prepare_request_failed error={exc}")
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        if status_code in {404, 405}:
+            return False
+        if (
+            not service_manager.pid_is_running(daemon_pid)
+            and not service_control.supervisor_is_running(paths)
+            and all(not _backend_port_in_use(port) for port in ports)
+        ):
+            return True
+
+    while time.monotonic() < deadline:
+        if paused():
+            return True
+        time.sleep(poll_interval_seconds)
+    return paused()
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -277,9 +348,7 @@ def _start_service_after_upgrade(args: argparse.Namespace) -> tuple[bool, str, s
     stderr = updater_module._clean_process_output(completed.stderr)
     if completed.returncode == 0:
         return True, stdout, stderr
-    _record_handoff_log(
-        f"restart_failed returncode={completed.returncode} stdout={stdout} stderr={stderr}"
-    )
+    _record_handoff_log(f"restart_failed returncode={completed.returncode} stdout={stdout} stderr={stderr}")
     return False, stdout, stderr
 
 
@@ -591,26 +660,36 @@ def run(argv: Sequence[str] | None = None) -> int:
         f"frontend={args.frontend_host}:{args.frontend_port}"
     )
     legacy_daemon_pid = _legacy_supervisor_pid(args) if args.prepare_handover else None
+    legacy_service_ports = tuple(sorted({args.backend_port, args.frontend_port}))
     supervisor_stopped = False
-
-    if args.prepare_handover:
-        supervisor_stopped = _stop_supervisor_before_restart(
-            daemon_pid=legacy_daemon_pid,
-            backend_port=args.backend_port,
-            service_ports=(args.frontend_port,),
-            force_daemon_stop=True,
-        )
-        if not supervisor_stopped:
-            _record_handoff_log("legacy_handover_stop_timeout")
-            _cleanup_dir(args.cleanup_dir)
-            return 1
 
     if args.parent_pid is not None and not _wait_for_parent_exit(args.parent_pid):
         _record_handoff_log(f"parent_exit_timeout parent_pid={args.parent_pid}")
         _cleanup_dir(args.cleanup_dir)
         return 1
 
-    if not args.prepare_handover and (args.pro_wheel_path or args.pro_bundle_manifest_path):
+    if args.prepare_handover:
+        legacy_prepared = _prepare_legacy_supervisor_for_upgrade(
+            daemon_pid=legacy_daemon_pid,
+            service_ports=legacy_service_ports,
+            timeout_seconds=max(
+                LEGACY_SUPERVISOR_PREPARE_TIMEOUT_SECONDS,
+                float(args.sync_timeout),
+            ),
+        )
+        if not legacy_prepared:
+            _record_handoff_log("legacy_handover_pause_timeout")
+            supervisor_stopped = _stop_supervisor_before_restart(
+                daemon_pid=legacy_daemon_pid,
+                backend_port=args.backend_port,
+                service_ports=(args.frontend_port,),
+                force_daemon_stop=True,
+            )
+            if not supervisor_stopped:
+                _record_handoff_log("legacy_handover_stop_timeout")
+                _cleanup_dir(args.cleanup_dir)
+                return 1
+    elif args.pro_wheel_path or args.pro_bundle_manifest_path:
         supervisor_stopped = _stop_supervisor_before_restart(
             backend_port=args.backend_port,
             service_ports=(args.frontend_port,),
@@ -644,7 +723,17 @@ def run(argv: Sequence[str] | None = None) -> int:
         _cleanup_dir(args.cleanup_dir)
         return 1
 
-    if not supervisor_stopped and not _stop_supervisor_before_restart():
+    if args.prepare_handover and not supervisor_stopped:
+        supervisor_stopped = _stop_supervisor_before_restart(
+            daemon_pid=legacy_daemon_pid,
+            backend_port=args.backend_port,
+            service_ports=(args.frontend_port,),
+            force_daemon_stop=True,
+        )
+    elif not supervisor_stopped:
+        supervisor_stopped = _stop_supervisor_before_restart()
+
+    if not supervisor_stopped:
         _record_handoff_log("supervisor_stop_timeout")
         _cleanup_dir(args.cleanup_dir)
         return 1

--- a/flocks/updater/restart_handoff.py
+++ b/flocks/updater/restart_handoff.py
@@ -19,6 +19,7 @@ DEFAULT_PARENT_TIMEOUT_SECONDS = 20.0
 DEFAULT_PORT_TIMEOUT_SECONDS = 10.0
 POST_STOP_PORT_TIMEOUT_SECONDS = 20.0
 SUPERVISOR_STOP_TIMEOUT_SECONDS = 20.0
+FORCED_SUPERVISOR_STOP_TIMEOUT_SECONDS = 5.0
 LEGACY_SUPERVISOR_PREPARE_TIMEOUT_SECONDS = 300.0
 DEFAULT_POLL_INTERVAL_SECONDS = 0.25
 
@@ -284,12 +285,13 @@ def _stop_services_before_upgrade(args: argparse.Namespace) -> bool:
     try:
         service_manager.stop_all(_NullConsole())
     except service_manager.ServiceError as exc:
-        _record_handoff_log(f"service_stop_failed error={exc}")
-        return False
+        _record_handoff_log(f"service_graceful_stop_failed error={exc}")
     return _stop_supervisor_before_restart(
         daemon_pid=args.daemon_pid,
         backend_port=args.backend_port,
         service_ports=_service_ports(args),
+        force_daemon_stop=True,
+        timeout_seconds=FORCED_SUPERVISOR_STOP_TIMEOUT_SECONDS,
     )
 
 

--- a/tests/updater/test_restart_handoff.py
+++ b/tests/updater/test_restart_handoff.py
@@ -674,7 +674,7 @@ def test_v2026_7_1_upgrade_handoff_runs_tasks_and_restarts(monkeypatch, tmp_path
     ]
 
 
-def test_v2026_7_15_upgrade_handoff_stops_before_tasks_and_restarts(
+def test_v2026_7_15_upgrade_handoff_pauses_before_tasks_and_restarts(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -707,8 +707,8 @@ def test_v2026_7_15_upgrade_handoff_stops_before_tasks_and_restarts(
     )
     monkeypatch.setattr(
         restart_handoff,
-        "_ensure_backend_port_free",
-        lambda _backend_port: pytest.fail("legacy handover must stop the supervisor first"),
+        "_prepare_legacy_supervisor_for_upgrade",
+        lambda **kwargs: events.append(f"prepare-supervisor:{kwargs}") or True,
     )
     monkeypatch.setattr(
         restart_handoff,
@@ -736,14 +736,64 @@ def test_v2026_7_15_upgrade_handoff_stops_before_tasks_and_restarts(
 
     assert restart_handoff.run(args) == 0
     assert events == [
+        "wait-parent:1234",
+        ("prepare-supervisor:{'daemon_pid': 2468, 'service_ports': (5173,), 'timeout_seconds': 300.0}"),
+        "install",
+        "cleanup-handover",
         (
             "stop-supervisor:{'daemon_pid': 2468, 'backend_port': 5173, "
             "'service_ports': (5173,), 'force_daemon_stop': True}"
         ),
-        "wait-parent:1234",
-        "install",
-        "cleanup-handover",
         f"spawn:{restart_argv}:{tmp_path}:True",
+    ]
+
+
+def test_v2026_7_15_upgrade_handoff_force_stops_after_pause_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    restart_argv = ["python.exe", "-m", "flocks.cli.main", "start"]
+    args = _v2026_7_15_handoff_args(tmp_path, restart_argv)
+
+    monkeypatch.setattr(restart_handoff, "_record_handoff_log", lambda message: events.append(f"log:{message}"))
+    monkeypatch.setattr(
+        restart_handoff,
+        "_wait_for_parent_exit",
+        lambda parent_pid: events.append(f"wait-parent:{parent_pid}") or True,
+    )
+    monkeypatch.setattr(
+        restart_handoff,
+        "_prepare_legacy_supervisor_for_upgrade",
+        lambda **_kwargs: events.append("prepare-supervisor") or False,
+    )
+    monkeypatch.setattr(restart_handoff, "_legacy_supervisor_pid", lambda _args: 2468)
+    monkeypatch.setattr(
+        restart_handoff,
+        "_stop_supervisor_before_restart",
+        lambda **kwargs: events.append(f"stop-supervisor:{kwargs}") or True,
+    )
+    monkeypatch.setattr(restart_handoff, "_run_upgrade_tasks", lambda _args: events.append("install") or None)
+    monkeypatch.setattr(restart_handoff, "_cleanup_legacy_upgrade_handover", lambda _args: True)
+    monkeypatch.setattr(
+        restart_handoff.subprocess,
+        "Popen",
+        lambda _argv, **_kwargs: events.append("spawn") or SimpleNamespace(pid=4321),
+    )
+
+    assert restart_handoff.run(args) == 0
+    assert events == [
+        "log:started parent_pid=1234 backend=127.0.0.1:5173 frontend=127.0.0.1:5173",
+        "wait-parent:1234",
+        "prepare-supervisor",
+        "log:legacy_handover_pause_timeout",
+        (
+            "stop-supervisor:{'daemon_pid': 2468, 'backend_port': 5173, "
+            "'service_ports': (5173,), 'force_daemon_stop': True}"
+        ),
+        "install",
+        "spawn",
+        "log:restart_spawned pid=4321",
     ]
 
 
@@ -1081,6 +1131,106 @@ def test_stop_supervisor_requests_stop_when_health_probe_is_temporarily_unavaila
         poll_interval_seconds=0.001,
     )
     assert events == ["request-stop"]
+
+
+def test_stop_supervisor_force_stops_after_graceful_timeout(monkeypatch) -> None:
+    from flocks.cli import service_control
+
+    events: list[str] = []
+    daemon_running = True
+
+    monkeypatch.setattr(service_control, "supervisor_is_running", lambda _paths: daemon_running)
+    monkeypatch.setattr(
+        restart_handoff.service_manager,
+        "pid_is_running",
+        lambda _pid: daemon_running,
+    )
+    monkeypatch.setattr(restart_handoff, "_backend_port_in_use", lambda _port: False)
+    monkeypatch.setattr(
+        service_control,
+        "request_stop",
+        lambda **_kwargs: events.append("request-stop"),
+    )
+
+    def terminate(pid, _label, _console) -> None:
+        nonlocal daemon_running
+        events.append(f"terminate:{pid}")
+        daemon_running = False
+
+    monkeypatch.setattr(restart_handoff.service_manager, "_terminate_orphan_pid", terminate)
+    monkeypatch.setattr(restart_handoff, "_record_handoff_log", lambda message: events.append(f"log:{message}"))
+
+    assert restart_handoff._stop_supervisor_before_restart(
+        daemon_pid=2468,
+        backend_port=5173,
+        force_daemon_stop=True,
+        timeout_seconds=0,
+        poll_interval_seconds=0,
+    )
+    assert events == [
+        "request-stop",
+        "log:supervisor_force_stop_after_timeout pid=2468",
+        "terminate:2468",
+    ]
+
+
+def test_prepare_legacy_supervisor_requests_upgrade_pause(monkeypatch) -> None:
+    from flocks.cli import service_control
+
+    events: list[str] = []
+    paused_status = SimpleNamespace(
+        backend=SimpleNamespace(paused=True),
+        webui=SimpleNamespace(paused=True),
+    )
+    response = SimpleNamespace(json=lambda: {"status": "paused"})
+
+    monkeypatch.setattr(service_control, "supervisor_is_running", lambda _paths: True)
+    monkeypatch.setattr(restart_handoff.service_manager, "pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(restart_handoff, "_backend_port_in_use", lambda _port: False)
+    monkeypatch.setattr(service_control, "parse_supervisor_status", lambda _payload: paused_status)
+
+    def control_api_request(method, path, **kwargs):
+        events.append(f"request:{method}:{path}:{kwargs['timeout']}")
+        return response
+
+    monkeypatch.setattr(service_control, "control_api_request", control_api_request)
+
+    assert restart_handoff._prepare_legacy_supervisor_for_upgrade(
+        daemon_pid=2468,
+        service_ports=(5173,),
+        timeout_seconds=45,
+        poll_interval_seconds=0,
+    )
+    assert events == ["request:POST:/upgrade/prepare:45"]
+
+
+def test_prepare_legacy_supervisor_polls_paused_state_after_request_timeout(monkeypatch) -> None:
+    from flocks.cli import service_control
+
+    events: list[str] = []
+    paused_status = SimpleNamespace(
+        backend=SimpleNamespace(paused=True),
+        webui=SimpleNamespace(paused=True),
+    )
+
+    monkeypatch.setattr(service_control, "supervisor_is_running", lambda _paths: True)
+    monkeypatch.setattr(restart_handoff.service_manager, "pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(restart_handoff, "_backend_port_in_use", lambda _port: False)
+    monkeypatch.setattr(
+        service_control,
+        "control_api_request",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("busy building")),
+    )
+    monkeypatch.setattr(service_control, "read_supervisor_status", lambda **_kwargs: paused_status)
+    monkeypatch.setattr(restart_handoff, "_record_handoff_log", lambda message: events.append(message))
+
+    assert restart_handoff._prepare_legacy_supervisor_for_upgrade(
+        daemon_pid=2468,
+        service_ports=(5173,),
+        timeout_seconds=45,
+        poll_interval_seconds=0,
+    )
+    assert events == ["legacy_handover_prepare_request_failed error=busy building"]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="uses the Unix domain socket control API")

--- a/tests/updater/test_restart_handoff.py
+++ b/tests/updater/test_restart_handoff.py
@@ -306,6 +306,42 @@ def test_upgrade_wait_ports_exclude_legacy_cleanup_port(tmp_path: Path) -> None:
     assert restart_handoff._service_ports(args) == (5273,)
 
 
+def test_upgrade_stop_forces_captured_daemon_after_graceful_timeout(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    args = restart_handoff._parse_args(_simple_upgrade_handoff_args(tmp_path))
+
+    monkeypatch.setattr(
+        restart_handoff.service_manager,
+        "stop_all",
+        lambda _console: (_ for _ in ()).throw(
+            service_manager.ServiceError("daemon did not exit"),
+        ),
+    )
+    monkeypatch.setattr(
+        restart_handoff,
+        "_stop_supervisor_before_restart",
+        lambda **kwargs: events.append(f"stop:{kwargs}") or True,
+    )
+    monkeypatch.setattr(
+        restart_handoff,
+        "_record_handoff_log",
+        lambda message: events.append(f"log:{message}"),
+    )
+
+    assert restart_handoff._stop_services_before_upgrade(args)
+    assert events == [
+        "log:service_graceful_stop_failed error=daemon did not exit",
+        (
+            "stop:{'daemon_pid': 2468, 'backend_port': 5273, "
+            "'service_ports': (5273,), 'force_daemon_stop': True, "
+            "'timeout_seconds': 5.0}"
+        ),
+    ]
+
+
 def test_upgrade_install_failure_keeps_backup_and_temp_without_restart_or_rollback(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Restore the v2026.7.15 upgrade handoff contract when upgrading into the current code.
- Prevent the legacy Supervisor from rebuilding or restarting the backend while the new handoff installs and restarts the service.

## Key Changes
- Wait for the legacy updater parent to exit before calling the v2026.7.15 `/upgrade/prepare` endpoint.
- Require the legacy backend and WebUI to report paused and release their service ports before upgrade tasks run.
- Treat prepare timeouts as recoverable: poll the Supervisor state, then fall back to stopping the trusted daemon.
- Make `force_daemon_stop=True` force the trusted daemon after a graceful stop timeout, not only after a request error.
- Add regression coverage for ordering, prepare-request timeouts, pause fallback, and forced daemon termination.

## Impact Scope
- User-visible behavior: v2026.7.15 upgrades no longer exit before spawning the restored service when the old daemon races to rebuild static assets.
- Compatibility / migration: only the hidden legacy `--prepare-handover` protocol changes; the current `--mode upgrade` protocol is unchanged.
- Configuration / environment: no changes.
- Dependencies: no changes.
- Performance / resources: legacy upgrades may wait for an in-flight old-daemon build to reach paused state instead of failing after 20 seconds.
- Security / permissions: forced termination remains limited to the previously identified trusted daemon PID.

## Business Logic to Review
- `_prepare_legacy_supervisor_for_upgrade` must run only after the v2026.7.15 updater parent exits, so Windows `taskkill /T` cannot terminate the handoff with its parent process tree.
- A timed-out `/upgrade/prepare` request may still complete server-side after the old Supervisor releases its build lock, so the handoff polls paused state before falling back.
- The final Supervisor stop happens after upgrade tasks, when the legacy daemon is paused and has no managed backend.

## Why This Approach
The already-released v2026.7.15 updater starts the handoff and exits independently, so reordering stop calls inside the child cannot guarantee that the daemon stops first. Reusing the old daemons upgrade-pause endpoint preserves its no-respawn invariant while keeping the handoff outside the backend process tree before any forced stop.

## Test Plan
- [x] `uv run ruff check flocks/updater/restart_handoff.py tests/updater/test_restart_handoff.py`
- [x] `uv run ruff format --check flocks/updater/restart_handoff.py tests/updater/test_restart_handoff.py`
- [x] `uv run pytest tests/updater/test_restart_handoff.py tests/updater/test_restart_handoff_process.py -q` (46 passed)
- [x] `uv run pytest tests/updater -q` (162 passed)
- [ ] Run the Windows v2026.7.15-to-current upgrade workflow.

## Compatibility, Migration & Rollback
- No public API or configuration migration.
- Reverting this commit restores the previous legacy stop-before-parent behavior; current-version upgrades are unaffected.