### PR TITLE
Add Kimi K2.7 Code HighSpeed model

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -1281,6 +1281,32 @@
           "currency": "CNY"
         }
       },
+      "kimi-k2.7-code-highspeed": {
+        "name": "Kimi K2.7 Code HighSpeed",
+        "family": "kimi-k2.7-code",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_vision": true,
+          "supports_reasoning": true,
+          "interleaved": {
+            "field": "reasoning_content",
+            "echo": "tool_calls",
+            "placeholder": " ",
+            "cross_provider_policy": "placeholder"
+          },
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 262144,
+          "max_output_tokens": 32768
+        },
+        "pricing": {
+          "input": 13.0,
+          "output": 54.0,
+          "cache_read": 2.6,
+          "currency": "CNY"
+        }
+      },
       "kimi-k2.5": {
         "name": "Kimi K2.5",
         "family": "kimi-k2.5",

--- a/flocks/provider/interleaved.py
+++ b/flocks/provider/interleaved.py
@@ -6,6 +6,11 @@ from typing import Any, Dict, Optional
 
 REASONING_TRANSPORT_GENERIC_CHAT = "generic_chat"
 REASONING_TRANSPORT_ANTHROPIC_MESSAGES = "anthropic_messages"
+KIMI_K27_CODE_MODELS = frozenset({
+    "kimi-k2.7-code",
+    "kimi-k2.7-code-highspeed",
+})
+KIMI_K3_MODELS = frozenset({"kimi-k3"})
 
 
 _STRICT_REASONING_CONTENT = {
@@ -43,10 +48,8 @@ _STRICT_REASONING_CONTENT_TOKENS = (
     "r1-0528",
     "kimi-k2.5",
     "kimi-k2.6",
-    "kimi-k2.7",
     "kimi-k2-thinking",
     "kimi-k2-thinking-turbo",
-    "kimi-k3",
     "k2-thinking",
     "k2-thinking-turbo",
     "mimo",
@@ -89,6 +92,18 @@ def _matches_any(text: str, *tokens: str) -> bool:
     return any(token in text for token in tokens)
 
 
+def normalize_model_id(model_id: str) -> str:
+    return model_id.strip().lower().replace("_", "-")
+
+
+def is_kimi_k27_code_model(model_id: str) -> bool:
+    return normalize_model_id(model_id) in KIMI_K27_CODE_MODELS
+
+
+def is_kimi_k3_model(model_id: str) -> bool:
+    return normalize_model_id(model_id) in KIMI_K3_MODELS
+
+
 def infer_interleaved_capability(
     *,
     provider_id: str,
@@ -102,7 +117,7 @@ def infer_interleaved_capability(
     works without user-visible toggles.
     """
     pid = _lower(provider_id)
-    mid = _lower(model_id)
+    mid = normalize_model_id(model_id)
     burl = _lower(base_url)
 
     if "minimax" in mid or pid == "minimax":
@@ -124,6 +139,8 @@ def infer_interleaved_capability(
     ):
         return dict(_PROMOTE_REASONING_CONTENT)
 
+    if is_kimi_k27_code_model(mid) or is_kimi_k3_model(mid):
+        return dict(_STRICT_REASONING_CONTENT)
     if _matches_any(mid, *_STRICT_REASONING_CONTENT_TOKENS):
         return dict(_STRICT_REASONING_CONTENT)
     if (

--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, Optional, Tuple
 from flocks.provider.interleaved import (
     REASONING_TRANSPORT_ANTHROPIC_MESSAGES,
     REASONING_TRANSPORT_GENERIC_CHAT,
+    is_kimi_k27_code_model,
+    is_kimi_k3_model,
     resolve_interleaved_capability,
     resolve_reasoning_transport,
 )
@@ -230,7 +232,7 @@ def _build_generic_chat_extra_body(
     model_lower = model_id.lower()
     enabled = reasoning_enabled is not False
 
-    if "kimi-k3" in model_lower:
+    if is_kimi_k3_model(model_id):
         effort = reasoning_effort or DEFAULT_KIMI_K3_REASONING_EFFORT
         if effort not in KIMI_K3_REASONING_EFFORTS:
             log.warning(
@@ -271,7 +273,7 @@ def _build_generic_chat_extra_body(
             )
         }
 
-    if "kimi-k2.7" in model_lower:
+    if is_kimi_k27_code_model(model_id):
         # K2.7 cannot disable thinking. Send the enabled form explicitly
         # because OpenAI-compatible gateways may not apply Moonshot's default.
         return {"thinking": {"type": "enabled"}}
@@ -399,8 +401,8 @@ def build_provider_options(
         configured_extra_body
         or interleaved_enabled
         or reasoning_enabled is True
-        or "kimi-k2.7" in model_lower
-        or "kimi-k3" in model_lower
+        or is_kimi_k27_code_model(model_id)
+        or is_kimi_k3_model(model_id)
     ):
         automatic_extra_body = _build_generic_chat_extra_body(
             provider_id,
@@ -410,7 +412,7 @@ def build_provider_options(
             reasoning_effort,
         )
         extra_body = dict(configured_extra_body or automatic_extra_body or {})
-        if "kimi-k3" in model_lower:
+        if is_kimi_k3_model(model_id):
             # K3 is always a reasoning model and uses the top-level
             # reasoning_effort field instead of the K2.x thinking object.
             extra_body.pop("thinking", None)
@@ -426,7 +428,7 @@ def build_provider_options(
                         "reasoning_effort",
                         DEFAULT_KIMI_K3_REASONING_EFFORT,
                     )
-        elif "kimi-k2.7" in model_lower:
+        elif is_kimi_k27_code_model(model_id):
             # K2.7 rejects disabled thinking. Normalize configured values so
             # direct and gateway-backed endpoints always request reasoning.
             extra_body["thinking"] = {"type": "enabled"}

--- a/flocks/provider/sdk/openai_base.py
+++ b/flocks/provider/sdk/openai_base.py
@@ -20,6 +20,7 @@ from flocks.provider.provider import (
     ModelInfo,
     StreamChunk,
 )
+from flocks.provider.interleaved import is_kimi_k27_code_model, is_kimi_k3_model
 from flocks.utils.log import Log
 
 log = Log.create(service="provider.openai_base")
@@ -396,8 +397,7 @@ def _is_effective_thinking_enabled(
     extra_body: Dict[str, Any],
 ) -> bool:
     """Return the effective reasoning state represented by a request."""
-    model_lower = model_id.lower()
-    if "kimi-k2.7" in model_lower or "kimi-k3" in model_lower:
+    if is_kimi_k27_code_model(model_id) or is_kimi_k3_model(model_id):
         return True
 
     if isinstance(thinking, dict):
@@ -963,7 +963,7 @@ class OpenAIBaseProvider(BaseProvider):
             params,
             max_tokens,
             prefer_completion_tokens=(
-                self.PREFER_MAX_COMPLETION_TOKENS or "kimi-k3" in model_id.lower()
+                self.PREFER_MAX_COMPLETION_TOKENS or is_kimi_k3_model(model_id)
             ),
             completion_tokens_explicit=max_completion_tokens_explicit,
         )
@@ -1056,7 +1056,7 @@ class OpenAIBaseProvider(BaseProvider):
             params,
             max_tokens,
             prefer_completion_tokens=(
-                self.PREFER_MAX_COMPLETION_TOKENS or "kimi-k3" in model_id.lower()
+                self.PREFER_MAX_COMPLETION_TOKENS or is_kimi_k3_model(model_id)
             ),
             completion_tokens_explicit=max_completion_tokens_explicit,
         )

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -171,6 +171,7 @@ class TestCuratedCatalogModels:
         assert {m.id for m in models} == {
             "kimi-k3",
             "kimi-k2.7-code",
+            "kimi-k2.7-code-highspeed",
             "kimi-k2.5",
             "kimi-k2.6",
         }
@@ -194,6 +195,16 @@ class TestCuratedCatalogModels:
         assert k27.pricing.cache_read == 1.3
         assert k27.limits.context_window == 262144
         assert k27.limits.max_output_tokens == 32768
+
+        k27_highspeed = next(m for m in models if m.id == "kimi-k2.7-code-highspeed")
+        assert k27_highspeed.capabilities.supports_vision is True
+        assert k27_highspeed.capabilities.supports_reasoning is True
+        assert k27_highspeed.capabilities.interleaved["field"] == "reasoning_content"
+        assert k27_highspeed.pricing.input == 13.0
+        assert k27_highspeed.pricing.output == 54.0
+        assert k27_highspeed.pricing.cache_read == 2.6
+        assert k27_highspeed.limits.context_window == 262144
+        assert k27_highspeed.limits.max_output_tokens == 32768
 
         k26 = next(m for m in models if m.id == "kimi-k2.6")
         assert k26.capabilities.supports_vision is True

--- a/tests/provider/test_openai_base_provider.py
+++ b/tests/provider/test_openai_base_provider.py
@@ -630,6 +630,7 @@ class TestOpenAIBaseProviderTemperature:
         [
             ("kimi-k2.6", {"thinking": {"type": "enabled"}}),
             ("kimi-k2.7-code", {"thinking": {"type": "enabled"}}),
+            ("kimi-k2.7-code-highspeed", {"thinking": {"type": "enabled"}}),
             ("kimi-k3", {"reasoning_effort": "max"}),
         ],
     )

--- a/tests/provider/test_openai_compatible_provider.py
+++ b/tests/provider/test_openai_compatible_provider.py
@@ -184,7 +184,18 @@ class TestOpenAICompatibleProviderTemperature:
         assert create.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_stream_logs_effective_kimi_k3_thinking_state(self):
+    @pytest.mark.parametrize(
+        ("model_id", "extra_body"),
+        [
+            ("kimi-k2.7-code-highspeed", {"thinking": {"type": "enabled"}}),
+            ("kimi-k3", {"reasoning_effort": "max"}),
+        ],
+    )
+    async def test_stream_logs_effective_kimi_thinking_state(
+        self,
+        model_id,
+        extra_body,
+    ):
         provider, create = _build_provider_with_client()
         provider.log = MagicMock()
         create.return_value = _stream_from_chunks(
@@ -202,9 +213,9 @@ class TestOpenAICompatibleProviderTemperature:
         _ = [
             chunk
             async for chunk in provider.chat_stream(
-                "kimi-k3",
+                model_id,
                 [ChatMessage(role="user", content="hello")],
-                extra_body={"reasoning_effort": "max"},
+                extra_body=extra_body,
             )
         ]
 

--- a/tests/provider/test_provider_options.py
+++ b/tests/provider/test_provider_options.py
@@ -68,6 +68,16 @@ class TestBuildProviderOptions:
 
         assert options["extra_body"] == KIMI_THINKING_EXTRA_BODY
 
+    def test_moonshot_kimi_k27_highspeed_forces_official_thinking_payload(self):
+        options = provider_options.build_provider_options(
+            "moonshot",
+            "kimi-k2.7-code-highspeed",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == KIMI_THINKING_EXTRA_BODY
+
     def test_moonshot_kimi_k3_uses_default_reasoning_effort(self):
         options = provider_options.build_provider_options(
             "moonshot",
@@ -81,7 +91,7 @@ class TestBuildProviderOptions:
     def test_kimi_k27_forces_thinking_even_when_toggle_is_disabled(self):
         options = provider_options.build_provider_options(
             "threatbook-cn-llm",
-            "kimi-k2.7-code",
+            "kimi-k2.7-code-highspeed",
             reasoning_enabled=False,
             resolve_max_tokens=False,
         )

--- a/tests/provider/test_thinking_params.py
+++ b/tests/provider/test_thinking_params.py
@@ -47,6 +47,7 @@ import pytest
 
 from flocks.provider import model_catalog
 from flocks.provider import options as provider_options
+from flocks.provider.interleaved import is_kimi_k27_code_model, is_kimi_k3_model
 
 DEEPSEEK_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
 GLM_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled", "clear_thinking": False}}
@@ -98,9 +99,9 @@ def _expected_generic_chat_extra_body(
         return GLM_THINKING_EXTRA_BODY
     if "mimo" in model_lower:
         return MIMO_THINKING_EXTRA_BODY
-    if "kimi-k3" in model_lower:
+    if is_kimi_k3_model(model_id):
         return {"reasoning_effort": "max"}
-    if "kimi-k2.7" in model_lower:
+    if is_kimi_k27_code_model(model_id):
         return KIMI_THINKING_EXTRA_BODY
     if "kimi" in model_lower:
         return KIMI_THINKING_EXTRA_BODY
@@ -441,8 +442,9 @@ class TestDispatchShape:
             ("qwen3-7b-uncatalogued", {"enable_thinking": True}),
             ("glm-5-uncatalogued", GLM_THINKING_EXTRA_BODY),
             ("kimi-k2.6-uncatalogued", KIMI_THINKING_EXTRA_BODY),
-            ("kimi-k2.7-code-uncatalogued", KIMI_THINKING_EXTRA_BODY),
-            ("kimi-k3-uncatalogued", {"reasoning_effort": "max"}),
+            ("kimi-k2.7-code", KIMI_THINKING_EXTRA_BODY),
+            ("kimi-k2.7-code-highspeed", KIMI_THINKING_EXTRA_BODY),
+            ("kimi-k3", {"reasoning_effort": "max"}),
             ("mimo-v2.5-pro-uncatalogued", MIMO_THINKING_EXTRA_BODY),
             ("minimax-m4-uncatalogued", {"reasoning_split": True}),
             ("step-3.5-flash-uncatalogued", {"enable_thinking": True}),
@@ -470,6 +472,16 @@ class TestDispatchShape:
             "series-token fallback should have inferred interleaved and "
             f"emitted {expected_extra_body}. options={options!r}"
         )
+
+    def test_kimi_k27_dispatch_does_not_match_unknown_suffix(self) -> None:
+        options = provider_options.build_provider_options(
+            "openai-compatible",
+            "kimi-k2.7-code-future",
+            reasoning_enabled=False,
+            resolve_max_tokens=False,
+        )
+
+        assert "extra_body" not in options
 
     @pytest.mark.parametrize(
         "provider_id,model_id,expected_extra_body",


### PR DESCRIPTION
## 变更说明

- 为 Moonshot/Kimi 供应商新增 `kimi-k2.7-code-highspeed` 模型。
- 补充 Kimi K2.7 Code / HighSpeed / K3 的显式模型识别，避免通过宽泛子串误匹配未来模型。
- 确保 K2.7 Code 系列按官方要求始终发送 `thinking.enabled`，K3 使用 `reasoning_effort`。
- 补充 catalog、provider options、interleaved、OpenAIBase/OpenAICompatible 回归测试。

## 测试

- `git diff --check`
- `python3 -m json.tool flocks/provider/catalog.json`
- `uv run pytest tests/provider/test_chinese_providers.py tests/provider/test_provider_options.py tests/provider/test_thinking_params.py tests/provider/test_openai_base_provider.py tests/provider/test_openai_compatible_provider.py -q`