### PR TITLE
feat(webui): add unified composer resource picker

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -2964,6 +2964,11 @@ describe('SessionChat composer references', () => {
         ),
         React.createElement(
           'button',
+          { type: 'button', onClick: () => insertReference('code-review', 'skill') },
+          '选择第二个技能',
+        ),
+        React.createElement(
+          'button',
           { type: 'button', onClick: () => insertReference('triage', 'workflow') },
           '选择工作流',
         ),
@@ -2973,12 +2978,15 @@ describe('SessionChat composer references', () => {
     await user.click(screen.getByRole('button', { name: '添加' }));
     await user.click(screen.getByRole('button', { name: '选择子智能体' }));
     await user.click(screen.getByRole('button', { name: '选择技能' }));
+    await user.click(screen.getByRole('button', { name: '选择第二个技能' }));
     await user.click(screen.getByRole('button', { name: '选择工作流' }));
+    expect(within(screen.getByLabelText('已选择的资源')).getByText('diagnose')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('已选择的资源')).getByText('code-review')).toBeInTheDocument();
     await user.type(screen.getByPlaceholderText('请输入消息'), 'check this{enter}');
 
     await waitFor(() => {
       expect(onCreateAndSend).toHaveBeenCalledWith(
-        'workflow:triage skill:diagnose subagent:explore check this',
+        'workflow:triage skill:code-review skill:diagnose subagent:explore check this',
         [],
         'explore',
         undefined,

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -87,6 +87,13 @@ const tMock = (key: string, options?: Record<string, unknown>) => {
   'chat.goal.status.completed': 'Completed',
   'chat.goal.status.blocked': 'Blocked',
   'chat.goal.status.paused': 'Paused',
+  'chat.addMenu.title': '添加',
+  'chat.addMenu.files': '文件和图片',
+  'chat.references.selected': '已选择的资源',
+  'chat.references.subagent': '子智能体',
+  'chat.references.skill': '技能',
+  'chat.references.workflow': '工作流',
+  'chat.references.remove': '移除 {{type}} {{name}}',
   'chat.mention.title': '选择 Agent',
   'chat.mention.navigate': '导航',
   'chat.mention.select': '选择',
@@ -1449,6 +1456,95 @@ describe('SessionChat composer controls', () => {
     expect(sendButton?.className).toContain('dark:text-[#b8c2cc]');
     expect(sendButton?.className).toContain('dark:border-[#5a6573]');
   });
+
+  it('groups attachment and injected actions in the Add menu', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      onComposerAddMenuOpenChange: onOpenChange,
+      composerAddMenuSlot: ({ insertMention, insertReference }) => React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(
+          'button',
+          { type: 'button', onClick: () => insertMention('explore') },
+          '智能体',
+        ),
+        React.createElement(
+          'button',
+          { type: 'button', onClick: () => insertReference('diagnose', 'skill') },
+          '技能',
+        ),
+      ),
+    }));
+
+    await user.click(screen.getByRole('button', { name: '添加' }));
+
+    expect(screen.getByRole('menu', { name: '添加' })).toBeInTheDocument();
+    expect(screen.getByText('文件和图片')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '智能体' }));
+    expect(within(screen.getByLabelText('已选择的资源')).getByText('explore')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '技能' }));
+    expect(within(screen.getByLabelText('已选择的资源')).getByText('diagnose')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('请输入消息')).toHaveValue('');
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('menu', { name: '添加' })).not.toBeInTheDocument();
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('keeps a selected subagent reference when the default agent changes', async () => {
+    const user = userEvent.setup();
+    const mentionAgents = [
+      {
+        name: 'rex',
+        description: 'Main orchestrator',
+        mode: 'primary',
+        permission: [],
+        options: {},
+        skills: [],
+        tools: [],
+      },
+      {
+        name: 'explore',
+        description: 'Explore the codebase',
+        mode: 'subagent',
+        native: true,
+        permission: [],
+        options: {},
+        skills: [],
+        tools: [],
+      },
+    ];
+    function AgentMenuHarness() {
+      const [agentName, setAgentName] = React.useState('rex');
+      return React.createElement(SessionChat, {
+        sessionId: 'sess-1',
+        agentName,
+        mentionAgents,
+        composerAddMenuSlot: ({ insertMention }) => React.createElement(
+          'button',
+          {
+            type: 'button',
+            onClick: () => {
+              setAgentName('explore');
+              insertMention('explore');
+            },
+          },
+          '选择 Explore',
+        ),
+      });
+    }
+    render(React.createElement(AgentMenuHarness));
+
+    await user.click(screen.getByRole('button', { name: '添加' }));
+    await user.click(screen.getByRole('button', { name: '选择 Explore' }));
+
+    expect(within(screen.getByLabelText('已选择的资源')).getByText('explore')).toBeInTheDocument();
+  });
 });
 
 describe('shouldRenderMessage', () => {
@@ -2782,7 +2878,7 @@ describe('SessionChat optimistic message identity', () => {
   });
 });
 
