### PR TITLE
fix(webui): bound restart readiness requests

### DIFF
--- a/webui/src/utils/restartPolling.test.ts
+++ b/webui/src/utils/restartPolling.test.ts
@@ -17,6 +17,7 @@ describe('checkRestartReadiness', () => {
       configurable: true,
       value: originalLocation,
     });
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -34,8 +35,55 @@ describe('checkRestartReadiness', () => {
       ready: false,
       reason: 'health check returned HTTP 404',
     });
-    expect(fetchMock).toHaveBeenCalledWith('/api/health', { cache: 'no-store' });
-    expect(fetchMock).toHaveBeenCalledWith('/', { cache: 'no-store' });
-    expect(fetchMock).not.toHaveBeenCalledWith('http://127.0.0.1:8000/api/health', { cache: 'no-store' });
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+      '/api/health',
+      '/',
+    ]);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/health',
+      expect.objectContaining({
+        cache: 'no-store',
+        signal: expect.anything(),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/',
+      expect.objectContaining({
+        cache: 'no-store',
+        signal: expect.anything(),
+      }),
+    );
+  });
+
+  it('aborts stalled readiness requests so polling can continue', async () => {
+    vi.useFakeTimers();
+    const requestSignals: AbortSignal[] = [];
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!signal) {
+        throw new Error('expected an abort signal');
+      }
+      requestSignals.push(signal);
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        }, { once: true });
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const readinessPromise = checkRestartReadiness();
+    await vi.advanceTimersByTimeAsync(3_000);
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    const readiness = await readinessPromise;
+    expect(readiness.ready).toBe(false);
+    expect(readiness.reason).toContain('health check failed');
+    expect(readiness.reason).toContain('root page check failed');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestSignals).toHaveLength(2);
+    expect(requestSignals.every((signal) => signal.aborted)).toBe(true);
   });
 });

--- a/webui/src/utils/restartPolling.ts
+++ b/webui/src/utils/restartPolling.ts
@@ -1,4 +1,5 @@
 const UPGRADE_PAGE_MARKER = 'flocks-upgrade-in-progress';
+const RESTART_READINESS_REQUEST_TIMEOUT_MS = 3_000;
 
 export interface RestartReadiness {
   ready: boolean;
@@ -11,9 +12,25 @@ function errorMessage(error: unknown): string {
   return 'request failed';
 }
 
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => {
+    controller.abort();
+  }, RESTART_READINESS_REQUEST_TIMEOUT_MS);
+
+  try {
+    return await fetch(url, {
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
 async function readUpgradePageState(): Promise<string | null> {
   try {
-    const rootResponse = await fetch('/', { cache: 'no-store' });
+    const rootResponse = await fetchWithTimeout('/');
     if (!rootResponse.ok) {
       return `root page returned HTTP ${rootResponse.status}`;
     }
@@ -31,7 +48,7 @@ async function readUpgradePageState(): Promise<string | null> {
 
 async function checkHealth(url: string): Promise<Response | null> {
   try {
-    return await fetch(url, { cache: 'no-store' });
+    return await fetchWithTimeout(url);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- add a 3-second timeout to restart readiness health and root-page requests
- abort stalled browser requests so the existing polling loop can continue after service restart
- add regression coverage for indefinitely pending fetches

## Scope

This is frontend-only and does not change updater, handoff, supervisor, port-release, or service-start behavior.

## Testing

- npm test -- --run src/utils/restartPolling.test.ts src/components/common/UpdateModal.test.tsx
- npx eslint src/utils/restartPolling.ts src/utils/restartPolling.test.ts --report-unused-disable-directives --max-warnings 0
- npx tsc --noEmit
- full WebUI suite: 725 passed, 1 unrelated existing chunkLoadRecovery localStorage-environment failure