### PR TITLE
feat(hooks): expand agent lifecycle hooks

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1,0 +1,133 @@
+# Lifecycle Hooks
+
+Flocks loads Python lifecycle-hook plugins from:
+
+- `~/.flocks/plugins/hooks/`
+- `<workspace>/.flocks/plugins/hooks/`
+
+A plugin exports a module-level `HOOKS` list containing `HookBase` instances.
+Handlers run in registration order, use the pipeline timeout and failure-isolation
+policy, and share one mutable `HookContext` per stage.
+
+```python
+from flocks.hooks.pipeline import HookBase, HookContext
+
+
+class AuditHook(HookBase):
+    name = "audit-hook"
+    order = 100
+
+    async def tool_before(self, ctx: HookContext) -> None:
+        tool = ctx.input["tool"]
+        if tool["name"] == "bash" and "rm -rf" in tool["input"].get("command", ""):
+            ctx.output["decision"] = "block"
+            ctx.output["reason"] = "Destructive command rejected"
+
+
+HOOKS = [AuditHook()]
+```
+
+Only methods overridden by the concrete hook class count as active handlers.
+The no-op implementations inherited from `HookBase` do not enable a stage.
+
+## Lifecycle
+
+| Hook method | Stage | Trigger |
+| --- | --- | --- |
+| `user_prompt_submit` | `user.prompt.submit` | Once before each real, non-synthetic user message is processed |
+| `session_start` | `session.start` | Once after the first system prompt is built and before the first LLM request |
+| `llm_before` | `llm.call.before` | Before every LLM request |
+| `llm_after` | `llm.call.after` | After every LLM request |
+| `tool_before` | `tool.execute.before` | Before sandbox, permission, and tool-handler execution |
+| `tool_after` | `tool.execute.after` | After every tool invocation that entered `tool_before` reaches a final state |
+| `turn_finish` | `turn.finish` | After a final assistant message with `finish="stop"` is persisted and the main Agent is ready to wait |
+| `subagent_start` | `subagent.start` | Before a new or resumed `delegate_task` child Session runs |
+| `subagent_stop` | `subagent.stop` | After the child Session completes, fails, or is interrupted |
+| `event` | `event` | Existing event-pipeline hook |
+| `channel_inbound` | `channel.inbound` | Existing inbound channel hook |
+| `channel_outbound_before` | `channel.outbound.before` | Existing pre-send channel hook |
+| `channel_outbound_after` | `channel.outbound.after` | Existing post-send channel hook |
+
+The independent `HookRegistry` event API is unchanged. Lifecycle methods map
+directly to `HookPipeline` stages and are not forwarded through that registry.
+
+## UserPromptSubmit
+
+The input contains `sessionID`, `workspace`, `agent`, `model`, `messageID`, and
+`prompt`. It is emitted once for a real user turn; tool loops, LLM retries,
+model failover, Goal continuations, and TurnFinish continuations do not emit it
+again.
+
+A handler can add temporary context to the current turn without changing the
+stored user message:
+
+```python
+async def user_prompt_submit(self, ctx: HookContext) -> None:
+    ctx.output["additionalContext"] = "Use the current release branch."
+```
+
+## Tool hooks
+
+`tool_before` receives:
+
+```python
+{
+    "sessionID": "...",
+    "workspace": "...",
+    "agent": "rex",
+    "tool": {
+        "name": "bash",
+        "input": {"command": "pwd"},
+        "callID": "...",
+    },
+}
+```
+
+A handler may mutate `ctx.input["tool"]["input"]`. To prevent execution, set
+`ctx.output["decision"] = "block"` and provide a non-empty
+`ctx.output["reason"]`.
+
+`tool_after` receives the final `tool` input plus `result`, `status`,
+`error`, and `durationMs`. Status is one of `completed`, `blocked`, `error`, or
+`interrupted`. Hook blocks, sandbox blocks, handler errors, and cancellation
+all produce a matching post hook. A handler may replace the final
+`ToolResult` by assigning a serialized result dictionary to
+`ctx.output["result"]`.
+
+## TurnFinish
+
+`turn_finish` represents the end of one user turn, not Session destruction. It
+is not emitted for tool-call responses, API errors, aborts, retries, queued
+user prompts, or when internal Goal logic continues the Agent loop.
+
+The input includes `sessionID`, `workspace`, `agent`, `model`, `step`, the
+turn's `userMessage`, the final `assistantMessage`, `finishReason="stop"`, and
+`stopHookActive`.
+
+Normally the hook returns no decision. To ask the Agent to continue:
+
+```python
+async def turn_finish(self, ctx: HookContext) -> None:
+    if not tests_were_run(ctx.input["assistantMessage"]["content"]):
+        ctx.output["decision"] = "block"
+        ctx.output["reason"] = "Run the relevant tests before finishing."
+```
+
+Flocks stores the reason as a synthetic user message with
+`turnFinishContinuation` metadata and continues the current loop. The next
+final response emits `turn_finish` again with `stopHookActive=True`. At the
+Agent step limit the hook still observes the final response, but continuation
+decisions are ignored to prevent an infinite loop. A queued real user message
+always takes priority.
+
+## Session and subagent hooks
+
+`session_start` contains the Session, workspace, Agent, and selected model. It
+fires once for a new Session even when the first LLM request retries or fails
+over.
+
+`subagent_start` and `subagent_stop` contain the parent and child Session IDs,
+parent message ID, child Agent type, prompt, description, workspace, and a
+`resumed` flag. The stop payload also contains `status`, `durationMs`,
+`summary`, and `error`. These hooks are observers; use `tool_before` to block
+the `delegate_task` tool itself.

--- a/flocks/hooks/pipeline.py
+++ b/flocks/hooks/pipeline.py
@@ -2,12 +2,16 @@
 Hook Pipeline
 
 Provides a lightweight hook registry and execution pipeline that mirrors
-oh-my-opencode's lifecycle stages:
-- chat.message
+agent lifecycle stages:
+- user.prompt.submit
+- session.start
 - llm.call.before
 - llm.call.after
 - tool.execute.before
 - tool.execute.after
