### PR TITLE
fix(provider): preserve compatible provider behavior

### DIFF
--- a/flocks/provider/provider.py
+++ b/flocks/provider/provider.py
@@ -1061,7 +1061,10 @@ class BaseProvider:
     
     def configure(self, config: ProviderConfig) -> None:
         """Configure the provider"""
+        config_changed = self._config != config
         self._config = config
+        if config_changed and hasattr(self, "_client"):
+            self._client = None
         self.log.info("provider.configured", {
             "provider_id": self.id,
             "has_api_key": config.api_key is not None,

--- a/flocks/provider/sdk/openai.py
+++ b/flocks/provider/sdk/openai.py
@@ -220,6 +220,7 @@ class OpenAIProvider(BaseProvider):
         
         # Track usage from final chunk (when stream_options.include_usage is set)
         stream_usage: Optional[Dict[str, int]] = None
+        usage_emitted = False
         
         async for chunk in stream:
             # Capture usage from the final chunk (OpenAI returns it in a chunk with no choices)
@@ -248,6 +249,7 @@ class OpenAIProvider(BaseProvider):
                             finish_reason=choice.finish_reason,
                             usage=stream_usage,
                         )
+                    usage_emitted = stream_usage is not None
                 continue
 
             # Handle reasoning/thinking content (for o1/o3/gpt-5 models)
@@ -312,6 +314,13 @@ class OpenAIProvider(BaseProvider):
                         finish_reason=choice.finish_reason,
                         usage=stream_usage,
                     )
