### PR TITLE
chore: bump version to v2026.7.29

### DIFF
--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -1,17 +1,16 @@
 name: Dispatch autotest Windows upgrade
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Optional Flocks version tag. Defaults to pyproject.toml version."
+        description: "Optional Flocks version tag. Defaults to the published release tag, then pyproject.toml."
         required: false
         type: string
       release_url:
-        description: "Optional source URL. Defaults to the release or commit URL."
+        description: "Optional source URL. Defaults to the published release URL or commit URL."
         required: false
         type: string
       rollback_version:
@@ -48,6 +47,9 @@ jobs:
           INPUT_RELEASE_URL: ${{ inputs.release_url }}
           INPUT_ROLLBACK_VERSION: ${{ inputs.rollback_version }}
           INPUT_RUN_FORCE_FALLBACK: ${{ inputs.run_force_fallback }}
+          RELEASE_EVENT_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_EVENT_URL: ${{ github.event.release.html_url }}
+          RELEASE_EVENT_ASSETS_JSON: ${{ toJson(github.event.release.assets) }}
           GITHUB_SERVER_URL_VALUE: ${{ github.server_url }}
           GITHUB_REPOSITORY_VALUE: ${{ github.repository }}
           GITHUB_SHA_VALUE: ${{ github.sha }}
@@ -64,8 +66,27 @@ jobs:
           PY
           )"
 
-          release_tag="${INPUT_RELEASE_TAG:-}"
-          release_url="${INPUT_RELEASE_URL:-}"
+          release_tag="${INPUT_RELEASE_TAG:-${RELEASE_EVENT_TAG:-}}"
+          release_url="${INPUT_RELEASE_URL:-${RELEASE_EVENT_URL:-}}"
+          installer_asset_name="$(python3 - <<'PY'
+          import json
+          import os
+
+          assets_json = os.environ.get("RELEASE_EVENT_ASSETS_JSON") or "[]"
+          try:
+              assets = json.loads(assets_json)
+          except json.JSONDecodeError:
+              assets = []
+          if not isinstance(assets, list):
+              assets = []
+
+          for asset in assets:
+              name = str(asset.get("name") or "")
+              if name.lower().endswith(".exe"):
+                  print(name)
+                  break
+          PY
+          )"
 
           if [ -z "$release_tag" ]; then
             release_tag="$pyproject_version"
@@ -88,6 +109,7 @@ jobs:
             echo "rollback_version=${INPUT_ROLLBACK_VERSION:-}"
             echo "run_force_fallback=${INPUT_RUN_FORCE_FALLBACK:-false}"
             echo "artifact_name=$artifact_name"
+            echo "installer_asset_name=$installer_asset_name"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -98,6 +120,7 @@ jobs:
             echo "- Release URL: ${release_url}"
             echo "- Source ref: ${GITHUB_REF_NAME_VALUE}"
             echo "- Source sha: ${GITHUB_SHA_VALUE}"
+            echo "- Installer asset: ${installer_asset_name}"
             echo "- Rollback version: ${INPUT_ROLLBACK_VERSION:-}"
             echo "- Run force fallback: ${INPUT_RUN_FORCE_FALLBACK:-false}"
             echo "- Expected autotest artifact: ${artifact_name}"
@@ -111,6 +134,7 @@ jobs:
           ROLLBACK_VERSION: ${{ steps.payload.outputs.rollback_version }}
           RUN_FORCE_FALLBACK: ${{ steps.payload.outputs.run_force_fallback }}
           ARTIFACT_NAME: ${{ steps.payload.outputs.artifact_name }}
+          INSTALLER_ASSET_NAME: ${{ steps.payload.outputs.installer_asset_name }}
           SOURCE_REPOSITORY: ${{ github.repository }}
           SOURCE_RUN_ID: ${{ github.run_id }}
           SOURCE_SHA: ${{ github.sha }}
