### PR TITLE
fix: add safe server restart recovery

### DIFF
--- a/flocks/agent/agents/rex/prompt_builder.py
+++ b/flocks/agent/agents/rex/prompt_builder.py
@@ -256,6 +256,11 @@ def _build_command_guidance_section() -> str:
 
 Use `flocks --help` to inspect Flocks CLI commands and usage.
 run_slash_command tool with help command to get the latest slash command guidance.
+
+### Safe Flocks Restart
+
+When you need to restart the running Flocks service yourself, use `flocks restart --server-only`.
+永远不要直接执行 `flocks restart`，这将会导致你杀死自己并且无法自启动。
 </Command_Guidance>"""
 
 

--- a/flocks/cli/main.py
+++ b/flocks/cli/main.py
@@ -41,6 +41,7 @@ from flocks.cli.service_manager import (
     ServiceError,
     resolve_flocks_cli_command,
     restart_all,
+    restart_server,
     runtime_paths,
     show_logs,
     show_status,
@@ -264,6 +265,11 @@ def stop():
 
 @app.command()
 def restart(
+    server_only: bool = typer.Option(
+        False,
+        "--server-only",
+        help="Restart only the backend server without stopping the supervisor daemon",
+    ),
     no_browser: bool = typer.Option(False, "--no-browser", help="Do not open WebUI in a browser"),
     skip_webui_build: bool = typer.Option(
         False,
@@ -281,6 +287,9 @@ def restart(
     Restart Flocks service.
     """
     try:
+        if server_only:
+            restart_server(console)
+            return
         restart_all(
             _restart_service_config(
                 no_browser=no_browser,

--- a/flocks/cli/service_manager.py
+++ b/flocks/cli/service_manager.py
@@ -31,6 +31,7 @@ from flocks.cli.service_control import (
     read_logs,
     read_supervisor_status,
     request_restart,
+    request_restart_backend,
     request_stop,
     stream_logs,
     supervisor_is_running,
@@ -1559,6 +1560,21 @@ def restart_all(config: ServiceConfig, console) -> None:
     with service_lock(paths):
         _stop_all_unlocked(console, paths=paths)
         _start_all_unlocked(config, console, paths=paths)
+
+
+def restart_server(console) -> None:
+    """Restart only the backend through the running supervisor daemon."""
+    paths = ensure_runtime_dirs()
+    with service_lock(paths):
+        if not supervisor_is_running(paths):
+            raise ServiceError("Flocks daemon 未运行；请执行 `flocks restart` 进行全量重启。")
+        try:
+            status = request_restart_backend(paths=paths)
+        except Exception as error:
+            raise ServiceError(f"Flocks server 重启请求失败：{error}") from error
+        _print_status_payload(status.raw, console, include_daemon_step=False)
+        if not _startup_payload_is_ready(status.raw):
+            raise ServiceError(_startup_failure_message(status.raw))
 
 
 def _print_static_port_migration_hint(config: ServiceConfig, console) -> None:

--- a/tests/cli/test_service_manager.py
+++ b/tests/cli/test_service_manager.py
@@ -1112,6 +1112,40 @@ def test_restart_all_stops_then_starts_daemon(monkeypatch) -> None:
     assert call_order == ["stop", "start"]
 
 
+def test_restart_server_requests_backend_restart(monkeypatch) -> None:
+    calls: list[str] = []
+    console = DummyConsole()
+    paths = _make_runtime_paths(Path("/tmp/flocks-test"))
+    status = _supervisor_status(_supervisor_status_payload())
+
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "supervisor_is_running", lambda _paths: True)
+    monkeypatch.setattr(
+        service_manager,
+        "request_restart_backend",
+        lambda **_kwargs: calls.append("backend") or status,
+    )
+    monkeypatch.setattr(
+        service_manager,
+        "_print_status_payload",
+        lambda *_args, **_kwargs: calls.append("status"),
+    )
+
+    service_manager.restart_server(console)
+
+    assert calls == ["backend", "status"]
+
+
+def test_restart_server_requires_running_supervisor(monkeypatch) -> None:
+    paths = _make_runtime_paths(Path("/tmp/flocks-test"))
+
+    monkeypatch.setattr(service_manager, "ensure_runtime_dirs", lambda: paths)
+    monkeypatch.setattr(service_manager, "supervisor_is_running", lambda _paths: False)
+
+    with pytest.raises(service_manager.ServiceError, match="请执行 `flocks restart` 进行全量重启"):
+        service_manager.restart_server(DummyConsole())
+
+
 def test_start_all_without_stop_starts_supervisor_daemon(monkeypatch, tmp_path: Path) -> None:
     paths = _make_runtime_paths(tmp_path)
     calls: list[str] = []

--- a/tests/server/test_server_port_config.py
+++ b/tests/server/test_server_port_config.py
@@ -307,6 +307,22 @@ class TestCommandLinePortConfiguration:
         assert captured["config"].frontend_port == 5273
         assert captured["config"].legacy_backend_port == 9100
 
+    def test_restart_server_only_does_not_restart_daemon(self, monkeypatch):
+        """Test server-only restart leaves the supervisor daemon running."""
+        calls = []
+
+        monkeypatch.setattr(cli_main, "restart_server", lambda _console: calls.append("server"))
+        monkeypatch.setattr(
+            cli_main,
+            "restart_all",
+            lambda _config, _console: calls.append("all"),
+        )
+
+        result = CliRunner().invoke(cli_main.app, ["restart", "--server-only"])
+
+        assert result.exit_code == 0
+        assert calls == ["server"]
+
     def test_restart_accepts_public_host_and_port(self, monkeypatch):
         """Test restart command accepts the unified public host/port options."""
         captured = {}

--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -3957,6 +3957,126 @@ describe('streaming activity helpers', () => {
   });
 });
 