+                usage_emitted = stream_usage is not None
+
+        # OpenAI sends the usage-only chunk after the terminal finish chunk.
+        # Surface it separately when it was not available on the terminal chunk
+        # so the runner can persist usage and nested reasoning tokens.
+        if stream_usage and not usage_emitted:
+            yield StreamChunk(delta="", finish_reason=None, usage=stream_usage)
     
     # Embeddings support (added for memory system)
     async def embed(

--- a/flocks/provider/sdk/openai.py
+++ b/flocks/provider/sdk/openai.py
@@ -18,6 +18,7 @@ from flocks.provider.provider import (
 )
 from flocks.provider.sdk.openai_base import (
     DEFAULT_HTTP_TIMEOUT,
+    _normalize_stream_usage,
     build_reasoning_metadata,
     _coerce_bool,
     extract_reasoning_content_with_source,
@@ -223,11 +224,7 @@ class OpenAIProvider(BaseProvider):
         async for chunk in stream:
             # Capture usage from the final chunk (OpenAI returns it in a chunk with no choices)
             if hasattr(chunk, 'usage') and chunk.usage:
-                stream_usage = {
-                    "prompt_tokens": getattr(chunk.usage, 'prompt_tokens', 0) or 0,
-                    "completion_tokens": getattr(chunk.usage, 'completion_tokens', 0) or 0,
-                    "total_tokens": getattr(chunk.usage, 'total_tokens', 0) or 0,
-                }
+                stream_usage = _normalize_stream_usage(chunk.usage)
             
             if not chunk.choices:
                 continue

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -303,12 +303,24 @@ def _normalize_stream_usage(raw_usage: Any) -> Optional[Dict[str, int]]:
     completion_tokens = (_ct if _ct is not None else getattr(raw_usage, "output_tokens", 0)) or 0
     completion_details = getattr(raw_usage, "completion_tokens_details", None)
     output_details = getattr(raw_usage, "output_tokens_details", None)
-    reasoning_tokens = (
-        getattr(raw_usage, "reasoning_tokens", 0)
-        or getattr(completion_details, "reasoning_tokens", 0)
+    nested_reasoning_tokens = (
+        getattr(completion_details, "reasoning_tokens", 0)
         or getattr(output_details, "reasoning_tokens", 0)
         or 0
     )
+    reasoning_tokens = (
+        getattr(raw_usage, "reasoning_tokens", 0)
+        or nested_reasoning_tokens
+        or 0
+    )
+    if nested_reasoning_tokens:
+        # OpenAI reports reasoning_tokens as a breakdown already included in
+        # completion_tokens / output_tokens. Flocks stores visible output and
+        # reasoning separately, so remove that nested subset before persisting.
+        completion_tokens = max(
+            0,
+            completion_tokens - nested_reasoning_tokens,
+        )
     total_tokens = getattr(raw_usage, "total_tokens", 0) or (
         prompt_tokens + completion_tokens + reasoning_tokens
     )

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -301,7 +301,14 @@ def _normalize_stream_usage(raw_usage: Any) -> Optional[Dict[str, int]]:
     prompt_tokens = (_pt if _pt is not None else getattr(raw_usage, "input_tokens", 0)) or 0
     _ct = getattr(raw_usage, "completion_tokens", None)
     completion_tokens = (_ct if _ct is not None else getattr(raw_usage, "output_tokens", 0)) or 0
-    reasoning_tokens = getattr(raw_usage, "reasoning_tokens", 0) or 0
+    completion_details = getattr(raw_usage, "completion_tokens_details", None)
+    output_details = getattr(raw_usage, "output_tokens_details", None)
+    reasoning_tokens = (
+        getattr(raw_usage, "reasoning_tokens", 0)
+        or getattr(completion_details, "reasoning_tokens", 0)
+        or getattr(output_details, "reasoning_tokens", 0)
+        or 0
+    )
     total_tokens = getattr(raw_usage, "total_tokens", 0) or (
         prompt_tokens + completion_tokens + reasoning_tokens
     )

--- a/flocks/security/__init__.py
+++ b/flocks/security/__init__.py
@@ -52,13 +52,19 @@ def _resolve_fofa_derived_secret(secret_id: str, secrets: SecretManager) -> Opti
 
 
 def resolve_secret_value(secret_id: str, secrets: Optional[SecretManager] = None) -> Optional[str]:
-    """Resolve a secret by id, including provider-specific derived secrets."""
+    """Resolve a secret by id, including read-only legacy fallbacks."""
     if secrets is None:
         secrets = get_secret_manager()
 
     value = secrets.get(secret_id)
     if value is not None:
         return value
+
+    if secret_id.endswith("_llm_key"):
+        provider_id = secret_id.removesuffix("_llm_key")
+        legacy_value = secrets.get(f"{provider_id}_api_key")
+        if legacy_value is not None:
+            return legacy_value
 
     return _resolve_fofa_derived_secret(secret_id, secrets)
 

--- a/flocks/server/routes/provider.py
+++ b/flocks/server/routes/provider.py
@@ -1938,6 +1938,10 @@ async def set_provider_credentials(
                 config_dict["name"] = request.provider_name
             ConfigWriter.add_provider(provider_id, config_dict)
 
+        # Config.get() caches resolved secret values. Invalidate it after
+        # persisting credentials so a later session cannot reapply the old key.
+        Config.clear_cache()
+
         # 3. Configure the provider runtime so is_configured() reflects the change
         await _ensure_provider_initialized()
         provider = Provider.get(provider_id)

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -764,6 +764,53 @@ class TestOpenAIBaseProviderStreamingUsage:
         }
 
     @pytest.mark.asyncio
+    async def test_chat_stream_preserves_nested_reasoning_tokens(self):
+        provider, create = self._build_provider_with_stream()
+
+        content_chunk = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(content="hello", tool_calls=None),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        )
+        usage_chunk = SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(
+                prompt_tokens=11,
+                completion_tokens=7,
+                total_tokens=18,
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=5),
+            ),
+        )
+        finish_chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=None, finish_reason="stop")],
+            usage=None,
+        )
+        create.return_value = _stream_from_chunks(
+            content_chunk, usage_chunk, finish_chunk
+        )
+
+        from flocks.provider.provider import ChatMessage
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "gpt-5.6-luna",
+                [ChatMessage(role="user", content="hello")],
+            )
+        ]
+
+        assert chunks[-1].usage == {
+            "prompt_tokens": 11,
+            "completion_tokens": 7,
+            "total_tokens": 18,
+            "reasoning_tokens": 5,
+        }
+
+    @pytest.mark.asyncio
     async def test_chat_stream_emits_trailing_usage_when_usage_only_chunk_arrives_after_finish(self):
         provider, create = self._build_provider_with_stream()
 

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -805,7 +805,7 @@ class TestOpenAIBaseProviderStreamingUsage:
 
         assert chunks[-1].usage == {
             "prompt_tokens": 11,
-            "completion_tokens": 7,
+            "completion_tokens": 2,
             "total_tokens": 18,
             "reasoning_tokens": 5,
         }

