### PR TITLE
fix(session): prevent direct commands from consuming model context

### DIFF
--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -4181,6 +4181,7 @@ async def _dispatch_sse_input(sessionID: str, session, event, working_directory:
         model_info: Optional[Dict[str, str]] = None,
         *,
         agent_override: Optional[str] = None,
+        ignored: Optional[bool] = None,
     ) -> str:
         now_ms = int(_time.time() * 1000)
         user_msg_id = event.message_id or Identifier.create("message")
@@ -4197,6 +4198,7 @@ async def _dispatch_sse_input(sessionID: str, session, event, working_directory:
                 agent=message_agent,
                 executionMode=event.execution_mode,
                 **({"model": model_info} if model_info else {}),
+                ignored=ignored,
                 part_id=user_part_id,
             ),
             expected_generation=lifecycle_generation,
@@ -4219,6 +4221,7 @@ async def _dispatch_sse_input(sessionID: str, session, event, working_directory:
                 "sessionID": sessionID,
                 "type": "text",
                 "text": user_text,
+                **({"ignored": ignored} if ignored is not None else {}),
                 "time": {"start": now_ms},
             }
         })
@@ -4226,7 +4229,7 @@ async def _dispatch_sse_input(sessionID: str, session, event, working_directory:
 
     async def _publish_direct_response(output_event, text: str) -> None:
         user_text = output_event.user_visible_text
-        parent_msg_id = await _create_user_message(user_text)
+        parent_msg_id = await _create_user_message(user_text, ignored=True)
         asst_now = int(_time.time() * 1000)
         asst_msg_id = Identifier.ascending("message")
         asst_part_id = Identifier.ascending("part")
@@ -4243,6 +4246,7 @@ async def _dispatch_sse_input(sessionID: str, session, event, working_directory:
                 providerID="builtin",
                 agent=agent_name,
                 finish="stop",
+                ignored=True,
                 part_id=asst_part_id,
             ),
             expected_generation=lifecycle_generation,
@@ -4274,6 +4278,7 @@ async def _dispatch_sse_input(sessionID: str, session, event, working_directory:
                 "sessionID": sessionID,
                 "type": "text",
                 "text": text,
+                "ignored": True,
                 "time": {"start": asst_now, "end": asst_now},
             }
         })
@@ -4281,8 +4286,6 @@ async def _dispatch_sse_input(sessionID: str, session, event, working_directory:
             publish_event,
             sessionID,
             session=session,
-            provider_id="builtin",
-            model_id="command",
         )
 
     async def _run_llm(output_event, prompt_text: str, display_text: Optional[str] = None) -> None:

--- a/flocks/session/context_usage.py
+++ b/flocks/session/context_usage.py
@@ -434,6 +434,8 @@ async def _estimate_message_breakdown(session_id: str, messages: List[Any]) -> t
         for part in parts:
             part_type = _field_value(part, "type", "")
             if part_type == "text":
+                if bool(_field_value(part, "ignored", False)):
+                    continue
                 tokens_by_key["conversation"] += SessionPrompt.count_tokens(_field_value(part, "text", "") or "")
                 continue
             if part_type in {"reasoning", "thinking"}:
@@ -540,6 +542,8 @@ def _resolve_message_model(messages: List[Any]) -> tuple[Optional[str], Optional
         if role == "assistant":
             provider_id = getattr(message, "providerID", None)
             model_id = getattr(message, "modelID", None)
+            if provider_id == "builtin" and model_id == "command":
+                continue
             if provider_id and model_id:
                 return provider_id, model_id
         if role == "user":

--- a/flocks/session/message.py
+++ b/flocks/session/message.py
@@ -1403,6 +1403,7 @@ class Message:
             # Pop TextPart-specific fields before message creation — they
             # belong on TextPart, not on UserMessageInfo/AssistantMessageInfo.
             _synthetic = kwargs.pop("synthetic", None)
+            _ignored = kwargs.pop("ignored", None)
             _part_metadata = kwargs.pop("part_metadata", None)
             
             # Create appropriate message type based on role
@@ -1454,6 +1455,8 @@ class Message:
             _part_extras = {}
             if _synthetic is not None:
                 _part_extras["synthetic"] = _synthetic
+            if _ignored is not None:
+                _part_extras["ignored"] = _ignored
             if _part_metadata is not None:
                 _part_extras["metadata"] = _part_metadata
             part = TextPart(

--- a/flocks/session/prompt.py
+++ b/flocks/session/prompt.py
@@ -585,6 +585,8 @@ class SessionPrompt:
             parts = await Message.parts(msg_id or "", session_id)
             for part in parts:
                 if part.type == "text":
+                    if getattr(part, "ignored", False):
+                        continue
                     total += cls.count_tokens(getattr(part, 'text', ''))
                 elif part.type == "tool":
                     state = getattr(part, 'state', None)

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -2852,6 +2852,8 @@ class SessionRunner:
                     
                     # Text parts
                     if part.type == "text" and hasattr(part, 'text'):
+                        if getattr(part, "ignored", False):
+                            continue
                         assistant_content_parts.append(part.text)
                     elif part.type == "reasoning" and hasattr(part, 'text'):
                         assistant_reasoning_parts.append(part.text)

--- a/tests/server/test_input_dispatcher.py
+++ b/tests/server/test_input_dispatcher.py
@@ -69,6 +69,92 @@ class TestDispatchUserInput:
         assert not llm
 
     @pytest.mark.asyncio
+    async def test_webui_direct_response_is_excluded_from_model_context(
+        self,
+        monkeypatch,
+    ):
+        from flocks.server.routes import session as session_routes
+
+        created_messages = AsyncMock()
+        context_usage_update = AsyncMock()
+        published_events = []
+
+        async def fake_persist(
+            _session_id,
+            write,
+            *,
+            expected_generation=None,
+        ):
+            del expected_generation
+            return await write()
+
+        async def fake_dispatch(event, sink):
+            await sink.publish_direct_response(
+                event,
+                "Available Tools\n" + ("x" * 16_000),
+            )
+
+        async def fake_publish(event_type, properties):
+            published_events.append((event_type, properties))
+
+        monkeypatch.setattr(
+            "flocks.input.dispatcher.dispatch_user_input",
+            fake_dispatch,
+        )
+        monkeypatch.setattr(
+            "flocks.session.message.Message.create",
+            created_messages,
+        )
+        monkeypatch.setattr(
+            "flocks.server.routes.event.publish_event",
+            fake_publish,
+        )
+        monkeypatch.setattr(
+            session_routes,
+            "_persist_active_session_write",
+            fake_persist,
+        )
+        monkeypatch.setattr(
+            session_routes,
+            "_publish_context_usage_update",
+            context_usage_update,
+        )
+        monkeypatch.setattr(
+            session_routes.Session,
+            "lifecycle_generation",
+            lambda _session_id: 0,
+        )
+        event = UserInputEvent(
+            source_type="webui",
+            sessionID="ses_direct_context",
+            text="/tools",
+            display_text="/tools",
+        )
+
+        await session_routes._dispatch_sse_input(
+            "ses_direct_context",
+            SimpleNamespace(id="ses_direct_context"),
+            event,
+            "/tmp/project",
+        )
+
+        assert created_messages.await_count == 2
+        assert all(
+            call.kwargs["ignored"] is True
+            for call in created_messages.await_args_list
+        )
+        text_part_events = [
+            properties["part"]
+            for event_type, properties in published_events
+            if event_type == "message.part.updated"
+        ]
+        assert len(text_part_events) == 2
+        assert all(part["ignored"] is True for part in text_part_events)
+        context_usage_update.assert_awaited_once()
+        assert "provider_id" not in context_usage_update.await_args.kwargs
+        assert "model_id" not in context_usage_update.await_args.kwargs
+
+    @pytest.mark.asyncio
     async def test_clear_uses_history_callback_without_direct_response(self):
         direct = []
         llm = []

--- a/tests/session/test_context_usage.py
+++ b/tests/session/test_context_usage.py
@@ -186,6 +186,47 @@ async def test_context_usage_does_not_scan_archived_history(context_usage_mocks)
 
 
 @pytest.mark.asyncio
+async def test_context_usage_ignores_ignored_text_parts(context_usage_mocks):
+    msg = _message("command-output", tokens=None)
+    context_usage_mocks["active"] = [msg]
+    context_usage_mocks["all"] = [msg]
+    context_usage_mocks["estimate"] = 0
+    context_usage_mocks["parts"] = {
+        "command-output": [
+            SimpleNamespace(
+                type="text",
+                text="Available Tools\n" + ("x" * 16_000),
+                ignored=True,
+            ),
+        ],
+    }
+
+    snapshot = await context_usage.build_context_usage_snapshot("sess-1")
+
+    assert snapshot.used_tokens == 0
+    assert all(segment.key != "conversation" for segment in snapshot.segments)
+
+
+def test_context_usage_uses_last_real_model_before_builtin_command():
+    real_model = _message(
+        "assistant-1",
+        provider_id="openai",
+        model_id="gpt-5.6-luna",
+    )
+    command_output = _message(
+        "command-output",
+        created=200,
+        provider_id="builtin",
+        model_id="command",
+    )
+
+    assert context_usage._resolve_message_model([real_model, command_output]) == (
+        "openai",
+        "gpt-5.6-luna",
+    )
+
+
+@pytest.mark.asyncio
 async def test_context_usage_splits_tool_parts_from_conversation(context_usage_mocks):
     msg = _message("assistant-1", tokens=None)
     context_usage_mocks["active"] = [msg]

--- a/tests/session/test_prompt_tokens.py
+++ b/tests/session/test_prompt_tokens.py
@@ -460,3 +460,33 @@ class TestEstimateFullContextTokens:
             "ses_x", messages,
         )
         assert result == 100
+
+    @pytest.mark.asyncio
+    async def test_ignored_text_part_is_not_counted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from flocks.session import message as message_mod
+
+        async def _ignored_parts(message_id, session_id):  # noqa: ARG001
+            return [
+                SimpleNamespace(
+                    type="text",
+                    text="Available Tools\n" + ("x" * 400),
+                    ignored=True,
+                ),
+            ]
+
+        monkeypatch.setattr(
+            message_mod.Message,
+            "parts",
+            staticmethod(_ignored_parts),
+        )
+        messages = [{"id": "ignored-command-output", "content": ""}]
+
+        result = await SessionPrompt.estimate_full_context_tokens(
+            "ses_x",
+            messages,
+        )
+
+        assert result == 0

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -1531,6 +1531,27 @@ async def test_to_chat_messages_invalidates_shared_cache_when_message_parts_chan
 
 
 @pytest.mark.asyncio
+async def test_to_chat_messages_excludes_ignored_assistant_text():
+    session = await Session.create(
+        project_id="test_runner_ignored_command_output",
+        directory="/tmp/runner-ignored-command-output",
+    )
+    assistant_message = await Message.create(
+        session_id=session.id,
+        role=MessageRole.ASSISTANT,
+        content="Available Tools\n" + ("x" * 400),
+        providerID="builtin",
+        modelID="command",
+        ignored=True,
+    )
+    runner = SessionRunner(session=session, static_cache={})
+
+    chat_messages = await runner._to_chat_messages([assistant_message], [])
+
+    assert chat_messages == []
+
+
+@pytest.mark.asyncio
 async def test_to_chat_messages_preserves_assistant_reasoning_for_replay():
     session = await Session.create(
         project_id="test_runner_reasoning_replay",


### PR DESCRIPTION
## Summary
- keep direct slash-command messages visible while excluding them from LLM context
- prevent the builtin command pseudo-model from replacing the active model context window
- add regression coverage for persistence, prompt conversion, token estimates, and context-model resolution

## Root cause
Direct command output was persisted as regular conversation text and the context meter resolved builtin/command as a 4,096-token model. Large outputs such as /tools therefore filled the estimated context and were replayed to the next model call.

## Validation
- 252 related tests passed
- Ruff checks passed
- git diff --check passed