### PR TITLE
fix(supervisor): debounce backend port probe failures

### DIFF
--- a/flocks/cli/service_process.py
+++ b/flocks/cli/service_process.py
@@ -54,7 +54,7 @@ class BackendProcessAdapter:
                 restart=True,
             )
         if not tcp_port_accepts_connections(host, port):
-            return ServiceProbeResult(healthy=False, reason=f"port {port} is not listening", restart=True)
+            return ServiceProbeResult(healthy=False, reason=f"port {port} is not listening")
         return ServiceProbeResult(healthy=True, reason="liveness check passed")
 
 

--- a/flocks/cli/service_supervisor.py
+++ b/flocks/cli/service_supervisor.py
@@ -27,8 +27,8 @@ from flocks.cli.service_control import (
 )
 from flocks.cli.service_process import BackendProcessAdapter, ProcessAdapter
 
-SUPERVISOR_CHECK_INTERVAL_SECONDS = 5.0
-SUPERVISOR_HEALTH_FAILURE_THRESHOLD = 2
+SUPERVISOR_CHECK_INTERVAL_SECONDS = 30.0
+SUPERVISOR_HEALTH_FAILURE_THRESHOLD = 10
 SUPERVISOR_BACKOFF_SECONDS = (1.0, 2.0, 5.0, 10.0, 30.0)
 _CLIENT_DISCONNECT_ERRORS = (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)
 

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -1518,7 +1518,10 @@ def _fake_process(pid: int, args: list[str] | None = None, returncode: int | Non
     return SimpleNamespace(pid=pid, args=args or [str(pid)], returncode=returncode, poll=lambda: returncode)
 
 
-def test_supervisor_recovers_backend_when_port_disappears(monkeypatch, tmp_path: Path) -> None:
+def test_supervisor_restarts_backend_after_tenth_consecutive_port_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     paths = _make_runtime_paths(tmp_path)
     calls: list[str] = []
     monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
@@ -1535,9 +1538,87 @@ def test_supervisor_recovers_backend_when_port_disappears(monkeypatch, tmp_path:
         lambda *_args, **_kwargs: calls.append("start:backend") or _fake_process(333, ["backend-new"]),
     )
 
+    assert daemon.interval == 30.0
+    assert daemon.failure_threshold == 10
+
+    for expected_failure_count in range(1, 10):
+        daemon.tick()
+        assert calls == []
+        assert daemon.backend.state == "degraded"
+        assert daemon.backend.health_failure_count == expected_failure_count
+
+    daemon.tick()
+    assert calls == ["stop:后端", "start:backend"]
+    assert daemon.backend.pid == 333
+
+
+def test_supervisor_resets_backend_port_failures_after_recovery(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    paths = _make_runtime_paths(tmp_path)
+    calls: list[str] = []
+    port_states = iter([False] * 9 + [True] + [False] * 9)
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    daemon = service_supervisor.SupervisorDaemon(service_manager.ServiceConfig(backend_port=9995))
+    daemon.paths = paths
+    daemon.backend.process = _fake_process(111, ["backend"])
+
+    monkeypatch.setattr(
+        service_process,
+        "tcp_port_accepts_connections",
+        lambda *_args: next(port_states),
+    )
+    monkeypatch.setattr(
+        service_manager,
+        "_terminate_process",
+        lambda *_args, **_kwargs: calls.append("stop"),
+    )
+
+    for _ in range(9):
+        daemon.tick()
+
+    assert calls == []
+    assert daemon.backend.health_failure_count == 9
+
     daemon.tick()
 
-    assert calls == ["stop:后端", "start:backend"]
+    assert daemon.backend.state == "healthy"
+    assert daemon.backend.health_failure_count == 0
+
+    for _ in range(9):
+        daemon.tick()
+
+    assert calls == []
+    assert daemon.backend.state == "degraded"
+    assert daemon.backend.health_failure_count == 9
+
+
+def test_supervisor_restarts_backend_on_first_probe_after_process_exits(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    paths = _make_runtime_paths(tmp_path)
+    calls: list[str] = []
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    daemon = service_supervisor.SupervisorDaemon(service_manager.ServiceConfig(backend_port=9995))
+    daemon.paths = paths
+    daemon.backend.process = _fake_process(111, ["backend"], returncode=7)
+
+    monkeypatch.setattr(
+        service_manager,
+        "_terminate_process",
+        lambda *_args, **_kwargs: calls.append("stop"),
+    )
+    monkeypatch.setattr(
+        service_manager,
+        "_start_backend_process",
+        lambda *_args, **_kwargs: calls.append("start") or _fake_process(333, ["backend-new"]),
+    )
+
+    daemon.tick()
+
+    assert calls == ["stop", "start"]
     assert daemon.backend.pid == 333
 
 


### PR DESCRIPTION
## Summary
- Prevent a single transient backend TCP probe failure from killing active agent sessions.
- Slow supervisor polling to 30 seconds and require 10 consecutive port failures before restarting a live backend process.

## Key Changes
- Treat a failed TCP listener probe as a debounced health failure instead of an immediate restart request.
- Change the default supervisor interval from 5 seconds to 30 seconds.
- Change the consecutive health failure threshold from 2 to 10.
- Add regression coverage for thresholded restarts, recovery counter resets, and process-exit recovery.

## Impact Scope
- User-visible behavior: a live backend enters degraded state on a failed port probe and restarts only after 10 consecutive failures (approximately 4.5-5 minutes). A process that has exited is still restarted on the next probe, within 30 seconds.
- Compatibility / migration: no public API change and no migration required.
- Configuration / environment: default internal supervisor timing changes only; no new settings.
- Dependencies: none.
- Performance / resources: health probes run less frequently.
- Security / permissions: no change.

## Business Logic to Review
- `BackendProcessAdapter.probe()` keeps immediate restart behavior only for confirmed process exit; TCP failures now flow through the existing consecutive-failure counter.
- Any successful liveness probe resets `health_failure_count`, so failures must be consecutive.
- Manual restart behavior is unchanged.

## Why This Approach
- Reuses the existing supervisor debounce mechanism and keeps the change focused. It prevents transient listener probes from immediately invoking the destructive Windows process-tree termination path while preserving eventual recovery from sustained failures.

## Compatibility, Migration & Rollback
- No migration is required.
- Rollback is a single commit revert; no persistent data or configuration is changed.

## logs
[2026-07-23T15:30:47] daemon.service_restart {"reason": "port 5173 is not listening", "service": "backend"}
[flocks] 停止 后端（PID=19976）...
[2026-07-23T15:32:14] daemon.service_restart {"reason": "port 5173 is not listening", "service": "backend"}
[flocks] 停止 后端（PID=14048）...
[2026-07-23T15:34:11] daemon.service_restart {"reason": "port 5173 is not listening", "service": "backend"}
[flocks] 停止 后端（PID=17480）...
[2026-07-23T15:35:28] daemon.service_restart {"reason": "port 5173 is not listening", "service": "backend"}