+- turn.finish
+- subagent.start
+- subagent.stop
 - event
 """
 
@@ -26,11 +30,15 @@ log = Log.create(service="hooks.pipeline")
 
 
 class HookStage:
-    CHAT_MESSAGE = "chat.message"
+    USER_PROMPT_SUBMIT = "user.prompt.submit"
+    SESSION_START = "session.start"
     LLM_BEFORE = "llm.call.before"
     LLM_AFTER = "llm.call.after"
     TOOL_BEFORE = "tool.execute.before"
     TOOL_AFTER = "tool.execute.after"
+    TURN_FINISH = "turn.finish"
+    SUBAGENT_START = "subagent.start"
+    SUBAGENT_STOP = "subagent.stop"
     EVENT = "event"
     CHANNEL_INBOUND = "channel.inbound"
     CHANNEL_OUTBOUND_BEFORE = "channel.outbound.before"
@@ -38,11 +46,15 @@ class HookStage:
 
 
 _DEFAULT_STAGE_TIMEOUTS: Dict[str, float] = {
-    HookStage.CHAT_MESSAGE: 5.0,
+    HookStage.USER_PROMPT_SUBMIT: 5.0,
+    HookStage.SESSION_START: 5.0,
     HookStage.LLM_BEFORE: 5.0,
     HookStage.LLM_AFTER: 5.0,
     HookStage.TOOL_BEFORE: 5.0,
     HookStage.TOOL_AFTER: 5.0,
+    HookStage.TURN_FINISH: 5.0,
+    HookStage.SUBAGENT_START: 5.0,
+    HookStage.SUBAGENT_STOP: 5.0,
     HookStage.CHANNEL_INBOUND: 5.0,
     HookStage.CHANNEL_OUTBOUND_BEFORE: 5.0,
     HookStage.CHANNEL_OUTBOUND_AFTER: 5.0,
@@ -58,7 +70,10 @@ class HookContext:
 
 
 class HookBase:
-    async def chat_message(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
+    async def user_prompt_submit(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
+        return None
+
+    async def session_start(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
         return None
 
     async def llm_before(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
@@ -71,6 +86,15 @@ class HookBase:
         return None
 
     async def tool_after(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
+        return None
+
+    async def turn_finish(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
+        return None
+
+    async def subagent_start(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
+        return None
+
+    async def subagent_stop(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
         return None
 
     async def event(self, ctx: HookContext) -> None:  # pragma: no cover - default no-op
@@ -218,12 +242,20 @@ class HookPipeline:
             cls._loaded_project_dir = str(load_project_dir.resolve(strict=False))
 
     @classmethod
-    async def run_chat_message(
+    async def run_user_prompt_submit(
         cls,
         input_data: Dict[str, Any],
         output_data: Optional[Dict[str, Any]] = None,
     ) -> HookContext:
-        return await cls._run_stage(HookStage.CHAT_MESSAGE, input_data, output_data)
+        return await cls._run_stage(HookStage.USER_PROMPT_SUBMIT, input_data, output_data)
+
+    @classmethod
+    async def run_session_start(
+        cls,
+        input_data: Dict[str, Any],
+        output_data: Optional[Dict[str, Any]] = None,
+    ) -> HookContext:
+        return await cls._run_stage(HookStage.SESSION_START, input_data, output_data)
 
     @classmethod
     async def run_llm_before(
@@ -256,6 +288,30 @@ class HookPipeline:
         output_data: Optional[Dict[str, Any]] = None,
     ) -> HookContext:
         return await cls._run_stage(HookStage.TOOL_AFTER, input_data, output_data)
+
+    @classmethod
+    async def run_turn_finish(
+        cls,
+        input_data: Dict[str, Any],
+        output_data: Optional[Dict[str, Any]] = None,
+    ) -> HookContext:
+        return await cls._run_stage(HookStage.TURN_FINISH, input_data, output_data)
+
+    @classmethod
+    async def run_subagent_start(
+        cls,
+        input_data: Dict[str, Any],
+        output_data: Optional[Dict[str, Any]] = None,
+    ) -> HookContext:
+        return await cls._run_stage(HookStage.SUBAGENT_START, input_data, output_data)
+
+    @classmethod
+    async def run_subagent_stop(
+        cls,
+        input_data: Dict[str, Any],
+        output_data: Optional[Dict[str, Any]] = None,
+    ) -> HookContext:
+        return await cls._run_stage(HookStage.SUBAGENT_STOP, input_data, output_data)
 
     @classmethod
     async def run_event(
@@ -411,22 +467,29 @@ class HookPipeline:
 
     @staticmethod
     def _resolve_handler(hook: HookBase, stage: str) -> Optional[Callable[[HookContext], Awaitable[None]]]:
-        if stage == HookStage.CHAT_MESSAGE:
-            return getattr(hook, "chat_message", None)
-        if stage == HookStage.LLM_BEFORE:
-            return getattr(hook, "llm_before", None)
-        if stage == HookStage.LLM_AFTER:
-            return getattr(hook, "llm_after", None)
-        if stage == HookStage.TOOL_BEFORE:
-            return getattr(hook, "tool_before", None)
-        if stage == HookStage.TOOL_AFTER:
-            return getattr(hook, "tool_after", None)
-        if stage == HookStage.EVENT:
-            return getattr(hook, "event", None)
-        if stage == HookStage.CHANNEL_INBOUND:
-            return getattr(hook, "channel_inbound", None)
-        if stage == HookStage.CHANNEL_OUTBOUND_BEFORE:
-            return getattr(hook, "channel_outbound_before", None)
-        if stage == HookStage.CHANNEL_OUTBOUND_AFTER:
-            return getattr(hook, "channel_outbound_after", None)
-        return None
+        method_name = {
+            HookStage.USER_PROMPT_SUBMIT: "user_prompt_submit",
+            HookStage.SESSION_START: "session_start",
+            HookStage.LLM_BEFORE: "llm_before",
+            HookStage.LLM_AFTER: "llm_after",
+            HookStage.TOOL_BEFORE: "tool_before",
+            HookStage.TOOL_AFTER: "tool_after",
+            HookStage.TURN_FINISH: "turn_finish",
+            HookStage.SUBAGENT_START: "subagent_start",
+            HookStage.SUBAGENT_STOP: "subagent_stop",
+            HookStage.EVENT: "event",
+            HookStage.CHANNEL_INBOUND: "channel_inbound",
+            HookStage.CHANNEL_OUTBOUND_BEFORE: "channel_outbound_before",
+            HookStage.CHANNEL_OUTBOUND_AFTER: "channel_outbound_after",
+        }.get(stage)
+        if method_name is None:
+            return None
+
+        handler = getattr(hook, method_name, None)
+        if not callable(handler):
+            return None
+        base_handler = getattr(HookBase, method_name, None)
+        concrete_handler = getattr(type(hook), method_name, None)
+        if base_handler is not None and concrete_handler is base_handler:
+            return None
+        return handler

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -302,6 +302,8 @@ class SessionRunner:
         static_cache: Optional[Dict[str, Any]] = None,
         defer_step_errors: bool = False,
         failover_available: bool = False,
+        turn_additional_context: Optional[str] = None,
+        session_start_pending: bool = False,
     ):
         self.session = session
         from flocks.session.core.defaults import fallback_provider_id, fallback_model_id
@@ -318,6 +320,9 @@ class SessionRunner:
         self._static_cache = static_cache if static_cache is not None else {}
         self._defer_step_errors = defer_step_errors
         self._failover_available = failover_available
+        self._turn_additional_context = turn_additional_context
+        self._session_start_pending = session_start_pending
+        self._session_start_fired = False
         self._attempt_state = LlmAttemptState()
 
     @staticmethod
@@ -355,6 +360,26 @@ class SessionRunner:
     def _should_warn_about_tool_loop(self, *, last_user_id: str) -> bool:
         state = self._get_tool_loop_guard_state(last_user_id=last_user_id)
         return int(state.get("exact_count", 0)) >= max(2, REPEATED_EXACT_TOOL_CALL_HALT_THRESHOLD - 1)
+
+    async def _run_session_start_hook(self, agent: Any) -> None:
+        """Run SessionStart after the first system prompt has been built."""
+        if not self._session_start_pending or self._session_start_fired:
+            return
+        self._session_start_fired = True
+        try:
+            from flocks.hooks.pipeline import HookPipeline
+
+            await HookPipeline.run_session_start({
+                "sessionID": self.session.id,
+                "workspace": self.session.directory,
+                "agent": agent.name,
+                "model": {
+                    "providerID": self.provider_id,
+                    "modelID": self.model_id,
+                },
+            })
+        except Exception as exc:
+            log.debug("runner.hook.session_start.error", {"error": str(exc)})
 
     def _build_tool_loop_halt_message(
         self,
@@ -1414,6 +1439,11 @@ class SessionRunner:
         )
         self._log_perf("runner.process_step.system_prompts_ready", prompts_started_at, prompt_count=len(system_prompts))
 
+        await self._run_session_start_hook(agent)
+
+        if self._turn_additional_context:
+            system_prompts.append(self._turn_additional_context)
+
         if self._should_use_text_tool_call_mode() and tools:
             text_tool_catalog = self._build_text_tool_call_catalog_prompt(tools)
             if text_tool_catalog:
@@ -1448,29 +1478,6 @@ class SessionRunner:
                 from flocks.session.prompt_strings import PROMPT_REPEATED_TOOL_CALLS
                 system_prompts.append(PROMPT_REPEATED_TOOL_CALLS)
 
-        # Hook pipeline: chat.message stage
-        try:
-            from flocks.hooks.pipeline import HookPipeline
-            user_text = await Message.get_text_content(last_user)
-            hook_input = {
-                "sessionID": self.session.id,
-                "workspace": self.session.directory,
-                "agent": agent.name,
-                "model": {"providerID": self.provider_id, "modelID": self.model_id},
-                "message": {
-                    "id": last_user.id,
-                    "role": "user",
-                    "content": user_text,
-                },
-            }
-            hook_output = {"message": {"variant": getattr(last_user, "variant", None)}}
-            ctx = await HookPipeline.run_chat_message(hook_input, hook_output)
-            variant = ctx.output.get("message", {}).get("variant") if ctx else None
-            if variant:
-                await Message.update(self.session.id, last_user.id, variant=variant)
-        except Exception as e:
-            log.debug("runner.hook.chat_message.error", {"error": str(e)})
-        
         # Convert messages to chat format with error handling
         try:
             queued_user_message_ids = self._get_queued_user_message_ids(messages)

--- a/flocks/session/session_loop.py
+++ b/flocks/session/session_loop.py
@@ -1039,6 +1039,48 @@ class SessionLoop:
                 "message_id": last_message.id,
             })
             return False
+        if ctx.should_abort():
+            log.info("loop.hook.turn_finish.ignored_after_abort", {
+                "session_id": ctx.session.id,
+                "message_id": last_message.id,
+            })
+            return False
+
+        try:
+            if ctx.session_ctx:
+                post_hook_messages = await ctx.session_ctx.get_messages()
+            else:
+                post_hook_messages = await Message.list(ctx.session.id)
+            queued_user = await cls._detect_queued_user_message(
+                ctx.session.id,
+                post_hook_messages,
+                last_user.id,
+                last_message,
+            )
+        except Exception as exc:
+            queued_user = None
+            log.debug("loop.hook.turn_finish.queued_recheck_error", {
+                "session_id": ctx.session.id,
+                "error": str(exc),
+            })
+        if queued_user is not None:
+            turn_state = set_turn_state(
+                ctx.session.id,
+                step=ctx.step,
+                status="continued",
+                continue_reason="queued_message",
+                queued_message_detected=True,
+            )
+            await cls._publish_runtime_event(callbacks, "turn.continued", {
+                **turn_state.model_dump(by_alias=True),
+                "queuedUserMessageID": queued_user.id,
+            })
+            log.info("loop.hook.turn_finish.queued_message_won", {
+                "session_id": ctx.session.id,
+                "queued_user_id": queued_user.id,
+                "source_assistant_message_id": last_message.id,
+            })
+            return True
 
         from flocks.agent.registry import Agent
         from flocks.session.core.defaults import DEFAULT_MAX_TOOL_STEPS
@@ -2081,6 +2123,7 @@ class SessionLoop:
 
                 if (
                     not step_result.error
+                    and not ctx.should_abort()
                     and last_message is not None
                     and getattr(last_message, "finish", None) == "stop"
                     and await cls._run_turn_finish_hook(
@@ -2155,6 +2198,7 @@ class SessionLoop:
                 "steps": ctx.step,
                 "session_id": ctx.session.id,
                 "last_compaction_step": ctx.last_compaction_step,
+                **({"aborted": True} if ctx.should_abort() else {}),
             },
         )
     

--- a/flocks/session/session_loop.py
+++ b/flocks/session/session_loop.py
@@ -113,6 +113,9 @@ class LoopContext:
     model_candidates: List[RuntimeModel] = field(default_factory=list)
     candidate_index: int = 0
     turn_user_id: Optional[str] = None
+    turn_additional_context: Optional[str] = None
+    stop_hook_active: bool = False
+    session_start_pending: bool = False
 
     @property
     def trace_step(self) -> int:
@@ -646,6 +649,7 @@ class SessionLoop:
             auto_failover_allowed=auto_failover,
             model_candidates=model_candidates,
             candidate_index=candidate_index,
+            session_start_pending=trace_offset == 0,
         )
         
         # Register context
@@ -836,8 +840,19 @@ class SessionLoop:
         cls,
         ctx: LoopContext,
         last_user: MessageInfo,
-    ) -> None:
-        """Synchronize routing when the loop advances to a real WebUI turn."""
+    ) -> bool:
+        """Synchronize routing when the loop advances to a real WebUI turn.
+
+        Returns:
+            True when ``last_user`` starts a new non-synthetic user turn.
+        """
+        if last_user.id == ctx.turn_user_id:
+            return False
+
+        parts = await Message.parts(last_user.id, ctx.session.id)
+        if any(bool(getattr(part, "synthetic", False)) for part in parts):
+            return False
+
         if ctx.turn_user_id is None:
             ctx.turn_user_id = last_user.id
             if ctx.auto_failover and ctx.auto_failover_allowed:
@@ -856,13 +871,7 @@ class SessionLoop:
                     ctx.model_candidates,
                 )
                 cls._select_candidate(ctx, next_index)
-            return
-        if last_user.id == ctx.turn_user_id:
-            return
-
-        parts = await Message.parts(last_user.id, ctx.session.id)
-        if any(bool(getattr(part, "synthetic", False)) for part in parts):
-            return
+            return True
 
         ctx.turn_user_id = last_user.id
         persisted_session = await Session.get_by_id(ctx.session.id)
@@ -904,7 +913,7 @@ class SessionLoop:
                 "provider_id": provider_id,
                 "model_id": model_id,
             })
-            return
+            return True
 
         from flocks.config.config import Config
 
@@ -938,6 +947,166 @@ class SessionLoop:
             "to_model_id": active.model_id,
             "cooldown_active": next_index > 0,
         })
+        return True
+
+    @classmethod
+    async def _run_user_prompt_submit_hook(
+        cls,
+        ctx: LoopContext,
+        last_user: MessageInfo,
+    ) -> None:
+        """Run UserPromptSubmit once for a newly observed real user turn."""
+        try:
+            from flocks.hooks.pipeline import HookPipeline
+
+            prompt = await Message.get_text_content(last_user)
+            hook_ctx = await HookPipeline.run_user_prompt_submit({
+                "sessionID": ctx.session.id,
+                "workspace": ctx.session.directory,
+                "agent": getattr(last_user, "agent", None) or ctx.agent_name,
+                "model": {
+                    "providerID": ctx.provider_id,
+                    "modelID": ctx.model_id,
+                },
+                "messageID": last_user.id,
+                "prompt": prompt,
+            })
+            additional_context = hook_ctx.output.get("additionalContext")
+            if isinstance(additional_context, str) and additional_context.strip():
+                ctx.turn_additional_context = additional_context.strip()
+        except Exception as exc:
+            log.debug("loop.hook.user_prompt_submit.error", {
+                "session_id": ctx.session.id,
+                "message_id": last_user.id,
+                "error": str(exc),
+            })
+
+    @classmethod
+    async def _run_turn_finish_hook(
+        cls,
+        ctx: LoopContext,
+        callbacks: LoopCallbacks,
+        last_user: MessageInfo,
+        last_message: MessageInfo,
+    ) -> bool:
+        """Run TurnFinish and continue the loop when the hook blocks stopping."""
+        try:
+            from flocks.hooks.pipeline import HookPipeline
+
+            hook_user = last_user
+            if ctx.turn_user_id:
+                hook_user = (
+                    await Message.get(ctx.session.id, ctx.turn_user_id)
+                    or last_user
+                )
+            user_text = await Message.get_text_content(hook_user)
+            assistant_text = await Message.get_text_content(last_message)
+            hook_ctx = await HookPipeline.run_turn_finish({
+                "sessionID": ctx.session.id,
+                "workspace": ctx.session.directory,
+                "agent": getattr(last_message, "agent", None) or ctx.agent_name,
+                "model": {
+                    "providerID": ctx.provider_id,
+                    "modelID": ctx.model_id,
+                },
+                "step": ctx.trace_step,
+                "userMessage": {
+                    "id": hook_user.id,
+                    "content": user_text,
+                },
+                "assistantMessage": {
+                    "id": last_message.id,
+                    "content": assistant_text,
+                },
+                "finishReason": "stop",
+                "stopHookActive": ctx.stop_hook_active,
+            })
+        except Exception as exc:
+            log.debug("loop.hook.turn_finish.error", {
+                "session_id": ctx.session.id,
+                "message_id": getattr(last_message, "id", None),
+                "error": str(exc),
+            })
+            return False
+
+        decision = str(hook_ctx.output.get("decision") or "").strip().lower()
+        reason = str(hook_ctx.output.get("reason") or "").strip()
+        if decision != "block":
+            return False
+        if not reason:
+            log.warn("loop.hook.turn_finish.missing_reason", {
+                "session_id": ctx.session.id,
+                "message_id": last_message.id,
+            })
+            return False
+
+        from flocks.agent.registry import Agent
+        from flocks.session.core.defaults import DEFAULT_MAX_TOOL_STEPS
+
+        try:
+            agent = await Agent.get(
+                getattr(last_message, "agent", None) or ctx.agent_name
+            )
+        except Exception as exc:
+            log.debug("loop.hook.turn_finish.agent_load_error", {
+                "session_id": ctx.session.id,
+                "error": str(exc),
+            })
+            agent = None
+        max_steps = (
+            agent.steps
+            if agent is not None and getattr(agent, "steps", None) is not None
+            else DEFAULT_MAX_TOOL_STEPS
+        )
+        if ctx.trace_step >= max_steps:
+            log.warn("loop.hook.turn_finish.step_limit", {
+                "session_id": ctx.session.id,
+                "step": ctx.trace_step,
+                "max_steps": max_steps,
+            })
+            return False
+
+        try:
+            continuation = await Message.create(
+                session_id=ctx.session.id,
+                role=MessageRole.USER,
+                content=reason,
+                agent=getattr(hook_user, "agent", None) or ctx.agent_name,
+                model={
+                    "providerID": ctx.provider_id,
+                    "modelID": ctx.model_id,
+                },
+                synthetic=True,
+                part_metadata={
+                    "turnFinishContinuation": True,
+                    "stopHookActive": True,
+                    "sourceAssistantMessageID": last_message.id,
+                },
+            )
+        except Exception as exc:
+            log.error("loop.hook.turn_finish.continuation_error", {
+                "session_id": ctx.session.id,
+                "error": str(exc),
+            })
+            return False
+        ctx.stop_hook_active = True
+        turn_state = set_turn_state(
+            ctx.session.id,
+            step=ctx.step,
+            status="continued",
+            continue_reason="turn_finish_hook",
+            queued_message_detected=False,
+        )
+        await cls._publish_runtime_event(callbacks, "turn.continued", {
+            **turn_state.model_dump(by_alias=True),
+            "turnFinishMessageID": continuation.id,
+        })
+        log.info("loop.continuing_for_turn_finish_hook", {
+            "session_id": ctx.session.id,
+            "continuation_message_id": continuation.id,
+            "source_assistant_message_id": last_message.id,
+        })
+        return True
 
     @classmethod
     async def _finalize_deferred_failure(
@@ -1001,10 +1170,14 @@ class SessionLoop:
                     ctx.auto_failover
                     and ctx.candidate_index + 1 < len(ctx.model_candidates)
                 ),
+                turn_additional_context=ctx.turn_additional_context,
+                session_start_pending=ctx.session_start_pending,
             )
             runner._step = ctx.trace_step
 
             step_result = await runner._process_step(messages, last_user)
+            if runner._session_start_fired:
+                ctx.session_start_pending = False
             failure = step_result.failure
             if not ctx.auto_failover or failure is None:
                 return step_result
@@ -1216,8 +1389,6 @@ class SessionLoop:
                 )
                 break
 
-            await cls._prepare_auto_turn(ctx, last_user)
-            
             last_assistant_parts = (
                 await Message.parts(last_assistant.id, ctx.session.id)
                 if last_assistant
@@ -1238,6 +1409,11 @@ class SessionLoop:
                 })
                 last_message = last_assistant
                 break
+
+            if await cls._prepare_auto_turn(ctx, last_user):
+                ctx.turn_additional_context = None
+                ctx.stop_hook_active = False
+                await cls._run_user_prompt_submit_hook(ctx, last_user)
             
             # Bootstrap memory on first step (once per loop, stored in ctx)
             if ctx.step == 1 and ctx.session.memory_enabled and ctx.memory_bootstrap_data is None:
@@ -1902,6 +2078,19 @@ class SessionLoop:
                             "reason": goal_decision.reason,
                         })
                         continue
+
+                if (
+                    not step_result.error
+                    and last_message is not None
+                    and getattr(last_message, "finish", None) == "stop"
+                    and await cls._run_turn_finish_hook(
+                        ctx,
+                        callbacks,
+                        last_user,
+                        last_message,
+                    )
+                ):
+                    continue
 
                 stop_reason = step_result.error or (getattr(last_message, "finish", None) if last_message else None) or "stop"
                 turn_state = set_turn_state(

--- a/flocks/session/streaming/stream_processor.py
+++ b/flocks/session/streaming/stream_processor.py
@@ -684,19 +684,13 @@ class StreamProcessor:
                 (hook_ctx.output.get("reason") if hook_ctx else "") or ""
             ).strip()
         except asyncio.CancelledError:
-            interrupted_result = ToolResult(
-                success=False,
-                error="Tool execution was interrupted",
-                metadata={"interrupted": True},
-            )
-            await self._run_tool_after_hook(
+            await self._finalize_interrupted_tool_call(
+                tool_state=tool_state,
                 tool_name=tool_name,
                 tool_input=tool_input,
                 tool_call_id=tool_call_id,
-                result=interrupted_result,
-                status="interrupted",
                 tool_start_time=tool_start_time,
-                allow_result_override=False,
+                post_hook_fired=False,
             )
             raise
         except Exception as e:
@@ -988,81 +982,15 @@ class StreamProcessor:
                     log.error("stream.tool_end_callback.error", {"error": str(e)})
             
         except asyncio.CancelledError:
-            interrupt_msg = "Tool execution was interrupted"
-            log.info("stream.tool_call.cancelled", {
-                "tool_call_id": tool_call_id,
-                "tool_name": tool_name,
-            })
-            if not post_hook_fired:
-                post_hook_fired = True
-                interrupted_result = ToolResult(
-                    success=False,
-                    error=interrupt_msg,
-                    metadata={"interrupted": True},
-                )
-                await self._run_tool_after_hook(
-                    tool_name=tool_name,
-                    tool_input=tool_input,
-                    tool_call_id=tool_call_id,
-                    result=interrupted_result,
-                    status="interrupted",
-                    tool_start_time=tool_start_time,
-                    allow_result_override=False,
-                )
-            try:
-                if tool_span_ctx is not None:
-                    tool_span_ctx.end(
-                        output=interrupt_msg,
-                        metadata={"success": False},
-                        level="ERROR",
-                        status_message="tool_cancelled",
-                    )
-            except Exception as _span_err:
-                log.debug("stream.tool_span.cancel_end_failed", {"error": str(_span_err)})
-
-            tool_state.status = "error"
-            tool_state.error = interrupt_msg
-
-            try:
-                tool_end_time = int(datetime.now().timestamp() * 1000)
-                error_state = ToolStateError(
-                    status="error",
-                    input=tool_input,
-                    error=interrupt_msg,
-                    time={"start": tool_start_time if 'tool_start_time' in locals() else tool_end_time, "end": tool_end_time},
-                )
-
-                error_part = ToolPart(
-                    id=tool_state.part_id,
-                    sessionID=self.session_id,
-                    messageID=self.assistant_message.id,
-                    type="tool",
-                    callID=tool_call_id,
-                    tool=tool_name,
-                    state=error_state,
-                )
-                await Message.store_part(self.session_id, self.assistant_message.id, error_part)
-
-                if self.event_publish_callback:
-                    await self.event_publish_callback("message.part.updated", {
-                        "part": {
-                            "id": tool_state.part_id,
-                            "messageID": self.assistant_message.id,
-                            "sessionID": self.session_id,
-                            "type": "tool",
-                            "callID": tool_call_id,
-                            "tool": tool_name,
-                            "state": {
-                                "status": "error",
-                                "input": tool_input,
-                                "error": interrupt_msg,
-                                "time": {"start": tool_start_time if 'tool_start_time' in locals() else tool_end_time, "end": tool_end_time},
-                            }
-                        }
-                    })
-            except Exception as store_e:
-                log.error("stream.tool_call.cancelled_update_failed", {"error": str(store_e)})
-
+            await self._finalize_interrupted_tool_call(
+                tool_state=tool_state,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                tool_call_id=tool_call_id,
+                tool_start_time=tool_start_time,
+                post_hook_fired=post_hook_fired,
+                tool_span_ctx=tool_span_ctx,
+            )
             raise
         except Exception as e:
             log.error("stream.tool_call.error", {
@@ -1157,6 +1085,107 @@ class StreamProcessor:
                     await self.tool_end_callback(tool_name, error_result)
                 except Exception as e2:
                     log.error("stream.tool_end_callback.error", {"error": str(e2)})
+
+    async def _finalize_interrupted_tool_call(
+        self,
+        *,
+        tool_state: ToolCallState,
+        tool_name: str,
+        tool_input: Dict[str, Any],
+        tool_call_id: str,
+        tool_start_time: int,
+        post_hook_fired: bool,
+        tool_span_ctx: Optional[Any] = None,
+    ) -> None:
+        """Emit and persist the terminal state for an interrupted tool call."""
+        interrupt_msg = "Tool execution was interrupted"
+        log.info("stream.tool_call.cancelled", {
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+        })
+        try:
+            if not post_hook_fired:
+                interrupted_result = ToolResult(
+                    success=False,
+                    error=interrupt_msg,
+                    metadata={"interrupted": True},
+                )
+                await self._run_tool_after_hook(
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                    tool_call_id=tool_call_id,
+                    result=interrupted_result,
+                    status="interrupted",
+                    tool_start_time=tool_start_time,
+                    allow_result_override=False,
+                )
+        finally:
+            try:
+                if tool_span_ctx is not None:
+                    tool_span_ctx.end(
+                        output=interrupt_msg,
+                        metadata={"success": False},
+                        level="ERROR",
+                        status_message="tool_cancelled",
+                    )
+            except Exception as span_error:
+                log.debug(
+                    "stream.tool_span.cancel_end_failed",
+                    {"error": str(span_error)},
+                )
+
+            tool_state.status = "error"
+            tool_state.error = interrupt_msg
+            tool_end_time = int(datetime.now().timestamp() * 1000)
+            error_state = ToolStateError(
+                status="error",
+                input=tool_input,
+                error=interrupt_msg,
+                time={"start": tool_start_time, "end": tool_end_time},
+            )
+            error_part = ToolPart(
+                id=tool_state.part_id,
+                sessionID=self.session_id,
+                messageID=self.assistant_message.id,
+                type="tool",
+                callID=tool_call_id,
+                tool=tool_name,
+                state=error_state,
+            )
+            try:
+                await Message.store_part(
+                    self.session_id,
+                    self.assistant_message.id,
+                    error_part,
+                )
+                if self.event_publish_callback:
+                    await self.event_publish_callback(
+                        "message.part.updated",
+                        {
+                            "part": {
+                                "id": tool_state.part_id,
+                                "messageID": self.assistant_message.id,
+                                "sessionID": self.session_id,
+                                "type": "tool",
+                                "callID": tool_call_id,
+                                "tool": tool_name,
+                                "state": {
+                                    "status": "error",
+                                    "input": tool_input,
+                                    "error": interrupt_msg,
+                                    "time": {
+                                        "start": tool_start_time,
+                                        "end": tool_end_time,
+                                    },
+                                },
+                            }
+                        },
+                    )
+            except Exception as store_error:
+                log.error(
+                    "stream.tool_call.cancelled_update_failed",
+                    {"error": str(store_error)},
+                )
 
     async def _run_tool_after_hook(
         self,

--- a/flocks/session/streaming/stream_processor.py
+++ b/flocks/session/streaming/stream_processor.py
@@ -703,6 +703,7 @@ class StreamProcessor:
             log.error("stream.tool_before_hook.error", {"error": str(e)})
             hook_blocked = False
             hook_block_reason = ""
+        tool_state.input = tool_input
 
         # Execute tool synchronously
         tool_span_ctx = None

--- a/flocks/session/streaming/stream_processor.py
+++ b/flocks/session/streaming/stream_processor.py
@@ -657,9 +657,11 @@ class StreamProcessor:
             except Exception as e:
                 log.error("stream.tool_start_callback.error", {"error": str(e)})
         
-        # Hook pipeline: tool.execute.before
+        # Hook pipeline: tool_before
+        post_hook_fired = False
         try:
             from flocks.hooks.pipeline import HookPipeline
+
             hook_ctx = await HookPipeline.run_tool_before({
                 "sessionID": self.session_id,
                 "workspace": self._workspace_dir,
@@ -674,10 +676,33 @@ class StreamProcessor:
                 updated = hook_ctx.input.get("tool", {}).get("input")
                 if isinstance(updated, dict):
                     tool_input = updated
-            hook_skip = hook_ctx.output.get("skip") if hook_ctx else False
+            decision = str(
+                (hook_ctx.output.get("decision") if hook_ctx else "") or ""
+            ).strip().lower()
+            hook_blocked = decision == "block"
+            hook_block_reason = str(
+                (hook_ctx.output.get("reason") if hook_ctx else "") or ""
+            ).strip()
+        except asyncio.CancelledError:
+            interrupted_result = ToolResult(
+                success=False,
+                error="Tool execution was interrupted",
+                metadata={"interrupted": True},
+            )
+            await self._run_tool_after_hook(
+                tool_name=tool_name,
+                tool_input=tool_input,
+                tool_call_id=tool_call_id,
+                result=interrupted_result,
+                status="interrupted",
+                tool_start_time=tool_start_time,
+                allow_result_override=False,
+            )
+            raise
         except Exception as e:
             log.error("stream.tool_before_hook.error", {"error": str(e)})
-            hook_skip = False
+            hook_blocked = False
+            hook_block_reason = ""
 
         # Execute tool synchronously
         tool_span_ctx = None
@@ -699,10 +724,11 @@ class StreamProcessor:
             except Exception as exc:
                 log.debug("stream.tool_span.init_failed", {"error": str(exc)})
         try:
-            if hook_skip:
+            if hook_blocked:
                 result = ToolResult(
                     success=False,
-                    error="Tool execution blocked by hook",
+                    error=hook_block_reason or "Tool execution blocked by hook",
+                    metadata={"blocked_by_hook": True},
                 )
             else:
                 sandbox_meta = await self._resolve_sandbox_meta(tool_name)
@@ -843,26 +869,23 @@ class StreamProcessor:
                         if cb and hasattr(cb, 'mark_finished'):
                             cb.mark_finished()
 
-            # Hook pipeline: tool.execute.after
-            try:
-                from flocks.hooks.pipeline import HookPipeline
-                hook_ctx = await HookPipeline.run_tool_after({
-                    "sessionID": self.session_id,
-                    "workspace": self._workspace_dir,
-                    "agent": self.agent.name,
-                    "tool": {
-                        "name": tool_name,
-                        "input": tool_input,
-                        "callID": tool_call_id,
-                    },
-                    "result": result.model_dump(),
-                })
-                if hook_ctx and isinstance(hook_ctx.output, dict):
-                    override = hook_ctx.output.get("result")
-                    if isinstance(override, dict):
-                        result = ToolResult(**override)
-            except Exception as e:
-                log.error("stream.tool_after_hook.error", {"error": str(e)})
+            if result.success:
+                hook_status = "completed"
+            elif (result.metadata or {}).get("blocked_by_hook"):
+                hook_status = "blocked"
+            elif (result.metadata or {}).get("blocked_by_policy"):
+                hook_status = "blocked"
+            else:
+                hook_status = "error"
+            post_hook_fired = True
+            result = await self._run_tool_after_hook(
+                tool_name=tool_name,
+                tool_input=tool_input,
+                tool_call_id=tool_call_id,
+                result=result,
+                status=hook_status,
+                tool_start_time=tool_start_time,
+            )
             
             # Update tool state
             tool_state.status = "completed" if result.success else "error"
@@ -973,6 +996,22 @@ class StreamProcessor:
                 "tool_call_id": tool_call_id,
                 "tool_name": tool_name,
             })
+            if not post_hook_fired:
+                post_hook_fired = True
+                interrupted_result = ToolResult(
+                    success=False,
+                    error=interrupt_msg,
+                    metadata={"interrupted": True},
+                )
+                await self._run_tool_after_hook(
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                    tool_call_id=tool_call_id,
+                    result=interrupted_result,
+                    status="interrupted",
+                    tool_start_time=tool_start_time,
+                    allow_result_override=False,
+                )
             try:
                 if tool_span_ctx is not None:
                     tool_span_ctx.end(
@@ -1034,6 +1073,21 @@ class StreamProcessor:
                 "tool_name": tool_name,
                 "error": str(e),
             })
+            if not post_hook_fired:
+                post_hook_fired = True
+                exception_result = ToolResult(
+                    success=False,
+                    error=str(e),
+                )
+                await self._run_tool_after_hook(
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                    tool_call_id=tool_call_id,
+                    result=exception_result,
+                    status="error",
+                    tool_start_time=tool_start_time,
+                    allow_result_override=False,
+                )
             try:
                 if tool_span_ctx is not None:
                     tool_span_ctx.end(
@@ -1106,6 +1160,47 @@ class StreamProcessor:
                     await self.tool_end_callback(tool_name, error_result)
                 except Exception as e2:
                     log.error("stream.tool_end_callback.error", {"error": str(e2)})
+
+    async def _run_tool_after_hook(
+        self,
+        *,
+        tool_name: str,
+        tool_input: Dict[str, Any],
+        tool_call_id: str,
+        result: ToolResult,
+        status: str,
+        tool_start_time: int,
+        allow_result_override: bool = True,
+    ) -> ToolResult:
+        """Run tool_after with a normalized result for every tool outcome."""
+        try:
+            from flocks.hooks.pipeline import HookPipeline
+
+            duration_ms = max(
+                0,
+                int(datetime.now().timestamp() * 1000) - tool_start_time,
+            )
+            hook_ctx = await HookPipeline.run_tool_after({
+                "sessionID": self.session_id,
+                "workspace": self._workspace_dir,
+                "agent": self.agent.name,
+                "tool": {
+                    "name": tool_name,
+                    "input": tool_input,
+                    "callID": tool_call_id,
+                },
+                "status": status,
+                "durationMs": duration_ms,
+                "result": result.model_dump(),
+                "error": result.error if not result.success else None,
+            })
+            if allow_result_override and isinstance(hook_ctx.output, dict):
+                override = hook_ctx.output.get("result")
+                if isinstance(override, dict):
+                    return ToolResult(**override)
+        except Exception as exc:
+            log.error("stream.tool_after_hook.error", {"error": str(exc)})
+        return result
 
     async def _load_config_data(self) -> Dict[str, Any]:
         """Load and cache config as plain dict."""

--- a/flocks/tool/agent/delegate_task.py
+++ b/flocks/tool/agent/delegate_task.py
@@ -28,7 +28,10 @@ from flocks.session.session_loop import SessionLoop
 from flocks.agent.registry import is_delegatable
 from flocks.skill.skill import Skill
 from flocks.config.config import Config
-from flocks.tool.subagent_result import format_sync_subagent_result
+from flocks.tool.subagent_result import (
+    _extract_message_error,
+    format_sync_subagent_result,
+)
 from flocks.utils.log import Log
 
 log = Log.create(service="tool.delegate_task")
@@ -121,6 +124,16 @@ async def _run_subagent_with_hooks(
                 "error": str(exc),
             })
     result_error = getattr(result, "error", None)
+    message_error = (
+        _extract_message_error(last_message)
+        if last_message is not None
+        else None
+    )
+    message_finish = (
+        getattr(last_message, "finish", None)
+        if last_message is not None
+        else None
+    )
     result_metadata = getattr(result, "metadata", None)
     interrupted = (
         isinstance(result_metadata, dict)
@@ -129,9 +142,18 @@ async def _run_subagent_with_hooks(
     if interrupted:
         status = "interrupted"
         stop_error = result_error or "Sub-agent execution was interrupted"
-    elif getattr(result, "action", None) == "error" or result_error:
+    elif (
+        getattr(result, "action", None) == "error"
+        or result_error
+        or message_error
+        or message_finish == "error"
+    ):
         status = "error"
-        stop_error = result_error
+        stop_error = (
+            result_error
+            or message_error
+            or "Sub-agent execution failed"
+        )
     else:
         status = "completed"
         stop_error = None

--- a/flocks/tool/agent/delegate_task.py
+++ b/flocks/tool/agent/delegate_task.py
@@ -4,6 +4,8 @@ delegate_task tool - category or subagent-based delegation (Oh-My-Flocks parity)
 
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Optional, List, Dict, Any
 
 from flocks.tool.registry import (
@@ -30,6 +32,111 @@ from flocks.tool.subagent_result import format_sync_subagent_result
 from flocks.utils.log import Log
 
 log = Log.create(service="tool.delegate_task")
+
+
+async def _run_subagent_with_hooks(
+    *,
+    ctx: ToolContext,
+    child_session_id: str,
+    child_agent: str,
+    workspace: str,
+    prompt: str,
+    description: str,
+    resumed: bool,
+    provider_id: Optional[str] = None,
+    model_id: Optional[str] = None,
+    callbacks: Optional[Any] = None,
+) -> Any:
+    """Run one child session with paired SubagentStart/SubagentStop hooks."""
+    from flocks.hooks.pipeline import HookPipeline
+
+    common_payload = {
+        "sessionID": ctx.session_id,
+        "workspace": workspace,
+        "parentSessionID": ctx.session_id,
+        "parentMessageID": ctx.message_id,
+        "childSessionID": child_session_id,
+        "agentType": child_agent,
+        "prompt": prompt,
+        "description": description,
+        "resumed": resumed,
+    }
+    try:
+        await HookPipeline.run_subagent_start(common_payload)
+    except Exception as exc:
+        log.debug("delegate_task.hook.subagent_start.error", {
+            "child_session_id": child_session_id,
+            "error": str(exc),
+        })
+
+    started_at = time.perf_counter()
+    try:
+        result = await SessionLoop.run(
+            child_session_id,
+            provider_id=provider_id,
+            model_id=model_id,
+            callbacks=callbacks,
+        )
+    except asyncio.CancelledError:
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        try:
+            await HookPipeline.run_subagent_stop({
+                **common_payload,
+                "status": "interrupted",
+                "durationMs": duration_ms,
+                "summary": None,
+                "error": "Sub-agent execution was interrupted",
+            })
+        except Exception as exc:
+            log.debug("delegate_task.hook.subagent_stop.error", {
+                "child_session_id": child_session_id,
+                "error": str(exc),
+            })
+        raise
+    except Exception as exc:
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        try:
+            await HookPipeline.run_subagent_stop({
+                **common_payload,
+                "status": "error",
+                "durationMs": duration_ms,
+                "summary": None,
+                "error": str(exc),
+            })
+        except Exception as hook_exc:
+            log.debug("delegate_task.hook.subagent_stop.error", {
+                "child_session_id": child_session_id,
+                "error": str(hook_exc),
+            })
+        raise
+
+    summary = None
+    last_message = getattr(result, "last_message", None)
+    if last_message is not None:
+        try:
+            summary = await Message.get_text_content(last_message)
+        except Exception as exc:
+            log.debug("delegate_task.hook.subagent_summary.error", {
+                "child_session_id": child_session_id,
+                "error": str(exc),
+            })
+    result_error = getattr(result, "error", None)
+    status = "error" if getattr(result, "action", None) == "error" or result_error else "completed"
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    try:
+        await HookPipeline.run_subagent_stop({
+            **common_payload,
+            "status": status,
+            "durationMs": duration_ms,
+            "summary": summary,
+            "error": result_error,
+        })
+    except Exception as exc:
+        log.debug("delegate_task.hook.subagent_stop.error", {
+            "child_session_id": child_session_id,
+            "error": str(exc),
+        })
+    return result
 
 
 async def _subagent_session_permissions(agent_name: str) -> list:
@@ -395,8 +502,15 @@ async def delegate_task_tool(
             agent=session.agent or ctx.agent,
         )
         from flocks.session.session_loop import LoopCallbacks
-        result = await SessionLoop.run(
-            session.id,
+
+        result = await _run_subagent_with_hooks(
+            ctx=ctx,
+            child_session_id=session.id,
+            child_agent=session.agent or ctx.agent,
+            workspace=getattr(session, "directory", None) or "",
+            prompt=prompt,
+            description=description,
+            resumed=True,
             callbacks=LoopCallbacks(
                 event_publish_callback=ctx.event_publish_callback,
             ),
@@ -494,8 +608,14 @@ async def delegate_task_tool(
         description=description,
     )
     ctx.metadata({"title": description, "metadata": {"sessionId": created.id, "status": "running"}})
-    result = await SessionLoop.run(
-        created.id,
+    result = await _run_subagent_with_hooks(
+        ctx=ctx,
+        child_session_id=created.id,
+        child_agent=agent_to_use,
+        workspace=runtime_directory,
+        prompt=full_prompt,
+        description=description,
+        resumed=False,
         provider_id=(category_model or {}).get("providerID"),
         model_id=(category_model or {}).get("modelID"),
         callbacks=forwarder.build_callbacks(

--- a/flocks/tool/agent/delegate_task.py
+++ b/flocks/tool/agent/delegate_task.py
@@ -121,7 +121,20 @@ async def _run_subagent_with_hooks(
                 "error": str(exc),
             })
     result_error = getattr(result, "error", None)
-    status = "error" if getattr(result, "action", None) == "error" or result_error else "completed"
+    result_metadata = getattr(result, "metadata", None)
+    interrupted = (
+        isinstance(result_metadata, dict)
+        and bool(result_metadata.get("aborted"))
+    )
+    if interrupted:
+        status = "interrupted"
+        stop_error = result_error or "Sub-agent execution was interrupted"
+    elif getattr(result, "action", None) == "error" or result_error:
+        status = "error"
+        stop_error = result_error
+    else:
+        status = "completed"
+        stop_error = None
     duration_ms = int((time.perf_counter() - started_at) * 1000)
     try:
         await HookPipeline.run_subagent_stop({
@@ -129,7 +142,7 @@ async def _run_subagent_with_hooks(
             "status": status,
             "durationMs": duration_ms,
             "summary": summary,
-            "error": result_error,
+            "error": stop_error,
         })
     except Exception as exc:
         log.debug("delegate_task.hook.subagent_stop.error", {

--- a/tests/hooks/test_pipeline.py
+++ b/tests/hooks/test_pipeline.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from flocks.hooks.pipeline import HookBase, HookPipeline
+from flocks.hooks.pipeline import HookBase, HookPipeline, HookStage
 from flocks.plugin.loader import PluginLoader
 
 
@@ -111,3 +111,60 @@ async def test_pipeline_resolves_project_dir_from_session_when_workspace_missing
     )
 
     assert "hook-session" in set(HookPipeline.list_hooks())
+
+
+def test_hook_base_exposes_only_canonical_lifecycle_names() -> None:
+    assert not hasattr(HookBase, "chat_message")
+    assert hasattr(HookBase, "tool_before")
+    assert hasattr(HookBase, "tool_after")
+    assert not hasattr(HookBase, "pre_tool_use")
+    assert not hasattr(HookBase, "post_tool_use")
+    assert not hasattr(HookPipeline, "run_chat_message")
+    assert hasattr(HookPipeline, "run_tool_before")
+    assert hasattr(HookPipeline, "run_tool_after")
+    assert not hasattr(HookPipeline, "run_pre_tool_use")
+    assert not hasattr(HookPipeline, "run_post_tool_use")
+
+
+def test_default_hook_methods_are_not_stage_handlers() -> None:
+    hook = HookBase()
+
+    assert HookPipeline._resolve_handler(
+        hook,
+        HookStage.USER_PROMPT_SUBMIT,
+    ) is None
+    assert HookPipeline._resolve_handler(hook, HookStage.LLM_BEFORE) is None
+    assert HookPipeline._resolve_handler(hook, HookStage.TOOL_BEFORE) is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runs_canonical_lifecycle_handlers() -> None:
+    seen: list[str] = []
+
+    class _CanonicalHook(HookBase):
+        async def user_prompt_submit(self, ctx) -> None:
+            seen.append(ctx.stage)
+
+        async def tool_before(self, ctx) -> None:
+            seen.append(ctx.stage)
+
+        async def tool_after(self, ctx) -> None:
+            seen.append(ctx.stage)
+
+        async def turn_finish(self, ctx) -> None:
+            seen.append(ctx.stage)
+
+    HookPipeline.register("canonical-hook", _CanonicalHook())
+    HookPipeline._initialized = True
+
+    await HookPipeline.run_user_prompt_submit({"sessionID": "ses_test"})
+    await HookPipeline.run_tool_before({"sessionID": "ses_test"})
+    await HookPipeline.run_tool_after({"sessionID": "ses_test"})
+    await HookPipeline.run_turn_finish({"sessionID": "ses_test"})
+
+    assert seen == [
+        HookStage.USER_PROMPT_SUBMIT,
+        HookStage.TOOL_BEFORE,
+        HookStage.TOOL_AFTER,
+        HookStage.TURN_FINISH,
+    ]

--- a/tests/server/routes/test_workflow_poller_routes.py
+++ b/tests/server/routes/test_workflow_poller_routes.py
@@ -23,6 +23,13 @@ async def test_save_poller_config_restarts_manager(
         assert workflow_id == "wf-1"
         return {"workflowId": workflow_id, "state": "running", "lastStatus": None}
 
+    async def _fake_persist(
+        _workflow_id: str,
+        workflow_data: dict[str, Any],
+        _triggers: list[Any],
+    ) -> dict[str, Any]:
+        return workflow_data
+
     monkeypatch.setattr(
         workflow_routes,
         "_read_workflow_from_fs",
@@ -31,6 +38,7 @@ async def test_save_poller_config_restarts_manager(
         ),
     )
     monkeypatch.setattr(workflow_routes.WorkflowStore, "put_config", _fake_put_config)
+    monkeypatch.setattr(workflow_routes, "_persist_workflow_triggers", _fake_persist)
     monkeypatch.setattr(
         "flocks.workflow.poller_manager.default_manager",
         SimpleNamespace(restart_workflow=_fake_restart),

--- a/tests/session/test_lifecycle_hooks.py
+++ b/tests/session/test_lifecycle_hooks.py
@@ -195,6 +195,65 @@ async def test_turn_finish_block_creates_synthetic_continuation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_queued_prompt_arriving_during_turn_finish_wins() -> None:
+    ctx = _loop_context("ses_turn_finish_queue_race")
+    ctx.turn_user_id = "msg_001"
+    user = SimpleNamespace(id="msg_001", agent="rex", role="user")
+    assistant = SimpleNamespace(
+        id="msg_002",
+        agent="rex",
+        role="assistant",
+        finish="stop",
+    )
+    queued_user = SimpleNamespace(id="msg_003", agent="rex", role="user")
+    ctx.session_ctx = SimpleNamespace(
+        get_messages=AsyncMock(
+            return_value=[user, assistant, queued_user],
+        )
+    )
+    callbacks = LoopCallbacks(event_publish_callback=AsyncMock())
+    create_message = AsyncMock()
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.get",
+            AsyncMock(return_value=user),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            AsyncMock(side_effect=["prompt", "response"]),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.create",
+            create_message,
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_turn_finish",
+            AsyncMock(
+                return_value=HookContext(
+                    stage=HookStage.TURN_FINISH,
+                    input={},
+                    output={"decision": "block", "reason": "continue"},
+                )
+            ),
+        ),
+    ):
+        continued = await SessionLoop._run_turn_finish_hook(
+            ctx,
+            callbacks,
+            user,
+            assistant,
+        )
+
+    assert continued is True
+    create_message.assert_not_awaited()
+    callbacks.event_publish_callback.assert_awaited_once()
+    event_name, payload = callbacks.event_publish_callback.await_args.args
+    assert event_name == "turn.continued"
+    assert payload["queuedUserMessageID"] == queued_user.id
+
+
+@pytest.mark.asyncio
 async def test_turn_finish_block_is_ignored_at_agent_step_limit() -> None:
     ctx = _loop_context("ses_turn_finish_limit")
     ctx.turn_user_id = "msg_user"
@@ -568,3 +627,73 @@ async def test_abort_does_not_trigger_turn_finish() -> None:
         await SessionLoop._run_loop(ctx, LoopCallbacks())
 
     run_turn_finish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_late_abort_after_step_completion_skips_turn_finish() -> None:
+    ctx = _loop_context("ses_turn_finish_late_abort")
+    user = _message("msg_001", "user")
+    assistant = _message("msg_002", "assistant", finish="stop")
+    ctx.session_ctx = SimpleNamespace(
+        get_messages=AsyncMock(
+            side_effect=[
+                [user],
+                [user, assistant],
+            ]
+        )
+    )
+    run_turn_finish = AsyncMock(return_value=False)
+
+    async def abort_after_step(_step: int) -> None:
+        ctx.abort_event.set()
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            AsyncMock(return_value="final response"),
+        ),
+        patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ),
+        patch(
+            "flocks.session.session_loop.GoalManager.evaluate_after_turn",
+            AsyncMock(
+                return_value=GoalDecision(
+                    status="inactive",
+                    verdict="inactive",
+                )
+            ),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_user_prompt_submit_hook",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_turn_finish_hook",
+            run_turn_finish,
+        ),
+        patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(return_value=StepResult(action="stop")),
+        ),
+        patch(
+            "flocks.session.lifecycle.title.SessionTitle.ensure_title",
+            MagicMock(return_value=None),
+        ),
+        patch(
+            "flocks.session.session_loop.fire_and_forget",
+            MagicMock(),
+        ),
+    ):
+        result = await SessionLoop._run_loop(
+            ctx,
+            LoopCallbacks(on_step_end=abort_after_step),
+        )
+
+    run_turn_finish.assert_not_awaited()
+    assert result.metadata["aborted"] is True

--- a/tests/session/test_lifecycle_hooks.py
+++ b/tests/session/test_lifecycle_hooks.py
@@ -1,0 +1,570 @@
+"""Focused tests for the Python lifecycle-hook seams."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+import pytest
+
+from flocks.hooks.pipeline import HookContext, HookStage
+from flocks.session.goal import GoalDecision
+from flocks.session.runner import SessionRunner, StepResult
+from flocks.session.session import SessionInfo
+from flocks.session.session_loop import LoopCallbacks, LoopContext, SessionLoop
+
+
+def _session(session_id: str = "ses_lifecycle_hooks") -> SessionInfo:
+    return SessionInfo.model_construct(
+        id=session_id,
+        slug="hooks",
+        project_id="project",
+        directory="/tmp/project",
+        title="Lifecycle Hooks",
+        agent="rex",
+    )
+
+
+def _loop_context(session_id: str = "ses_lifecycle_hooks") -> LoopContext:
+    return LoopContext(
+        session=_session(session_id),
+        provider_id="test-provider",
+        model_id="test-model",
+        agent_name="rex",
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_user_turn_is_detected_once_and_synthetic_is_ignored() -> None:
+    ctx = _loop_context()
+    first_user = SimpleNamespace(id="msg_user", model={})
+    synthetic_user = SimpleNamespace(id="msg_synthetic", model={})
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(
+                side_effect=[
+                    [],
+                    [SimpleNamespace(synthetic=True)],
+                ]
+            ),
+        ),
+        patch.object(
+            SessionLoop,
+            "_run_user_prompt_submit_hook",
+            AsyncMock(),
+        ) as submit_hook,
+    ):
+        for user in (first_user, first_user, synthetic_user):
+            if await SessionLoop._prepare_auto_turn(ctx, user):
+                await SessionLoop._run_user_prompt_submit_hook(ctx, user)
+
+    assert ctx.turn_user_id == first_user.id
+    submit_hook.assert_awaited_once_with(ctx, first_user)
+
+
+@pytest.mark.asyncio
+async def test_user_prompt_submit_adds_ephemeral_turn_context() -> None:
+    ctx = _loop_context()
+    user = SimpleNamespace(id="msg_user", agent="rex")
+    run_hook = AsyncMock(
+        return_value=HookContext(
+            stage=HookStage.USER_PROMPT_SUBMIT,
+            input={},
+            output={"additionalContext": "  current sprint context  "},
+        )
+    )
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            AsyncMock(return_value="implement hooks"),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_user_prompt_submit",
+            run_hook,
+        ),
+    ):
+        await SessionLoop._run_user_prompt_submit_hook(ctx, user)
+
+    assert ctx.turn_additional_context == "current sprint context"
+    payload = run_hook.await_args.args[0]
+    assert payload["messageID"] == user.id
+    assert payload["prompt"] == "implement hooks"
+    assert payload["model"] == {
+        "providerID": "test-provider",
+        "modelID": "test-model",
+    }
+
+
+@pytest.mark.asyncio
+async def test_session_start_runs_only_when_pending() -> None:
+    runner = SessionRunner(
+        session=_session("ses_session_start"),
+        provider_id="test-provider",
+        model_id="test-model",
+        session_start_pending=True,
+    )
+    run_hook = AsyncMock()
+
+    with patch(
+        "flocks.session.runner.HookPipeline.run_session_start",
+        run_hook,
+    ):
+        await runner._run_session_start_hook(SimpleNamespace(name="rex"))
+        await runner._run_session_start_hook(SimpleNamespace(name="rex"))
+
+    run_hook.assert_awaited_once()
+    assert runner._session_start_fired is True
+    assert run_hook.await_args.args[0]["sessionID"] == "ses_session_start"
+
+
+@pytest.mark.asyncio
+async def test_turn_finish_block_creates_synthetic_continuation() -> None:
+    ctx = _loop_context("ses_turn_finish")
+    ctx.turn_user_id = "msg_user"
+    user = SimpleNamespace(
+        id="msg_user",
+        agent="rex",
+        model={"providerID": "test-provider", "modelID": "test-model"},
+    )
+    assistant = SimpleNamespace(
+        id="msg_assistant",
+        agent="rex",
+        finish="stop",
+    )
+    continuation = SimpleNamespace(id="msg_continuation")
+    callbacks = LoopCallbacks(event_publish_callback=AsyncMock())
+    create_message = AsyncMock(return_value=continuation)
+    run_hook = AsyncMock(
+        return_value=HookContext(
+            stage=HookStage.TURN_FINISH,
+            input={},
+            output={
+                "decision": "block",
+                "reason": "Run the test suite before finishing.",
+            },
+        )
+    )
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.get",
+            AsyncMock(return_value=user),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            AsyncMock(side_effect=["implement hooks", "implementation complete"]),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.create",
+            create_message,
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_turn_finish",
+            run_hook,
+        ),
+        patch(
+            "flocks.agent.registry.Agent.get",
+            AsyncMock(return_value=SimpleNamespace(steps=10)),
+        ),
+    ):
+        continued = await SessionLoop._run_turn_finish_hook(
+            ctx,
+            callbacks,
+            user,
+            assistant,
+        )
+
+    assert continued is True
+    assert ctx.stop_hook_active is True
+    assert create_message.await_args.kwargs["content"] == ("Run the test suite before finishing.")
+    assert create_message.await_args.kwargs["synthetic"] is True
+    assert create_message.await_args.kwargs["part_metadata"] == {
+        "turnFinishContinuation": True,
+        "stopHookActive": True,
+        "sourceAssistantMessageID": assistant.id,
+    }
+    hook_payload = run_hook.await_args.args[0]
+    assert hook_payload["finishReason"] == "stop"
+    assert hook_payload["stopHookActive"] is False
+    callbacks.event_publish_callback.assert_awaited_once()
+    assert callbacks.event_publish_callback.await_args.args[0] == "turn.continued"
+
+
+@pytest.mark.asyncio
+async def test_turn_finish_block_is_ignored_at_agent_step_limit() -> None:
+    ctx = _loop_context("ses_turn_finish_limit")
+    ctx.turn_user_id = "msg_user"
+    ctx.trace_step_offset = 2
+    ctx.step = 1
+    user = SimpleNamespace(id="msg_user", agent="rex")
+    assistant = SimpleNamespace(
+        id="msg_assistant",
+        agent="rex",
+        finish="stop",
+    )
+    create_message = AsyncMock()
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.get",
+            AsyncMock(return_value=user),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            AsyncMock(side_effect=["prompt", "response"]),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.create",
+            create_message,
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_turn_finish",
+            AsyncMock(
+                return_value=HookContext(
+                    stage=HookStage.TURN_FINISH,
+                    input={},
+                    output={"decision": "block", "reason": "continue"},
+                )
+            ),
+        ),
+        patch(
+            "flocks.agent.registry.Agent.get",
+            AsyncMock(return_value=SimpleNamespace(steps=3)),
+        ),
+    ):
+        continued = await SessionLoop._run_turn_finish_hook(
+            ctx,
+            LoopCallbacks(),
+            user,
+            assistant,
+        )
+
+    assert continued is False
+    create_message.assert_not_awaited()
+
+
+def _message(
+    message_id: str,
+    role: str,
+    *,
+    finish: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=message_id,
+        role=role,
+        finish=finish,
+        tokens=None,
+        summary=False,
+        agent="rex",
+        model={"providerID": "test-provider", "modelID": "test-model"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_finish_runs_only_after_persisted_stop() -> None:
+    ctx = _loop_context("ses_turn_finish_integration")
+    user = _message("msg_001", "user")
+    assistant = _message("msg_002", "assistant", finish="stop")
+    ctx.session_ctx = SimpleNamespace(
+        get_messages=AsyncMock(
+            side_effect=[
+                [user],
+                [user, assistant],
+            ]
+        )
+    )
+    run_turn_finish = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            AsyncMock(return_value="final response"),
+        ),
+        patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ),
+        patch(
+            "flocks.session.session_loop.GoalManager.evaluate_after_turn",
+            AsyncMock(
+                return_value=GoalDecision(
+                    status="inactive",
+                    verdict="inactive",
+                )
+            ),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_user_prompt_submit_hook",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_turn_finish_hook",
+            run_turn_finish,
+        ),
+        patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(return_value=StepResult(action="stop")),
+        ),
+        patch(
+            "flocks.session.lifecycle.title.SessionTitle.ensure_title",
+            MagicMock(return_value=None),
+        ),
+        patch(
+            "flocks.session.session_loop.fire_and_forget",
+            MagicMock(),
+        ),
+    ):
+        result = await SessionLoop._run_loop(ctx, LoopCallbacks())
+
+    assert result.action == "stop"
+    run_turn_finish.assert_awaited_once_with(
+        ctx,
+        ANY,
+        user,
+        assistant,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("step_result", "assistant_finish"),
+    [
+        (StepResult(action="stop", error="provider failed"), "error"),
+        (StepResult(action="continue"), "tool-calls"),
+    ],
+)
+async def test_turn_finish_skips_errors_and_tool_calls(
+    step_result: StepResult,
+    assistant_finish: str,
+) -> None:
+    ctx = _loop_context(f"ses_turn_finish_{assistant_finish}")
+    user = _message("msg_001", "user")
+    assistant = _message("msg_002", "assistant", finish=assistant_finish)
+    ctx.session_ctx = SimpleNamespace(
+        get_messages=AsyncMock(
+            side_effect=[
+                [user],
+                [user, assistant],
+            ]
+        )
+    )
+    run_turn_finish = AsyncMock(return_value=False)
+
+    async def process_step(*_args, **_kwargs):
+        if step_result.action == "continue":
+            ctx.signal_abort()
+        return step_result
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_user_prompt_submit_hook",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_turn_finish_hook",
+            run_turn_finish,
+        ),
+        patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(side_effect=process_step),
+        ),
+        patch(
+            "flocks.session.lifecycle.title.SessionTitle.ensure_title",
+            MagicMock(return_value=None),
+        ),
+        patch(
+            "flocks.session.session_loop.fire_and_forget",
+            MagicMock(),
+        ),
+    ):
+        result = await SessionLoop._run_loop(ctx, LoopCallbacks())
+
+    assert result.action == "stop"
+    run_turn_finish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_queued_user_message_takes_priority_over_turn_finish() -> None:
+    ctx = _loop_context("ses_turn_finish_queue")
+    user = _message("msg_001", "user")
+    assistant = _message("msg_002", "assistant", finish="stop")
+    queued_user = _message("msg_003", "user")
+    ctx.session_ctx = SimpleNamespace(
+        get_messages=AsyncMock(
+            side_effect=[
+                [user],
+                [user, assistant, queued_user],
+            ]
+        )
+    )
+    run_turn_finish = AsyncMock(return_value=False)
+
+    async def process_step(*_args, **_kwargs):
+        ctx.signal_abort()
+        return StepResult(action="stop")
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_user_prompt_submit_hook",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_turn_finish_hook",
+            run_turn_finish,
+        ),
+        patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(side_effect=process_step),
+        ),
+        patch(
+            "flocks.session.lifecycle.title.SessionTitle.ensure_title",
+            MagicMock(return_value=None),
+        ),
+        patch(
+            "flocks.session.session_loop.fire_and_forget",
+            MagicMock(),
+        ),
+    ):
+        await SessionLoop._run_loop(ctx, LoopCallbacks())
+
+    run_turn_finish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_goal_continuation_takes_priority_over_turn_finish() -> None:
+    ctx = _loop_context("ses_turn_finish_goal")
+    user = _message("msg_001", "user")
+    assistant = _message("msg_002", "assistant", finish="stop")
+    goal_user = _message("msg_003", "user")
+    ctx.session_ctx = SimpleNamespace(
+        get_messages=AsyncMock(
+            side_effect=[
+                [user],
+                [user, assistant],
+            ]
+        )
+    )
+    run_turn_finish = AsyncMock(return_value=False)
+
+    async def process_step(*_args, **_kwargs):
+        ctx.signal_abort()
+        return StepResult(action="stop")
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.get_text_content",
+            AsyncMock(return_value="not done"),
+        ),
+        patch(
+            "flocks.session.session_loop.Message.create",
+            AsyncMock(return_value=goal_user),
+        ),
+        patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ),
+        patch(
+            "flocks.session.session_loop.GoalManager.evaluate_after_turn",
+            AsyncMock(
+                return_value=GoalDecision(
+                    status="active",
+                    verdict="continue",
+                    should_continue=True,
+                    continuation_prompt="continue the goal",
+                )
+            ),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_user_prompt_submit_hook",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_turn_finish_hook",
+            run_turn_finish,
+        ),
+        patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(side_effect=process_step),
+        ),
+        patch(
+            "flocks.session.lifecycle.title.SessionTitle.ensure_title",
+            MagicMock(return_value=None),
+        ),
+        patch(
+            "flocks.session.session_loop.fire_and_forget",
+            MagicMock(),
+        ),
+    ):
+        await SessionLoop._run_loop(ctx, LoopCallbacks())
+
+    run_turn_finish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_abort_does_not_trigger_turn_finish() -> None:
+    ctx = _loop_context("ses_turn_finish_abort")
+    user = _message("msg_001", "user")
+    ctx.session_ctx = SimpleNamespace(get_messages=AsyncMock(return_value=[user]))
+    run_turn_finish = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(0, 0, None),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_user_prompt_submit_hook",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.session.session_loop.SessionLoop._run_turn_finish_hook",
+            run_turn_finish,
+        ),
+        patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+        patch(
+            "flocks.session.lifecycle.title.SessionTitle.ensure_title",
+            MagicMock(return_value=None),
+        ),
+        patch(
+            "flocks.session.session_loop.fire_and_forget",
+            MagicMock(),
+        ),
+    ):
+        await SessionLoop._run_loop(ctx, LoopCallbacks())
+
+    run_turn_finish.assert_not_awaited()