@@ -127,7 +151,7 @@ jobs:
               "client_payload": {
                   "release_tag": os.environ["RELEASE_TAG"],
                   "release_url": os.environ["RELEASE_URL"],
-                  "installer_asset_name": "",
+                  "installer_asset_name": os.environ.get("INSTALLER_ASSET_NAME", ""),
                   "source_repository": os.environ["SOURCE_REPOSITORY"],
                   "source_run_id": os.environ["SOURCE_RUN_ID"],
                   "source_sha": os.environ["SOURCE_SHA"],

--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -290,7 +290,11 @@ jobs:
               rf"(?<![0-9A-Za-z._+-]){re.escape(release_tag)}"
               rf"(?![0-9A-Za-z._+-])"
           )
-          version_artifact_prefix = f"flocks-windows-upgrade-{release_tag}-"
+          version_artifact_pattern = re.compile(
+              rf"(?<![0-9A-Za-z.]){re.escape(release_tag)}"
+              rf"(?![0-9.]|\+|[-_.](?:rc|alpha|beta|pre|preview|dev|post)(?:[0-9._-]|$))",
+              re.IGNORECASE,
+          )
           dispatch_started = parse_github_time(dispatch_started_at) - timedelta(seconds=30)
           deadline = time.time() + wait_timeout
           source_discovery_deadline = time.time() + 120
@@ -313,7 +317,13 @@ jobs:
               candidates.sort(key=lambda run: run.get("created_at") or "", reverse=True)
               return candidates[0] if candidates else None
 
-          def find_artifact(run_id, *, exact_name="", name_prefix="", retry_seconds=120):
+          def find_artifact(
+              run_id,
+              *,
+              exact_name="",
+              match_release_version=False,
+              retry_seconds=120,
+          ):
               artifacts_url = (
                   f"{api_root}/repos/{autotest_repo}/actions/runs/{run_id}/artifacts?per_page=100"
               )
@@ -333,13 +343,16 @@ jobs:
                       if not artifact.get("expired")
                       and (
                           (exact_name and (artifact.get("name") or "") == exact_name)
-                          or (name_prefix and (artifact.get("name") or "").startswith(name_prefix))
+                          or (
+                              match_release_version
+                              and version_artifact_pattern.search(artifact.get("name") or "")
+                          )
                       )
                   ]
                   if matching_artifacts or time.time() >= lookup_deadline:
                       break
                   available_text = ", ".join(available_artifact_names) if available_artifact_names else "(none)"
-                  expected_text = exact_name or f"{name_prefix}*"
+                  expected_text = exact_name or f"artifact containing exact version {release_tag}"
                   print(
                       f"Waiting for artifact {expected_text}. Available artifacts: {available_text}",
                       flush=True,
@@ -432,7 +445,7 @@ jobs:
                   fallback_run_id = fallback_run["id"]
                   artifact, available_names = find_artifact(
                       fallback_run_id,
-                      name_prefix=version_artifact_prefix,
+                      match_release_version=True,
                       retry_seconds=120,
                   )
                   if artifact:
@@ -493,7 +506,7 @@ jobs:
               f"- Conclusion: {conclusion}",
               f"- Source run: {source_run_url or 'not found'}",
               f"- Source status: {source_failure or 'ok'}",
-              f"- Version fallback prefix: {version_artifact_prefix}",
+              f"- Version fallback match: exact version {release_tag} anywhere in artifact name",
               f"- Expected artifact: {expected_artifact_name}",
           ]
           if artifact_name:

--- a/.github/workflows/dispatch-autotest-windows-upgrade.yml
+++ b/.github/workflows/dispatch-autotest-windows-upgrade.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Optional Flocks version tag. Defaults to the published release tag, then pyproject.toml."
+        description: "Optional expected version. It must match project.version in pyproject.toml."
         required: false
         type: string
       release_url:
@@ -66,7 +66,7 @@ jobs:
           PY
           )"
 