+describe('SessionChat SSE reconnect recovery', () => {
+  async function renderStreamingSession(onStreamingDone = vi.fn()) {
+    const refetch = vi.fn();
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'assistant-1',
+          finish: null,
+          parts: [{
+            id: 'tool-1',
+            type: 'tool',
+            tool: 'bash',
+            state: {
+              status: 'error',
+              error: 'Interrupted by server restart',
+            },
+          }] as Message['parts'],
+        }),
+      ],
+      loading: false,
+      refetch,
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      replaceMessageText: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      live: true,
+      onStreamingDone,
+    }));
+
+    await waitFor(() => {
+      expect(clientGetMock).toHaveBeenCalledWith('/api/session/status');
+    });
+    clientGetMock.mockClear();
+
+    act(() => {
+      useSSEOptionsRef.current.onEvent({
+        type: 'session.status',
+        properties: { sessionID: 'sess-1', status: { type: 'busy' } },
+      });
+    });
+    expect(screen.getByTitle('chat.stopTitle')).toBeInTheDocument();
+
+    return { onStreamingDone, refetch };
+  }
+
+  it('clears streaming after reconnect when the restarted server reports the session idle', async () => {
+    const { onStreamingDone, refetch } = await renderStreamingSession();
+
+    act(() => {
+      useSSEOptionsRef.current.onReconnect();
+    });
+
+    await waitFor(() => {
+      expect(clientGetMock).toHaveBeenCalledWith('/api/session/status');
+      expect(screen.queryByTitle('chat.stopTitle')).not.toBeInTheDocument();
+    });
+    expect(refetch).toHaveBeenCalled();
+    expect(onStreamingDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps streaming after reconnect while a long-running session is still busy', async () => {
+    const { onStreamingDone } = await renderStreamingSession();
+    clientGetMock.mockImplementation((url: string) => {
+      if (url === '/api/session/status') {
+        return Promise.resolve({ data: { 'sess-1': { type: 'busy' } } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    act(() => {
+      useSSEOptionsRef.current.onReconnect();
+    });
+
+    await waitFor(() => {
+      expect(clientGetMock).toHaveBeenCalledWith('/api/session/status');
+    });
+    expect(screen.getByTitle('chat.stopTitle')).toBeInTheDocument();
+    expect(onStreamingDone).not.toHaveBeenCalled();
+  });
+
+  it('ignores a stale idle response after a newer busy event arrives', async () => {
+    let resolveStatus: ((value: { data: Record<string, unknown> }) => void) | undefined;
+    const { onStreamingDone } = await renderStreamingSession();
+    clientGetMock.mockImplementation((url: string) => {
+      if (url === '/api/session/status') {
+        return new Promise((resolve) => {
+          resolveStatus = resolve;
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    act(() => {
+      useSSEOptionsRef.current.onReconnect();
+    });
+    await waitFor(() => {
+      expect(resolveStatus).toBeDefined();
+    });
+
+    act(() => {
+      useSSEOptionsRef.current.onEvent({
+        type: 'session.status',
+        properties: { sessionID: 'sess-1', status: { type: 'busy' } },
+      });
+      resolveStatus?.({ data: {} });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTitle('chat.stopTitle')).toBeInTheDocument();
+    expect(onStreamingDone).not.toHaveBeenCalled();
+  });
+});
+
 describe('SessionChat fallback polling', () => {
   it('reconciles pending questions while the session is busy', async () => {
     vi.useFakeTimers();

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -1652,6 +1652,7 @@ export default function SessionChat({
   const initialMessageSentRef = useRef('');
   const abortingRef = useRef(false);
   const sessionBusyRef = useRef(false);
+  const sessionStatusRevisionRef = useRef(0);
   const goalHydrationVersionRef = useRef(0);
   // ID of the assistant message that was aborted; used to ignore its finish event
   const abortedMessageIdRef = useRef<string | null>(null);
@@ -1822,6 +1823,7 @@ export default function SessionChat({
         case 'ignore':
           return;
         case 'session-cleared':
+          sessionStatusRevisionRef.current += 1;
           abortingRef.current = false;
           sessionBusyRef.current = false;
           activeToolPartIdsRef.current.clear();
@@ -1834,6 +1836,7 @@ export default function SessionChat({
           void refreshContextUsage({ clear: true });
           return;
         case 'session-status':
+          sessionStatusRevisionRef.current += 1;
           if (action.statusType === 'busy') {
             sessionBusyRef.current = true;
             if (
@@ -2045,11 +2048,52 @@ export default function SessionChat({
     [onError, submitReject, t, toast],
   );
 
+  const reconcileSessionStatusAfterReconnect = useCallback(async () => {
+    if (!sessionId) return;
+    const statusRevision = sessionStatusRevisionRef.current;
+
+    try {
+      const response = await client.get('/api/session/status');
+      if (statusRevision !== sessionStatusRevisionRef.current) return;
+
+      const status = response.data?.[sessionId];
+      if (isActiveSessionStatus(status)) {
+        sessionBusyRef.current = true;
+        if (!abortingRef.current && !suppressStreamingUntilIdleRef.current) {
+          setIsStreaming(true);
+        }
+        if (status?.type === 'compacting') {
+          setIsCompacting(true);
+          isCompactingRef.current = true;
+          setCompactingMessage(status.message || t('chat.compacting'));
+        } else {
+          setIsCompacting(false);
+          isCompactingRef.current = false;
+          setCompactingMessage('');
+          setCompactionStages([]);
+        }
+        return;
+      }
+
+      sessionBusyRef.current = false;
+      activeToolPartIdsRef.current.clear();
+      setSending(false);
+      setIsStreaming(false);
+      setIsCompacting(false);
+      isCompactingRef.current = false;
+      setCompactingMessage('');
+      setCompactionStages([]);
+    } catch {
+      // Keep the current activity state when reconnect status cannot be verified.
+    }
+  }, [sessionId, t]);
+
   const { status: sseStatus } = useSSE({
     url: `${getApiBase()}/api/event`,
     onEvent: handleSSEEvent,
     onReconnect: () => {
       if (!sessionId) return;
+      void reconcileSessionStatusAfterReconnect();
       refetch();
       refreshContextUsage();
       fetchPromptQueue();
@@ -2120,6 +2164,7 @@ export default function SessionChat({
     abortedMessageIdRef.current = null;
     suppressStreamingUntilIdleRef.current = false;
     sessionBusyRef.current = false;
+    sessionStatusRevisionRef.current += 1;
     statusCheckedRef.current = null;
     isAtBottomRef.current = true;
     clearPendingQuestions();


### PR DESCRIPTION
## Summary
- add a `--server-only` option to restart the backend through the supervisor
- keep the existing full restart behavior unchanged
- instruct Rex to use the safe restart option and avoid self-termination
- reconcile WebUI session activity after SSE reconnects so interrupted turns do not leave the composer stuck
- preserve active long-running sessions and discard stale reconnect status responses

## Testing
- `uv run pytest -q tests/server/test_server_port_config.py tests/cli/test_service_manager.py`
- `uv run ruff check flocks/cli/main.py flocks/cli/service_manager.py flocks/agent/agents/rex/prompt_builder.py tests/server/test_server_port_config.py tests/cli/test_service_manager.py`
- `npm run test:run -- src/components/common/SessionChat.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/components/common/SessionChat.tsx src/components/common/SessionChat.test.ts --max-warnings 0`
- `git diff --check`