--- a/tests/session/test_runner_llm_hooks.py
+++ b/tests/session/test_runner_llm_hooks.py
@@ -59,6 +59,9 @@ class _FakeProcessor:
     def get_finish_reason(self):
         return self.finish_reason
 
+    async def drain_parallel_tool_calls(self) -> None:
+        return None
+
 
 class _FakeToolAccumulator:
     def __init__(self, processor):

--- a/tests/session/test_stream_processor.py
+++ b/tests/session/test_stream_processor.py
@@ -461,6 +461,9 @@ class TestToolCallExecution:
         assert post_payload["tool"]["input"] == {"command": "echo changed"}
         assert post_payload["result"]["output"] == "original result"
         assert post_payload["durationMs"] >= 0
+        assert proc.tool_calls["tc_changed"].input == {
+            "command": "echo changed"
+        }
         assert proc.tool_calls["tc_changed"].output == "hook result"
 
     @pytest.mark.asyncio

--- a/tests/session/test_stream_processor.py
+++ b/tests/session/test_stream_processor.py
@@ -683,6 +683,51 @@ class TestToolCallExecution:
         assert post_hook.await_args.args[0]["status"] == "interrupted"
 
     @pytest.mark.asyncio
+    async def test_cancelled_tool_before_persists_interrupted_state(self):
+        proc = _make_processor()
+        store_part = AsyncMock()
+        post_hook = AsyncMock(return_value=HookContext(
+            stage=HookStage.TOOL_AFTER,
+            input={},
+        ))
+
+        with (
+            patch(
+                "flocks.session.streaming.stream_processor.Message.store_part",
+                new=store_part,
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_before",
+                new=AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_after",
+                new=post_hook,
+            ),
+            patch(
+                "flocks.session.streaming.stream_processor.ToolRegistry.execute",
+                new=AsyncMock(),
+            ) as execute,
+        ):
+            await proc.process_event(
+                ToolInputStartEvent(id="tc_before_cancel", tool_name="bash")
+            )
+            with pytest.raises(asyncio.CancelledError):
+                await proc.process_event(ToolCallEvent(
+                    tool_call_id="tc_before_cancel",
+                    tool_name="bash",
+                    input={"command": "sleep 10"},
+                ))
+
+        execute.assert_not_awaited()
+        post_hook.assert_awaited_once()
+        assert post_hook.await_args.args[0]["status"] == "interrupted"
+        assert proc.tool_calls["tc_before_cancel"].status == "error"
+        final_part = store_part.await_args.args[2]
+        assert final_part.state.status == "error"
+        assert final_part.state.error == "Tool execution was interrupted"
+
+    @pytest.mark.asyncio
     async def test_tool_call_executes_tool(self):
         proc = _make_processor()
 