-          release_tag="${INPUT_RELEASE_TAG:-${RELEASE_EVENT_TAG:-}}"
+          requested_release_tag="${INPUT_RELEASE_TAG:-${RELEASE_EVENT_TAG:-}}"
           release_url="${INPUT_RELEASE_URL:-${RELEASE_EVENT_URL:-}}"
           installer_asset_name="$(python3 - <<'PY'
           import json
@@ -88,16 +88,13 @@ jobs:
           PY
           )"
 
-          if [ -z "$release_tag" ]; then
-            release_tag="$pyproject_version"
+          if [ -n "$requested_release_tag" ] && [ "$requested_release_tag" != "$pyproject_version" ]; then
+            echo "::error::Release version mismatch: requested=$requested_release_tag pyproject=$pyproject_version"
+            exit 1
           fi
+          release_tag="$pyproject_version"
           if [ -z "$release_url" ]; then
             release_url="${GITHUB_SERVER_URL_VALUE}/${GITHUB_REPOSITORY_VALUE}/commit/${GITHUB_SHA_VALUE}"
-          fi
-
-          if [ -z "$release_tag" ]; then
-            echo "release_tag is empty" >&2
-            exit 1
           fi
 
           artifact_time="$(printf "%02d" "${GITHUB_RUN_ATTEMPT_VALUE:-1}")"
@@ -116,7 +113,8 @@ jobs:
             echo "### flocks_autotest dispatch payload"
             echo ""
             echo "- Event: ${EVENT_NAME}"
-            echo "- Release tag: ${release_tag}"
+            echo "- Release tag: ${requested_release_tag:-not provided}"
+            echo "- pyproject.toml version: ${release_tag}"
             echo "- Release URL: ${release_url}"
             echo "- Source ref: ${GITHUB_REF_NAME_VALUE}"
             echo "- Source sha: ${GITHUB_SHA_VALUE}"
@@ -147,7 +145,7 @@ jobs:
           import os
 
           payload = {
-              "event_type": "flocks_main_updated",
+              "event_type": "flocks_release_published",
               "client_payload": {
                   "release_tag": os.environ["RELEASE_TAG"],
                   "release_url": os.environ["RELEASE_URL"],
@@ -207,6 +205,7 @@ jobs:
           python3 - <<'PY'
           import json
           import os
+          import re
           import sys
           import time
           import urllib.error
@@ -287,7 +286,10 @@ jobs:
               f"{api_root}/repos/{autotest_repo}/actions/workflows/"
               f"{workflow_ref}/runs?per_page=50"
           )
-          version_title_prefix = f"Windows upgrade {release_tag} "
+          version_title_pattern = re.compile(
+              rf"(?<![0-9A-Za-z._+-]){re.escape(release_tag)}"
+              rf"(?![0-9A-Za-z._+-])"
+          )
           version_artifact_prefix = f"flocks-windows-upgrade-{release_tag}-"
           dispatch_started = parse_github_time(dispatch_started_at) - timedelta(seconds=30)
           deadline = time.time() + wait_timeout
@@ -303,7 +305,7 @@ jobs:
               candidates = []
               for run in runs:
                   title = run.get("display_title") or run.get("name") or ""
-                  if not title.startswith(version_title_prefix):
+                  if not version_title_pattern.search(title):
                       continue
                   if run.get("status") != "completed" or run.get("conclusion") != "success":
                       continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.7.23"
+version = "v2026.7.29"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -553,7 +553,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.7.23"
+version = "2026.7.29"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- change the flocks autotest dispatch workflow from main push to GitHub release published
- keep workflow_dispatch for manual debugging
- resolve release tag and URL from the published release event before falling back to inputs or pyproject.toml
- pass the first .exe release asset name in the repository_dispatch payload when present

## Validation
- git diff --check -- .github/workflows/dispatch-autotest-windows-upgrade.yml
- staged only .github/workflows/dispatch-autotest-windows-upgrade.yml; existing local uv.lock changes were left unstaged

## Compatibility
- repository_dispatch event_type is intentionally kept as flocks_main_updated because flocks_autotest/main currently listens for that event type.