### PR TITLE
fix(webui): harden session loading and presentation

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -55,6 +55,8 @@ const tMock = (key: string, options?: Record<string, unknown>) => {
   const value = ({
   'chat.placeholder': '请输入消息',
   'chat.emptyText': '暂无消息',
+  'chat.loadFailed': '消息加载失败',
+  'chat.retry': '重试',
   'chat.sending': '发送中...',
   'chat.thinking': '思考中...',
   'chat.streaming': '继续输出中...',
@@ -267,6 +269,7 @@ beforeEach(() => {
   useSessionMessagesMock.mockReturnValue({
     messages: [],
     loading: false,
+    error: null,
     refetch: vi.fn(),
     addMessage: vi.fn(),
     updateMessage: vi.fn(),
@@ -397,6 +400,7 @@ function mockStatefulSessionMessages() {
     return {
       messages,
       loading: false,
+      error: null,
       refetch: vi.fn(),
       addMessage: (message: Message) => setMessages((prev) => [...prev, message]),
       updateMessage: upsertMessage,
@@ -404,6 +408,7 @@ function mockStatefulSessionMessages() {
       removeMessage: (messageId: string) => setMessages((prev) => prev.filter(
         (message) => message.id !== messageId,
       )),
+      clearMessages: () => setMessages([]),
       replaceMessageText: vi.fn(),
       markMessageStopped: (messageId: string) => setMessages((prev) => prev.map(
         (message) => (message.id === messageId ? { ...message, finish: 'stop' } : message),
@@ -412,6 +417,120 @@ function mockStatefulSessionMessages() {
     };
   });
 }
+
+describe('SessionChat message loading state', () => {
+  it('renders a retry action instead of an empty conversation after loading fails', async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+    useSessionMessagesMock.mockReturnValue({
+      messages: [],
+      loading: false,
+      error: 'server unavailable',
+      refetch,
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      removeMessage: vi.fn(),
+      clearMessages: vi.fn(),
+      replaceMessageText: vi.fn(),
+      markMessageStopped: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent('消息加载失败');
+    expect(screen.queryByText('暂无消息')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '重试' }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ChatToolPart file operation titles', () => {
+  it('shows only the filename in the header while preserving the full path in details', () => {
+    const fullPath = '/Users/example/.flocks/workspace/outputs/2026-07-24/gold_price_retrieval_plan.md';
+    const { container } = render(React.createElement(ChatToolPart, {
+      part: {
+        id: 'tool-write-file',
+        type: 'tool',
+        tool: 'write',
+        state: {
+          status: 'completed',
+          input: { filePath: fullPath, content: '# Plan' },
+          output: 'Wrote file successfully.',
+          title: fullPath,
+        },
+      } as Message['parts'][number],
+    }));
+
+    const header = container.querySelector('summary');
+    expect(header).toHaveTextContent('gold_price_retrieval_plan.md');
+    expect(header).not.toHaveTextContent(fullPath);
+    expect(container).toHaveTextContent(fullPath);
+  });
+
+  it('handles Windows-style file paths in file tool headers', () => {
+    const { container } = render(React.createElement(ChatToolPart, {
+      part: {
+        id: 'tool-read-file',
+        type: 'tool',
+        tool: 'read_file',
+        state: {
+          status: 'completed',
+          input: { path: 'C:\\workspace\\reports\\summary.txt' },
+          output: 'summary',
+        },
+      } as Message['parts'][number],
+    }));
+
+    expect(container.querySelector('summary')).toHaveTextContent('summary.txt');
+  });
+
+  it('shows only the first filename and file count for multi-file patches', () => {
+    const firstPath = '/repo/src/a.ts';
+    const { container } = render(React.createElement(ChatToolPart, {
+      part: {
+        id: 'tool-apply-patch',
+        type: 'tool',
+        tool: 'apply_patch',
+        state: {
+          status: 'completed',
+          input: {
+            patchText: [
+              '*** Begin Patch',
+              `*** Update File: ${firstPath}`,
+              '*** Add File: /repo/src/b.ts',
+              '*** End Patch',
+            ].join('\n'),
+          },
+          output: 'Done!',
+        },
+      } as Message['parts'][number],
+    }));
+
+    const header = container.querySelector('summary');
+    expect(header).toHaveTextContent('a.ts +1');
+    expect(header).not.toHaveTextContent(firstPath);
+    expect(container).toHaveTextContent(firstPath);
+  });
+
+  it('does not change summaries for non-file tools', () => {
+    const { container } = render(React.createElement(ChatToolPart, {
+      part: {
+        id: 'tool-custom',
+        type: 'tool',
+        tool: 'custom_tool',
+        state: {
+          status: 'completed',
+          input: { path: '/api/v1/incidents' },
+          output: 'ok',
+        },
+      } as Message['parts'][number],
+    }));
+
+    expect(container.querySelector('summary')).toHaveTextContent('path=/api/v1/incidents');
+  });
+});
 
 describe('dedupeUploadedDocumentAttachments', () => {
   it('keeps the latest successful document for a workspace path', () => {
@@ -1141,7 +1260,7 @@ describe('SessionChat standalone thinking indicator', () => {
     }
   });
 
-  it('clears local messages before refetching after session.cleared', () => {
+  it('clears local messages without refetching after session.cleared', () => {
     const clearMessages = vi.fn();
     const refetch = vi.fn();
     useSessionMessagesMock.mockReturnValue({
@@ -1167,10 +1286,7 @@ describe('SessionChat standalone thinking indicator', () => {
     });
 
     expect(clearMessages).toHaveBeenCalledOnce();
-    expect(refetch).toHaveBeenCalledOnce();
-    expect(clearMessages.mock.invocationCallOrder[0]).toBeLessThan(
-      refetch.mock.invocationCallOrder[0],
-    );
+    expect(refetch).not.toHaveBeenCalled();
   });
 
   it('removes an intermediate assistant when message.removed arrives', () => {
@@ -2984,7 +3100,8 @@ describe('ChatToolPart semantic tool presentation', () => {
 
     summary = screen.getByTestId('chat-process-tool-step').querySelector('summary');
     expect(summary).toHaveTextContent('写入文件');
-    expect(summary).toHaveTextContent('/repo/report.md');
+    expect(summary).toHaveTextContent('report.md');
+    expect(summary).not.toHaveTextContent('/repo/report.md');
     expect(screen.getByText('输入参数')).toBeInTheDocument();
     expect(screen.queryByTestId('chat-tool-action-progress')).not.toBeInTheDocument();
   });
@@ -3032,7 +3149,8 @@ describe('ChatToolPart semantic tool presentation', () => {
 
     const summary = screen.getByTestId('chat-process-tool-step').querySelector('summary');
     expect(summary).toHaveTextContent('读取文件');
-    expect(summary).toHaveTextContent('/repo/webui/src/components/common/SessionChat.tsx · 5200');
+    expect(summary).toHaveTextContent('SessionChat.tsx');
+    expect(summary).not.toHaveTextContent('/repo/webui/src/components/common/SessionChat.tsx');
     expect(summary).not.toHaveTextContent('已完成');
     expect(summary).not.toHaveTextContent('filePath=');
   });

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -671,6 +671,10 @@ describe('getMessageBubbleClassName', () => {
 
     expect(className).toContain('w-auto');
     expect(className.split(' ')).not.toContain('w-full');
+    expect(className).toContain('rounded-[18px]');
+    expect(className).toContain('py-3');
+    expect(className).not.toContain('rounded-[24px]');
+    expect(className).not.toContain('py-4');
   });
 
   it('expands editing user bubbles to full width in full layout', () => {
@@ -692,6 +696,7 @@ describe('getMessageBubbleClassName', () => {
     });
 
     expect(className).toContain('w-full');
+    expect(className).toContain('text-[15px]');
   });
 
   it('fills the fixed compact assistant message column', () => {
@@ -739,7 +744,7 @@ describe('getMessageBubbleClassName', () => {
     });
 
     expect(className).toContain('bg-zinc-50');
-    expect(className).toContain('border-black/[0.07]');
+    expect(className).toContain(compact ? 'border-black/[0.07]' : 'border-black/[0.09]');
     expect(className).not.toContain('bg-sky-50');
     expect(className).not.toContain('border-sky-100');
   });
@@ -1951,7 +1956,8 @@ describe('SessionChat intermediate process collapse', () => {
     const processGroup = screen.getByTestId('chat-process-group') as HTMLDetailsElement;
     expect(processGroup.open).toBe(false);
     expect(screen.getByText('查看 2 个步骤')).toBeInTheDocument();
-    expect(processGroup.querySelector('summary')).toHaveClass('text-sm');
+    expect(processGroup.querySelector('summary')).toHaveClass('text-sm', 'font-medium');
+    expect(processGroup.querySelector('summary')).not.toHaveClass('font-semibold');
     expect(processGroup.className).not.toContain('rounded-lg');
     expect(processGroup.closest('[data-process-output="true"]')?.className).not.toContain('bg-white');
     expect(screen.getByText('已读取当前 workflow.md。')).toBeInTheDocument();
@@ -3212,7 +3218,7 @@ describe('ChatToolPart semantic tool presentation', () => {
 });
 
 describe('ChatMessageBubble session typography', () => {
-  it('uses the outer navigation font size for the agent label', () => {
+  it('gives the full-layout agent label a clear heading level', () => {
     render(React.createElement(ChatMessageBubble, {
       message: makeMessage({
         id: 'assistant-agent-label',
@@ -3223,9 +3229,10 @@ describe('ChatMessageBubble session typography', () => {
           text: '已加载技能。',
         } as any],
       }),
+      compact: false,
     }));
 
-    expect(screen.getByText('Rex')).toHaveClass('text-sm');
+    expect(screen.getByText('Rex')).toHaveClass('text-base', 'font-semibold', 'text-[#3f444a]');
   });
 });
 
@@ -3253,7 +3260,8 @@ describe('ChatMessageBubble footer layout', () => {
 
     expect(footer).toHaveClass('justify-start', 'gap-1.5');
     expect(footer?.children[0]).toBe(actionGroup);
-    expect(footer?.children[1]).toHaveClass('text-[11px]');
+    expect(footer?.children[1]).toHaveClass('text-[11px]', 'text-[#8b929d]');
+    expect(regenerateButton).toHaveClass('text-[#8b929d]');
     expect(regenerateButton).toHaveClass(
       'border-transparent',
       'bg-transparent',
@@ -3447,7 +3455,9 @@ describe('SessionChat context usage popover', () => {
     render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
 
     const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
-    expect(contextButton).toHaveClass('h-6', 'w-6');
+    expect(contextButton).toHaveClass('h-6');
+    expect(contextButton).not.toHaveClass('w-6');
+    expect(contextButton).toHaveTextContent('12%');
     await user.click(contextButton);
 
     expect(screen.getByText('System prompt')).toBeInTheDocument();

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -564,18 +564,18 @@ function ContextUsageRing({
   return (
     <div
       ref={wrapperRef}
-      className="relative inline-flex h-6 w-6 shrink-0 items-center justify-center"
+      className="relative inline-flex h-6 shrink-0 items-center justify-center"
     >
       <button
         type="button"
-        className="relative inline-flex h-6 w-6 items-center justify-center rounded-full transition-colors hover:bg-zinc-200/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+        className="relative inline-flex h-6 items-center gap-1 rounded-md px-1 text-[10px] font-medium tabular-nums text-zinc-500 transition-colors hover:bg-zinc-200/60 hover:text-zinc-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
         title={title}
         aria-label={title}
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
       >
-        <svg className="absolute inset-0 h-6 w-6 -rotate-90" viewBox="0 0 24 24" aria-hidden="true">
+        <svg className="h-5 w-5 shrink-0 -rotate-90" viewBox="0 0 24 24" aria-hidden="true">
           <circle cx="12" cy="12" r={radius} fill="none" strokeWidth="2" className="stroke-zinc-200 dark:stroke-zinc-800" />
           <circle
             cx="12"
@@ -589,6 +589,7 @@ function ContextUsageRing({
             strokeDashoffset={strokeDashoffset}
           />
         </svg>
+        <span aria-hidden="true">{clamped}%</span>
       </button>
 
       {open && (
@@ -824,7 +825,9 @@ export function getMessageBubbleClassName({
   isEditing: boolean;
 }): string {
   if (!isUser) {
-    return 'w-full max-w-full min-w-0 bg-transparent py-1 text-sm text-[#34393e] break-words dark:text-zinc-100';
+    const typographyClass = compact ? 'text-sm' : 'text-[15px]';
+
+    return `w-full max-w-full min-w-0 bg-transparent py-1 ${typographyClass} text-[#34393e] break-words dark:text-zinc-100`;
   }
 
   if (compact) {
@@ -835,7 +838,7 @@ export function getMessageBubbleClassName({
 
   const widthClass = isEditing ? 'w-full' : 'w-auto';
 
-  return `${widthClass} min-w-0 max-w-full px-5 py-4 rounded-[24px] text-sm break-words shadow-sm border border-black/[0.07] bg-zinc-50 text-[#30343a] dark:border-white/[0.08] dark:bg-[#303842] dark:text-zinc-50 dark:shadow-none`;
+  return `${widthClass} min-w-0 max-w-full px-5 py-3 rounded-[18px] text-sm break-words shadow-sm border border-black/[0.09] bg-zinc-50 text-[#30343a] dark:border-white/[0.10] dark:bg-[#303842] dark:text-zinc-50 dark:shadow-none`;
 }
 
 export function getInstructionDisplayBubbleClassName(compact: boolean): string {
@@ -3507,7 +3510,7 @@ export default function SessionChat({
                     : isStreaming
                       ? 'border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900/70'
                       : pageCanvas && !compact
-                        ? 'border-black/[0.07] bg-zinc-50 hover:border-black/[0.11] focus-within:border-black/[0.11] focus-within:bg-white focus-within:ring-4 focus-within:ring-black/[0.025] dark:border-white/[0.08] dark:bg-[#303842] dark:hover:border-white/[0.13] dark:focus-within:border-white/[0.14] dark:focus-within:bg-[#343d48] dark:focus-within:ring-white/[0.03]'
+                        ? 'border-black/[0.09] bg-zinc-50 hover:border-black/[0.14] focus-within:border-black/[0.14] focus-within:bg-white focus-within:ring-4 focus-within:ring-black/[0.025] dark:border-white/[0.10] dark:bg-[#303842] dark:hover:border-white/[0.16] dark:focus-within:border-white/[0.16] dark:focus-within:bg-[#343d48] dark:focus-within:ring-white/[0.03]'
                         : 'border-zinc-200 bg-zinc-50 hover:border-zinc-300 focus-within:border-zinc-300 focus-within:bg-white focus-within:ring-4 focus-within:ring-zinc-100 dark:border-zinc-800 dark:bg-zinc-900/70 dark:hover:border-zinc-700 dark:focus-within:border-zinc-700 dark:focus-within:bg-zinc-900 dark:focus-within:ring-zinc-800/60'
               }`}
             >
@@ -3676,7 +3679,7 @@ export default function SessionChat({
                             ? t('chat.placeholderNodeRef', { nodeId: nodeRef.id })
                             : effectivePlaceholder
                     }
-                    className={`w-full resize-none outline-none bg-transparent text-sm placeholder-zinc-400 dark:placeholder-zinc-600 ${
+                    className={`w-full resize-none bg-transparent text-sm outline-none placeholder:text-[#7b838e] dark:placeholder:text-[#9aa7b4] ${
                       sending ? 'text-zinc-400 cursor-not-allowed dark:text-zinc-500' : 'text-zinc-900 dark:text-zinc-100'
                     }`}
                     style={{
@@ -3963,11 +3966,11 @@ function ProcessGroupDetails({
     <details
       open={effectiveOpen}
       data-testid="chat-process-group"
-      className="group/process mt-2 w-full first:mt-0 text-[#6f757c] dark:text-zinc-400"
+      className="group/process mt-2 w-full first:mt-0 text-[#626874] dark:text-[#aab4bf]"
     >
       <summary
         onClick={handleSummaryClick}
-        className="flex min-h-7 cursor-pointer list-none items-center gap-2 text-sm font-semibold transition-colors hover:text-zinc-900 dark:hover:text-zinc-200 [&::-webkit-details-marker]:hidden"
+        className="flex min-h-7 cursor-pointer list-none items-center gap-2 text-sm font-medium transition-colors hover:text-zinc-900 dark:hover:text-zinc-100 [&::-webkit-details-marker]:hidden"
       >
         {summary}
         <ChevronDown className="ml-0.5 h-3 w-3 flex-shrink-0 text-[#9da29f] transition-transform group-open/process:rotate-180 dark:text-zinc-500" />
@@ -4057,12 +4060,12 @@ function ChatMessageBubbleInner({
   const bubbleClass = instructionDisplayLabel
     ? getInstructionDisplayBubbleClassName(compact)
     : hasProcessOutput
-      ? 'w-full max-w-full min-w-0 break-words text-sm text-zinc-700 dark:text-zinc-200'
+      ? `w-full max-w-full min-w-0 break-words ${compact ? 'text-sm' : 'text-[15px]'} text-[#34393e] dark:text-zinc-100`
       : getMessageBubbleClassName({ compact, isUser, isEditing });
   const messageGroupClass = getMessageGroupClassName({ compact, isUser, isEditing });
   const actionBarClass = `flex items-center gap-1.5`;
   const editingActionBarClass = getEditingActionBarClassName();
-  const iconButtonClass = 'group/action relative inline-flex h-6 w-6 items-center justify-center rounded-full border border-transparent bg-transparent text-gray-400 transition-colors duration-150 hover:bg-white hover:text-gray-700 active:bg-white focus-visible:bg-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40 dark:text-zinc-500 dark:hover:bg-white/[0.08] dark:hover:text-zinc-200 dark:active:bg-white/[0.08] dark:focus-visible:bg-white/[0.08]';
+  const iconButtonClass = 'group/action relative inline-flex h-6 w-6 items-center justify-center rounded-full border border-transparent bg-transparent text-[#8b929d] transition-colors duration-150 hover:bg-white hover:text-[#4f5660] active:bg-white focus-visible:bg-white focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40 dark:text-[#9aa7b4] dark:hover:bg-white/[0.08] dark:hover:text-zinc-100 dark:active:bg-white/[0.08] dark:focus-visible:bg-white/[0.08]';
   const tooltipClass = 'pointer-events-none absolute bottom-full left-1/2 z-10 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-gray-900 px-2 py-1 text-[11px] font-medium text-white opacity-0 shadow-sm transition-opacity duration-150 group-hover/action:opacity-100';
   const messageErrorText = isUser ? '' : getMessageErrorText(message);
   const hasOnlyBlankTextParts = parts.length > 0 && parts.every((part) =>
@@ -4468,7 +4471,7 @@ function ChatMessageBubbleInner({
     </div>
   );
   const footerTimestamp = showTimestamp && message.timestamp
-    ? <span className="text-[11px] text-zinc-400 select-none">{formatSmartTime(message.timestamp, i18n.language)}</span>
+    ? <span className="select-none text-[11px] text-[#8b929d] dark:text-[#9aa7b4]">{formatSmartTime(message.timestamp, i18n.language)}</span>
     : null;
   const footer = !compact && showActions && parts.length > 0 && !isEditing ? (
     <div className={`mt-1.5 flex items-center ${
@@ -4578,7 +4581,7 @@ function ChatMessageBubbleInner({
         </div>
         <div className="flex w-full min-w-0 flex-col items-start">
           <div className={`flex items-center gap-2 ${headerHeight}`}>
-            <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+            <span className="text-base font-semibold text-[#3f444a] dark:text-[#d7dee8]">
               {agentName}
             </span>
           </div>

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -34,7 +34,7 @@ import type { Command } from '@/api/skill';
 import type { Agent } from '@/api/agent';
 import { useToast } from './Toast';
 import { buildRunWorkflowHeaderSummary } from './toolStageSummary';
-import { redactToolInput, resolveToolPresentation } from './toolPresentation';
+import { getFileOperationDisplayName, redactToolInput, resolveToolPresentation } from './toolPresentation';
 import { areChatMessagePartsRenderEqual } from './sessionChatRenderEquality';
 import { workspaceAPI } from '@/api/workspace';
 import { formatSmartTime } from '@/utils/time';
@@ -1730,6 +1730,7 @@ export default function SessionChat({
   const {
     messages,
     loading,
+    error: messagesError,
     refetch,
     addMessage,
     updateMessage,
@@ -1819,7 +1820,6 @@ export default function SessionChat({
           setGoalBanner(null);
           setDismissedGoalKey('');
           clearMessages();
-          refetch();
           void refreshContextUsage({ clear: true });
           return;
         case 'session-status':
@@ -3207,6 +3207,21 @@ export default function SessionChat({
               delayMs={180}
               className="opacity-60 [&_svg]:text-zinc-400 dark:[&_svg]:text-zinc-500"
             />
+          </div>
+        ) : messagesError && messages.length === 0 ? (
+          <div className="flex min-h-40 items-center justify-center px-6" role="alert">
+            <div className="flex flex-col items-center gap-3 text-center">
+              <span className="text-sm text-zinc-500 dark:text-zinc-400">
+                {t('chat.loadFailed')}
+              </span>
+              <button
+                type="button"
+                onClick={() => void refetch()}
+                className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              >
+                {t('chat.retry')}
+              </button>
+            </div>
           </div>
         ) : messages.length === 0 ? (
           welcomeContent ? (
@@ -5259,18 +5274,21 @@ export function ChatToolPart({ part, pendingQuestion, onAnswer, onReject, proces
   const displayTitle = state.title ? truncateToolDisplayText(state.title) : '';
   const workflowHeaderSummary = truncateToolDisplayText(buildRunWorkflowHeaderSummary(toolName, state, t));
   const semanticDetail = truncateToolDisplayText(toolPresentation.detail);
+  const fileOperationDisplayName = truncateToolDisplayText(getFileOperationDisplayName(toolName, state));
   const toolDisplayName = toolPresentation.label;
   const processStepLabel = isTodoTool
     ? t('chat.tool.todoUpdated')
     : toolPresentation.known
       ? toolDisplayName
       : config.label;
-  const processStepDetail = workflowHeaderSummary
+  const processStepDetail = fileOperationDisplayName
+    || workflowHeaderSummary
     || semanticDetail
     || displayTitle
     || inputSummary
     || (toolPresentation.known ? '' : toolDisplayName);
-  const cardHeaderDetail = workflowHeaderSummary
+  const cardHeaderDetail = fileOperationDisplayName
+    || workflowHeaderSummary
     || semanticDetail
     || inputSummary
     || displayTitle;

--- a/webui/src/components/common/StreamingMarkdown.test.tsx
+++ b/webui/src/components/common/StreamingMarkdown.test.tsx
@@ -330,4 +330,18 @@ describe('StreamingMarkdown', () => {
     expect(paragraph?.querySelectorAll('br')).toHaveLength(2);
     expect(paragraph?.textContent).toBe('first line\nsecond line\nthird line');
   });
+
+  it('renders inline code as a lightweight chip', () => {
+    const { container } = render(
+      <StreamingMarkdown content={'Saved to `.flocks/plans/plan.md`.'} isStreaming={false} />,
+    );
+
+    expect(container.querySelector('code')).toHaveClass(
+      'rounded-md',
+      'bg-zinc-100/80',
+      'font-normal',
+      'text-zinc-700',
+    );
+    expect(container.querySelector('code')).not.toHaveClass('font-semibold');
+  });
 });

--- a/webui/src/components/common/StreamingMarkdown.tsx
+++ b/webui/src/components/common/StreamingMarkdown.tsx
@@ -265,7 +265,7 @@ const MarkdownContent = memo(function MarkdownContent({ content }: { content: st
             if (!isBlock) {
               return (
                 <code
-                  className="bg-gray-100 text-gray-800 px-1 py-0.5 rounded text-[0.85em] font-mono"
+                  className="rounded-md bg-zinc-100/80 px-1.5 py-0.5 font-mono text-[0.85em] font-normal text-zinc-700 dark:bg-white/[0.07] dark:text-zinc-200"
                   {...props}
                 >
                   {children}

--- a/webui/src/components/common/toolPresentation.test.ts
+++ b/webui/src/components/common/toolPresentation.test.ts
@@ -4,6 +4,7 @@ import enSession from '@/locales/en-US/session.json';
 import zhSession from '@/locales/zh-CN/session.json';
 
 import {
+  getFileOperationDisplayName,
   redactToolInput,
   resolveToolPresentation,
   type ToolPresentationTranslator,
@@ -151,6 +152,21 @@ describe('resolveToolPresentation', () => {
       label: 'custom plugin action',
       detail: '',
     });
+  });
+});
+
+describe('getFileOperationDisplayName', () => {
+  it('uses the first filename and changed-file count for apply_patch', () => {
+    expect(getFileOperationDisplayName('apply_patch', {
+      input: {
+        patchText: [
+          '*** Begin Patch',
+          '*** Update File: /repo/src/a.ts',
+          '*** Add File: C:\\repo\\src\\b.ts',
+          '*** End Patch',
+        ].join('\n'),
+      },
+    })).toBe('a.ts +1');
   });
 });
 

--- a/webui/src/components/common/toolPresentation.ts
+++ b/webui/src/components/common/toolPresentation.ts
@@ -113,6 +113,17 @@ const ACTION_LABEL_KEYS: Record<string, Record<string, string>> = {
 
 const SENSITIVE_KEY_PATTERN =
   /(?:api[_-]?key|password|passwd|token|secret|authorization|credential|private[_-]?key|access[_-]?key|cookie)/i;
+const FILE_OPERATION_TOOL_NAMES = new Set([
+  'read',
+  'write',
+  'edit',
+  'apply_patch',
+  'read_file',
+  'write_file',
+  'edit_file',
+  'create_file',
+  'delete_file',
+]);
 
 function stringValue(
   input: Record<string, unknown>,
@@ -147,15 +158,49 @@ function workflowName(value: unknown): string {
   return lastSegment.replace(/\.json$/i, '');
 }
 
-function patchDetail(value: unknown): string {
-  if (typeof value !== 'string') return '';
-  const paths = Array.from(
+function patchPaths(value: unknown): string[] {
+  if (typeof value !== 'string') return [];
+  return Array.from(
     value.matchAll(/^\*\*\* (?:Add|Update|Delete) File:\s*(.+)$/gm),
     (match) => match[1]?.trim(),
   ).filter((path): path is string => Boolean(path));
+}
+
+function patchDetail(value: unknown): string {
+  const paths = patchPaths(value);
   if (paths.length === 0) return '';
   if (paths.length === 1) return paths[0];
   return `${paths[0]} +${paths.length - 1}`;
+}
+
+function fileName(value: string): string {
+  const normalized = value.trim().replace(/[\\/]+$/g, '');
+  if (!normalized) return '';
+  return normalized.split(/[\\/]/).filter(Boolean).pop() || normalized;
+}
+
+export function getFileOperationDisplayName(
+  toolName: string,
+  state: Partial<ToolState>,
+): string {
+  if (!FILE_OPERATION_TOOL_NAMES.has(toolName)) return '';
+
+  if (toolName === 'apply_patch') {
+    const paths = patchPaths(state.input?.patchText);
+    if (paths.length > 0) {
+      const firstFileName = fileName(paths[0]);
+      return paths.length === 1 ? firstFileName : `${firstFileName} +${paths.length - 1}`;
+    }
+  }
+
+  const path = stringValue(
+    state.input || {},
+    'filePath',
+    'filepath',
+    'file_path',
+    'path',
+  ) || (typeof state.title === 'string' ? state.title : '');
+  return fileName(path);
 }
 
 function resolveLabelKey(toolName: string, input: Record<string, unknown>): string | undefined {

--- a/webui/src/hooks/useSessions.test.ts
+++ b/webui/src/hooks/useSessions.test.ts
@@ -926,6 +926,58 @@ describe('updateMessagePart scheduling', () => {
     expect(result.current.messages).toEqual([]);
   });
 
+  it('keeps messages empty when a request started before clear resolves late', async () => {
+    const pendingRequest = deferred<any>();
+    vi.mocked(client.get).mockReturnValueOnce(pendingRequest.promise);
+
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    expect(result.current.loading).toBe(true);
+
+    act(() => {
+      result.current.clearMessages();
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      pendingRequest.resolve({
+        data: [{
+          info: {
+            id: 'msg-deleted-before-response',
+            sessionID: 'sess-1',
+            role: 'assistant',
+            time: { created: 100 },
+          },
+          parts: [{ id: 'part-deleted-before-response', type: 'text', text: 'stale' }],
+        }],
+      });
+      await pendingRequest.promise;
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('resets a previous loading error when messages are cleared', async () => {
+    vi.mocked(client.get).mockRejectedValueOnce(new Error('storage unavailable'));
+
+    const { result } = renderHook(() => useSessionMessages('sess-1'));
+    await act(async () => {});
+    expect(result.current.error).toBe('storage unavailable');
+
+    act(() => {
+      result.current.clearMessages();
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(client.get).toHaveBeenCalledOnce();
+  });
+
 });
 
 describe('useSessions list loading', () => {

--- a/webui/src/hooks/useSessions.ts
+++ b/webui/src/hooks/useSessions.ts
@@ -654,9 +654,13 @@ export function useSessionMessages(sessionId?: string) {
       setMessages(prev => prev.filter((message) => message.id !== messageId));
     },
     clearMessages: () => {
+      requestIdRef.current += 1;
       provisionalMessageIdsRef.current.clear();
       messageMutationVersionsRef.current.clear();
+      mutationVersionRef.current = 0;
       setMessages([]);
+      setError(null);
+      setLoading(false);
     },
     replaceMessageText: (messageId: string, partId: string, text: string) => {
       markMessageMutation(messageId);

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -106,6 +106,8 @@
     "placeholderStreaming": "AI is processing, please wait...",
     "placeholderNodeRef": "Describe the change intent for node {{nodeId}}...",
     "emptyText": "No execution records",
+    "loadFailed": "Failed to load messages",
+    "retry": "Retry",
     "suggestions": "Example questions",
     "stopTitle": "Stop execution",
     "contextUsageTitle": "Context used: {{used}} / {{total}} ({{percent}}%)",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -106,6 +106,8 @@
     "placeholderStreaming": "AI 正在处理中，请稍候...",
     "placeholderNodeRef": "描述对节点 {{nodeId}} 的修改意图...",
     "emptyText": "暂无执行记录",
+    "loadFailed": "消息加载失败",
+    "retry": "重试",
     "suggestions": "示例问题",
     "stopTitle": "停止执行",
     "contextUsageTitle": "上下文已用：{{used}} / {{total}}（{{percent}}%）",

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -451,9 +451,9 @@ describe('SessionPage session actions menu', () => {
     const sessionTitle = await within(workbenchSidebar).findByText('Original Session');
     const selectedRow = sessionTitle.closest('div.group');
 
-    expect(workbenchCanvas).toHaveClass('bg-gray-50', 'dark:bg-[#252c35]');
-    expect(workbenchSidebar).toHaveClass('bg-white', 'dark:bg-[#303842]');
-    expect(mainCanvas).toHaveClass('bg-gray-50', 'dark:bg-[#252c35]');
+    expect(workbenchCanvas).toHaveClass('bg-[#fcfcfd]', 'dark:bg-[#303842]');
+    expect(workbenchSidebar).toHaveClass('bg-gray-50', 'dark:bg-[#252c35]');
+    expect(mainCanvas).toHaveClass('bg-[#fcfcfd]', 'dark:bg-[#303842]');
     await waitFor(() => {
       expect(selectedRow).toHaveClass('bg-zinc-200/70', 'dark:bg-[#3a434e]');
     });

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -453,7 +453,12 @@ describe('SessionPage session actions menu', () => {
 
     expect(workbenchCanvas).toHaveClass('bg-[#fcfcfd]', 'dark:bg-[#303842]');
     expect(workbenchSidebar).toHaveClass('bg-gray-50', 'dark:bg-[#252c35]');
+    expect(workbenchSidebar).toHaveClass('h-full', 'border-r');
+    expect(workbenchSidebar).toHaveClass('border-black/[0.10]');
+    expect(workbenchSidebar).not.toHaveClass('rounded-2xl');
+    expect(workbenchSidebar.className).not.toContain('shadow-');
     expect(mainCanvas).toHaveClass('bg-[#fcfcfd]', 'dark:bg-[#303842]');
+    expect(within(mainCanvas as HTMLElement).getByRole('heading', { level: 2 })).toHaveClass('text-[#555a61]');
     await waitFor(() => {
       expect(selectedRow).toHaveClass('bg-zinc-200/70', 'dark:bg-[#3a434e]');
     });

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -1838,10 +1838,10 @@ export default function SessionPage() {
   const showSessionListSkeleton = loadingSessions && sessions.length === 0;
 
   return (
-    <div className="flex h-full w-full overflow-hidden bg-gray-50 text-[#202328] dark:bg-[#252c35] dark:text-[#d7dee8]">
+    <div className="flex h-full w-full overflow-hidden bg-[#fcfcfd] text-[#202328] dark:bg-[#303842] dark:text-[#d7dee8]">
       {/* ── Sidebar ── */}
       <div
-        className={`flex h-[calc(100%_-_1.5rem)] flex-shrink-0 flex-col overflow-hidden rounded-2xl border bg-white shadow-[0_3px_12px_rgba(22,27,34,0.045)] transition-[width,margin,opacity] duration-200 dark:border-white/[0.08] dark:bg-[#303842] dark:shadow-[0_8px_24px_rgba(15,18,22,0.16)] ${
+        className={`flex h-[calc(100%_-_1.5rem)] flex-shrink-0 flex-col overflow-hidden rounded-2xl border bg-gray-50 shadow-[0_3px_12px_rgba(22,27,34,0.045)] transition-[width,margin,opacity] duration-200 dark:border-white/[0.08] dark:bg-[#252c35] dark:shadow-[0_8px_24px_rgba(15,18,22,0.16)] ${
           sidebarCollapsed
             ? 'my-3 w-0 border-transparent opacity-0'
             : 'm-3 w-[282px] border-black/[0.07] opacity-100'
@@ -2294,7 +2294,7 @@ export default function SessionPage() {
       </div>
 
       {/* ── Main area ── */}
-      <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden bg-gray-50 dark:bg-[#252c35]">
+      <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden bg-[#fcfcfd] dark:bg-[#303842]">
         {/* Header */}
         <div className="relative flex h-[52px] flex-shrink-0 items-center gap-2 px-4 text-[13px]">
           <div className="shrink-0">

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -1841,10 +1841,10 @@ export default function SessionPage() {
     <div className="flex h-full w-full overflow-hidden bg-[#fcfcfd] text-[#202328] dark:bg-[#303842] dark:text-[#d7dee8]">
       {/* ── Sidebar ── */}
       <div
-        className={`flex h-[calc(100%_-_1.5rem)] flex-shrink-0 flex-col overflow-hidden rounded-2xl border bg-gray-50 shadow-[0_3px_12px_rgba(22,27,34,0.045)] transition-[width,margin,opacity] duration-200 dark:border-white/[0.08] dark:bg-[#252c35] dark:shadow-[0_8px_24px_rgba(15,18,22,0.16)] ${
+        className={`flex h-full flex-shrink-0 flex-col overflow-hidden border-r bg-gray-50 transition-[width,opacity] duration-200 dark:bg-[#252c35] ${
           sidebarCollapsed
-            ? 'my-3 w-0 border-transparent opacity-0'
-            : 'm-3 w-[282px] border-black/[0.07] opacity-100'
+            ? 'w-0 border-transparent opacity-0'
+            : 'w-[282px] border-black/[0.10] opacity-100 dark:border-white/[0.10]'
         }`}
         aria-label={t('managementTitle')}
       >
@@ -2296,7 +2296,7 @@ export default function SessionPage() {
       {/* ── Main area ── */}
       <div className="flex h-full min-w-0 flex-1 flex-col overflow-hidden bg-[#fcfcfd] dark:bg-[#303842]">
         {/* Header */}
-        <div className="relative flex h-[52px] flex-shrink-0 items-center gap-2 px-4 text-[13px]">
+        <header className="relative flex h-[52px] flex-shrink-0 items-center gap-2 px-4 text-[13px]">
           <div className="shrink-0">
             <button
               onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
@@ -2317,7 +2317,7 @@ export default function SessionPage() {
           {workbenchRefreshing && (
             <WorkbenchRefreshStatus label={workbenchRefreshLabel} />
           )}
-        </div>
+        </header>
 
         {/* Chat — powered by unified SessionChat */}
         {resolvingSelectedSession ? (


### PR DESCRIPTION
Show recoverable message-loading failures and invalidate stale requests when sessions are cleared without adding a redundant refetch. Display filenames for file operations, including multi-file patches, and refine the workbench canvas colors.