-describe('SessionChat agent mentions', () => {
+describe('SessionChat composer references', () => {
   const mentionAgents = [
     {
       name: 'rex',
@@ -2807,20 +2903,20 @@ describe('SessionChat agent mentions', () => {
     },
   ];
 
-  it('shows matching agents when typing @', async () => {
+  it('opens the same Add menu when typing @', async () => {
     const user = userEvent.setup();
     render(React.createElement(SessionChat, {
       sessionId: 'sess-1',
       mentionAgents,
     }));
 
-    await user.type(screen.getByPlaceholderText('请输入消息'), '@ex');
+    await user.type(screen.getByPlaceholderText('请输入消息'), '@');
 
-    expect(screen.getByText('@explore')).toBeInTheDocument();
-    expect(screen.getByText('探索代码库')).toBeInTheDocument();
+    expect(screen.getByRole('menu', { name: '添加' })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('请输入消息')).toHaveValue('');
   });
 
-  it('routes one message to the mentioned agent without changing the default agent', async () => {
+  it('routes one message to a structured subagent reference', async () => {
     const user = userEvent.setup();
     render(React.createElement(SessionChat, {
       sessionId: 'sess-1',
@@ -2828,7 +2924,10 @@ describe('SessionChat agent mentions', () => {
       mentionAgents,
     }));
 
-    await user.type(screen.getByPlaceholderText('请输入消息'), '@explore summarize this file{enter}');
+    await user.type(
+      screen.getByPlaceholderText('请输入消息'),
+      'subagent:explore summarize this file{enter}',
+    );
 
     await waitFor(() => {
       expect(clientPostMock).toHaveBeenCalledWith(
@@ -2837,6 +2936,51 @@ describe('SessionChat agent mentions', () => {
           agent: 'explore',
           parts: expect.any(Array),
         }),
+      );
+    });
+  });
+
+  it('sends selected resources using the unified structured syntax', async () => {
+    const user = userEvent.setup();
+    const onCreateAndSend = vi.fn().mockResolvedValue('sess-created');
+    render(React.createElement(SessionChat, {
+      sessionId: null,
+      agentName: 'rex',
+      mentionAgents,
+      onCreateAndSend,
+      composerAddMenuSlot: ({ insertMention, insertReference }) => React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(
+          'button',
+          { type: 'button', onClick: () => insertMention('explore') },
+          '选择子智能体',
+        ),
+        React.createElement(
+          'button',
+          { type: 'button', onClick: () => insertReference('diagnose', 'skill') },
+          '选择技能',
+        ),
+        React.createElement(
+          'button',
+          { type: 'button', onClick: () => insertReference('triage', 'workflow') },
+          '选择工作流',
+        ),
+      ),
+    }));
+
+    await user.click(screen.getByRole('button', { name: '添加' }));
+    await user.click(screen.getByRole('button', { name: '选择子智能体' }));
+    await user.click(screen.getByRole('button', { name: '选择技能' }));
+    await user.click(screen.getByRole('button', { name: '选择工作流' }));
+    await user.type(screen.getByPlaceholderText('请输入消息'), 'check this{enter}');
+
+    await waitFor(() => {
+      expect(onCreateAndSend).toHaveBeenCalledWith(
+        'workflow:triage skill:diagnose subagent:explore check this',
+        [],
+        'explore',
+        undefined,
       );
     });
   });
@@ -2880,7 +3024,7 @@ describe('SessionChat agent mentions', () => {
     });
 
     sessionApiEnqueuePromptMock.mockClear();
-    await user.type(screen.getByRole('textbox'), '@explore queued message{enter}');
+    await user.type(screen.getByRole('textbox'), 'subagent:explore queued message{enter}');
 
     await waitFor(() => {
       expect(sessionApiEnqueuePromptMock).toHaveBeenCalledWith(

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect, useMemo, memo } from 'react';
-import { Send, Loader2, ChevronDown, Square, Copy, User, FileText, AlertCircle, X, RefreshCw, Pencil, Save, ImageIcon, Paperclip, ArrowUp, Clock, CheckCircle2, XCircle, Brain, Trash2, Bot, Check, Eye, ListTree } from 'lucide-react';
+import { Send, Loader2, ChevronDown, Square, Copy, User, FileText, AlertCircle, X, RefreshCw, Pencil, Save, ImageIcon, Paperclip, Plus, ArrowUp, Clock, CheckCircle2, XCircle, Brain, Trash2, Bot, Check, Eye, ListTree, BookOpen, Workflow as WorkflowIcon } from 'lucide-react';
 import { StreamingMarkdown, useStreamingContent } from './StreamingMarkdown';
 import { useTranslation } from 'react-i18next';
 import LoadingSpinner from './LoadingSpinner';
@@ -112,6 +112,19 @@ export interface ConversationBottomSlotActions {
   hasMessages: boolean;
 }
 
+export interface ComposerAddMenuActions {
+  closeMenu: () => void;
+  insertMention: (agentName: string) => void;
+  insertReference: (value: string, kind: 'workflow' | 'skill') => void;
+}
+
+type ComposerReferenceKind = 'subagent' | 'skill' | 'workflow';
+
+interface ComposerReference {
+  kind: ComposerReferenceKind;
+  value: string;
+}
+
 function getMessagePartDisplayText(part: MessagePart, hideTaskMetadata = false): string {
   const metadataDisplayText = part.metadata?.displayText ?? part.metadata?.display_text;
   const displayText = typeof metadataDisplayText === 'string' && metadataDisplayText
@@ -169,6 +182,10 @@ export interface SessionChatProps {
   onError?: (message: string) => void;
   /** Extra content injected into the left side of the composer toolbar */
   toolbarSlot?: React.ReactNode;
+  /** Extra actions shown below the file picker in the composer's Add menu. */
+  composerAddMenuSlot?: React.ReactNode | ((actions: ComposerAddMenuActions) => React.ReactNode);
+  /** Called when the composer's Add menu opens or closes. */
+  onComposerAddMenuOpenChange?: (open: boolean) => void;
   /** Minimum textarea height in px. Defaults to the compact single-line composer height. */
   composerTextareaMinHeight?: number;
   /** Maximum textarea height in px. Defaults to the existing compact/full-page values. */
@@ -1466,13 +1483,17 @@ function findMentionTrigger(text: string, cursor: number): { start: number; end:
   };
 }
 
-function resolveMentionAgentName(text: string, agents: Agent[]): string | null {
+function resolveReferencedAgentName(text: string, agents: Agent[]): string | null {
   const sorted = [...agents].sort((a, b) => b.name.length - a.name.length);
   for (const agent of sorted) {
-    const pattern = new RegExp(`(^|\\s)@${escapeRegExp(agent.name)}(?=$|\\s|[,.!?;:，。！？；：])`, 'i');
+    const pattern = new RegExp(`(^|\\s)subagent:${escapeRegExp(agent.name)}(?=$|\\s|[,.!?;，。！？；])`, 'i');
     if (pattern.test(text)) return agent.name;
   }
   return null;
+}
+
+function formatComposerReference(reference: ComposerReference): string {
+  return `${reference.kind}:${reference.value}`;
 }
 
 export default function SessionChat({
@@ -1502,6 +1523,8 @@ export default function SessionChat({
   onInitialMessageConsumed,
   supportsVision,
   toolbarSlot,
+  composerAddMenuSlot,
+  onComposerAddMenuOpenChange,
   composerTextareaMinHeight,
   composerTextareaMaxHeight,
   centerToolbarSlot,
@@ -1538,11 +1561,13 @@ export default function SessionChat({
   // sidebar → Agents → back to Sessions) doesn't wipe the user's half-typed
   // message. Subsequent session changes are re-hydrated by the effect below.
   const [input, setInput] = useState<string>(() => readChatDraft(sessionId));
+  const [composerReferences, setComposerReferences] = useState<ComposerReference[]>([]);
   const [sending, setSending] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const activeToolPartIdsRef = useRef<Set<string>>(new Set());
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [showComposerAddMenu, setShowComposerAddMenu] = useState(false);
   // Lightbox preview for composer thumbnails. Shares the same overlay
   // component used by message bubbles so the click-to-enlarge gesture is
   // consistent across the upload tray and the rendered chat history.
@@ -1667,6 +1692,45 @@ export default function SessionChat({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isComposingRef = useRef(false);
 
+  const closeComposerAddMenu = useCallback(() => {
+    setShowComposerAddMenu(false);
+    onComposerAddMenuOpenChange?.(false);
+  }, [onComposerAddMenuOpenChange]);
+
+  const openComposerAddMenu = useCallback(() => {
+    setShowComposerAddMenu(true);
+    onComposerAddMenuOpenChange?.(true);
+  }, [onComposerAddMenuOpenChange]);
+
+  const toggleComposerAddMenu = useCallback(() => {
+    setShowComposerAddMenu((open) => {
+      const nextOpen = !open;
+      onComposerAddMenuOpenChange?.(nextOpen);
+      return nextOpen;
+    });
+  }, [onComposerAddMenuOpenChange]);
+
+  useEffect(() => {
+    if (!showComposerAddMenu) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest('[data-composer-add-menu]')) closeComposerAddMenu();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeComposerAddMenu();
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [closeComposerAddMenu, showComposerAddMenu]);
+
+  useEffect(() => {
+    if (sending && showComposerAddMenu) closeComposerAddMenu();
+  }, [closeComposerAddMenu, sending, showComposerAddMenu]);
+
   // Slash command autocomplete state
   const [commands, setCommands] = useState<Command[]>([]);
   const [showCommandDropdown, setShowCommandDropdown] = useState(false);
@@ -1693,7 +1757,12 @@ export default function SessionChat({
   );
   const hasUploadingFiles = attachments.some((attachment) => attachment.status === 'uploading');
   const canSend = !sending && !hasUploadingFiles &&
-    (!!input.trim() || successfulDocAttachments.length > 0 || successfulImageAttachments.length > 0);
+    (
+      !!input.trim()
+      || composerReferences.length > 0
+      || successfulDocAttachments.length > 0
+      || successfulImageAttachments.length > 0
+    );
   const filteredMentionAgents = useMemo(() => {
     const q = mentionQuery.trim().toLowerCase();
     return mentionAgents
@@ -2107,7 +2176,6 @@ export default function SessionChat({
     setMentionRange(null);
     setMentionQuery('');
     setSelectedMentionIndex(0);
-    setPendingAgentName(agentName || 'rex');
     abortingRef.current = false;
     abortedMessageIdRef.current = null;
     suppressStreamingUntilIdleRef.current = false;
@@ -2119,8 +2187,9 @@ export default function SessionChat({
     // don't force a remount (Session/index.tsx does, but other consumers
     // such as WorkflowDetail/ChatTab may swap sessionId without a remount).
     setInput(readChatDraft(sessionId));
+    setComposerReferences([]);
     setProcessGroupOpenState(readProcessGroupOpenState(sessionId));
-  }, [sessionId, agentName, clearPendingQuestions]);
+  }, [sessionId, clearPendingQuestions]);
 
   const handleProcessGroupOpenChange = useCallback((key: string, open: boolean) => {
     setProcessGroupOpenState(prev => {
@@ -2654,16 +2723,24 @@ export default function SessionChat({
 
   const handleSend = async () => {
     if (!canSend) return;
-    const rawText = input.trim();
+    const draftText = input.trim();
+    const referencesToSend = [...composerReferences];
+    const referenceText = referencesToSend.map(formatComposerReference).join(' ');
+    const rawText = [referenceText, draftText].filter(Boolean).join(' ');
     const docAttachmentsToSend = [...successfulDocAttachments];
     const imageAttachmentsToSend = [...successfulImageAttachments];
     const text = buildMessageText(rawText, docAttachmentsToSend);
-    const mentionedAgent = resolveMentionAgentName(rawText, mentionAgents);
+    const mentionedAgent = resolveReferencedAgentName(rawText, mentionAgents);
+    const restoreDraft = () => {
+      setInput(draftText);
+      setComposerReferences(referencesToSend);
+    };
 
     // Need either text content or image attachments
     if (!text && imageAttachmentsToSend.length === 0) return;
 
     setInput('');
+    setComposerReferences([]);
     setShowCommandDropdown(false);
     setMentionRange(null);
 
@@ -2688,7 +2765,7 @@ export default function SessionChat({
         await enqueueText(text, imageParts, mentionedAgent || undefined);
         setAttachments([]);
       } catch {
-        setInput(rawText);
+        restoreDraft();
         setAttachments([...docAttachmentsToSend, ...imageAttachmentsToSend]);
       }
       return;
@@ -2698,13 +2775,13 @@ export default function SessionChat({
     if (parsed) {
       if (!sessionId) {
         // Slash commands need an existing session; restore input and do nothing
-        setInput(rawText);
+        restoreDraft();
         return;
       }
       try {
         await sendCommand(parsed.command, parsed.args);
       } catch {
-        setInput(rawText);
+        restoreDraft();
       }
       return;
     }
@@ -2721,7 +2798,7 @@ export default function SessionChat({
           // Restore both the text and the attachment list so the user can
           // retry without re-uploading images. Image data URLs are already
           // in memory, so restoring the array is safe and cheap.
-          setInput(rawText);
+          restoreDraft();
           setAttachments(imageAttachmentsToSend);
         } finally {
           setSending(false);
@@ -2734,7 +2811,7 @@ export default function SessionChat({
       await sendText(text, imageParts, mentionedAgent || undefined);
       setAttachments([]);
     } catch {
-      setInput(rawText);
+      restoreDraft();
       setAttachments(imageAttachmentsToSend);
     }
   };
@@ -2772,6 +2849,35 @@ export default function SessionChat({
       textareaRef.current?.setSelectionRange(cursor, cursor);
     });
   }, [input, mentionRange]);
+
+  const insertAgentMention = useCallback((name: string) => {
+    setComposerReferences((current) => [
+      { kind: 'subagent', value: name },
+      ...current.filter((reference) => reference.kind !== 'subagent'),
+    ]);
+    setMentionRange(null);
+    setMentionQuery('');
+    setSelectedMentionIndex(0);
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+  }, []);
+
+  const insertComposerReference = useCallback((
+    value: string,
+    kind: 'workflow' | 'skill',
+  ) => {
+    setComposerReferences((current) => [
+      { kind, value },
+      ...current.filter((reference) => reference.kind !== kind),
+    ]);
+    setMentionRange(null);
+    setMentionQuery('');
+    setSelectedMentionIndex(0);
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+  }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     const currentValue = e.currentTarget instanceof HTMLTextAreaElement ? e.currentTarget.value : input;
@@ -3633,14 +3739,74 @@ export default function SessionChat({
                     {t('chat.upload.dropHint')}
                   </div>
                 )}
-                <div className="px-4 pt-3 pb-1">
+                {composerReferences.length > 0 && (
+                  <div
+                    className="flex flex-wrap gap-1.5 px-4 pt-3"
+                    aria-label={t('chat.references.selected')}
+                  >
+                    {composerReferences.map((reference) => {
+                      const referenceStyle = reference.kind === 'subagent'
+                        ? 'border-sky-200/80 bg-sky-50 text-sky-700 dark:border-sky-400/20 dark:bg-sky-400/[0.10] dark:text-sky-200'
+                        : reference.kind === 'skill'
+                          ? 'border-emerald-200/80 bg-emerald-50 text-emerald-700 dark:border-emerald-400/20 dark:bg-emerald-400/[0.10] dark:text-emerald-200'
+                          : 'border-amber-200/80 bg-amber-50 text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/[0.10] dark:text-amber-200';
+                      const ReferenceIcon = reference.kind === 'subagent'
+                        ? Bot
+                        : reference.kind === 'skill'
+                          ? BookOpen
+                          : WorkflowIcon;
+                      return (
+                        <span
+                          key={reference.kind}
+                          className={`inline-flex h-7 max-w-full items-center gap-1.5 rounded-lg border px-2 text-[11px] font-medium shadow-[0_1px_2px_rgba(22,27,34,0.03)] ${referenceStyle}`}
+                        >
+                          <ReferenceIcon className="h-3 w-3 shrink-0" />
+                          <span className="shrink-0 opacity-65">
+                            {t(`chat.references.${reference.kind}`)}
+                          </span>
+                          <span className="truncate font-semibold">{reference.value}</span>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setComposerReferences((current) => current.filter(
+                                (item) => item.kind !== reference.kind,
+                              ));
+                              textareaRef.current?.focus();
+                            }}
+                            className="-mr-1 grid h-5 w-5 shrink-0 place-items-center rounded-md opacity-55 transition hover:bg-black/[0.06] hover:opacity-100 dark:hover:bg-white/[0.08]"
+                            aria-label={t('chat.references.remove', {
+                              type: t(`chat.references.${reference.kind}`),
+                              name: reference.value,
+                            })}
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+                <div className={`px-4 pb-1 ${composerReferences.length > 0 ? 'pt-2' : 'pt-3'}`}>
                   <textarea
                     ref={textareaRef}
                     value={input}
                     onChange={(e) => {
                       const val = e.target.value;
-                      setInput(val);
                       const cursor = e.target.selectionStart ?? val.length;
+                      const beforeCursor = val.slice(0, cursor);
+                      if (/(^|\s)@$/.test(beforeCursor)) {
+                        const next = `${val.slice(0, cursor - 1)}${val.slice(cursor)}`;
+                        setInput(next);
+                        setShowCommandDropdown(false);
+                        setMentionRange(null);
+                        openComposerAddMenu();
+                        requestAnimationFrame(() => {
+                          textareaRef.current?.focus();
+                          textareaRef.current?.setSelectionRange(cursor - 1, cursor - 1);
+                        });
+                        return;
+                      }
+                      setInput(val);
                       const mention = mentionAgents.length > 0 ? findMentionTrigger(val, cursor) : null;
                       const trimmed = val.trimStart();
                       const slashQuery = trimmed.startsWith('/') ? trimmed.slice(1) : '';
@@ -3693,15 +3859,61 @@ export default function SessionChat({
 
                 {/* Bottom toolbar inside the composer card */}
                 <div className="flex items-center gap-1 px-2 pb-2">
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={sending}
-                    title={t('chat.upload.selectWithImage')}
-                    className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-zinc-200/60 hover:text-zinc-800 disabled:cursor-not-allowed disabled:opacity-40"
-                  >
-                    <Paperclip className="h-4 w-4" />
-                  </button>
+                  <div className="relative" data-composer-add-menu>
+                    <button
+                      type="button"
+                      onClick={toggleComposerAddMenu}
+                      disabled={sending}
+                      title={t('chat.addMenu.title')}
+                      aria-label={t('chat.addMenu.title')}
+                      aria-haspopup="menu"
+                      aria-expanded={showComposerAddMenu}
+                      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40 ${
+                        showComposerAddMenu
+                          ? 'border-zinc-300 bg-white text-zinc-900 shadow-[0_2px_8px_rgba(22,27,34,0.08)] dark:border-white/[0.14] dark:bg-white/[0.09] dark:text-white'
+                          : 'border-transparent text-zinc-500 hover:border-zinc-200 hover:bg-white hover:text-zinc-900 dark:text-zinc-400 dark:hover:border-white/[0.10] dark:hover:bg-white/[0.07] dark:hover:text-white'
+                      }`}
+                    >
+                      <Plus className="h-[17px] w-[17px]" strokeWidth={2} />
+                    </button>
+
+                    {showComposerAddMenu && (
+                      <div
+                        role="menu"
+                        aria-label={t('chat.addMenu.title')}
+                        className="absolute bottom-full left-0 z-50 mb-2 w-[264px] max-w-[calc(100vw-2rem)] overflow-visible rounded-[14px] border border-black/[0.09] bg-white/95 p-1.5 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]"
+                      >
+                        <div className="px-2.5 pb-1.5 pt-1 text-[11px] font-medium text-zinc-400 dark:text-zinc-500">
+                          {t('chat.addMenu.title')}
+                        </div>
+                        <button
+                          type="button"
+                          role="menuitem"
+                          onClick={() => {
+                            closeComposerAddMenu();
+                            fileInputRef.current?.click();
+                          }}
+                          className="group flex h-10 w-full items-center gap-2.5 rounded-[9px] px-2 text-left text-[13px] font-medium text-zinc-700 transition-colors hover:bg-zinc-100/90 hover:text-zinc-950 dark:text-zinc-200 dark:hover:bg-white/[0.07] dark:hover:text-white"
+                        >
+                          <span className="grid h-7 w-7 shrink-0 place-items-center rounded-lg border border-zinc-200/80 bg-white text-zinc-500 shadow-[0_1px_2px_rgba(22,27,34,0.04)] transition-colors group-hover:text-zinc-800 dark:border-white/[0.10] dark:bg-white/[0.05] dark:text-zinc-400 dark:group-hover:text-white">
+                            <Paperclip className="h-3.5 w-3.5" />
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">{t('chat.addMenu.files')}</span>
+                        </button>
+                        {composerAddMenuSlot && (
+                          <div className="mt-0.5 border-t border-zinc-100 pt-0.5 dark:border-white/[0.07]">
+                            {typeof composerAddMenuSlot === 'function'
+                              ? composerAddMenuSlot({
+                                closeMenu: closeComposerAddMenu,
+                                insertMention: insertAgentMention,
+                                insertReference: insertComposerReference,
+                              })
+                              : composerAddMenuSlot}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
 
                   <div className="mx-1 h-4 w-px shrink-0 bg-zinc-200 dark:bg-zinc-800" />
 

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -2901,10 +2901,18 @@ export default function SessionChat({
     value: string,
     kind: 'workflow' | 'skill',
   ) => {
-    setComposerReferences((current) => [
-      { kind, value },
-      ...current.filter((reference) => reference.kind !== kind),
-    ]);
+    setComposerReferences((current) => {
+      if (kind === 'skill') {
+        if (current.some((reference) => reference.kind === 'skill' && reference.value === value)) {
+          return current;
+        }
+        return [{ kind, value }, ...current];
+      }
+      return [
+        { kind, value },
+        ...current.filter((reference) => reference.kind !== kind),
+      ];
+    });
     setMentionRange(null);
     setMentionQuery('');
     setSelectedMentionIndex(0);
@@ -3791,7 +3799,7 @@ export default function SessionChat({
                           : WorkflowIcon;
                       return (
                         <span
-                          key={reference.kind}
+                          key={`${reference.kind}:${reference.value}`}
                           className={`inline-flex h-7 max-w-full items-center gap-1.5 rounded-lg border px-2 text-[11px] font-medium shadow-[0_1px_2px_rgba(22,27,34,0.03)] ${referenceStyle}`}
                         >
                           <ReferenceIcon className="h-3 w-3 shrink-0" />
@@ -3803,7 +3811,10 @@ export default function SessionChat({
                             type="button"
                             onClick={() => {
                               setComposerReferences((current) => current.filter(
-                                (item) => item.kind !== reference.kind,
+                                (item) => (
+                                  item.kind !== reference.kind
+                                  || item.value !== reference.value
+                                ),
                               ));
                               textareaRef.current?.focus();
                             }}
@@ -3915,7 +3926,7 @@ export default function SessionChat({
                       <div
                         role="menu"
                         aria-label={t('chat.addMenu.title')}
-                        className="absolute bottom-full left-0 z-50 mb-2 w-[264px] max-w-[calc(100vw-2rem)] overflow-visible rounded-[14px] border border-black/[0.09] bg-white/95 p-1.5 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]"
+                        className="absolute bottom-full left-0 z-50 mb-2 w-[228px] max-w-[calc(100vw-2rem)] overflow-visible rounded-[14px] border border-black/[0.09] bg-white/95 p-1.5 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]"
                       >
                         <div className="px-2.5 pb-1.5 pt-1 text-[11px] font-medium text-zinc-400 dark:text-zinc-500">
                           {t('chat.addMenu.title')}

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -50,7 +50,7 @@
   "smartAssistant": "AI Smart Assistant",
   "agentPicker": {
     "title": "Choose Chat Agent",
-    "hint": "New chats start with Rex; type @Agent to route one message",
+    "hint": "Rex is the default; selections route the current message as a subagent reference",
     "filter": {
       "all": "All",
       "builtin": "Built-in",
@@ -233,6 +233,24 @@
       "errorGeneric": "Upload failed. Please try again.",
       "imageNotSupported": "The current model does not support image analysis. Please select a vision-capable model in the model settings.",
       "imageNotSupportedBanner": "Image analysis is not supported by the current model"
+    },
+    "addMenu": {
+      "title": "Add",
+      "files": "Files and images",
+      "agent": "Agent",
+      "workflows": "Workflows",
+      "skills": "Skills",
+      "selectWorkflow": "Select workflow",
+      "selectSkill": "Select skill",
+      "noWorkflows": "No workflows available",
+      "noSkills": "No skills available"
+    },
+    "references": {
+      "selected": "Selected resources",
+      "subagent": "Subagent",
+      "skill": "Skill",
+      "workflow": "Workflow",
+      "remove": "Remove {{type}} {{name}}"
     },
     "tool": {
       "pending": "Pending",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -50,7 +50,7 @@
   "smartAssistant": "智能AI助手",
   "agentPicker": {
     "title": "选择对话 Agent",
-    "hint": "新会话首条默认由 Rex 处理；输入 @Agent 可路由单条消息",
+    "hint": "Rex 为默认智能体；选择后以子智能体标签路由当前消息",
     "filter": {
       "all": "全部",
       "builtin": "内置",
@@ -233,6 +233,24 @@
       "errorGeneric": "上传失败，请重试",
       "imageNotSupported": "当前模型不支持图片分析，请在模型配置中选择支持视觉的模型",
       "imageNotSupportedBanner": "当前模型不支持图片分析"
+    },
+    "addMenu": {
+      "title": "添加",
+      "files": "文件和图片",
+      "agent": "智能体",
+      "workflows": "工作流",
+      "skills": "技能",
+      "selectWorkflow": "选择工作流",
+      "selectSkill": "选择技能",
+      "noWorkflows": "暂无可用工作流",
+      "noSkills": "暂无可用技能"
+    },
+    "references": {
+      "selected": "已选择的资源",
+      "subagent": "子智能体",
+      "skill": "技能",
+      "workflow": "工作流",
+      "remove": "移除 {{type}} {{name}}"
     },
     "tool": {
       "pending": "等待中",

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -453,7 +453,7 @@ describe('SessionPage session actions menu', () => {
     renderSessionPage();
 
     await screen.findByRole('button', { name: 'executionMode.title' });
-    const agentButton = screen.getByRole('button', { name: /Rex/i });
+    const agentButton = screen.getByRole('button', { name: 'chat.addMenu.agent' });
 
     expect(screen.getByTestId('session-chat')).toHaveAttribute('data-execution-mode', 'build');
     expect(agentButton).toHaveAttribute('aria-haspopup', 'menu');
@@ -2040,7 +2040,7 @@ describe('SessionPage session actions menu', () => {
 
     expect(screen.getByTestId('session-chat')).toHaveAttribute('data-mention-agents', 'rex,explore');
 
-    await user.click(screen.getByRole('button', { name: /Rex/i }));
+    await user.click(screen.getByRole('button', { name: 'chat.addMenu.agent' }));
 
     expect(screen.getByRole('button', { name: /Explore/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /hidden-system/i })).not.toBeInTheDocument();
@@ -2081,7 +2081,7 @@ describe('SessionPage session actions menu', () => {
     await waitFor(() => {
       expect(screen.getByTestId('session-chat')).toHaveTextContent('session-1');
     });
-    await user.click(screen.getByRole('button', { name: /Rex/i }));
+    await user.click(screen.getByRole('button', { name: 'chat.addMenu.agent' }));
     await user.click(screen.getByRole('button', { name: /Explore/i }));
     expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('subagent:explore');
     expect(screen.getByTestId('session-chat')).toHaveAttribute('data-agent-name', 'rex');
@@ -2092,7 +2092,7 @@ describe('SessionPage session actions menu', () => {
     expect(client.post).not.toHaveBeenCalledWith('/api/session', expect.anything());
     expect(screen.getByRole('button', { name: 'projectPicker.title' })).toHaveAttribute('aria-expanded', 'false');
     expect(screen.queryByRole('menu', { name: 'projectPicker.title' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Rex/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'chat.addMenu.agent' })).toBeInTheDocument();
   });
 
   it('shows the pinned model for the selected session on load', async () => {
@@ -2596,8 +2596,8 @@ describe('SessionPage session actions menu', () => {
 
     renderSessionPage();
 
-    await user.click(screen.getByRole('button', { name: /Rex/i }));
-    expect(screen.getAllByRole('button', { name: /Rex/i })).toHaveLength(1);
+    await user.click(screen.getByRole('button', { name: 'chat.addMenu.agent' }));
+    expect(screen.queryByRole('button', { name: /Rex/i })).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /Explore/i }));
     expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('subagent:explore');
     expect(screen.getByTestId('session-chat')).toHaveAttribute('data-agent-name', 'rex');
@@ -2634,7 +2634,7 @@ describe('SessionPage session actions menu', () => {
 
     renderSessionPage();
 
-    await user.click(screen.getByRole('button', { name: /Rex/i }));
+    await user.click(screen.getByRole('button', { name: 'chat.addMenu.agent' }));
     await user.click(screen.getByRole('button', { name: /Explore/i }));
 
     expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('subagent:explore');
@@ -2677,7 +2677,13 @@ describe('SessionPage session actions menu', () => {
     renderSessionPage();
 
     await user.click(screen.getByRole('button', { name: 'mock-open-add-menu' }));
-    await user.click(screen.getByRole('button', { name: 'chat.addMenu.workflows' }));
+    const skillButton = screen.getByRole('button', { name: 'chat.addMenu.skills' });
+    const workflowButton = screen.getByRole('button', { name: 'chat.addMenu.workflows' });
+    const menuButtons = screen.getAllByRole('button');
+    expect(menuButtons.indexOf(skillButton)).toBeLessThan(menuButtons.indexOf(workflowButton));
+
+    await user.click(workflowButton);
+    expect(screen.queryByText('security')).not.toBeInTheDocument();
     await user.click(await screen.findByRole('button', { name: /Alert triage/i }));
     expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('workflow:alert-triage');
 
@@ -2685,5 +2691,6 @@ describe('SessionPage session actions menu', () => {
     await user.click(screen.getByRole('button', { name: 'chat.addMenu.skills' }));
     await user.click(await screen.findByRole('button', { name: /diagnose/i }));
     expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('skill:diagnose');
+    expect(screen.getByText('chat.addMenu.selectSkill')).toBeInTheDocument();
   });
 });

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -28,6 +28,8 @@ const {
   defaultModelAPI,
   modelV2API,
   hubAPI,
+  workflowAPI,
+  skillAPI,
   toast,
 } = vi.hoisted(() => ({
   client: {
@@ -61,6 +63,12 @@ const {
     install: vi.fn(),
     installStream: vi.fn(),
   },
+  workflowAPI: {
+    listSummaries: vi.fn(),
+  },
+  skillAPI: {
+    status: vi.fn(),
+  },
   toast: {
     error: vi.fn(),
     info: vi.fn(),
@@ -81,6 +89,14 @@ vi.mock('@/api/session', () => ({
 
 vi.mock('@/api/hub', () => ({
   hubAPI,
+}));
+
+vi.mock('@/api/workflow', () => ({
+  workflowAPI,
+}));
+
+vi.mock('@/api/skill', () => ({
+  skillAPI,
 }));
 
 vi.mock('@/hooks/useSessions', () => ({
@@ -131,6 +147,8 @@ vi.mock('@/components/common/SessionChat', () => ({
     sessionId,
     mentionAgents,
     toolbarSlot,
+    composerAddMenuSlot,
+    onComposerAddMenuOpenChange,
     centerToolbarSlot,
     welcomeContent,
     initialMessage,
@@ -148,6 +166,12 @@ vi.mock('@/components/common/SessionChat', () => ({
     agentName?: string;
     mentionAgents?: Array<{ name: string }>;
     toolbarSlot?: React.ReactNode;
+    composerAddMenuSlot?: React.ReactNode | ((actions: {
+      closeMenu: () => void;
+      insertMention: (agentName: string) => void;
+      insertReference: (value: string, kind: 'workflow' | 'skill') => void;
+    }) => React.ReactNode);
+    onComposerAddMenuOpenChange?: (open: boolean) => void;
     centerToolbarSlot?: React.ReactNode;
     welcomeContent?: React.ReactNode | ((setInput: (text: string) => void) => React.ReactNode);
     initialMessage?: string | null;
@@ -190,6 +214,18 @@ vi.mock('@/components/common/SessionChat', () => ({
         data-initial-display={initialDisplayText ?? ''}
       >
         {sessionId ?? 'no-session'}
+        <button type="button" onClick={() => onComposerAddMenuOpenChange?.(true)}>
+          mock-open-add-menu
+        </button>
+        {typeof composerAddMenuSlot === 'function'
+          ? composerAddMenuSlot({
+            closeMenu: vi.fn(),
+            insertMention: (agentName) => setInput(`subagent:${agentName} `),
+            insertReference: (value, kind) => {
+              setInput(`${kind}:${value} `);
+            },
+          })
+          : composerAddMenuSlot}
         {toolbarSlot}
         {centerToolbarSlot}
         {!sessionId && welcomeContent ? (
@@ -340,6 +376,8 @@ describe('SessionPage session actions menu', () => {
     });
     defaultModelAPI.getResolved.mockResolvedValue({ data: { provider_id: '', model_id: '' } });
     modelV2API.listDefinitions.mockResolvedValue({ data: { models: [] } });
+    workflowAPI.listSummaries.mockResolvedValue({ data: [] });
+    skillAPI.status.mockResolvedValue({ data: [] });
     client.get.mockResolvedValue({
       data: [{
         id: 'default',
@@ -1925,7 +1963,8 @@ describe('SessionPage session actions menu', () => {
     });
     await user.click(screen.getByRole('button', { name: /Rex/i }));
     await user.click(screen.getByRole('button', { name: /Explore/i }));
-    expect(screen.getByRole('button', { name: /Explore/i })).toBeInTheDocument();
+    expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('subagent:explore');
+    expect(screen.getByTestId('session-chat')).toHaveAttribute('data-agent-name', 'rex');
 
     await user.click(screen.getByRole('button', { name: 'newSession' }));
 
@@ -2406,7 +2445,45 @@ describe('SessionPage session actions menu', () => {
     });
   });
 
-  it('uses the selected agent for the first message when an empty session is created by sending', async () => {
+  it('keeps Rex as the default while selecting a one-turn subagent reference', async () => {
+    const user = userEvent.setup();
+    useAgents.mockReturnValue({
+      agents: [
+        {
+          name: 'rex',
+          description: 'Rex',
+          mode: 'primary',
+          permission: [],
+          options: {},
+          skills: [],
+          tools: [],
+        },
+        {
+          name: 'explore',
+          description: 'Explore',
+          mode: 'subagent',
+          native: true,
+          permission: [],
+          options: {},
+          skills: [],
+          tools: [],
+        },
+      ],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    renderSessionPage();
+
+    await user.click(screen.getByRole('button', { name: /Rex/i }));
+    expect(screen.getAllByRole('button', { name: /Rex/i })).toHaveLength(1);
+    await user.click(screen.getByRole('button', { name: /Explore/i }));
+    expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('subagent:explore');
+    expect(screen.getByTestId('session-chat')).toHaveAttribute('data-agent-name', 'rex');
+  });
+
+  it('inserts the selected agent as a structured subagent reference', async () => {
     const user = userEvent.setup();
     useAgents.mockReturnValue({
       agents: [
@@ -2439,15 +2516,54 @@ describe('SessionPage session actions menu', () => {
 
     await user.click(screen.getByRole('button', { name: /Rex/i }));
     await user.click(screen.getByRole('button', { name: /Explore/i }));
-    expect(screen.getByRole('button', { name: /Explore/i })).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'mock-create-and-send' }));
 
-    await waitFor(() => {
-      expect(client.post).toHaveBeenCalledWith(
-        '/api/session/session-2/prompt_async',
-        expect.objectContaining({ agent: 'explore' }),
-      );
+    expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('subagent:explore');
+  });
+
+  it('inserts selected workflows and skills as composer references', async () => {
+    const user = userEvent.setup();
+    workflowAPI.listSummaries.mockResolvedValue({
+      data: [{
+        id: 'alert-triage',
+        name: 'Alert triage',
+        description: 'Investigate security alerts',
+        category: 'security',
+        status: 'active',
+        source: 'project',
+        createdAt: 1,
+        updatedAt: 1,
+        nodeCount: 2,
+        stats: {
+          callCount: 0,
+          successCount: 0,
+          errorCount: 0,
+          totalRuntime: 0,
+          avgRuntime: 0,
+          thumbsUp: 0,
+          thumbsDown: 0,
+        },
+      }],
     });
-    expect(screen.getByRole('button', { name: /Explore/i })).toBeInTheDocument();
+    skillAPI.status.mockResolvedValue({
+      data: [{
+        name: 'diagnose',
+        description: 'Debug difficult failures',
+        location: '/skills/diagnose',
+        source: 'project',
+        eligible: true,
+      }],
+    });
+
+    renderSessionPage();
+
+    await user.click(screen.getByRole('button', { name: 'mock-open-add-menu' }));
+    await user.click(screen.getByRole('button', { name: 'chat.addMenu.workflows' }));
+    await user.click(await screen.findByRole('button', { name: /Alert triage/i }));
+    expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('workflow:alert-triage');
+
+    await user.click(screen.getByRole('button', { name: 'mock-open-add-menu' }));
+    await user.click(screen.getByRole('button', { name: 'chat.addMenu.skills' }));
+    await user.click(await screen.findByRole('button', { name: /diagnose/i }));
+    expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('skill:diagnose');
   });
 });

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -168,7 +168,7 @@ function ComposerResourcePicker({
         <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-zinc-400 transition-transform ${open ? '-rotate-90' : ''}`} />
       </button>
       {open && (
-        <div className="absolute bottom-0 left-[calc(100%+0.5rem)] z-[60] w-[336px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[14px] border border-black/[0.09] bg-white/95 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]">
+        <div className="absolute bottom-0 left-[calc(100%+0.5rem)] z-[60] w-[300px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[14px] border border-black/[0.09] bg-white/95 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]">
           <div className="flex min-h-12 items-center justify-between gap-3 border-b border-zinc-100 px-3 py-2 dark:border-white/[0.08]">
             <span className="min-w-0 truncate text-[12px] font-semibold text-zinc-800 dark:text-zinc-100">
               {title}
@@ -277,10 +277,6 @@ type SelectorTooltip = {
   x: number;
   y: number;
 };
-
-function formatAgentName(name: string): string {
-  return name ? name.charAt(0).toUpperCase() + name.slice(1) : name;
-}
 
 function readLastSelectedSessionId(): string | null {
   try {
@@ -736,10 +732,6 @@ export default function SessionPage() {
       return true;
     }),
     [chatAgents, agentSourceFilter],
-  );
-  const selectedAgentInfo = useMemo(
-    () => chatAgents.find((agent) => agent.name === selectedAgent),
-    [chatAgents, selectedAgent],
   );
   const loadComposerResources = useCallback(async () => {
     if (composerResourcesLoadedRef.current || loadingComposerResources) return;
@@ -2707,11 +2699,7 @@ export default function SessionPage() {
                 }}
                 className="group flex h-10 w-full items-center gap-2.5 rounded-[9px] px-2 text-left text-[13px] font-medium text-zinc-700 transition-colors hover:bg-zinc-100/90 hover:text-zinc-950 dark:text-zinc-200 dark:hover:bg-white/[0.07] dark:hover:text-white"
                 title={t('agentPicker.title')}
-                aria-label={`${t('chat.addMenu.agent')}: ${
-                  selectedAgentInfo
-                    ? getAgentDisplayName(selectedAgentInfo, i18n.language)
-                    : formatAgentName(selectedAgent)
-                }`}
+                aria-label={t('chat.addMenu.agent')}
                 aria-haspopup="menu"
                 aria-expanded={showAgentOptions}
               >
@@ -2719,15 +2707,10 @@ export default function SessionPage() {
                   <Bot className="h-3.5 w-3.5" />
                 </span>
                 <span className="min-w-0 flex-1 truncate">{t('chat.addMenu.agent')}</span>
-                <span className="max-w-[108px] truncate text-[11px] font-normal text-zinc-400 dark:text-zinc-500">
-                  {selectedAgentInfo
-                    ? getAgentDisplayName(selectedAgentInfo, i18n.language)
-                    : formatAgentName(selectedAgent)}
-                </span>
                 <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-zinc-400 transition-transform ${showAgentOptions ? '-rotate-90' : ''}`} />
               </button>
               {showAgentOptions && (
-                <div className="absolute bottom-0 left-[calc(100%+0.5rem)] z-[60] w-[336px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[14px] border border-black/[0.09] bg-white/95 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]">
+                <div className="absolute bottom-0 left-[calc(100%+0.5rem)] z-[60] w-[300px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[14px] border border-black/[0.09] bg-white/95 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]">
                   <div className="flex min-h-12 items-center justify-between gap-3 border-b border-zinc-100 px-3 py-2 dark:border-white/[0.08]">
                     <div className="min-w-0">
                       <div className="text-[12px] font-semibold text-zinc-800 dark:text-zinc-100">{t('agentPicker.title')}</div>
@@ -2831,31 +2814,6 @@ export default function SessionPage() {
               )}
             </div>
             <ComposerResourcePicker
-              label={t('chat.addMenu.workflows')}
-              title={t('chat.addMenu.selectWorkflow')}
-              emptyText={t('chat.addMenu.noWorkflows')}
-              icon={WorkflowIcon}
-              items={composerWorkflows.map((workflow) => ({
-                id: workflow.id,
-                name: getWorkflowDisplayName(workflow, i18n.language),
-                description: workflow.description,
-                badge: workflow.category,
-                source: workflow.source === 'project' ? 'builtin' : 'custom',
-              }))}
-              loading={loadingComposerResources}
-              open={showWorkflowOptions}
-              onToggle={() => {
-                setShowWorkflowOptions((open) => !open);
-                setShowAgentOptions(false);
-                setShowSkillOptions(false);
-              }}
-              onSelect={(workflow) => {
-                insertReference(workflow.id, 'workflow');
-                setShowWorkflowOptions(false);
-                closeMenu();
-              }}
-            />
-            <ComposerResourcePicker
               label={t('chat.addMenu.skills')}
               title={t('chat.addMenu.selectSkill')}
               emptyText={t('chat.addMenu.noSkills')}
@@ -2876,7 +2834,29 @@ export default function SessionPage() {
               }}
               onSelect={(skill) => {
                 insertReference(skill.id, 'skill');
+              }}
+            />
+            <ComposerResourcePicker
+              label={t('chat.addMenu.workflows')}
+              title={t('chat.addMenu.selectWorkflow')}
+              emptyText={t('chat.addMenu.noWorkflows')}
+              icon={WorkflowIcon}
+              items={composerWorkflows.map((workflow) => ({
+                id: workflow.id,
+                name: getWorkflowDisplayName(workflow, i18n.language),
+                description: workflow.description,
+                source: workflow.source === 'project' ? 'builtin' : 'custom',
+              }))}
+              loading={loadingComposerResources}
+              open={showWorkflowOptions}
+              onToggle={() => {
+                setShowWorkflowOptions((open) => !open);
+                setShowAgentOptions(false);
                 setShowSkillOptions(false);
+              }}
+              onSelect={(workflow) => {
+                insertReference(workflow.id, 'workflow');
+                setShowWorkflowOptions(false);
                 closeMenu();
               }}
             />

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -5,7 +5,7 @@ import {
   PanelLeftClose, PanelLeft, Bot, Loader2,
   Workflow as WorkflowIcon, Settings2, CheckSquare,
   MoreHorizontal, PencilLine, Download, Share2, Cpu, Info, X, Check,
-  FolderGit2, FolderPlus, FolderOpen, Copy, ArrowUp, HardDrive,
+  FolderGit2, FolderPlus, FolderOpen, Copy, ArrowUp, HardDrive, BookOpen,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
@@ -22,6 +22,8 @@ import SuiteInstallProgressPanel, {
 } from '@/components/hub/SuiteInstallProgressPanel';
 import { sessionApi } from '@/api/session';
 import { hubAPI, type HubInstallProgressEvent } from '@/api/hub';
+import { skillAPI, type Skill } from '@/api/skill';
+import { workflowAPI, type WorkflowSummary } from '@/api/workflow';
 import type { Agent } from '@/api/agent';
 import { useSessions } from '@/hooks/useSessions';
 import { useAgents } from '@/hooks/useAgents';
@@ -35,6 +37,7 @@ import { useDefaultModelVision } from '@/hooks/useDefaultModelVision';
 import { buildPromptParts, type ImagePartData } from '@/utils/imageUpload';
 import { getAgentDisplayDescription, getAgentDisplayName, isAgentUsableInChat } from '@/utils/agentDisplay';
 import { formatRelativeTime, formatSessionDate } from '@/utils/time';
+import { getWorkflowDisplayName } from '@/utils/workflowDisplay';
 import type { ModelDefinitionV2, Session } from '@/types';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -89,6 +92,124 @@ type FolderBrowserResponse = {
   roots: FolderEntry[];
   entries: FolderEntry[];
 };
+
+type ComposerResourceItem = {
+  id: string;
+  name: string;
+  description?: string;
+  badge?: string;
+  source: 'builtin' | 'custom';
+};
+
+function ComposerResourcePicker({
+  label,
+  title,
+  emptyText,
+  icon: Icon,
+  items,
+  loading,
+  open,
+  onToggle,
+  onSelect,
+}: {
+  label: string;
+  title: string;
+  emptyText: string;
+  icon: React.ComponentType<{ className?: string }>;
+  items: ComposerResourceItem[];
+  loading: boolean;
+  open: boolean;
+  onToggle: () => void;
+  onSelect: (item: ComposerResourceItem) => void;
+}) {
+  const { t } = useTranslation('session');
+  const [sourceFilter, setSourceFilter] = useState<AgentSourceFilter>('all');
+  const filteredItems = items.filter((item) => (
+    sourceFilter === 'all' || item.source === sourceFilter
+  ));
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="group flex h-10 w-full items-center gap-2.5 rounded-[9px] px-2 text-left text-[13px] font-medium text-zinc-700 transition-colors hover:bg-zinc-100/90 hover:text-zinc-950 dark:text-zinc-200 dark:hover:bg-white/[0.07] dark:hover:text-white"
+        aria-label={label}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span className="grid h-7 w-7 shrink-0 place-items-center rounded-lg border border-zinc-200/80 bg-white text-zinc-500 shadow-[0_1px_2px_rgba(22,27,34,0.04)] transition-colors group-hover:text-zinc-800 dark:border-white/[0.10] dark:bg-white/[0.05] dark:text-zinc-400 dark:group-hover:text-white">
+          <Icon className="h-3.5 w-3.5" />
+        </span>
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-zinc-400 transition-transform ${open ? '-rotate-90' : ''}`} />
+      </button>
+      {open && (
+        <div className="absolute bottom-0 left-[calc(100%+0.5rem)] z-[60] w-[336px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[14px] border border-black/[0.09] bg-white/95 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]">
+          <div className="flex min-h-12 items-center justify-between gap-3 border-b border-zinc-100 px-3 py-2 dark:border-white/[0.08]">
+            <span className="min-w-0 truncate text-[12px] font-semibold text-zinc-800 dark:text-zinc-100">
+              {title}
+            </span>
+            <div className="inline-flex shrink-0 items-center rounded-lg bg-zinc-100 p-0.5 text-[10px] dark:bg-black/15">
+              {(['all', 'builtin', 'custom'] as AgentSourceFilter[]).map((filter) => (
+                <button
+                  key={filter}
+                  type="button"
+                  onClick={() => setSourceFilter(filter)}
+                  className={`rounded-md px-2 py-1 transition-colors ${
+                    sourceFilter === filter
+                      ? 'bg-white text-zinc-900 shadow-[0_1px_3px_rgba(22,27,34,0.08)] dark:bg-white/[0.12] dark:text-zinc-50'
+                      : 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100'
+                  }`}
+                >
+                  {t(`agentPicker.filter.${filter}`)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="h-64 space-y-0.5 overflow-y-auto p-1.5">
+            {loading ? (
+              <div className="flex h-full items-center justify-center text-zinc-400">
+                <Loader2 className="h-4 w-4 animate-spin" />
+              </div>
+            ) : filteredItems.length > 0 ? (
+              filteredItems.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => onSelect(item)}
+                  title={item.description}
+                  className="flex w-full min-w-0 items-center gap-2 rounded-lg px-2.5 py-2 text-left text-zinc-700 transition-colors hover:bg-zinc-50 hover:text-zinc-950 dark:text-zinc-300 dark:hover:bg-white/[0.06] dark:hover:text-white"
+                >
+                  <span className="grid h-6 w-6 shrink-0 place-items-center rounded-md bg-zinc-100 text-zinc-400 dark:bg-white/[0.05] dark:text-zinc-500">
+                    <Icon className="h-3 w-3" />
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-xs font-medium">{item.name}</span>
+                  <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium ${
+                    item.source === 'builtin'
+                      ? 'bg-zinc-100 text-zinc-600 dark:bg-white/[0.08] dark:text-zinc-300'
+                      : 'bg-teal-50 text-teal-600 dark:bg-teal-950/40 dark:text-teal-300'
+                  }`}>
+                    {t(`agentPicker.badge.${item.source}`)}
+                  </span>
+                  {item.badge && (
+                    <span className="max-w-20 shrink-0 truncate rounded bg-zinc-100 px-1.5 py-0.5 text-[9px] font-medium text-zinc-500 dark:bg-white/[0.07] dark:text-zinc-400">
+                      {item.badge}
+                    </span>
+                  )}
+                </button>
+              ))
+            ) : (
+              <div className="flex h-full items-center justify-center px-4 text-center text-xs text-zinc-400">
+                {emptyText}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 const MULTI_PROJECT_SESSION_PAGE_SIZE = 6;
 const SINGLE_PROJECT_SESSION_PAGE_SIZE = 20;
 
@@ -460,6 +581,11 @@ export default function SessionPage() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState('rex');
   const [showAgentOptions, setShowAgentOptions] = useState(false);
+  const [showWorkflowOptions, setShowWorkflowOptions] = useState(false);
+  const [showSkillOptions, setShowSkillOptions] = useState(false);
+  const [composerWorkflows, setComposerWorkflows] = useState<WorkflowSummary[]>([]);
+  const [composerSkills, setComposerSkills] = useState<Skill[]>([]);
+  const [loadingComposerResources, setLoadingComposerResources] = useState(false);
   const [showProjectOptions, setShowProjectOptions] = useState(false);
   const [selectedModelKey, setSelectedModelKey] = useState<string | null>(null);
   const [showModelOptions, setShowModelOptions] = useState(false);
@@ -533,6 +659,7 @@ export default function SessionPage() {
   const sessionUpdateRefetchTimerRef = useRef<number | null>(null);
   const sessionStatusEventVersionRef = useRef(0);
   const projectListRequestSeqRef = useRef(0);
+  const composerResourcesLoadedRef = useRef(false);
   const toast = useToast();
 
   const sessionProjectIds = useMemo(
@@ -572,6 +699,7 @@ export default function SessionPage() {
   const chatAgents = useMemo(() => [...primaryAgents, ...subAgents], [primaryAgents, subAgents]);
   const filteredChatAgents = useMemo(
     () => chatAgents.filter((agent) => {
+      if (agent.name.toLowerCase() === 'rex') return false;
       if (agentSourceFilter === 'builtin') return agent.native;
       if (agentSourceFilter === 'custom') return !agent.native;
       return true;
@@ -582,6 +710,39 @@ export default function SessionPage() {
     () => chatAgents.find((agent) => agent.name === selectedAgent),
     [chatAgents, selectedAgent],
   );
+  const loadComposerResources = useCallback(async () => {
+    if (composerResourcesLoadedRef.current || loadingComposerResources) return;
+    setLoadingComposerResources(true);
+    try {
+      const [workflowResult, skillResult] = await Promise.allSettled([
+        workflowAPI.listSummaries({ status: 'active' }),
+        skillAPI.status(),
+      ]);
+      if (workflowResult.status === 'fulfilled') {
+        setComposerWorkflows(
+          workflowResult.value.data
+            .filter((workflow) => workflow.status === 'active')
+            .sort((a, b) => getWorkflowDisplayName(a, i18n.language)
+              .localeCompare(getWorkflowDisplayName(b, i18n.language))),
+        );
+      }
+      if (skillResult.status === 'fulfilled') {
+        setComposerSkills(
+          skillResult.value.data
+            .filter((skill) => (
+              !skill.ui_hidden
+              && !skill.disabled
+              && skill.eligible !== false
+              && skill.category !== 'system'
+            ))
+            .sort((a, b) => a.name.localeCompare(b.name)),
+        );
+      }
+      composerResourcesLoadedRef.current = true;
+    } finally {
+      setLoadingComposerResources(false);
+    }
+  }, [i18n.language, loadingComposerResources]);
   const chatModelOptions = useMemo<ChatModelOption[]>(() => {
     const providerById = new Map(
       providers
@@ -2366,6 +2527,204 @@ export default function SessionPage() {
               alertOperationsBusy={installingSocWorkspace}
             />
           )}
+          onComposerAddMenuOpenChange={(open) => {
+            setShowAgentOptions(false);
+            setShowWorkflowOptions(false);
+            setShowSkillOptions(false);
+            if (!open) return;
+            setShowProjectOptions(false);
+            setShowModelOptions(false);
+            void loadComposerResources();
+          }}
+          composerAddMenuSlot={({ closeMenu, insertMention, insertReference }) => (
+            <>
+            <div className="relative" data-agent-selector>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowAgentOptions((open) => !open);
+                  setShowWorkflowOptions(false);
+                  setShowSkillOptions(false);
+                  setShowProjectOptions(false);
+                  setShowModelOptions(false);
+                }}
+                className="group flex h-10 w-full items-center gap-2.5 rounded-[9px] px-2 text-left text-[13px] font-medium text-zinc-700 transition-colors hover:bg-zinc-100/90 hover:text-zinc-950 dark:text-zinc-200 dark:hover:bg-white/[0.07] dark:hover:text-white"
+                title={t('agentPicker.title')}
+                aria-label={`${t('chat.addMenu.agent')}: ${
+                  selectedAgentInfo
+                    ? getAgentDisplayName(selectedAgentInfo, i18n.language)
+                    : formatAgentName(selectedAgent)
+                }`}
+                aria-haspopup="menu"
+                aria-expanded={showAgentOptions}
+              >
+                <span className="grid h-7 w-7 shrink-0 place-items-center rounded-lg border border-zinc-200/80 bg-white text-zinc-500 shadow-[0_1px_2px_rgba(22,27,34,0.04)] transition-colors group-hover:text-zinc-800 dark:border-white/[0.10] dark:bg-white/[0.05] dark:text-zinc-400 dark:group-hover:text-white">
+                  <Bot className="h-3.5 w-3.5" />
+                </span>
+                <span className="min-w-0 flex-1 truncate">{t('chat.addMenu.agent')}</span>
+                <span className="max-w-[108px] truncate text-[11px] font-normal text-zinc-400 dark:text-zinc-500">
+                  {selectedAgentInfo
+                    ? getAgentDisplayName(selectedAgentInfo, i18n.language)
+                    : formatAgentName(selectedAgent)}
+                </span>
+                <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-zinc-400 transition-transform ${showAgentOptions ? '-rotate-90' : ''}`} />
+              </button>
+              {showAgentOptions && (
+                <div className="absolute bottom-0 left-[calc(100%+0.5rem)] z-[60] w-[336px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[14px] border border-black/[0.09] bg-white/95 shadow-[0_18px_46px_rgba(22,27,34,0.14),0_2px_8px_rgba(22,27,34,0.06)] backdrop-blur-xl dark:border-white/[0.11] dark:bg-[#252c35]/95 dark:shadow-[0_20px_48px_rgba(8,10,13,0.44)]">
+                  <div className="flex min-h-12 items-center justify-between gap-3 border-b border-zinc-100 px-3 py-2 dark:border-white/[0.08]">
+                    <div className="min-w-0">
+                      <div className="text-[12px] font-semibold text-zinc-800 dark:text-zinc-100">{t('agentPicker.title')}</div>
+                      <div
+                        className="truncate text-[10px] text-zinc-400 dark:text-zinc-500"
+                        onPointerEnter={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
+                        onMouseEnter={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
+                        onMouseOver={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
+                        onMouseLeave={() => setSelectorTooltip(null)}
+                        onPointerLeave={() => setSelectorTooltip(null)}
+                      >
+                        {t('agentPicker.hint')}
+                      </div>
+                    </div>
+                    <div className="inline-flex shrink-0 items-center rounded-lg bg-zinc-100 p-0.5 text-[10px] dark:bg-black/15">
+                      {(['all', 'builtin', 'custom'] as AgentSourceFilter[]).map((filter) => (
+                        <button
+                          key={filter}
+                          type="button"
+                          onClick={() => setAgentSourceFilter(filter)}
+                          className={`rounded-md px-2 py-1 transition-colors ${
+                            agentSourceFilter === filter
+                              ? 'bg-white text-zinc-900 shadow-[0_1px_3px_rgba(22,27,34,0.08)] dark:bg-white/[0.12] dark:text-zinc-50'
+                              : 'text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100'
+                          }`}
+                        >
+                          {t(`agentPicker.filter.${filter}`)}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="h-64 space-y-0.5 overflow-y-auto p-1.5">
+                    {loadingAgents ? (
+                      <div className="p-3 text-center text-xs text-zinc-500">{t('loading')}</div>
+                    ) : filteredChatAgents.length > 0 ? (
+                      filteredChatAgents.map((agent) => {
+                        const displayName = getAgentDisplayName(agent, i18n.language);
+                        const primaryDesc = getAgentDisplayDescription(agent, i18n.language) || t('smartAssistant');
+                        return (
+                          <button
+                            key={agent.name}
+                            type="button"
+                            onClick={() => {
+                              setShowAgentOptions(false);
+                              insertMention(agent.name);
+                              closeMenu();
+                            }}
+                            className={`w-full min-w-0 rounded-lg px-2.5 py-2 text-left transition-colors ${
+                              selectedAgent === agent.name
+                                ? 'bg-zinc-100/90 text-zinc-900 dark:bg-white/[0.09] dark:text-zinc-50'
+                                : 'text-zinc-700 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-white/[0.06] dark:hover:text-zinc-50'
+                            }`}
+                          >
+                            <div className="flex min-w-0 items-center gap-2">
+                              <span className={`grid h-6 w-6 shrink-0 place-items-center rounded-md ${
+                                selectedAgent === agent.name
+                                  ? 'bg-white text-zinc-700 shadow-[0_1px_3px_rgba(22,27,34,0.08)] dark:bg-white/[0.10] dark:text-white'
+                                  : 'bg-zinc-100 text-zinc-400 dark:bg-white/[0.05] dark:text-zinc-500'
+                              }`}>
+                                <Bot className="h-3 w-3" />
+                              </span>
+                              <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">
+                                {displayName}
+                              </span>
+                              <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium ${
+                                agent.mode === 'primary'
+                                  ? 'bg-zinc-100 text-zinc-600 dark:bg-white/[0.08] dark:text-zinc-300'
+                                  : agent.native
+                                    ? 'bg-zinc-100 text-zinc-600 dark:bg-white/[0.08] dark:text-zinc-300'
+                                    : 'bg-teal-50 text-teal-600 dark:bg-teal-950/40 dark:text-teal-300'
+                              }`}>
+                                {agent.mode === 'primary'
+                                  ? t('agentPicker.badge.primary')
+                                  : agent.native
+                                    ? t('agentPicker.badge.builtin')
+                                    : t('agentPicker.badge.custom')}
+                              </span>
+                              {primaryDesc && (
+                                <span
+                                  className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200 dark:hover:bg-white/[0.08]"
+                                  onMouseDown={(event) => { event.preventDefault(); event.stopPropagation(); }}
+                                  onClick={(event) => { event.preventDefault(); event.stopPropagation(); }}
+                                  onPointerEnter={(event) => showSelectorTooltip(event.currentTarget, displayName, [primaryDesc])}
+                                  onMouseEnter={(event) => showSelectorTooltip(event.currentTarget, displayName, [primaryDesc])}
+                                  onMouseOver={(event) => showSelectorTooltip(event.currentTarget, displayName, [primaryDesc])}
+                                  onMouseLeave={() => setSelectorTooltip(null)}
+                                  onPointerLeave={() => setSelectorTooltip(null)}
+                                >
+                                  <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-300" />
+                                </span>
+                              )}
+                            </div>
+                          </button>
+                        );
+                      })
+                    ) : (
+                      <div className="p-3 text-center text-xs text-zinc-500">{t('noAgents')}</div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+            <ComposerResourcePicker
+              label={t('chat.addMenu.workflows')}
+              title={t('chat.addMenu.selectWorkflow')}
+              emptyText={t('chat.addMenu.noWorkflows')}
+              icon={WorkflowIcon}
+              items={composerWorkflows.map((workflow) => ({
+                id: workflow.id,
+                name: getWorkflowDisplayName(workflow, i18n.language),
+                description: workflow.description,
+                badge: workflow.category,
+                source: workflow.source === 'project' ? 'builtin' : 'custom',
+              }))}
+              loading={loadingComposerResources}
+              open={showWorkflowOptions}
+              onToggle={() => {
+                setShowWorkflowOptions((open) => !open);
+                setShowAgentOptions(false);
+                setShowSkillOptions(false);
+              }}
+              onSelect={(workflow) => {
+                insertReference(workflow.id, 'workflow');
+                setShowWorkflowOptions(false);
+                closeMenu();
+              }}
+            />
+            <ComposerResourcePicker
+              label={t('chat.addMenu.skills')}
+              title={t('chat.addMenu.selectSkill')}
+              emptyText={t('chat.addMenu.noSkills')}
+              icon={BookOpen}
+              items={composerSkills.map((skill) => ({
+                id: skill.name,
+                name: skill.name,
+                description: skill.description,
+                badge: skill.category,
+                source: skill.source === 'project' ? 'builtin' : 'custom',
+              }))}
+              loading={loadingComposerResources}
+              open={showSkillOptions}
+              onToggle={() => {
+                setShowSkillOptions((open) => !open);
+                setShowAgentOptions(false);
+                setShowWorkflowOptions(false);
+              }}
+              onSelect={(skill) => {
+                insertReference(skill.id, 'skill');
+                setShowSkillOptions(false);
+                closeMenu();
+              }}
+            />
+            </>
+          )}
           toolbarSlot={
             <>
             {!activeChatSessionId && (
@@ -2440,118 +2799,6 @@ export default function SessionPage() {
                 )}
               </div>
             )}
-            <div className="relative" data-agent-selector>
-              <button
-                type="button"
-                onClick={() => {
-                  setShowAgentOptions(!showAgentOptions);
-                  setShowProjectOptions(false);
-                  setShowModelOptions(false);
-                }}
-                className="flex h-7 w-auto max-w-[150px] min-w-0 items-center gap-1.5 rounded-lg px-2 text-xs text-zinc-600 transition-colors hover:bg-zinc-200/60 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
-                title={t('agentPicker.title')}
-              >
-                <Bot className="h-3 w-3 shrink-0" />
-                <span className="truncate font-medium">
-                  {selectedAgentInfo ? getAgentDisplayName(selectedAgentInfo, i18n.language) : formatAgentName(selectedAgent)}
-                </span>
-                <ChevronDown className={`h-3 w-3 shrink-0 transition-transform ${showAgentOptions ? 'rotate-180' : ''}`} />
-              </button>
-              {showAgentOptions && (
-                <div className="absolute left-0 bottom-full z-50 mb-2 w-80 max-w-[calc(100vw-2rem)] rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:shadow-xl dark:shadow-black/30">
-                  <div className="flex items-center justify-between gap-2 border-b border-zinc-100 px-2.5 py-1.5 dark:border-zinc-800">
-                    <div className="min-w-0">
-                      <div className="text-xs font-semibold text-zinc-700 dark:text-zinc-100">{t('agentPicker.title')}</div>
-                      <div
-                        className="truncate text-[10px] text-zinc-400 dark:text-zinc-500"
-                        onPointerEnter={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
-                        onMouseEnter={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
-                        onMouseOver={(event) => showSelectorTooltip(event.currentTarget, t('agentPicker.title'), [t('agentPicker.hint')])}
-                        onMouseLeave={() => setSelectorTooltip(null)}
-                        onPointerLeave={() => setSelectorTooltip(null)}
-                      >
-                        {t('agentPicker.hint')}
-                      </div>
-                    </div>
-                    <div className="inline-flex shrink-0 items-center rounded-md border border-zinc-200 bg-white p-0.5 text-[10px] dark:border-zinc-800 dark:bg-zinc-950">
-                      {(['all', 'builtin', 'custom'] as AgentSourceFilter[]).map((filter) => (
-                        <button
-                          key={filter}
-                          type="button"
-                          onClick={() => setAgentSourceFilter(filter)}
-                          className={`rounded px-1.5 py-0.5 transition-colors ${
-                            agentSourceFilter === filter
-                              ? 'bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50'
-                              : 'text-zinc-500 hover:bg-zinc-50 hover:text-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100'
-                          }`}
-                        >
-                          {t(`agentPicker.filter.${filter}`)}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  <div className="h-64 space-y-0.5 overflow-y-auto p-1.5">
-                    {loadingAgents ? (
-                      <div className="p-3 text-center text-xs text-zinc-500">{t('loading')}</div>
-                    ) : filteredChatAgents.length > 0 ? (
-                      filteredChatAgents.map((agent) => {
-                        const displayName = getAgentDisplayName(agent, i18n.language);
-                        const primaryDesc = getAgentDisplayDescription(agent, i18n.language) || t('smartAssistant');
-                        return (
-                        <button
-                          key={agent.name}
-                          onClick={() => { setSelectedAgent(agent.name); setShowAgentOptions(false); }}
-                          className={`w-full min-w-0 rounded-md px-2 py-1.5 text-left transition-colors ${
-                            selectedAgent === agent.name
-                              ? 'bg-zinc-50 text-zinc-900 shadow-[inset_2px_0_0_#a1a1aa] dark:bg-zinc-800 dark:text-zinc-50 dark:shadow-[inset_2px_0_0_#539bf5]'
-                              : 'hover:bg-zinc-50 text-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-50'
-                          }`}
-                        >
-                          <div className="flex min-w-0 items-center gap-2">
-                            <Bot className={`h-3 w-3 shrink-0 ${selectedAgent === agent.name ? 'text-zinc-600 dark:text-zinc-200' : 'text-zinc-400 dark:text-zinc-500'}`} />
-                            <span className="min-w-0 flex-1 truncate text-xs font-medium text-zinc-900 dark:text-zinc-100">
-                              {displayName}
-                            </span>
-                            <span className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium ${
-                              agent.mode === 'primary'
-                                ? 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
-                                : agent.native
-                                  ? 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
-                                  : 'bg-teal-50 text-teal-600 dark:bg-teal-950/40 dark:text-teal-300'
-                            }`}>
-                              {agent.mode === 'primary'
-                                ? t('agentPicker.badge.primary')
-                                : agent.native
-                                  ? t('agentPicker.badge.builtin')
-                                  : t('agentPicker.badge.custom')}
-                            </span>
-                            <div className="ml-auto flex shrink-0 items-center gap-1">
-                              {primaryDesc && (
-                                <span
-                                  className="group relative rounded p-0.5 transition-colors hover:bg-zinc-200 dark:hover:bg-zinc-700"
-                                  onMouseDown={(event) => { event.preventDefault(); event.stopPropagation(); }}
-                                  onClick={(event) => { event.preventDefault(); event.stopPropagation(); }}
-                                  onPointerEnter={(event) => showSelectorTooltip(event.currentTarget, displayName, [primaryDesc])}
-                                  onMouseEnter={(event) => showSelectorTooltip(event.currentTarget, displayName, [primaryDesc])}
-                                  onMouseOver={(event) => showSelectorTooltip(event.currentTarget, displayName, [primaryDesc])}
-                                  onMouseLeave={() => setSelectorTooltip(null)}
-                                  onPointerLeave={() => setSelectorTooltip(null)}
-                                >
-                                  <Info className="h-3 w-3 text-zinc-300 transition-colors group-hover:text-zinc-500 dark:text-zinc-600 dark:group-hover:text-zinc-300" />
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        </button>
-                        );
-                      })
-                    ) : (
-                      <div className="p-3 text-center text-xs text-zinc-500">{t('noAgents')}</div>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
             </>
           }
           centerToolbarSlot={


### PR DESCRIPTION
## Summary
- replace the composer attachment control with a unified Add menu for files, subagents, workflows, and skills
- open the same resource menu when the user types a standalone @ character
- exclude Rex from subagent selection and add built-in/custom filters for all resource types
- render selected resources as removable colored chips and send unified subagent:, skill:, and workflow: references
- preserve one-turn subagent routing and restore references when sending fails

## Validation
- npm run test:run -- src/pages/Session/index.test.tsx src/components/common/SessionChat.test.ts
- npm run lint
- npm run build
- browser interaction and dark-theme visual verification