### PR TITLE
fix(session): unify conversation history rendering

### DIFF
--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -2007,9 +2007,10 @@ async def get_session_messages(
         return result
     except Exception as e:
         log.error("session.messages.error", {"error": str(e), "sessionID": sessionID})
-        if page or before is not None:
-            return MessagePage(sessionID=sessionID, items=[], hasMore=False, nextBefore=None)
-        return []
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to load session messages",
+        ) from e
 
 
 @router.get(

--- a/tests/server/routes/test_session_routes.py
+++ b/tests/server/routes/test_session_routes.py
@@ -1061,6 +1061,24 @@ class TestSessionMessages:
         assert len(data) == 0
 
     @pytest.mark.asyncio
+    async def test_list_messages_reports_storage_failure(
+        self,
+        client: AsyncClient,
+        session_id: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A read failure must not look like a successfully empty history."""
+        monkeypatch.setattr(
+            Message,
+            "list_with_parts",
+            AsyncMock(side_effect=RuntimeError("storage unavailable")),
+        )
+
+        resp = await client.get(f"/api/session/{session_id}/message")
+
+        assert resp.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    @pytest.mark.asyncio
     async def test_send_message_noReply(self, client: AsyncClient, session_id: str):
         """POST /api/session/{id}/message with noReply=True stores without triggering LLM."""
         payload = {

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -272,6 +272,7 @@ beforeEach(() => {
     updateMessage: vi.fn(),
     updateMessagePart: vi.fn(),
     removeMessage: vi.fn(),
+    clearMessages: vi.fn(),
     replaceMessageText: vi.fn(),
     truncateAfterMessage: vi.fn(),
   });
@@ -669,7 +670,139 @@ describe('getMessageGroupClassName', () => {
   });
 });
 
+describe('SessionChat embedded full layout', () => {
+  it('reserves horizontal space for avatars in full-width panels', () => {
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'assistant-contained-avatar',
+          role: 'assistant',
+          parts: [{ id: 'text-1', type: 'text', text: 'Task complete.' } as any],
+        }),
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      removeMessage: vi.fn(),
+      replaceMessageText: vi.fn(),
+      markMessageStopped: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    const { container } = render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      hideInput: true,
+      display: {
+        compact: false,
+        fullWidth: true,
+        pageCanvas: true,
+      },
+    }));
+
+    expect(container.querySelector('.space-y-5.px-12')).toBeInTheDocument();
+  });
+});
+
 describe('SessionChat copy action', () => {
+  it('excludes hidden task metadata from copied text', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'assistant-copy-filtered',
+          role: 'assistant',
+          parts: [{
+            id: 'text-1',
+            type: 'text',
+            text: 'copy this result\n\n<task_metadata>\nsession_id: ses-child\n</task_metadata>',
+          }],
+        }),
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      display: { compact: false, showActions: true },
+    }));
+
+    await user.click(screen.getByRole('button', { name: 'chat.copy' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+
+    const copiedText = writeText.mock.calls[0][0];
+    expect(copiedText).toContain('copy this result');
+    expect(copiedText).not.toContain('task_metadata');
+    expect(copiedText).not.toContain('ses-child');
+  });
+
+  it('preserves user-authored task metadata in the bubble and copied text', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const text = [
+      'Please explain this payload:',
+      '',
+      '```xml',
+      '<task_metadata>',
+      'session_id: ses-user-example',
+      '</task_metadata>',
+      '```',
+    ].join('\n');
+
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'user-task-metadata-example',
+          role: 'user',
+          parts: [{ id: 'text-1', type: 'text', text }],
+        }),
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      display: { compact: false, showActions: true },
+    }));
+
+    expect(screen.getByText(/session_id: ses-user-example/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'chat.copy' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(text));
+  });
+
   it('falls back when async clipboard is unavailable', async () => {
     const user = userEvent.setup();
     const execCommand = vi.fn().mockReturnValue(true);
@@ -1008,6 +1141,38 @@ describe('SessionChat standalone thinking indicator', () => {
     }
   });
 
+  it('clears local messages before refetching after session.cleared', () => {
+    const clearMessages = vi.fn();
+    const refetch = vi.fn();
+    useSessionMessagesMock.mockReturnValue({
+      messages: [makeMessage({ id: 'message-before-clear', role: 'assistant', parts: [] })],
+      loading: false,
+      refetch,
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      removeMessage: vi.fn(),
+      clearMessages,
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    act(() => {
+      useSSEOptionsRef.current.onEvent({
+        type: 'session.cleared',
+        properties: { sessionID: 'sess-1' },
+      });
+    });
+
+    expect(clearMessages).toHaveBeenCalledOnce();
+    expect(refetch).toHaveBeenCalledOnce();
+    expect(clearMessages.mock.invocationCallOrder[0]).toBeLessThan(
+      refetch.mock.invocationCallOrder[0],
+    );
+  });
+
   it('removes an intermediate assistant when message.removed arrives', () => {
     const removeMessage = vi.fn();
     useSessionMessagesMock.mockReturnValue({
@@ -1040,6 +1205,42 @@ describe('SessionChat standalone thinking indicator', () => {
 });
 
 describe('SessionChat instruction display text', () => {
+  it('filters internal task metadata from visible message text', () => {
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'assistant-with-task-metadata',
+          role: 'assistant',
+          parts: [{
+            id: 'assistant-with-task-metadata-part',
+            type: 'text',
+            text: [
+              '查询完成。',
+              '<task_metadata>',
+              'session_id: ses-child',
+              '</task_metadata>',
+              '消息发送失败。',
+            ].join('\n'),
+          }] as Message['parts'],
+        }),
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    expect(screen.getByText('查询完成。')).toBeInTheDocument();
+    expect(screen.getByText('消息发送失败。')).toBeInTheDocument();
+    expect(screen.queryByText(/task_metadata/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ses-child/)).not.toBeInTheDocument();
+  });
+
   it('renders metadata displayText while keeping the raw prompt out of the bubble', () => {
     useSessionMessagesMock.mockReturnValue({
       messages: [
@@ -1695,7 +1896,8 @@ describe('SessionChat intermediate process collapse', () => {
     expect(processGroup.open).toBe(false);
   });
 
-  it('uses one global process group and leaves only the final reply visible', () => {
+  it('uses one global process group and renders intermediate summaries as peer steps', async () => {
+    const user = userEvent.setup();
     useSessionMessagesMock.mockReturnValue({
       messages: [
         makeMessage({
@@ -1779,6 +1981,16 @@ describe('SessionChat intermediate process collapse', () => {
     expect(processGroup.open).toBe(false);
     expect(screen.getByText('查看 5 个步骤')).toBeInTheDocument();
     expect(screen.getByText('最终结果已生成。')).toBeVisible();
+
+    await user.click(screen.getByText('查看 5 个步骤'));
+
+    const summaryStep = screen.getByTestId('chat-process-text-step');
+    const reasoningStep = screen.getAllByTestId('chat-process-reasoning-step')[0];
+    expect(summaryStep).toHaveTextContent('已经读取文件，继续检查相关配置。');
+    expect(summaryStep.querySelector('svg')).not.toBeInTheDocument();
+    expect(summaryStep.className).not.toContain('pl-');
+    expect(summaryStep.querySelector('.border-l')).not.toBeInTheDocument();
+    expect(summaryStep.parentElement?.parentElement).toBe(reasoningStep.parentElement?.parentElement);
   });
 
   it('keeps a user-opened process group open when new tool parts arrive', async () => {
@@ -2334,6 +2546,45 @@ describe('SessionChat intermediate process collapse', () => {
 });
 
 describe('SessionChat optimistic message identity', () => {
+  it.each([
+    ['prompt', 'message that fails', '/api/session/sess-1/prompt_async'],
+    ['slash command', '/tools', '/api/session/sess-1/command'],
+  ])('removes the optimistic message when a %s request fails', async (_kind, input, endpoint) => {
+    const user = userEvent.setup();
+    const addMessage = vi.fn();
+    const removeMessage = vi.fn();
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    clientPostMock.mockRejectedValueOnce(new Error('network down'));
+    useSessionMessagesMock.mockReturnValue({
+      messages: [],
+      loading: false,
+      refetch: vi.fn(),
+      addMessage,
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      removeMessage,
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    try {
+      render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+      await user.type(screen.getByPlaceholderText('请输入消息'), `${input}{enter}`);
+
+      await waitFor(() => expect(clientPostMock).toHaveBeenCalledWith(
+        endpoint,
+        expect.any(Object),
+      ));
+      await waitFor(() => expect(removeMessage).toHaveBeenCalledOnce());
+
+      const optimisticMessage = addMessage.mock.calls[0][0] as Message;
+      expect(removeMessage).toHaveBeenCalledWith(optimisticMessage.id);
+    } finally {
+      alertSpy.mockRestore();
+    }
+  });
+
   it('uses the optimistic user message ID for the persisted prompt', async () => {
     const user = userEvent.setup();
     const addMessage = vi.fn();

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -59,6 +59,7 @@ import {
   parseInstructionDisplayText,
   resolveSessionChatSSEAction,
   shouldForwardSSEEventToParent,
+  stripTaskMetadata,
   type CompactionStage,
   usePendingQuestions,
   useSessionContextUsage,
@@ -111,11 +112,12 @@ export interface ConversationBottomSlotActions {
   hasMessages: boolean;
 }
 
-function getMessagePartDisplayText(part: MessagePart): string {
+function getMessagePartDisplayText(part: MessagePart, hideTaskMetadata = false): string {
   const metadataDisplayText = part.metadata?.displayText ?? part.metadata?.display_text;
-  return typeof metadataDisplayText === 'string' && metadataDisplayText
+  const displayText = typeof metadataDisplayText === 'string' && metadataDisplayText
     ? metadataDisplayText
     : part.text || '';
+  return hideTaskMetadata ? stripTaskMetadata(displayText) : displayText;
 }
 
 export interface SessionChatProps {
@@ -1712,9 +1714,6 @@ export default function SessionChat({
     }
   }, []);
 
-  const loadOlderMessagesRef = useRef<(() => Promise<void>) | null>(null);
-  const hasMoreMessagesRef = useRef(false);
-  const loadingOlderMessagesRef = useRef(false);
   const rafScheduledRef = useRef(false);
   const handleScroll = useCallback(() => {
     if (rafScheduledRef.current) return;
@@ -1723,18 +1722,6 @@ export default function SessionChat({
       const el = scrollContainerRef.current;
       if (el) {
         isAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX;
-        if (el.scrollTop <= 80 && hasMoreMessagesRef.current && !loadingOlderMessagesRef.current) {
-          const previousHeight = el.scrollHeight;
-          const previousTop = el.scrollTop;
-          const loadPromise = loadOlderMessagesRef.current?.();
-          if (loadPromise) void loadPromise.finally(() => {
-            requestAnimationFrame(() => {
-              const current = scrollContainerRef.current;
-              if (!current) return;
-              current.scrollTop = current.scrollHeight - previousHeight + previousTop;
-            });
-          });
-        }
       }
       rafScheduledRef.current = false;
     });
@@ -1743,22 +1730,17 @@ export default function SessionChat({
   const {
     messages,
     loading,
-    loadingOlder,
-    hasMore: hasMoreMessages,
     refetch,
-    loadOlder,
     addMessage,
     updateMessage,
     updateMessagePart,
     removeMessage,
+    clearMessages,
     replaceMessageText,
     markMessageStopped,
     truncateAfterMessage,
   } =
     useSessionMessages(sessionId || undefined);
-  useEffect(() => { loadOlderMessagesRef.current = loadOlder; }, [loadOlder]);
-  useEffect(() => { hasMoreMessagesRef.current = hasMoreMessages; }, [hasMoreMessages]);
-  useEffect(() => { loadingOlderMessagesRef.current = loadingOlder; }, [loadingOlder]);
   const contextUsageMessages = contextUsageRefreshing && !contextUsageSnapshot ? [] : messages;
   const contextUsageBreakdown = useMemo(
     () => buildContextUsageBreakdown(contextUsageMessages, input, contextUsageSnapshot),
@@ -1836,6 +1818,7 @@ export default function SessionChat({
           setIsStreaming(false);
           setGoalBanner(null);
           setDismissedGoalKey('');
+          clearMessages();
           refetch();
           void refreshContextUsage({ clear: true });
           return;
@@ -2004,6 +1987,7 @@ export default function SessionChat({
       updateMessage,
       updateMessagePart,
       removeMessage,
+      clearMessages,
       refetch,
       refreshContextUsage,
       applyContextUsagePushSnapshot,
@@ -2520,6 +2504,7 @@ export default function SessionChat({
       }
     } catch (err: unknown) {
       setIsStreaming(false);
+      removeMessage(messageId);
       const axiosErr = err as any;
       if (axiosErr?.response?.status === 404) {
         onError?.('Session not found. Please start a new session.');
@@ -2581,6 +2566,7 @@ export default function SessionChat({
       await client.post(`/api/session/${sessionId}/prompt_async`, payload);
     } catch (err: unknown) {
       setIsStreaming(false);
+      removeMessage(messageId);
       const axiosErr = err as any;
       if (axiosErr?.response?.status === 404) {
         onError?.(`Session not found. Please start a new session.`);
@@ -3192,7 +3178,7 @@ export default function SessionChat({
   const msgListClass = compact
     ? fullWidth ? 'space-y-3 w-full px-4' : 'space-y-3'
     : fullWidth
-      ? 'space-y-5 w-full px-5'
+      ? 'space-y-5 w-full px-12'
       : pageCanvas
         ? 'space-y-[18px] w-full max-w-[760px] mx-auto px-7'
         : 'space-y-5 w-[min(76%,64rem)] mx-auto px-6';
@@ -3216,7 +3202,11 @@ export default function SessionChat({
       >
         {loading && messages.length === 0 ? (
           <div className="flex justify-center py-8">
-            <LoadingSpinner />
+            <LoadingSpinner
+              size="sm"
+              delayMs={180}
+              className="opacity-60 [&_svg]:text-zinc-400 dark:[&_svg]:text-zinc-500"
+            />
           </div>
         ) : messages.length === 0 ? (
           welcomeContent ? (
@@ -3234,19 +3224,6 @@ export default function SessionChat({
           )
         ) : (
           <div ref={messagesContentRef} className={msgListClass}>
-            {hasMoreMessages && (
-              <div className="flex justify-center pb-2">
-                <button
-                  type="button"
-                  onClick={() => void loadOlder()}
-                  disabled={loadingOlder}
-                  className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-500 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {loadingOlder ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ChevronDown className="h-3.5 w-3.5 rotate-180" />}
-                  <span>{loadingOlder ? t('chat.loadingOlder', 'Loading...') : t('chat.loadOlder', 'Load earlier messages')}</span>
-                </button>
-              </div>
-            )}
             <ChatMessageTimeline
               items={historyItems}
               pendingQuestions={pendingQuestions}
@@ -4034,11 +4011,13 @@ function ChatMessageBubbleInner({
   const rawAgentName = message.agent || 'rex';
   const agentName = rawAgentName.charAt(0).toUpperCase() + rawAgentName.slice(1);
 
-  const getTextContent = () =>
-    parts
+  const getTextContent = () => {
+    const text = parts
       .filter((p) => p.type === 'text' && p.text)
       .map((p) => p.text)
       .join('\n\n');
+    return isUser ? text : stripTaskMetadata(text);
+  };
 
   const editableTextParts = parts.filter((part): part is MessagePart & { text: string } =>
     part.type === 'text' && typeof part.text === 'string',
@@ -4057,7 +4036,7 @@ function ChatMessageBubbleInner({
     return !(part.callID && pendingQuestions?.[part.callID]);
   });
   const instructionDisplayLabel = isUser && !isEditing && editableTextParts.length === 1
-    ? parseInstructionDisplayText(getMessagePartDisplayText(editableTextParts[0]))
+    ? parseInstructionDisplayText(getMessagePartDisplayText(editableTextParts[0], false))
     : null;
 
   const bubbleClass = instructionDisplayLabel
@@ -4154,7 +4133,7 @@ function ChatMessageBubbleInner({
             return true;
           };
           const isRenderableTextPart = (part: MessagePart): boolean => (
-            part.type === 'text' && !!getMessagePartDisplayText(part).trim()
+            part.type === 'text' && !!getMessagePartDisplayText(part, !isUser).trim()
           );
           const isRenderableDisplayPart = (part: MessagePart): boolean => {
             if (isIntermediateProcessPart(part)) return true;
@@ -4180,7 +4159,7 @@ function ChatMessageBubbleInner({
                 const nodeRefMatch = isUser
                   ? rawText.match(/^@@node:([^|\n]+)\|([^\n]+)\n([\s\S]*)$/)
                   : null;
-                const partDisplayText = getMessagePartDisplayText(part);
+                const partDisplayText = getMessagePartDisplayText(part, !isUser);
                 if (!partDisplayText.trim()) return null;
                 const displayText = nodeRefMatch && partDisplayText === rawText ? nodeRefMatch[3] : partDisplayText;
                 const instructionLabel = isUser ? parseInstructionDisplayText(displayText) : null;
@@ -4201,7 +4180,10 @@ function ChatMessageBubbleInner({
                       </div>
                     )}
                     {processStep ? (
-                      <div className="mb-[9px] ml-2 mt-[3px] border-l border-[#e3e6e3] py-1.5 pl-[26px] pr-0 text-sm leading-7 text-[#686e6c] dark:border-zinc-700 dark:text-zinc-400">
+                      <div
+                        data-testid="chat-process-text-step"
+                        className="min-w-0 py-1 text-sm leading-7 text-[#686e6c] dark:text-zinc-400"
+                      >
                         <StreamingMarkdown
                           content={displayText}
                           isStreaming={isActive && !isUser}

--- a/webui/src/features/session-chat/display.test.ts
+++ b/webui/src/features/session-chat/display.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildInstructionDisplayText, parseInstructionDisplayText } from './display';
+import {
+  buildInstructionDisplayText,
+  parseInstructionDisplayText,
+  stripTaskMetadata,
+} from './display';
 
 describe('session chat display metadata', () => {
   it('round-trips instruction display labels', () => {
@@ -12,5 +16,29 @@ describe('session chat display metadata', () => {
 
   it('ignores regular display text', () => {
     expect(parseInstructionDisplayText('普通消息')).toBeNull();
+  });
+
+  it('removes task metadata while preserving the visible result', () => {
+    const text = [
+      '查询完成。',
+      '',
+      '<task_metadata>',
+      'session_id: ses-child',
+      '</task_metadata>',
+      '',
+      '消息发送失败。',
+    ].join('\n');
+
+    const visibleText = stripTaskMetadata(text);
+
+    expect(visibleText).toContain('查询完成。');
+    expect(visibleText).toContain('消息发送失败。');
+    expect(visibleText).not.toContain('task_metadata');
+    expect(visibleText).not.toContain('ses-child');
+  });
+
+  it('hides a trailing task metadata block while it is still streaming', () => {
+    expect(stripTaskMetadata('查询完成。\n\n<task_metadata>\nsession_id: ses-child'))
+      .toBe('查询完成。\n\n');
   });
 });

--- a/webui/src/features/session-chat/display.ts
+++ b/webui/src/features/session-chat/display.ts
@@ -3,6 +3,8 @@ export interface PromptDisplayOptions {
 }
 
 const INSTRUCTION_DISPLAY_PREFIX = '@@flocks-instruction:';
+const TASK_METADATA_BLOCK_PATTERN = /<task_metadata\b[^>]*>[\s\S]*?<\/task_metadata\s*>/gi;
+const TRAILING_TASK_METADATA_PATTERN = /<task_metadata\b[^>]*>[\s\S]*$/i;
 
 export function buildInstructionDisplayText(label: string): string {
   return `${INSTRUCTION_DISPLAY_PREFIX}${label}`;
@@ -12,6 +14,12 @@ export function parseInstructionDisplayText(text: string): string | null {
   return text.startsWith(INSTRUCTION_DISPLAY_PREFIX)
     ? text.slice(INSTRUCTION_DISPLAY_PREFIX.length).trim() || null
     : null;
+}
+
+export function stripTaskMetadata(text: string): string {
+  return text
+    .replace(TASK_METADATA_BLOCK_PATTERN, '')
+    .replace(TRAILING_TASK_METADATA_PATTERN, '');
 }
 
 /** Display-related options grouped to reduce prop surface. */

--- a/webui/src/features/session-chat/index.ts
+++ b/webui/src/features/session-chat/index.ts
@@ -1,6 +1,7 @@
 export {
   buildInstructionDisplayText,
   parseInstructionDisplayText,
+  stripTaskMetadata,
   type PromptDisplayOptions,
   type SessionChatDisplay,
 } from './display';

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -405,225 +405,6 @@ describe('updateMessagePart scheduling', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it('ignores an older-page response after switching sessions', async () => {
-    let resolveOlderSessionA: (value: unknown) => void = () => {};
-    vi.mocked(client.get).mockImplementation((url: string, config?: any) => {
-      if (url.includes('sess-a') && config?.params?.before) {
-        return new Promise((resolve) => {
-          resolveOlderSessionA = resolve;
-        }) as any;
-      }
-      if (url.includes('sess-a')) {
-        return Promise.resolve({
-          data: {
-            items: [{
-              info: {
-                id: 'msg-a-new',
-                sessionID: 'sess-a',
-                role: 'assistant',
-                time: { created: 200 },
-              },
-              parts: [],
-            }],
-            hasMore: true,
-            nextBefore: 'msg-a-new',
-          },
-        }) as any;
-      }
-      return Promise.resolve({
-        data: [{
-          info: {
-            id: 'msg-b',
-            sessionID: 'sess-b',
-            role: 'assistant',
-            time: { created: 300 },
-          },
-          parts: [],
-        }],
-      }) as any;
-    });
-
-    const { result, rerender } = renderHook(
-      ({ id }: { id: string }) => useSessionMessages(id),
-      { initialProps: { id: 'sess-a' } },
-    );
-    await act(async () => {});
-
-    let olderRequest: Promise<void> = Promise.resolve();
-    act(() => {
-      olderRequest = result.current.loadOlder();
-    });
-
-    rerender({ id: 'sess-b' });
-    await act(async () => {});
-    expect(result.current.messages.map((message) => message.id)).toEqual(['msg-b']);
-
-    await act(async () => {
-      resolveOlderSessionA({
-        data: {
-          items: [{
-            info: {
-              id: 'msg-a-old',
-              sessionID: 'sess-a',
-              role: 'user',
-              time: { created: 100 },
-            },
-            parts: [],
-          }],
-          hasMore: false,
-          nextBefore: null,
-        },
-      });
-      await olderRequest;
-    });
-
-    expect(result.current.messages.map((message) => message.id)).toEqual(['msg-b']);
-    expect(result.current.loadingOlder).toBe(false);
-  });
-
-  it('clears older-page loading when a first-page refetch invalidates it', async () => {
-    let resolveOlderPage: (value: unknown) => void = () => {};
-    let firstPageRequestCount = 0;
-    vi.mocked(client.get).mockImplementation((_url: string, config?: any) => {
-      if (config?.params?.before) {
-        return new Promise((resolve) => {
-          resolveOlderPage = resolve;
-        }) as any;
-      }
-
-      firstPageRequestCount += 1;
-      const messageId = firstPageRequestCount === 1 ? 'msg-current' : 'msg-refreshed';
-      return Promise.resolve({
-        data: {
-          items: [{
-            info: {
-              id: messageId,
-              sessionID: 'sess-1',
-              role: 'assistant',
-              time: { created: 200 + firstPageRequestCount },
-            },
-            parts: [],
-          }],
-          hasMore: true,
-          nextBefore: messageId,
-        },
-      }) as any;
-    });
-
-    const { result } = renderHook(() => useSessionMessages('sess-1'));
-    await act(async () => {});
-
-    let olderRequest: Promise<void> = Promise.resolve();
-    act(() => {
-      olderRequest = result.current.loadOlder();
-    });
-    expect(result.current.loadingOlder).toBe(true);
-
-    await act(async () => {
-      await result.current.refetch();
-    });
-    expect(result.current.loadingOlder).toBe(false);
-    expect(result.current.messages.map((message) => message.id)).toEqual([
-      'msg-current',
-      'msg-refreshed',
-    ]);
-
-    await act(async () => {
-      resolveOlderPage({
-        data: {
-          items: [{
-            info: {
-              id: 'msg-stale-older',
-              sessionID: 'sess-1',
-              role: 'user',
-              time: { created: 100 },
-            },
-            parts: [],
-          }],
-          hasMore: false,
-          nextBefore: null,
-        },
-      });
-      await olderRequest;
-    });
-
-    expect(result.current.loadingOlder).toBe(false);
-    expect(result.current.messages.map((message) => message.id)).toEqual([
-      'msg-current',
-      'msg-refreshed',
-    ]);
-  });
-
-  it('does not start an older-page request while a first-page refetch is pending', async () => {
-    let resolveRefetch: (value: unknown) => void = () => {};
-    let firstPageRequests = 0;
-    let olderPageRequests = 0;
-    vi.mocked(client.get).mockImplementation((_url: string, config?: any) => {
-      if (config?.params?.before) {
-        olderPageRequests += 1;
-        return Promise.resolve({ data: { items: [], hasMore: false, nextBefore: null } }) as any;
-      }
-
-      firstPageRequests += 1;
-      if (firstPageRequests === 1) {
-        return Promise.resolve({
-          data: {
-            items: [{
-              info: {
-                id: 'msg-current',
-                sessionID: 'sess-1',
-                role: 'assistant',
-                time: { created: 200 },
-              },
-              parts: [],
-            }],
-            hasMore: true,
-            nextBefore: 'old-cursor',
-          },
-        }) as any;
-      }
-
-      return new Promise((resolve) => {
-        resolveRefetch = resolve;
-      }) as any;
-    });
-
-    const { result } = renderHook(() => useSessionMessages('sess-1'));
-    await act(async () => {});
-
-    let refetchRequest: Promise<void> = Promise.resolve();
-    act(() => {
-      refetchRequest = result.current.refetch();
-    });
-    await act(async () => {
-      await result.current.loadOlder();
-    });
-
-    expect(olderPageRequests).toBe(0);
-
-    await act(async () => {
-      resolveRefetch({
-        data: {
-          items: [{
-            info: {
-              id: 'msg-refreshed',
-              sessionID: 'sess-1',
-              role: 'assistant',
-              time: { created: 300 },
-            },
-            parts: [],
-          }],
-          hasMore: true,
-          nextBefore: 'new-cursor',
-        },
-      });
-      await refetchRequest;
-    });
-
-    expect(result.current.loading).toBe(false);
-    expect(olderPageRequests).toBe(0);
-  });
-
   it('replaceMessageText updates the targeted text part by partId', async () => {
     const { result } = renderHook(() => useSessionMessages('sess-1'));
     await act(async () => {});
@@ -921,103 +702,228 @@ describe('updateMessagePart scheduling', () => {
     expect((msg?.parts as any[])[0].state.status).toBe('completed');
   });
 
-  it('fetches the first message page and prepends older messages', async () => {
-    vi.mocked(client.get)
-      .mockResolvedValueOnce({
-        data: {
-          items: [{
-            info: {
-              id: 'msg-new',
-              sessionID: 'sess-1',
-              role: 'assistant',
-              time: { created: 200 },
-            },
-            parts: [],
-          }],
-          hasMore: true,
-          nextBefore: 'msg-new',
+  it('fetches the complete message history in one request', async () => {
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: [
+        {
+          info: {
+            id: 'msg-old',
+            sessionID: 'sess-1',
+            role: 'user',
+            time: { created: 100 },
+          },
+          parts: [{ id: 'part-old', type: 'text', text: 'old' }],
         },
-      } as any)
-      .mockResolvedValueOnce({
-        data: {
-          items: [{
-            info: {
-              id: 'msg-old',
-              sessionID: 'sess-1',
-              role: 'user',
-              time: { created: 100 },
-              model: { providerID: 'openai', modelID: 'gpt-4o' },
-            },
-            parts: [{ id: 'part-old', type: 'text', text: 'old' }],
-          }],
-          hasMore: false,
-          nextBefore: null,
+        {
+          info: {
+            id: 'msg-new',
+            sessionID: 'sess-1',
+            role: 'assistant',
+            time: { created: 200 },
+          },
+          parts: [],
         },
-      } as any);
+      ],
+    } as any);
 
     const { result } = renderHook(() => useSessionMessages('sess-1'));
     await act(async () => {});
 
-    expect(result.current.messages.map((msg) => msg.id)).toEqual(['msg-new']);
-    expect(result.current.hasMore).toBe(true);
-    expect(client.get).toHaveBeenCalledWith('/api/session/sess-1/message', {
-      params: { page: true, limit: 50, include_archived: true },
-    });
-
-    await act(async () => {
-      await result.current.loadOlder();
-    });
-
     expect(result.current.messages.map((msg) => msg.id)).toEqual(['msg-old', 'msg-new']);
-    expect(result.current.hasMore).toBe(false);
-    expect(client.get).toHaveBeenLastCalledWith('/api/session/sess-1/message', {
-      params: { page: true, limit: 50, before: 'msg-new', include_archived: true },
+    expect(client.get).toHaveBeenCalledOnce();
+    expect(client.get).toHaveBeenCalledWith('/api/session/sess-1/message', {
+      params: { include_archived: true },
     });
   });
 
-  it('starts only one older-page request when loadOlder is called twice before rerender', async () => {
-    let resolveOlderPage: (value: unknown) => void = () => {};
-    let olderPageRequests = 0;
-    vi.mocked(client.get).mockImplementation((_url: string, config?: any) => {
-      if (config?.params?.before) {
-        olderPageRequests += 1;
-        return new Promise((resolve) => {
-          resolveOlderPage = resolve;
-        }) as any;
-      }
+  it('removes messages that are absent from a complete refetch', async () => {
+    vi.mocked(client.get)
+      .mockResolvedValueOnce({
+        data: [{
+          info: {
+            id: 'msg-before-clear',
+            sessionID: 'sess-1',
+            role: 'assistant',
+            time: { created: 100 },
+          },
+          parts: [{ id: 'part-before-clear', type: 'text', text: 'old result' }],
+        }],
+      } as any)
+      .mockResolvedValueOnce({ data: [] });
 
-      return Promise.resolve({
-        data: {
-          items: [],
-          hasMore: true,
-          nextBefore: 'older-cursor',
-        },
-      }) as any;
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+    expect(result.current.messages.map((message) => message.id)).toEqual(['msg-before-clear']);
+
+    await act(async () => {
+      await result.current.refetch();
     });
+
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it('keeps the current history when a complete refetch fails', async () => {
+    vi.mocked(client.get)
+      .mockResolvedValueOnce({
+        data: [{
+          info: {
+            id: 'msg-before-error',
+            sessionID: 'sess-1',
+            role: 'assistant',
+            time: { created: 100 },
+          },
+          parts: [{ id: 'part-before-error', type: 'text', text: 'keep me' }],
+        }],
+      } as any)
+      .mockRejectedValueOnce(new Error('storage unavailable'));
 
     const { result } = renderHook(() => useSessionMessages('sess-1'));
     await act(async () => {});
 
-    let firstRequest: Promise<void> = Promise.resolve();
-    let secondRequest: Promise<void> = Promise.resolve();
-    act(() => {
-      firstRequest = result.current.loadOlder();
-      secondRequest = result.current.loadOlder();
+    await act(async () => {
+      await result.current.refetch();
     });
 
-    expect(olderPageRequests).toBe(1);
+    expect(result.current.messages.map((message) => message.id)).toEqual(['msg-before-error']);
+    expect(result.current.error).toBe('storage unavailable');
+  });
+
+  it('keeps an optimistic local message until the complete history confirms it', async () => {
+    vi.mocked(client.get)
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] });
+
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
 
     await act(async () => {
-      resolveOlderPage({
-        data: {
-          items: [],
-          hasMore: false,
-          nextBefore: null,
-        },
-      });
-      await Promise.all([firstRequest, secondRequest]);
+      result.current.addMessage(makeMsg({
+        id: 'msg-optimistic',
+        role: 'user',
+        parts: [{ id: 'temp-msg-optimistic-text', type: 'text', text: 'hello' } as any],
+      }));
+      await result.current.refetch();
     });
-    expect(result.current.loadingOlder).toBe(false);
+
+    expect(result.current.messages.map((message) => message.id)).toEqual(['msg-optimistic']);
+  });
+
+  it('keeps an optimistic message when an older refetch resolves after SSE confirmation', async () => {
+    const olderRefetch = deferred<any>();
+    vi.mocked(client.get)
+      .mockResolvedValueOnce({ data: [] })
+      .mockReturnValueOnce(olderRefetch.promise);
+
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.addMessage(makeMsg({
+        id: 'msg-racing',
+        role: 'user',
+        parts: [{ id: 'temp-msg-racing-text', type: 'text', text: 'hello' } as any],
+      }));
+    });
+
+    let refetchPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refetchPromise = result.current.refetch();
+    });
+    expect(client.get).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      result.current.updateMessage({
+        id: 'msg-racing',
+        sessionID: 'sess-1',
+        role: 'user',
+        time: { created: 200 },
+      });
+    });
+
+    await act(async () => {
+      olderRefetch.resolve({ data: [] });
+      await refetchPromise;
+    });
+
+    expect(result.current.messages.map((message) => message.id)).toEqual(['msg-racing']);
+  });
+
+  it('keeps newer SSE message state when an older complete refetch resolves', async () => {
+    const olderRefetch = deferred<any>();
+    const staleMessage = {
+      info: {
+        id: 'msg-existing',
+        sessionID: 'sess-1',
+        role: 'assistant',
+        time: { created: 100 },
+      },
+      parts: [{
+        id: 'part-existing',
+        messageID: 'msg-existing',
+        sessionID: 'sess-1',
+        type: 'text',
+        text: 'stale text',
+      }],
+    };
+    vi.mocked(client.get)
+      .mockResolvedValueOnce({ data: [staleMessage] })
+      .mockReturnValueOnce(olderRefetch.promise);
+
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+
+    let refetchPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      refetchPromise = result.current.refetch();
+    });
+
+    act(() => {
+      result.current.updateMessagePart({
+        id: 'part-existing',
+        messageID: 'msg-existing',
+        sessionID: 'sess-1',
+        type: 'text',
+        text: 'new streamed text',
+      }, 'new streamed text');
+      result.current.updateMessage({
+        id: 'msg-new-assistant',
+        sessionID: 'sess-1',
+        role: 'assistant',
+        time: { created: 200 },
+      });
+    });
+
+    await act(async () => {
+      olderRefetch.resolve({ data: [staleMessage] });
+      await refetchPromise;
+    });
+
+    expect(result.current.messages.map((message) => message.id)).toEqual([
+      'msg-existing',
+      'msg-new-assistant',
+    ]);
+    expect((result.current.messages[0].parts as any[])[0].text).toBe('new streamed text');
+  });
+
+  it('clears optimistic messages before applying an empty session history', async () => {
+    vi.mocked(client.get)
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] });
+
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.addMessage(makeMsg({
+        id: 'msg-pending-clear',
+        role: 'user',
+        parts: [{ id: 'temp-msg-pending-clear-text', type: 'text', text: 'hello' } as any],
+      }));
+      result.current.clearMessages();
+      await result.current.refetch();
+    });
+
+    expect(result.current.messages).toEqual([]);
   });
 
 });

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -6,7 +6,6 @@ import type { Session, Message } from '@/types';
 const VISIBLE_CATEGORIES = new Set(['user', 'workflow', 'entity-config']);
 const ABORTED_TOOL_ERROR = 'Tool execution was interrupted';
 const SESSION_LIST_PAGE_SIZE = 100;
-const MESSAGE_PAGE_SIZE = 50;
 
 function finalizeStoppedMessageParts(parts: Message['parts'], stoppedAt = Date.now()): Message['parts'] {
   return parts.map((part) => {
@@ -92,52 +91,51 @@ function mergeFetchedMessages(prev: Message[], fetched: Message[]): Message[] {
   }));
 }
 
-function mergeLatestFetchedMessages(prev: Message[], fetched: Message[]): Message[] {
-  if (prev.length === 0) return normalizeMessageOrder(fetched);
+function mergeCompleteFetchedMessages(
+  prev: Message[],
+  fetched: Message[],
+  provisionalMessageIds: Set<string>,
+  protectedMessageIds: Set<string>,
+): Message[] {
   const fetchedIds = new Set(fetched.map((message) => message.id));
+  const previousById = new Map(prev.map((message) => [message.id, message]));
   const mergedFetched = mergeFetchedMessages(prev, fetched);
-  const firstFetchedTimestamp = mergedFetched[0]?.timestamp ?? Number.POSITIVE_INFINITY;
-  const retainedOlder = prev.filter(
-    (message) => !fetchedIds.has(message.id) && message.timestamp <= firstFetchedTimestamp,
+  const protectedFetched = mergedFetched.map((message) => (
+    protectedMessageIds.has(message.id)
+      ? previousById.get(message.id) ?? message
+      : message
+  ));
+  const retainedLocal = prev.filter(
+    (message) => (
+      !fetchedIds.has(message.id)
+      && (
+        provisionalMessageIds.has(message.id)
+        || protectedMessageIds.has(message.id)
+      )
+    ),
   );
-  const retainedNewer = prev.filter(
-    (message) => !fetchedIds.has(message.id) && message.timestamp > firstFetchedTimestamp,
-  );
-  return normalizeMessageOrder([...retainedOlder, ...mergedFetched, ...retainedNewer]);
+  return normalizeMessageOrder([...protectedFetched, ...retainedLocal]);
 }
 
-function prependOlderMessages(prev: Message[], older: Message[]): Message[] {
-  const existingIds = new Set(prev.map((message) => message.id));
-  return normalizeMessageOrder([...older.filter((message) => !existingIds.has(message.id)), ...prev]);
-}
-
-function transformMessageResponse(data: any): {
-  messages: Message[];
-  hasMore: boolean;
-  nextBefore: string | null;
-} {
+function transformMessageResponse(data: any): Message[] {
   const items = Array.isArray(data) ? data : (data?.items ?? []);
-  return {
-    messages: items.map((msg: any) => ({
-      id: msg.info.id,
-      sessionID: msg.info.sessionID,
-      role: msg.info.role,
-      parts: msg.parts || [],
-      parentID: msg.info.parentID,
-      agent: msg.info.agent,
-      model: msg.info.model,
-      modelID: msg.info.modelID,
-      providerID: msg.info.providerID,
-      cost: msg.info.cost,
-      tokens: msg.info.tokens,
-      timestamp: msg.info.time?.created || Date.now(),
-      finish: msg.info.finish || null,
-      error: msg.info.error || null,
-      compacted: msg.info.compacted || null,
-    })),
-    hasMore: Array.isArray(data) ? false : Boolean(data?.hasMore),
-    nextBefore: Array.isArray(data) ? null : (data?.nextBefore ?? null),
-  };
+  return items.map((msg: any) => ({
+    id: msg.info.id,
+    sessionID: msg.info.sessionID,
+    role: msg.info.role,
+    parts: msg.parts || [],
+    parentID: msg.info.parentID,
+    agent: msg.info.agent,
+    model: msg.info.model,
+    modelID: msg.info.modelID,
+    providerID: msg.info.providerID,
+    cost: msg.info.cost,
+    tokens: msg.info.tokens,
+    timestamp: msg.info.time?.created || Date.now(),
+    finish: msg.info.finish || null,
+    error: msg.info.error || null,
+    compacted: msg.info.compacted || null,
+  }));
 }
 
 function markMeasure(name: string, startMark: string) {
@@ -458,122 +456,81 @@ export function useSessions(search = '', options?: UseSessionsOptions) {
 export function useSessionMessages(sessionId?: string) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(false);
-  const [loadingOlder, setLoadingOlder] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
-  const [nextBefore, setNextBefore] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const activeSessionIdRef = useRef(sessionId);
-  const firstPageRequestIdRef = useRef(0);
-  const firstPageInFlightRequestIdRef = useRef<number | null>(null);
-  const olderPageRequestIdRef = useRef(0);
-  const olderPageInFlightRequestIdRef = useRef<number | null>(null);
+  const requestIdRef = useRef(0);
+  const provisionalMessageIdsRef = useRef<Set<string>>(new Set());
+  const messageMutationVersionsRef = useRef<Map<string, number>>(new Map());
+  const mutationVersionRef = useRef(0);
+
+  const markMessageMutation = (messageId: string) => {
+    mutationVersionRef.current += 1;
+    messageMutationVersionsRef.current.set(messageId, mutationVersionRef.current);
+  };
 
   const fetchMessages = useCallback(async () => {
     if (!sessionId || activeSessionIdRef.current !== sessionId) return;
 
     const requestSessionId = sessionId;
-    const requestId = ++firstPageRequestIdRef.current;
-    firstPageInFlightRequestIdRef.current = requestId;
-    // A fresh first page invalidates pagination based on an older snapshot.
-    olderPageRequestIdRef.current += 1;
-    olderPageInFlightRequestIdRef.current = null;
-    setLoadingOlder(false);
+    const requestId = ++requestIdRef.current;
+    const requestMutationVersion = mutationVersionRef.current;
     const isCurrentRequest = () => (
       activeSessionIdRef.current === requestSessionId
-      && firstPageRequestIdRef.current === requestId
+      && requestIdRef.current === requestId
     );
     
     try {
       setLoading(true);
       setError(null);
-      const startMark = 'session:messages:first-page-start';
+      const startMark = 'session:messages:start';
       if (typeof performance !== 'undefined') performance.mark(startMark);
       const response = await client.get(`/api/session/${sessionId}/message`, {
-        params: { page: true, limit: MESSAGE_PAGE_SIZE, include_archived: true },
+        params: { include_archived: true },
       });
-      markMeasure('session:messages:first-page', startMark);
+      markMeasure('session:messages', startMark);
       if (!isCurrentRequest()) return;
-      const { messages: messagesData, hasMore, nextBefore } = transformMessageResponse(response.data);
-      setMessages(prev => mergeLatestFetchedMessages(prev, messagesData));
-      setHasMore(hasMore);
-      setNextBefore(nextBefore);
+      const messagesData = transformMessageResponse(response.data);
+      const protectedMessageIds = new Set(
+        Array.from(messageMutationVersionsRef.current.entries())
+          .filter(([, version]) => version > requestMutationVersion)
+          .map(([messageId]) => messageId),
+      );
+      messagesData.forEach((message) => {
+        if (!protectedMessageIds.has(message.id)) {
+          provisionalMessageIdsRef.current.delete(message.id);
+        }
+      });
+      messageMutationVersionsRef.current.forEach((version, messageId) => {
+        if (version <= requestMutationVersion) {
+          messageMutationVersionsRef.current.delete(messageId);
+        }
+      });
+      setMessages(prev => mergeCompleteFetchedMessages(
+        prev,
+        messagesData,
+        provisionalMessageIdsRef.current,
+        protectedMessageIds,
+      ));
     } catch (err: any) {
       if (isCurrentRequest()) {
         setError(err.message || 'Failed to fetch messages');
       }
     } finally {
-      if (firstPageInFlightRequestIdRef.current === requestId) {
-        firstPageInFlightRequestIdRef.current = null;
-      }
       if (isCurrentRequest()) {
         setLoading(false);
       }
     }
   }, [sessionId]);
 
-  const loadOlder = useCallback(async () => {
-    if (
-      !sessionId
-      || activeSessionIdRef.current !== sessionId
-      || firstPageInFlightRequestIdRef.current !== null
-      || olderPageInFlightRequestIdRef.current !== null
-      || !hasMore
-      || !nextBefore
-    ) return;
-
-    const requestSessionId = sessionId;
-    const requestId = ++olderPageRequestIdRef.current;
-    olderPageInFlightRequestIdRef.current = requestId;
-    const firstPageRequestId = firstPageRequestIdRef.current;
-    const isCurrentRequest = () => (
-      activeSessionIdRef.current === requestSessionId
-      && olderPageRequestIdRef.current === requestId
-      && firstPageRequestIdRef.current === firstPageRequestId
-    );
-
-    try {
-      setLoadingOlder(true);
-      setError(null);
-      const startMark = 'session:messages:older-page-start';
-      if (typeof performance !== 'undefined') performance.mark(startMark);
-      const response = await client.get(`/api/session/${sessionId}/message`, {
-        params: {
-          page: true,
-          limit: MESSAGE_PAGE_SIZE,
-          before: nextBefore,
-          include_archived: true,
-        },
-      });
-      markMeasure('session:messages:older-page', startMark);
-      if (!isCurrentRequest()) return;
-      const page = transformMessageResponse(response.data);
-      setMessages(prev => prependOlderMessages(prev, page.messages));
-      setHasMore(page.hasMore);
-      setNextBefore(page.nextBefore);
-    } catch (err: any) {
-      if (isCurrentRequest()) {
-        setError(err.message || 'Failed to fetch older messages');
-      }
-    } finally {
-      if (olderPageInFlightRequestIdRef.current === requestId) {
-        olderPageInFlightRequestIdRef.current = null;
-      }
-      if (isCurrentRequest()) {
-        setLoadingOlder(false);
-      }
-    }
-  }, [hasMore, nextBefore, sessionId]);
-
   // Reset state synchronously before paint when session changes
   // to prevent flash of welcome screen (useEffect runs AFTER paint)
   useLayoutEffect(() => {
     activeSessionIdRef.current = sessionId;
+    provisionalMessageIdsRef.current.clear();
+    messageMutationVersionsRef.current.clear();
+    mutationVersionRef.current = 0;
     setMessages([]);
     setError(null);
-    setHasMore(false);
-    setNextBefore(null);
-    olderPageInFlightRequestIdRef.current = null;
-    setLoadingOlder(false);
     if (sessionId) {
       setLoading(true);
     } else {
@@ -588,15 +545,15 @@ export function useSessionMessages(sessionId?: string) {
   return {
     messages,
     loading,
-    loadingOlder,
-    hasMore,
     error,
     refetch: fetchMessages,
-    loadOlder,
     addMessage: (message: Message) => {
+      provisionalMessageIdsRef.current.add(message.id);
+      markMessageMutation(message.id);
       setMessages(prev => [...prev, message]);
     },
     updateMessage: (messageInfo: any) => {
+      markMessageMutation(messageInfo.id);
       setMessages(prev => {
         const existingIndex = prev.findIndex(m => m.id === messageInfo.id);
         if (existingIndex >= 0) {
@@ -630,6 +587,9 @@ export function useSessionMessages(sessionId?: string) {
           );
           if (tempIndex >= 0) {
             const updated = [...prev];
+            provisionalMessageIdsRef.current.delete(updated[tempIndex].id);
+            messageMutationVersionsRef.current.delete(updated[tempIndex].id);
+            provisionalMessageIdsRef.current.add(messageInfo.id);
             const nextUser = {
               id: messageInfo.id,
               sessionID: messageInfo.sessionID,
@@ -649,6 +609,7 @@ export function useSessionMessages(sessionId?: string) {
         }
 
         // Add new message
+        provisionalMessageIdsRef.current.add(messageInfo.id);
         const nextMessage = {
           id: messageInfo.id,
           sessionID: messageInfo.sessionID,
@@ -679,12 +640,26 @@ export function useSessionMessages(sessionId?: string) {
      * frame-level typing cadence and Markdown parse budget.
      */
     updateMessagePart: (partInfo: any, delta?: string) => {
-      setMessages(prev => applyMessagePartUpdate(prev, partInfo, delta));
+      markMessageMutation(partInfo.messageID);
+      setMessages(prev => {
+        if (!prev.some((message) => message.id === partInfo.messageID)) {
+          provisionalMessageIdsRef.current.add(partInfo.messageID);
+        }
+        return applyMessagePartUpdate(prev, partInfo, delta);
+      });
     },
     removeMessage: (messageId: string) => {
+      provisionalMessageIdsRef.current.delete(messageId);
+      messageMutationVersionsRef.current.delete(messageId);
       setMessages(prev => prev.filter((message) => message.id !== messageId));
     },
+    clearMessages: () => {
+      provisionalMessageIdsRef.current.clear();
+      messageMutationVersionsRef.current.clear();
+      setMessages([]);
+    },
     replaceMessageText: (messageId: string, partId: string, text: string) => {
+      markMessageMutation(messageId);
       setMessages(prev => prev.map((message) => {
         if (message.id !== messageId) return message;
 
@@ -705,6 +680,7 @@ export function useSessionMessages(sessionId?: string) {
       }));
     },
     markMessageStopped: (messageId: string) => {
+      markMessageMutation(messageId);
       setMessages(prev => prev.map((message) => {
         if (message.id !== messageId) return message;
         if (message.finish === 'stop') return message;
@@ -720,7 +696,12 @@ export function useSessionMessages(sessionId?: string) {
       setMessages(prev => {
         const targetIndex = prev.findIndex((message) => message.id === messageId);
         if (targetIndex < 0) return prev;
-        return prev.slice(0, options?.includeTarget ? targetIndex : targetIndex + 1);
+        const keepCount = options?.includeTarget ? targetIndex : targetIndex + 1;
+        prev.slice(keepCount).forEach((message) => {
+          provisionalMessageIdsRef.current.delete(message.id);
+          messageMutationVersionsRef.current.delete(message.id);
+        });
+        return prev.slice(0, keepCount);
       });
     },
   };

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -1767,9 +1767,8 @@ describe('SessionPage session actions menu', () => {
       expect(sessionApi.get).toHaveBeenCalledWith('session-missing-from-list');
     });
     expect(screen.queryByTestId('session-chat')).not.toBeInTheDocument();
-    expect(screen.getByTestId('session-chat-skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId('session-chat-skeleton')).not.toHaveClass('animate-pulse');
     expect(screen.getByTestId('workbench-refresh-status')).toHaveTextContent('restoringTask');
-    expect(screen.queryByText('loading-spinner')).not.toBeInTheDocument();
 
     await act(async () => {
       request.resolve(fetchedSession);

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -10,6 +10,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { getAnchoredMenuLeftOffset } from '@/components/common/ChatPromptSelectors';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useToast } from '@/components/common/Toast';
 import SessionChat, { buildInstructionDisplayText, type PromptDisplayOptions, type SSEChatEvent, type SSEConnectionStatus } from '@/components/common/SessionChat';
 import { useSSE } from '@/hooks/useSSE';
@@ -435,18 +436,13 @@ function SessionChatSkeleton() {
     <div
       data-testid="session-chat-skeleton"
       aria-hidden="true"
-      className="flex min-h-0 flex-1 justify-center overflow-hidden px-7 py-6"
+      className="flex min-h-0 flex-1 justify-center overflow-hidden px-7 pt-16"
     >
-      <div className="w-full max-w-[760px] animate-pulse space-y-7">
-        <div className="ml-auto h-16 w-[42%] rounded-2xl bg-black/[0.045] dark:bg-white/[0.055]" />
-        <div className="space-y-3">
-          <div className="h-3 w-24 rounded-full bg-black/[0.06] dark:bg-white/[0.07]" />
-          <div className="h-4 w-[86%] rounded-full bg-black/[0.055] dark:bg-white/[0.065]" />
-          <div className="h-4 w-[68%] rounded-full bg-black/[0.045] dark:bg-white/[0.055]" />
-          <div className="h-20 w-full rounded-2xl bg-black/[0.035] dark:bg-white/[0.045]" />
-        </div>
-        <div className="ml-auto h-12 w-[34%] rounded-2xl bg-black/[0.04] dark:bg-white/[0.05]" />
-      </div>
+      <LoadingSpinner
+        size="sm"
+        delayMs={180}
+        className="opacity-60 [&_svg]:text-zinc-400 dark:[&_svg]:text-zinc-500"
+      />
     </div>
   );
 }

--- a/webui/src/pages/Task/QueuedSection.test.tsx
+++ b/webui/src/pages/Task/QueuedSection.test.tsx
@@ -344,6 +344,15 @@ describe('QueuedSection', () => {
         sessionId: 'ses-task-1',
         live: true,
         hideInput: true,
+        display: {
+          compact: false,
+          fullWidth: true,
+          pageCanvas: true,
+          showTimestamp: true,
+          collapseIntermediateSteps: true,
+          processGroupsDefaultOpen: false,
+          processGroupsOpenWhileActive: true,
+        },
       }),
     );
   });

--- a/webui/src/pages/Task/QueuedSection.tsx
+++ b/webui/src/pages/Task/QueuedSection.tsx
@@ -467,6 +467,15 @@ function QueuedDetailPanel({ task, onClose, onAction, onRefresh }: {
               sessionId={sessionId}
               live={shouldStreamSession}
               hideInput
+              display={{
+                compact: false,
+                fullWidth: true,
+                pageCanvas: true,
+                showTimestamp: true,
+                collapseIntermediateSteps: true,
+                processGroupsDefaultOpen: false,
+                processGroupsOpenWhileActive: true,
+              }}
               emptyText={emptyText}
               className="flex-1 min-h-0"
               onSSEEvent={(event) => {


### PR DESCRIPTION
- load complete message history while preserving optimistic and SSE updates

- align task detail chat, loading states, avatars, and intermediate process summaries

- hide internal task metadata and surface message history read failures