### PR TITLE
fix(feishu): support lark-oapi dispatcher method conventions

### DIFF
--- a/flocks/channel/builtin/feishu/monitor.py
+++ b/flocks/channel/builtin/feishu/monitor.py
@@ -172,7 +172,7 @@ def _build_ws_client(
         native_client_cls = ws_module.Client
 
         class _Dispatcher:
-            def do_without_validation(self, payload: bytes) -> None:
+            def _do_without_validation(self, payload: bytes) -> None:
                 try:
                     data = json.loads(payload.decode("utf-8"))
                 except Exception as e:
@@ -180,6 +180,9 @@ def _build_ws_client(
                     return None
                 event_handler(data)
                 return None
+
+            def do_without_validation(self, payload: bytes) -> None:
+                return self._do_without_validation(payload)
 
         class _CompatWSClient:
             def __init__(self) -> None:

--- a/tests/channel/test_feishu.py
+++ b/tests/channel/test_feishu.py
@@ -549,7 +549,14 @@ async def test_build_ws_client_adapter_branch_surfaces_disconnect_error(monkeypa
     assert ws_client.disconnected_error is disconnect_error
 
 
-def test_build_ws_client_falls_back_to_modern_sdk(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "dispatch_method",
+    ["do_without_validation", "_do_without_validation"],
+)
+def test_build_ws_client_falls_back_to_modern_sdk(
+    monkeypatch,
+    dispatch_method: str,
+) -> None:
     dispatched: list[dict] = []
     captured: dict[str, object] = {}
 
@@ -570,7 +577,10 @@ def test_build_ws_client_falls_back_to_modern_sdk(monkeypatch) -> None:
             self._disconnect_called = False
 
         def start(self):
-            captured["event_handler"].do_without_validation(b'{"header":{"event_type":"ping"}}')
+            dispatcher = captured["event_handler"]
+            getattr(dispatcher, dispatch_method)(
+                b'{"header":{"event_type":"ping"}}',
+            )
 
         async def _disconnect(self):
             self._disconnect_called = True


### PR DESCRIPTION
## Summary
- add the private _do_without_validation dispatcher entry point required by lark-oapi 1.7.1
- preserve do_without_validation as a compatibility proxy for older callers
- cover both dispatcher conventions with regression tests

## Root cause
lark-oapi 1.7.1 calls _do_without_validation, while the compatibility dispatcher only implemented do_without_validation. This caused websocket startup to fail with AttributeError.

## Validation
- uv run pytest tests/channel/test_feishu.py -q (36 passed)
- uv run ruff check flocks/channel/builtin/feishu/monitor.py tests/channel/test_feishu.py