### PR TITLE
fix(session): restore sidebar creation actions and centered search

### DIFF
--- a/flocks/cli/main.py
+++ b/flocks/cli/main.py
@@ -284,7 +284,8 @@ def restart(
     webui_port: Optional[int] = typer.Option(None, "--webui-port", help="WebUI port"),
 ):
     """
-    Restart Flocks service.
+    Restart Flocks service. Agents must use `flocks restart --server-only`;
+    bare restart stops the supervisor and terminates the running agent.
     """
     try:
         if server_only:

--- a/tests/cli/test_service_commands.py
+++ b/tests/cli/test_service_commands.py
@@ -31,6 +31,9 @@ def test_cli_help_lists_service_commands(monkeypatch, tmp_path) -> None:
     assert result.exit_code == 0
     for command in ("start", "stop", "restart", "status", "logs", "session", "mcp", "task", "skills"):
         assert _help_contains_command(result.stdout, command)
+    assert "Agents must use `flocks restart" in result.stdout
+    assert "--server-only`;" in result.stdout
+    assert "bare restart stops the supervisor and terminates the running agent" in result.stdout
     for command in ("agent", "acp", "debug", "run", "serve", "service-watchdog", "service-daemon", "auth", "models"):
         assert not _help_contains_command(result.stdout, command)
 

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -490,6 +490,11 @@
     "copyPathFailed": "Failed to copy project path",
     "saveFailed": "Failed to save project"
   },
+  "openTaskSearch": "Search tasks",
+  "closeTaskSearch": "Close task search",
+  "taskSearchDialog": "Task search",
+  "recentTasks": "Recent tasks",
+  "searchResults": "Search results",
   "filterConversations": "Search tasks",
   "noResults": "No matching tasks",
   "showMore": "Show {{count}} more",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -490,6 +490,11 @@
     "copyPathFailed": "复制项目路径失败",
     "saveFailed": "保存项目失败"
   },