--- a/tests/provider/test_openai_provider.py
+++ b/tests/provider/test_openai_provider.py
@@ -1,7 +1,15 @@
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from flocks.provider.provider import ProviderConfig
+import pytest
+
+from flocks.provider.provider import ChatMessage, ProviderConfig
 from flocks.provider.sdk.openai import OpenAIProvider
+
+
+async def _stream_from_chunks(*chunks):
+    for chunk in chunks:
+        yield chunk
 
 
 class TestOpenAIProviderConfiguration:
@@ -40,3 +48,57 @@ class TestOpenAIProviderConfiguration:
             base_url="https://gateway.internal/v1",
             http_client=http_client,
         )
+
+    def test_configure_invalidates_existing_client_when_credentials_change(self):
+        provider = OpenAIProvider()
+        stale_client = MagicMock()
+        provider._client = stale_client
+
+        provider.configure(
+            ProviderConfig(
+                provider_id=provider.id,
+                api_key="new-api-key",
+                base_url="https://new-gateway.internal/v1",
+            )
+        )
+
+        assert provider._client is None
+
+
+class TestOpenAIProviderStreamingUsage:
+    @pytest.mark.asyncio
+    async def test_chat_stream_preserves_nested_reasoning_tokens(self):
+        provider = OpenAIProvider()
+        create = AsyncMock()
+        provider._client = MagicMock()
+        provider._client.chat.completions.create = create
+
+        usage_chunk = SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(
+                prompt_tokens=11,
+                completion_tokens=7,
+                total_tokens=18,
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=5),
+            ),
+        )
+        finish_chunk = SimpleNamespace(
+            choices=[SimpleNamespace(delta=None, finish_reason="stop")],
+            usage=None,
+        )
+        create.return_value = _stream_from_chunks(usage_chunk, finish_chunk)
+
+        chunks = [
+            chunk
+            async for chunk in provider.chat_stream(
+                "gpt-5.6-luna",
+                [ChatMessage(role="user", content="hello")],
+            )
+        ]
+
+        assert chunks[-1].usage == {
+            "prompt_tokens": 11,
+            "completion_tokens": 7,
+            "total_tokens": 18,
+            "reasoning_tokens": 5,
+        }

--- a/tests/provider/test_openai_provider.py
+++ b/tests/provider/test_openai_provider.py
@@ -86,7 +86,7 @@ class TestOpenAIProviderStreamingUsage:
             choices=[SimpleNamespace(delta=None, finish_reason="stop")],
             usage=None,
         )