--- a/tests/session/test_stream_processor.py
+++ b/tests/session/test_stream_processor.py
@@ -16,6 +16,7 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from flocks.hooks.pipeline import HookContext, HookStage
 from flocks.tool.registry import ToolResult
 from flocks.session.streaming.stream_processor import StreamProcessor, ToolCallState
 from flocks.session.streaming.stream_events import (
@@ -399,6 +400,285 @@ class TestToolInputStart:
 # ---------------------------------------------------------------------------
 
 class TestToolCallExecution:
+    @pytest.mark.asyncio
+    async def test_tool_before_can_update_input_and_tool_after_can_replace_result(self):
+        proc = _make_processor()
+        execute = AsyncMock(return_value=ToolResult(
+            success=True,
+            output="original result",
+        ))
+
+        async def update_input(payload):
+            payload["tool"]["input"] = {"command": "echo changed"}
+            return HookContext(
+                stage=HookStage.TOOL_BEFORE,
+                input=payload,
+            )
+
+        post_hook = AsyncMock(return_value=HookContext(
+            stage=HookStage.TOOL_AFTER,
+            input={},
+            output={
+                "result": {
+                    "success": True,
+                    "output": "hook result",
+                },
+            },
+        ))
+
+        with (
+            patch(
+                "flocks.session.streaming.stream_processor.Message.store_part",
+                new=AsyncMock(),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_before",
+                new=AsyncMock(side_effect=update_input),
+            ) as pre_hook,
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_after",
+                new=post_hook,
+            ),
+            patch(
+                "flocks.session.streaming.stream_processor.ToolRegistry.execute",
+                new=execute,
+            ),
+        ):
+            await proc.process_event(
+                ToolInputStartEvent(id="tc_changed", tool_name="bash")
+            )
+            await proc.process_event(ToolCallEvent(
+                tool_call_id="tc_changed",
+                tool_name="bash",
+                input={"command": "echo original"},
+            ))
+
+        pre_hook.assert_awaited_once()
+        assert execute.await_args.kwargs["command"] == "echo changed"
+        post_hook.assert_awaited_once()
+        post_payload = post_hook.await_args.args[0]
+        assert post_payload["status"] == "completed"
+        assert post_payload["tool"]["input"] == {"command": "echo changed"}
+        assert post_payload["result"]["output"] == "original result"
+        assert post_payload["durationMs"] >= 0
+        assert proc.tool_calls["tc_changed"].output == "hook result"
+
+    @pytest.mark.asyncio
+    async def test_tool_error_still_emits_tool_after(self):
+        proc = _make_processor()
+        post_hook = AsyncMock(return_value=HookContext(
+            stage=HookStage.TOOL_AFTER,
+            input={},
+        ))
+
+        with (
+            patch(
+                "flocks.session.streaming.stream_processor.Message.store_part",
+                new=AsyncMock(),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_before",
+                new=AsyncMock(return_value=HookContext(
+                    stage=HookStage.TOOL_BEFORE,
+                    input={
+                        "tool": {
+                            "name": "bash",
+                            "input": {"command": "false"},
+                            "callID": "tc_error",
+                        }
+                    },
+                )),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_after",
+                new=post_hook,
+            ),
+            patch(
+                "flocks.session.streaming.stream_processor.ToolRegistry.execute",
+                new=AsyncMock(return_value=ToolResult(
+                    success=False,
+                    error="command failed",
+                )),
+            ),
+        ):
+            await proc.process_event(
+                ToolInputStartEvent(id="tc_error", tool_name="bash")
+            )
+            await proc.process_event(ToolCallEvent(
+                tool_call_id="tc_error",
+                tool_name="bash",
+                input={"command": "false"},
+            ))
+
+        post_hook.assert_awaited_once()
+        post_payload = post_hook.await_args.args[0]
+        assert post_payload["status"] == "error"
+        assert post_payload["error"] == "command failed"
+
+    @pytest.mark.asyncio
+    async def test_tool_before_can_block_and_tool_after_reports_blocked(self):
+        proc = _make_processor()
+        execute = AsyncMock(
+            return_value=ToolResult(success=True, output="should not run")
+        )
+        post_hook = AsyncMock(return_value=HookContext(
+            stage=HookStage.TOOL_AFTER,
+            input={},
+        ))
+
+        with (
+            patch(
+                "flocks.session.streaming.stream_processor.Message.store_part",
+                new=AsyncMock(),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_before",
+                new=AsyncMock(return_value=HookContext(
+                    stage=HookStage.TOOL_BEFORE,
+                    input={
+                        "tool": {
+                            "name": "bash",
+                            "input": {"command": "rm -rf target"},
+                            "callID": "tc_blocked",
+                        }
+                    },
+                    output={
+                        "decision": "block",
+                        "reason": "Destructive command is not allowed",
+                    },
+                )),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_after",
+                new=post_hook,
+            ),
+            patch(
+                "flocks.session.streaming.stream_processor.ToolRegistry.execute",
+                new=execute,
+            ),
+        ):
+            await proc.process_event(
+                ToolInputStartEvent(id="tc_blocked", tool_name="bash")
+            )
+            await proc.process_event(ToolCallEvent(
+                tool_call_id="tc_blocked",
+                tool_name="bash",
+                input={"command": "rm -rf target"},
+            ))
+
+        execute.assert_not_awaited()
+        assert proc.tool_calls["tc_blocked"].status == "error"
+        assert proc.tool_calls["tc_blocked"].error == (
+            "Destructive command is not allowed"
+        )
+        post_payload = post_hook.await_args.args[0]
+        assert post_payload["status"] == "blocked"
+        assert post_payload["error"] == "Destructive command is not allowed"
+
+    @pytest.mark.asyncio
+    async def test_sandbox_block_still_emits_tool_after(self):
+        proc = _make_processor()
+        post_hook = AsyncMock(return_value=HookContext(
+            stage=HookStage.TOOL_AFTER,
+            input={},
+        ))
+
+        with (
+            patch(
+                "flocks.session.streaming.stream_processor.Message.store_part",
+                new=AsyncMock(),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_before",
+                new=AsyncMock(return_value=HookContext(
+                    stage=HookStage.TOOL_BEFORE,
+                    input={
+                        "tool": {
+                            "name": "bash",
+                            "input": {"command": "pwd"},
+                            "callID": "tc_sandbox",
+                        }
+                    },
+                )),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_after",
+                new=post_hook,
+            ),
+            patch.object(
+                proc,
+                "_resolve_sandbox_meta",
+                new=AsyncMock(return_value={
+                    "blocked": True,
+                    "error": "Sandbox denied tool",
+                    "extra": {},
+                }),
+            ),
+            patch(
+                "flocks.session.streaming.stream_processor.ToolRegistry.execute",
+                new=AsyncMock(),
+            ) as execute,
+        ):
+            await proc.process_event(
+                ToolInputStartEvent(id="tc_sandbox", tool_name="bash")
+            )
+            await proc.process_event(ToolCallEvent(
+                tool_call_id="tc_sandbox",
+                tool_name="bash",
+                input={"command": "pwd"},
+            ))
+
+        execute.assert_not_awaited()
+        assert post_hook.await_args.args[0]["status"] == "blocked"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_tool_emits_interrupted_tool_after(self):
+        proc = _make_processor()
+        post_hook = AsyncMock(return_value=HookContext(
+            stage=HookStage.TOOL_AFTER,
+            input={},
+        ))
+
+        with (
+            patch(
+                "flocks.session.streaming.stream_processor.Message.store_part",
+                new=AsyncMock(),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_before",
+                new=AsyncMock(return_value=HookContext(
+                    stage=HookStage.TOOL_BEFORE,
+                    input={
+                        "tool": {
+                            "name": "bash",
+                            "input": {"command": "sleep 10"},
+                            "callID": "tc_interrupted",
+                        }
+                    },
+                )),
+            ),
+            patch(
+                "flocks.hooks.pipeline.HookPipeline.run_tool_after",
+                new=post_hook,
+            ),
+            patch(
+                "flocks.session.streaming.stream_processor.ToolRegistry.execute",
+                new=AsyncMock(side_effect=asyncio.CancelledError()),
+            ),
+        ):
+            await proc.process_event(
+                ToolInputStartEvent(id="tc_interrupted", tool_name="bash")
+            )
+            with pytest.raises(asyncio.CancelledError):
+                await proc.process_event(ToolCallEvent(
+                    tool_call_id="tc_interrupted",
+                    tool_name="bash",
+                    input={"command": "sleep 10"},
+                ))
+
+        post_hook.assert_awaited_once()
+        assert post_hook.await_args.args[0]["status"] == "interrupted"
+
     @pytest.mark.asyncio
     async def test_tool_call_executes_tool(self):
         proc = _make_processor()