+  "openTaskSearch": "搜索任务",
+  "closeTaskSearch": "关闭任务搜索",
+  "taskSearchDialog": "任务搜索",
+  "recentTasks": "最近任务",
+  "searchResults": "搜索结果",
   "filterConversations": "搜索任务",
   "noResults": "没有匹配的任务",
   "showMore": "显示更多 {{count}} 条",

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -578,10 +578,18 @@ describe('SessionPage session actions menu', () => {
     const tasksSection = tasksHeading.closest('section');
     const projectsSection = projectsHeading.closest('section');
     const newSessionButton = screen.getByRole('button', { name: 'newSession' });
-    const searchInput = screen.getByPlaceholderText('filterConversations');
+    const searchButton = screen.getByRole('button', { name: 'openTaskSearch' });
+    expect(screen.queryByPlaceholderText('filterConversations')).not.toBeInTheDocument();
+    await user.click(searchButton);
+    const searchDialog = screen.getByRole('dialog', { name: 'taskSearchDialog' });
+    const searchInput = within(searchDialog).getByPlaceholderText('filterConversations');
+    expect(searchDialog).toHaveClass('fixed', 'inset-0', 'justify-center');
+    expect(searchDialog.firstElementChild).toHaveClass('max-w-[620px]', 'rounded-2xl');
     expect(newSessionButton.previousElementSibling).toHaveClass('left-2', 'h-3.5', 'w-3.5');
-    expect(searchInput.previousElementSibling).toHaveClass('left-2', 'h-3.5', 'w-3.5');
-    expect(searchInput).toHaveClass('text-sm', 'font-medium');
+    expect(searchButton.closest('div')).toContainElement(screen.getByText('managementTitle'));
+    expect(searchInput).toHaveFocus();
+    expect(searchInput).toHaveClass('text-[15px]', 'font-medium');
+    await user.click(within(searchDialog).getByRole('button', { name: 'closeTaskSearch' }));
     expect(tasksHeading.closest('div')).toHaveClass('px-2', 'text-xs', 'text-zinc-500');
     expect(projectsHeading.closest('div')).toHaveClass('px-2', 'text-xs', 'text-zinc-500');
     expect(tasksHeading.nextElementSibling).toHaveTextContent('(1)');
@@ -603,13 +611,68 @@ describe('SessionPage session actions menu', () => {
     expect(tasksToggle).toContainElement(tasksHeading);
     expect(tasksToggle.querySelector('svg')).toHaveClass('h-3.5', 'w-3.5');
     expect(screen.queryByRole('button', { name: 'selectTasks' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'createTaskSession' })).not.toBeInTheDocument();
+    const createTaskButton = screen.getByRole('button', { name: 'createTaskSession' });
+    expect(createTaskButton).toHaveClass(
+      'opacity-0',
+      'group-hover/tasks-section:opacity-100',
+      'group-focus-within/tasks-section:opacity-100',
+    );
 
     await user.click(tasksToggle);
     expect(screen.queryByText('Original Session')).not.toBeInTheDocument();
 
     await user.click(tasksToggle);
     expect(screen.getByText('Original Session')).toBeInTheDocument();
+  });
+
+  it('shows the five most recently updated sessions when search opens', async () => {
+    const user = userEvent.setup();
+    const recentSessions = Array.from({ length: 6 }, (_, index) => ({
+      ...session,
+      id: `recent-${index + 1}`,
+      slug: `recent-${index + 1}`,
+      title: `Recent ${index + 1}`,
+      time: {
+        ...session.time,
+        updated: session.time.updated + index,
+      },
+    }));
+    useSessions.mockReturnValue({
+      sessions: recentSessions,
+      loading: false,
+      error: null,
+      refetch: refetchSessions,
+      updateSessionTitle,
+      removeSession,
+      removeSessions,
+      addSession,
+    });
+
+    renderSessionPage();
+    await user.click(screen.getByRole('button', { name: 'openTaskSearch' }));
+
+    const searchDialog = screen.getByRole('dialog', { name: 'taskSearchDialog' });
+    expect(within(searchDialog).getAllByRole('button')).toHaveLength(6);
+    expect(within(searchDialog).queryByText('Recent 1')).not.toBeInTheDocument();
+    expect(within(searchDialog).getByText('Recent 6')).toBeInTheDocument();
+    expect(within(searchDialog).getByText('recentTasks')).toBeInTheDocument();
+
+    await user.click(within(searchDialog).getByText('Recent 6'));
+    expect(screen.queryByRole('dialog', { name: 'taskSearchDialog' })).not.toBeInTheDocument();
+  });
+
+  it('creates a new session from the tasks row', async () => {
+    const user = userEvent.setup();
+    renderSessionPage();
+
+    await screen.findByText('tasksSection');
+    await user.click(screen.getByRole('button', { name: 'createTaskSession' }));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledWith('/api/session', {
+        title: 'New Session',
+      });
+    });
   });
 
   it('keeps the workbench canvas, sidebar, selected row, and dark palette classes stable', async () => {
@@ -1202,6 +1265,7 @@ describe('SessionPage session actions menu', () => {
 
     renderSessionPage();
 
+    await user.click(screen.getByRole('button', { name: 'openTaskSearch' }));
     await user.type(screen.getByPlaceholderText('filterConversations'), 'nothing matches');
     await user.click(await screen.findByRole('button', { name: 'projectDialog.createTitle' }));
     const nameInput = screen.getByLabelText('projectDialog.nameLabel');
@@ -1319,7 +1383,7 @@ describe('SessionPage session actions menu', () => {
 
     const projectRow = (await screen.findByText('Shared Labs')).closest('[class*="group/project"]');
     expect(projectRow).not.toBeNull();
-    expect(within(projectRow as HTMLElement).queryByRole('button', { name: 'createSessionInProject' })).not.toBeInTheDocument();
+    expect(within(projectRow as HTMLElement).getByRole('button', { name: 'createSessionInProject' })).toBeDisabled();
     await user.click(within(projectRow as HTMLElement).getByRole('button', { name: 'projectActions' }));
     expect(within(projectRow as HTMLElement).getByRole('menuitem', { name: 'projectDialog.copyPathAction' })).toBeInTheDocument();
     expect(within(projectRow as HTMLElement).queryByRole('menuitem', { name: 'shareAction' })).not.toBeInTheDocument();
@@ -1341,6 +1405,7 @@ describe('SessionPage session actions menu', () => {
 
     renderSessionPage();
     await screen.findByText('tasksSection');
+    await userEvent.setup().click(screen.getByRole('button', { name: 'openTaskSearch' }));
     const searchInput = screen.getByPlaceholderText('filterConversations');
     fireEvent.change(searchInput, { target: { value: 'a' } });
     fireEvent.change(searchInput, { target: { value: 'ab' } });
@@ -1412,10 +1477,19 @@ describe('SessionPage session actions menu', () => {
     });
   });
 
-  it('does not show a create-session button on a project row', async () => {
+  it('creates a session from a specific project row', async () => {
+    const user = userEvent.setup();
     const currentProject = { id: 'default', worktree: '/tmp/project', name: '默认', isDefault: true };
     client.get.mockResolvedValue({
       data: [currentProject, { id: 'prj_project2', worktree: '/tmp/labs', name: 'Labs' }],
+    });
+    client.post.mockResolvedValue({
+      data: {
+        ...secondSession,
+        id: 'session-labs',
+        projectID: 'prj_project2',
+        title: 'New Session',
+      },
     });
 
     renderSessionPage();
@@ -1423,7 +1497,23 @@ describe('SessionPage session actions menu', () => {
     const projectLabel = await screen.findByText('Labs');
     const projectRow = projectLabel.closest('[class*="group/project"]');
     expect(projectRow).not.toBeNull();
-    expect(within(projectRow as HTMLElement).queryByRole('button', { name: 'createSessionInProject' })).not.toBeInTheDocument();
+    const projectActionsButton = within(projectRow as HTMLElement).getByRole('button', { name: 'projectActions' });
+    const createProjectSessionButton = within(projectRow as HTMLElement).getByRole('button', {
+      name: 'createSessionInProject',
+    });
+    expect(projectActionsButton.nextElementSibling).toBe(createProjectSessionButton);
+    await user.click(createProjectSessionButton);
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledWith('/api/session', {
+        title: 'New Session',
+        projectID: 'prj_project2',
+      });
+    });
+    expect(addSession).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'session-labs',
+      projectID: 'prj_project2',
+    }));
   });
 
   it('opens the actions menu for a session item', async () => {

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -65,6 +65,7 @@ const SESSION_PAGE_VISITED_STORAGE_KEY = 'flocks:sessions:visited';
 const SOC_WORKSPACE_COMPONENT_ID = 'soc-workspace';
 const INSTALLED_HUB_STATES = new Set(['installed', 'localOnly', 'updateAvailable']);
 const SESSION_UPDATE_REFETCH_DEBOUNCE_MS = 500;
+const RECENT_SEARCH_SESSION_LIMIT = 5;
 const AUTO_MODEL_KEY = '__flocks_auto__';
 const TASK_SESSION_GROUP_ID = 'tasks';
 const SESSION_EXECUTION_MODES: SessionExecutionMode[] = ['build', 'plan', 'goal'];
@@ -669,6 +670,7 @@ export default function SessionPage() {
   const [renameSubmitting, setRenameSubmitting] = useState(false);
   const [downloadingSessionId, setDownloadingSessionId] = useState<string | null>(null);
   const supportsVision = useDefaultModelVision();
+  const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [agentSourceFilter, setAgentSourceFilter] = useState<AgentSourceFilter>('all');
   const [selectedSessionFallback, setSelectedSessionFallback] = useState<Session | null>(null);
@@ -715,6 +717,14 @@ export default function SessionPage() {
     projectIds: sessionProjectIds,
     pageSize: sessionListPageSize,
   });
+  const searchPanelSessions = useMemo(() => {
+    const sortedSessions = [...sessions].sort(
+      (left, right) => (right.time?.updated ?? 0) - (left.time?.updated ?? 0),
+    );
+    return searchQuery.trim()
+      ? sortedSessions
+      : sortedSessions.slice(0, RECENT_SEARCH_SESSION_LIMIT);
+  }, [searchQuery, sessions]);
   const { agents, loading: loadingAgents } = useAgents();
   const { providers, loading: loadingProviders } = useProviders();
   const {
@@ -985,6 +995,7 @@ export default function SessionPage() {
     [projects, sessions, t],
   );
   const taskGroupCollapsed = collapsedProjectIds.has(TASK_SESSION_GROUP_ID);
+  const taskGroupSelected = selectedProjectId === TASK_SESSION_GROUP_ID;
   const taskSessionsCollapsedToFirstPage = collapsedLoadedSessionGroupIds.has(TASK_SESSION_GROUP_ID);
   const visibleTaskSessions = taskSessionsCollapsedToFirstPage
     ? taskSessionGroup.sessions.slice(0, sessionListPageSize)
@@ -1487,6 +1498,10 @@ export default function SessionPage() {
       setCreating(false);
     }
   }, [creating, selectedProjectId, selectedSessionId, selectedModelAuto, addSession, fetchProjects, searchQuery, toast, t]);
+
+  const handleCreateSessionInProject = useCallback((projectId: string) => {
+    void handleCreateSession(projectId);
+  }, [handleCreateSession]);
 
   const handleSelectModel = useCallback(async (option: ChatModelOption) => {
     const previousModelKey = selectedModelKey;
@@ -2033,6 +2048,14 @@ export default function SessionPage() {
       setSelectedSessionId(sessionId);
     }
   }, [handleToggleCheck, selectMode]);
+  const handleCloseSessionSearch = useCallback(() => {
+    setSessionSearchOpen(false);
+    setSearchQuery('');
+  }, []);
+  const handleSelectSearchResult = useCallback((sessionId: string) => {
+    handleSelectSessionRow(sessionId);
+    handleCloseSessionSearch();
+  }, [handleCloseSessionSearch, handleSelectSessionRow]);
   const handleToggleSessionMenu = useCallback((sessionId: string, trigger: HTMLElement) => {
     setMovePickerSessionId(null);
     setOpenMenuSessionId((current) => {
@@ -2197,14 +2220,14 @@ export default function SessionPage() {
     <div className="flex h-full w-full overflow-hidden bg-[#fcfcfd] text-[#202328] dark:bg-[#303842] dark:text-[#d7dee8]">
       {/* ── Sidebar ── */}
       <div
-        className={`flex h-full flex-shrink-0 flex-col overflow-hidden border-r bg-gray-50 transition-[width,opacity] duration-200 dark:bg-[#252c35] ${
+        className={`relative flex h-full flex-shrink-0 flex-col overflow-hidden border-r bg-gray-50 transition-[width,opacity] duration-200 dark:bg-[#252c35] ${
           sidebarCollapsed
             ? 'w-0 border-transparent opacity-0'
             : 'w-[282px] border-black/[0.10] opacity-100 dark:border-white/[0.10]'
         }`}
         aria-label={t('managementTitle')}
       >
-        {/* Header：始终显示标题、新建与搜索 */}
+        {/* Header */}
         <div className="flex-shrink-0 px-3 pb-2 pt-3.5">
           <div className="mb-2 flex h-8 items-center justify-between px-1">
             <div className="min-w-0">
@@ -2215,9 +2238,19 @@ export default function SessionPage() {
                 {t('sessionCount', { count: sessions.length })}
               </span>
             </div>
+            <button
+              type="button"
+              onClick={() => setSessionSearchOpen(true)}
+              className="grid h-7 w-7 shrink-0 place-items-center rounded-lg text-[#7b8087] transition-colors hover:bg-black/[0.05] hover:text-[#202328] dark:text-[#9aa7b4] dark:hover:bg-white/[0.07] dark:hover:text-white"
+              title={t('openTaskSearch')}
+              aria-label={t('openTaskSearch')}
+              aria-expanded={sessionSearchOpen}
+            >
+              <Search className="h-3.5 w-3.5" />
+            </button>
           </div>
 
-          <div className="space-y-0.5">
+          <div>
             <div className="relative h-[34px] rounded-lg transition-colors hover:bg-black/[0.04] dark:hover:bg-white/[0.06]">
               {creating
                 ? <Loader2 className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 animate-spin text-[#7b8087]" />
@@ -2230,29 +2263,76 @@ export default function SessionPage() {
                 {t('newSession')}
               </button>
             </div>
-
-            <div className="relative h-[34px] rounded-lg transition-colors hover:bg-black/[0.04] focus-within:bg-black/[0.04] dark:hover:bg-white/[0.06] dark:focus-within:bg-white/[0.06]">
-              <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[#7b8087] dark:text-[#9aa7b4]" />
-              <input
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder={t('filterConversations', 'Search tasks')}
-                className="h-full w-full rounded-lg border-0 bg-transparent pl-9 pr-8 text-sm font-medium text-[#474b51] outline-none placeholder:text-[#474b51] focus:bg-transparent dark:text-[#c3ccd6] dark:placeholder:text-[#c3ccd6]"
-              />
-              {searchQuery && (
-                <button
-                  type="button"
-                  onClick={() => setSearchQuery('')}
-                  className="absolute right-1.5 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-md text-[#7b8087] transition-colors hover:bg-black/[0.065] hover:text-[#202328] dark:text-[#9aa7b4] dark:hover:bg-white/[0.08] dark:hover:text-white"
-                  title={t('clearSearch')}
-                  aria-label={t('clearSearch')}
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              )}
-            </div>
           </div>
         </div>
+
+        {sessionSearchOpen && (
+          <div
+            role="dialog"
+            aria-label={t('taskSearchDialog')}
+            aria-modal="true"
+            onClick={handleCloseSessionSearch}
+            className="fixed inset-0 z-[80] flex items-start justify-center bg-black/20 px-4 pt-[18vh] backdrop-blur-[1px] dark:bg-black/45"
+          >
+            <div
+              onClick={(event) => event.stopPropagation()}
+              className="w-full max-w-[620px] overflow-hidden rounded-2xl border border-black/[0.12] bg-[#fdfdfc] shadow-[0_24px_70px_rgba(22,27,34,0.24)] dark:border-white/[0.11] dark:bg-[#303030] dark:shadow-[0_28px_80px_rgba(0,0,0,0.55)]"
+            >
+              <div className="relative h-[52px] border-b border-black/[0.07] dark:border-white/[0.08]">
+                <Search className="pointer-events-none absolute left-4 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-[#7b8087] dark:text-[#a7adb5]" />
+                <input
+                  autoFocus
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      event.preventDefault();
+                      handleCloseSessionSearch();
+                    }
+                  }}
+                  placeholder={t('filterConversations', 'Search tasks')}
+                  className="h-full w-full border-0 bg-transparent pl-12 pr-12 text-[15px] font-medium text-[#3f444a] outline-none placeholder:text-[#858a91] dark:text-[#e1e5ea] dark:placeholder:text-[#9298a0]"
+                />
+                <button
+                  type="button"
+                  onClick={handleCloseSessionSearch}
+                  className="absolute right-3 top-1/2 grid h-7 w-7 -translate-y-1/2 place-items-center rounded-lg text-[#7b8087] transition-colors hover:bg-black/[0.06] hover:text-[#202328] dark:text-[#9aa7b4] dark:hover:bg-white/[0.08] dark:hover:text-white"
+                  title={t('closeTaskSearch')}
+                  aria-label={t('closeTaskSearch')}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+              <div className="max-h-[420px] overflow-y-auto p-2">
+                <div className="px-2 pb-1.5 pt-1 text-[11px] font-medium text-[#969aa0] dark:text-[#8f9ba8]">
+                  {t(searchQuery.trim() ? 'searchResults' : 'recentTasks')}
+                </div>
+                {searchPanelSessions.length > 0 ? (
+                  <div className="space-y-0.5">
+                    {searchPanelSessions.map((session) => (
+                      <button
+                        key={session.id}
+                        type="button"
+                        onClick={() => handleSelectSearchResult(session.id)}
+                        className="flex h-10 w-full min-w-0 items-center gap-2.5 rounded-xl px-3 text-left text-sm text-[#4e5359] transition-colors hover:bg-black/[0.055] hover:text-[#202328] focus:bg-black/[0.055] focus:outline-none dark:text-[#d1d5da] dark:hover:bg-white/[0.09] dark:hover:text-white dark:focus:bg-white/[0.09]"
+                      >
+                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#6aa7ee]" />
+                        <span className="min-w-0 flex-1 truncate font-medium">{session.title}</span>
+                        <span className="max-w-[110px] shrink-0 truncate text-xs text-[#969aa0] dark:text-[#8f9ba8]">
+                          {session.projectName || getPathBasename(session.directory)}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="px-3 py-10 text-center text-sm text-[#969aa0] dark:text-[#8f9ba8]">
+                    {t('noResults')}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Session list */}
         <div
@@ -2360,6 +2440,23 @@ export default function SessionPage() {
                             <MoreHorizontal className="h-3.5 w-3.5" />
                           </button>
                         )}
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            handleCreateSessionInProject(group.id);
+                          }}
+                          disabled={creating || !group.canWrite || group.pathStatus !== 'available'}
+                          className={`grid h-[26px] w-[26px] place-items-center rounded-lg text-[#7b8087] transition-all hover:bg-black/[0.065] hover:text-[#202328] disabled:cursor-not-allowed disabled:opacity-40 dark:text-[#9aa7b4] dark:hover:bg-white/[0.08] dark:hover:text-white ${
+                            isSelectedProject ? 'opacity-100' : 'opacity-0 group-hover/project:opacity-100 group-focus-within/project:opacity-100'
+                          }`}
+                          title={t('createSessionInProject', { project: group.label })}
+                          aria-label={t('createSessionInProject', { project: group.label })}
+                        >
+                          {creating && isSelectedProject
+                            ? <Loader2 className="h-3 w-3 animate-spin" />
+                            : <Plus className="h-3 w-3" />}
+                        </button>
                       </div>
                       {persistedProject && openProjectMenuId === group.id && (
                         <div
@@ -2506,6 +2603,21 @@ export default function SessionPage() {
                       {taskGroupCollapsed
                         ? <ChevronRight className="h-3.5 w-3.5 shrink-0" />
                         : <ChevronDown className="h-3.5 w-3.5 shrink-0" />}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void handleCreateSession(TASK_SESSION_GROUP_ID);
+                      }}
+                      disabled={creating}
+                      className="ml-auto grid h-6 w-6 place-items-center rounded-lg text-[#8a8e94] opacity-0 transition-all hover:bg-black/[0.04] hover:text-[#474b51] group-hover/tasks-section:opacity-100 group-focus-within/tasks-section:opacity-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-[#8f9ba8] dark:hover:bg-white/[0.06] dark:hover:text-white"
+                      title={t('createTaskSession')}
+                      aria-label={t('createTaskSession')}
+                    >
+                      {creating && taskGroupSelected
+                        ? <Loader2 className="h-3 w-3 animate-spin" />
+                        : <Plus className="h-3 w-3" />}
                     </button>
                   </div>
                   {!taskGroupCollapsed && (


### PR DESCRIPTION
## Summary

- restore create-session actions on the Tasks and project rows
- keep row actions hover-driven and place the project create action after the actions menu
- move task search into a centered command-style dialog
- show the five most recently updated sessions before a query is entered
- add interaction coverage and localized search labels

## Testing

- `npm run test:run -- src/pages/Session/index.test.tsx src/i18n.test.ts`
- `npm run lint -- --quiet`
- `npm run build`