-        create.return_value = _stream_from_chunks(usage_chunk, finish_chunk)
+        create.return_value = _stream_from_chunks(finish_chunk, usage_chunk)
 
         chunks = [
             chunk
@@ -98,7 +98,7 @@ class TestOpenAIProviderStreamingUsage:
 
         assert chunks[-1].usage == {
             "prompt_tokens": 11,
-            "completion_tokens": 7,
+            "completion_tokens": 2,
             "total_tokens": 18,
             "reasoning_tokens": 5,
         }

--- a/tests/security/test_secret_resolution.py
+++ b/tests/security/test_secret_resolution.py
@@ -25,6 +25,20 @@ def test_resolve_secret_value_prefers_real_fofa_split_secrets():
     assert resolve_secret_value("fofa_api_key", secrets) == "override-api-key"
 
 
+def test_resolve_secret_value_reads_legacy_llm_key_without_mutating_secrets():
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "custom-codex_api_key": "legacy-provider-key",
+    }.get(key)
+
+    assert (
+        resolve_secret_value("custom-codex_llm_key", secrets)
+        == "legacy-provider-key"
+    )
+    secrets.set.assert_not_called()
+    secrets.delete.assert_not_called()
+
+
 def test_resolve_secret_refs_returns_empty_for_invalid_fofa_canonical_secret():
     secrets = MagicMock()
     secrets.get.side_effect = lambda key: {

--- a/tests/server/routes/test_provider_optional_api_key.py
+++ b/tests/server/routes/test_provider_optional_api_key.py
@@ -32,6 +32,8 @@ def patched_runtime(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("flocks.security.get_secret_manager", lambda: fake_secrets)
     monkeypatch.setattr(provider_routes.Provider, "_ensure_initialized", MagicMock())
     monkeypatch.setattr(provider_routes.Provider, "get", lambda _pid: runtime_provider)
+    clear_config_cache = MagicMock()
+    monkeypatch.setattr(provider_routes.Config, "clear_cache", clear_config_cache)
 
     # Pretend the provider already exists in flocks.json so set_provider_credentials
     # follows the "update existing" path and never calls add_provider() with real
@@ -58,10 +60,30 @@ def patched_runtime(monkeypatch: pytest.MonkeyPatch):
         lambda _provider: {},
     )
 
-    return {"secrets": fake_secrets, "provider": runtime_provider}
+    return {
+        "secrets": fake_secrets,
+        "provider": runtime_provider,
+        "clear_config_cache": clear_config_cache,
+    }
 
 
 class TestOptionalApiKey:
+    @pytest.mark.asyncio
+    async def test_saving_credentials_invalidates_resolved_config_cache(
+        self, patched_runtime
+    ):
+        """The next request must not reapply a secret cached before this update."""
+        result = await provider_routes.set_provider_credentials(
+            "custom-local-gateway",
+            provider_routes.ProviderCredentialRequest(
+                api_key="new-secret",
+                base_url="http://127.0.0.1:8317/v1",
+            ),
+        )
+
+        assert result["success"] is True
+        patched_runtime["clear_config_cache"].assert_called_once_with()
+
     @pytest.mark.asyncio
     async def test_openai_compatible_accepts_empty_api_key(self, patched_runtime):
         """openai-compatible: empty api_key -> success, placeholder persisted."""

--- a/webui/src/pages/Model/index.test.tsx
+++ b/webui/src/pages/Model/index.test.tsx
@@ -311,6 +311,15 @@ describe('ModelPage configure provider dialog', () => {
     expect(mocks.revealCredentials).toHaveBeenCalledWith('openai');
   }
 
+  it('does not test provider credentials when the page loads', async () => {
+    renderWithRouter(<ModelPage />);
+
+    await waitFor(() => {
+      expect(mocks.getCredentials).toHaveBeenCalledWith('openai');
+    });
+    expect(mocks.testCredentials).not.toHaveBeenCalled();
+  });
+
   it('displays and preserves the existing API key when saving a new base URL', async () => {
     const user = userEvent.setup();
     await openConfigureDialog(user);
@@ -327,6 +336,7 @@ describe('ModelPage configure provider dialog', () => {
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(mocks.setCredentials).toHaveBeenCalled());
+    expect(mocks.testCredentials).not.toHaveBeenCalled();
     const payload = mocks.setCredentials.mock.calls.at(-1)?.[1];
     expect(payload).toEqual(expect.objectContaining({
       base_url: 'https://new.example.com/v1',

--- a/webui/src/pages/Model/index.tsx
+++ b/webui/src/pages/Model/index.tsx
@@ -185,11 +185,6 @@ export default function ModelPage() {
     });
   }, []);
 
-  // Auto-test all configured providers on initial load, with cache (connected: 1h, failed: 5min)
-  const [autoTested, setAutoTested] = useState(false);
-  const handleTestConnectionRef = useRef<(id: string, silent?: boolean) => Promise<void>>(null!);
-
-
   // Only show configured (connected) providers
   const configuredProviders = useMemo(() => {
     return providers.filter(p => p.configured).sort((a, b) => a.name.localeCompare(b.name));
@@ -270,42 +265,28 @@ export default function ModelPage() {
   }, []);
   handleSelectProviderRef.current = handleSelectProvider;
 
-  const handleTestConnection = async (providerId: string, silent = false) => {
-    try {
-      const response = await providerAPI.testCredentials(providerId);
-      if (response.data.success) {
-        setConnectionStatus(prev => ({ ...prev, [providerId]: 'connected' }));
-        saveConnectionCache(providerId, 'connected');
-        if (!silent) toast.success(t('testSuccess'), `${t('latency')}: ${response.data.latency_ms}ms`);
-      } else {
-        setConnectionStatus(prev => ({ ...prev, [providerId]: 'failed' }));
-        saveConnectionCache(providerId, 'failed');
-        if (!silent) toast.error(t('testFailed'), response.data.message);
-      }
-    } catch (err: any) {
-      setConnectionStatus(prev => ({ ...prev, [providerId]: 'failed' }));
-      saveConnectionCache(providerId, 'failed');
-      if (!silent) toast.error(t('testFailed'), err.message);
-    }
-  };
-  handleTestConnectionRef.current = handleTestConnection;
-
-  // Auto-test effect (runs once after handlers are defined)
+  // Restore statuses from explicit connection tests without issuing API calls.
   useEffect(() => {
-    if (!loading && !autoTested && providers.length > 0) {
-      setAutoTested(true);
-      const cache = loadConnectionCache();
-      const configuredList = providers.filter(p => p.configured);
-      configuredList.forEach(p => {
-        const cached = getCachedStatus(cache, p.id);
-        if (cached !== null) {
-          setConnectionStatus(prev => ({ ...prev, [p.id]: cached }));
+    if (!loading && providers.length > 0) {
+      const cachedStatuses = loadConnectionCache();
+      setConnectionStatus(prev => {
+        let changed = false;
+        const next = { ...prev };
+        providers.filter(p => p.configured).forEach(p => {
+          const cached = getCachedStatus(cachedStatuses, p.id);
+          if (cached !== null && next[p.id] !== cached) {
+            next[p.id] = cached;
+            changed = true;
+          }
+        });
+        if (changed) {
+          return next;
         } else {
-          handleTestConnectionRef.current(p.id, true);
+          return prev;
         }
       });
     }
-  }, [loading, providers, autoTested]);
+  }, [loading, providers]);
 
   const handleDeleteProvider = async (providerId: string) => {
     const isDefaultAffected = defaultModel && defaultModel.provider_id === providerId;
@@ -363,10 +344,7 @@ export default function ModelPage() {
     if (addedProviderId) {
       setConnectionStatus(prev => ({ ...prev, [addedProviderId]: 'unknown' }));
       setPendingSelectId(addedProviderId);
-      setTimeout(() => {
-        refetch();
-        handleTestConnection(addedProviderId, true);
-      }, 500);
+      setTimeout(() => refetch(), 500);
     } else {
       setTimeout(() => refetch(), 300);
     }
@@ -577,8 +555,6 @@ export default function ModelPage() {
               setCredentials(res.data);
               // Refresh model list in right panel
               handleSelectProvider(selectedProvider);
-              // Auto-test after credential update
-              handleTestConnection(selectedProvider.id, true);
             }
             refetch();
             setShowConfigDialog(false);


### PR DESCRIPTION
## Summary

- preserve existing custom-provider credentials through read-only legacy secret resolution and invalidate cached provider clients/config after updates
- retain nested reasoning-token usage from OpenAI-compatible streaming responses
- stop the Provider page from issuing automatic credential tests and real model requests on load or save
- add regression coverage for credential compatibility, cache invalidation, reasoning usage, and explicit-only connection tests

## Validation

- `uv run ruff check ...` — passed
- `npm run test:run -- src/pages/Model/index.test.tsx` — 6 passed
- `npm run lint` — passed
- `npm run build` — passed
- targeted Python suite — 67 passed, 1 pre-existing baseline failure: the test expects HTTP read/write timeout values of 600 seconds while the existing `dev` implementation uses 180/1800 seconds; this PR does not change those timeout values
- `git diff --check` — passed