--- a/tests/tool/test_subagent_hooks.py
+++ b/tests/tool/test_subagent_hooks.py
@@ -119,6 +119,61 @@ async def test_subagent_stop_reports_child_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_subagent_stop_reports_persisted_message_error() -> None:
+    ctx = ToolContext(
+        session_id="ses_parent",
+        message_id="msg_parent",
+        agent="rex",
+    )
+    last_message = SimpleNamespace(
+        id="msg_child_error",
+        finish="error",
+        error={"message": "provider authentication failed"},
+    )
+    loop_result = SimpleNamespace(
+        action="stop",
+        error=None,
+        last_message=last_message,
+        metadata={},
+    )
+    stop_hook = AsyncMock()
+
+    with (
+        patch(
+            "flocks.tool.agent.delegate_task.SessionLoop.run",
+            AsyncMock(return_value=loop_result),
+        ),
+        patch(
+            "flocks.tool.agent.delegate_task.Message.get_text_content",
+            AsyncMock(return_value=""),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_start",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_stop",
+            stop_hook,
+        ),
+    ):
+        await _run_subagent_with_hooks(
+            ctx=ctx,
+            child_session_id="ses_child",
+            child_agent="explore",
+            workspace="/tmp/project",
+            prompt="inspect hooks",
+            description="Inspect hooks",
+            resumed=False,
+        )
+
+    stop_hook.assert_awaited_once()
+    stop_payload = stop_hook.await_args.args[0]
+    assert stop_payload["status"] == "error"
+    assert stop_payload["summary"] == ""
+    assert stop_payload["error"] == "provider authentication failed"
+
+
+@pytest.mark.asyncio
 async def test_subagent_stop_reports_interruption() -> None:
     ctx = ToolContext(
         session_id="ses_parent",

--- a/tests/tool/test_subagent_hooks.py
+++ b/tests/tool/test_subagent_hooks.py
@@ -157,3 +157,50 @@ async def test_subagent_stop_reports_interruption() -> None:
     assert stop_payload["status"] == "interrupted"
     assert stop_payload["summary"] is None
     assert stop_payload["error"] == "Sub-agent execution was interrupted"
+
+
+@pytest.mark.asyncio
+async def test_subagent_stop_reports_normalized_loop_abort() -> None:
+    ctx = ToolContext(
+        session_id="ses_parent",
+        message_id="msg_parent",
+        agent="rex",
+    )
+    stop_hook = AsyncMock()
+    loop_result = SimpleNamespace(
+        action="stop",
+        error=None,
+        last_message=None,
+        metadata={"aborted": True},
+    )
+
+    with (
+        patch(
+            "flocks.tool.agent.delegate_task.SessionLoop.run",
+            AsyncMock(return_value=loop_result),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_start",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_stop",
+            stop_hook,
+        ),
+    ):
+        result = await _run_subagent_with_hooks(
+            ctx=ctx,
+            child_session_id="ses_child",
+            child_agent="explore",
+            workspace="/tmp/project",
+            prompt="inspect hooks",
+            description="Inspect hooks",
+            resumed=False,
+        )
+
+    assert result is loop_result
+    stop_hook.assert_awaited_once()
+    stop_payload = stop_hook.await_args.args[0]
+    assert stop_payload["status"] == "interrupted"
+    assert stop_payload["summary"] is None
+    assert stop_payload["error"] == "Sub-agent execution was interrupted"

--- a/tests/tool/test_subagent_hooks.py
+++ b/tests/tool/test_subagent_hooks.py
@@ -1,0 +1,159 @@
+"""Tests for paired delegate_task subagent lifecycle hooks."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flocks.tool.agent.delegate_task import _run_subagent_with_hooks
+from flocks.tool.registry import ToolContext
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resumed", [False, True])
+async def test_subagent_hooks_wrap_child_run(resumed: bool) -> None:
+    ctx = ToolContext(
+        session_id="ses_parent",
+        message_id="msg_parent",
+        agent="rex",
+    )
+    last_message = SimpleNamespace(id="msg_child_final")
+    loop_result = SimpleNamespace(
+        action="stop",
+        error=None,
+        last_message=last_message,
+    )
+    start_hook = AsyncMock()
+    stop_hook = AsyncMock()
+
+    with (
+        patch(
+            "flocks.tool.agent.delegate_task.SessionLoop.run",
+            AsyncMock(return_value=loop_result),
+        ) as run_loop,
+        patch(
+            "flocks.tool.agent.delegate_task.Message.get_text_content",
+            AsyncMock(return_value="child summary"),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_start",
+            start_hook,
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_stop",
+            stop_hook,
+        ),
+    ):
+        result = await _run_subagent_with_hooks(
+            ctx=ctx,
+            child_session_id="ses_child",
+            child_agent="explore",
+            workspace="/tmp/project",
+            prompt="inspect hooks",
+            description="Inspect hooks",
+            resumed=resumed,
+        )
+
+    assert result is loop_result
+    run_loop.assert_awaited_once_with(
+        "ses_child",
+        provider_id=None,
+        model_id=None,
+        callbacks=None,
+    )
+    start_payload = start_hook.await_args.args[0]
+    assert start_payload["parentSessionID"] == "ses_parent"
+    assert start_payload["childSessionID"] == "ses_child"
+    assert start_payload["agentType"] == "explore"
+    assert start_payload["resumed"] is resumed
+    stop_payload = stop_hook.await_args.args[0]
+    assert stop_payload["status"] == "completed"
+    assert stop_payload["summary"] == "child summary"
+    assert stop_payload["durationMs"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_subagent_stop_reports_child_error() -> None:
+    ctx = ToolContext(
+        session_id="ses_parent",
+        message_id="msg_parent",
+        agent="rex",
+    )
+    start_hook = AsyncMock()
+    stop_hook = AsyncMock()
+
+    with (
+        patch(
+            "flocks.tool.agent.delegate_task.SessionLoop.run",
+            AsyncMock(side_effect=RuntimeError("child failed")),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_start",
+            start_hook,
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_stop",
+            stop_hook,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="child failed"):
+            await _run_subagent_with_hooks(
+                ctx=ctx,
+                child_session_id="ses_child",
+                child_agent="explore",
+                workspace="/tmp/project",
+                prompt="inspect hooks",
+                description="Inspect hooks",
+                resumed=False,
+            )
+
+    start_hook.assert_awaited_once()
+    stop_hook.assert_awaited_once()
+    stop_payload = stop_hook.await_args.args[0]
+    assert stop_payload["status"] == "error"
+    assert stop_payload["summary"] is None
+    assert stop_payload["error"] == "child failed"
+
+
+@pytest.mark.asyncio
+async def test_subagent_stop_reports_interruption() -> None:
+    ctx = ToolContext(
+        session_id="ses_parent",
+        message_id="msg_parent",
+        agent="rex",
+    )
+    stop_hook = AsyncMock()
+
+    with (
+        patch(
+            "flocks.tool.agent.delegate_task.SessionLoop.run",
+            AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_start",
+            AsyncMock(),
+        ),
+        patch(
+            "flocks.hooks.pipeline.HookPipeline.run_subagent_stop",
+            stop_hook,
+        ),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await _run_subagent_with_hooks(
+                ctx=ctx,
+                child_session_id="ses_child",
+                child_agent="explore",
+                workspace="/tmp/project",
+                prompt="inspect hooks",
+                description="Inspect hooks",
+                resumed=True,
+            )
+
+    stop_hook.assert_awaited_once()
+    stop_payload = stop_hook.await_args.args[0]
+    assert stop_payload["status"] == "interrupted"
+    assert stop_payload["summary"] is None
+    assert stop_payload["error"] == "Sub-agent execution was interrupted"


### PR DESCRIPTION
## Summary

- replace the obsolete `chat_message` lifecycle hook with `user_prompt_submit`
- add `session_start`, `turn_finish`, `subagent_start`, and `subagent_stop`
- preserve the existing per-request `llm_before` / `llm_after` behavior
- retain the public `tool_before` / `tool_after` names while adding input mutation, blocking, final-status pairing, duration reporting, and result replacement
- make hook handler detection require a concrete `HookBase` override
- document lifecycle contracts and add regression coverage

## Behavior

- `user_prompt_submit` fires once for each real, non-synthetic user message and can inject ephemeral context
- `turn_finish` fires only after a persisted final assistant response and can continue the turn through a guarded synthetic message
- queued prompts and GoalManager continuations take precedence over `turn_finish`
- every tool invocation that enters `tool_before` receives a matching `tool_after`, including hook blocks, sandbox blocks, failures, and interruptions
- subagent hooks observe create/resume, success, failure, and interruption paths

## Validation

- `uv run ruff check ...`
- 83 focused Hook and Langfuse regression tests passed
- 40 adjacent Session loop, parallel tool, and delegation assertions passed

## Compatibility

This is an intentional Hook API cleanup. The removed `chat_message` API and the temporary `pre_tool_use` / `post_tool_use` names do not have compatibility aliases.
