### PR TITLE
fix(updater): add snapshot fallback for source backups

### DIFF
--- a/flocks/updater/updater.py
+++ b/flocks/updater/updater.py
@@ -1450,6 +1450,42 @@ async def _download_with_fallback(
     raise RuntimeError(summary)
 
 
+def _backup_path_is_excluded(parts: tuple[str, ...]) -> bool:
+    """Return whether a source-relative path should be excluded from backups."""
+    if parts and parts[0] in _ROOT_RUNTIME_NAMES:
+        return True
+    return any(part in _PRESERVE_NAMES or part == "dist" for part in parts)
+
+
+def _write_backup_archive(source_root: Path, archive_path: Path) -> None:
+    """Write a source-only tar archive from *source_root*."""
+
+    def _filter(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
+        parts = info.name.split("/")
+        relative_parts = tuple(parts[1:]) if parts and parts[0] == "flocks" else tuple(parts)
+        if _backup_path_is_excluded(relative_parts):
+            return None
+        return info
+
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(str(source_root), arcname="flocks", filter=_filter)
+
+
+def _copy_backup_snapshot(install_root: Path, snapshot_root: Path) -> None:
+    """Copy backup-eligible source files into a stable temporary snapshot."""
+
+    def _ignore(directory: str, names: list[str]) -> set[str]:
+        relative_dir = Path(directory).relative_to(install_root)
+        return {name for name in names if _backup_path_is_excluded((*relative_dir.parts, name))}
+
+    shutil.copytree(
+        install_root,
+        snapshot_root,
+        ignore=_ignore,
+        ignore_dangling_symlinks=True,
+    )
+
+
 def _backup_current_version(
     install_root: Path,
     current_version: str,
@@ -1457,6 +1493,7 @@ def _backup_current_version(
 ) -> Path | None:
     """
     Compress the current source tree into ~/.flocks/version/ .
+    Falls back to archiving a temporary source snapshot when direct archiving fails.
     Returns the backup path on success, None on failure.
     Preserved runtime/user directories are excluded.
     """
@@ -1464,25 +1501,40 @@ def _backup_current_version(
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
     backup_name = f"flocks-{current_version}-{ts}"
     backup_path = _BACKUP_DIR / f"{backup_name}.tar.gz"
-
-    def _filter(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
-        parts = info.name.split("/")
-        if len(parts) >= 2 and parts[0] == "flocks" and parts[1] in _ROOT_RUNTIME_NAMES:
-            return None
-        for part in parts:
-            if part in _PRESERVE_NAMES:
-                return None
-            if part == "dist":
-                return None
-        return info
+    partial_path = _BACKUP_DIR / f"{backup_name}.tar.gz.partial"
+    partial_path.unlink(missing_ok=True)
 
     try:
-        with tarfile.open(backup_path, "w:gz") as tar:
-            tar.add(str(install_root), arcname="flocks", filter=_filter)
+        _write_backup_archive(install_root, partial_path)
+    except Exception as direct_exc:
+        partial_path.unlink(missing_ok=True)
+        log.warning("updater.backup.direct_failed", {"error": str(direct_exc)})
+        snapshot_dir: Path | None = None
+        try:
+            snapshot_dir = Path(tempfile.mkdtemp(prefix="flocks-backup-"))
+            snapshot_root = snapshot_dir / "flocks"
+            _copy_backup_snapshot(install_root, snapshot_root)
+            _write_backup_archive(snapshot_root, partial_path)
+        except Exception as snapshot_exc:
+            partial_path.unlink(missing_ok=True)
+            log.warning(
+                "updater.backup.failed",
+                {
+                    "direct_error": str(direct_exc),
+                    "snapshot_error": str(snapshot_exc),
+                },
+            )
+            return None
+        finally:
+            if snapshot_dir is not None:
+                shutil.rmtree(snapshot_dir, ignore_errors=True)
+
+    try:
+        partial_path.replace(backup_path)
     except Exception as exc:
+        partial_path.unlink(missing_ok=True)
         log.warning("updater.backup.failed", {"error": str(exc)})
         return None
-
     _cleanup_old_backups(retain_count)
     return backup_path
 

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1218,6 +1218,73 @@ def test_backup_current_version_excludes_all_dist_directories(
     assert "flocks/dist/ignored.txt" not in names
 
 
+def test_backup_current_version_uses_filtered_snapshot_after_direct_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    install_root = tmp_path / "install"
+    install_root.mkdir()
+    (install_root / "source.py").write_text("print('ok')", encoding="utf-8")
+    venv_dir = install_root / ".venv"
+    venv_dir.mkdir()
+    (venv_dir / "dependency.py").write_text("excluded", encoding="utf-8")
+    node_modules = install_root / "webui" / "node_modules"
+    node_modules.mkdir(parents=True)
+    (node_modules / "dependency.js").write_text("excluded", encoding="utf-8")
+    backup_dir = tmp_path / "backups"
+    archive_sources: list[Path] = []
+    original_write_backup_archive = updater._write_backup_archive
+
+    def fail_first_archive(source_root: Path, archive_path: Path) -> None:
+        archive_sources.append(source_root)
+        if len(archive_sources) == 1:
+            archive_path.write_text("partial", encoding="utf-8")
+            raise RuntimeError("unexpected end of data")
+        original_write_backup_archive(source_root, archive_path)
+
+    monkeypatch.setattr(updater, "_BACKUP_DIR", backup_dir)
+    monkeypatch.setattr(updater, "_write_backup_archive", fail_first_archive)
+
+    backup_path = updater._backup_current_version(install_root, "2026.7.29", retain_count=1)
+
+    assert backup_path is not None
+    assert archive_sources[0] == install_root
+    assert archive_sources[1] != install_root
+    assert not archive_sources[1].exists()
+    assert not list(backup_dir.glob("*.partial"))
+    with tarfile.open(backup_path, "r:gz") as tar:
+        names = tar.getnames()
+    assert "flocks/source.py" in names
+    assert "flocks/.venv/dependency.py" not in names
+    assert "flocks/webui/node_modules/dependency.js" not in names
+
+
+def test_backup_current_version_cleans_partial_when_snapshot_fallback_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    install_root = tmp_path / "install"
+    install_root.mkdir()
+    (install_root / "source.py").write_text("print('ok')", encoding="utf-8")
+    backup_dir = tmp_path / "backups"
+    archive_attempts = 0
+
+    def fail_archive(_source_root: Path, archive_path: Path) -> None:
+        nonlocal archive_attempts
+        archive_attempts += 1
+        archive_path.write_text("partial", encoding="utf-8")
+        raise RuntimeError("archive failed")
+
+    monkeypatch.setattr(updater, "_BACKUP_DIR", backup_dir)
+    monkeypatch.setattr(updater, "_write_backup_archive", fail_archive)
+
+    backup_path = updater._backup_current_version(install_root, "2026.7.29", retain_count=1)
+
+    assert backup_path is None
+    assert archive_attempts == 2
+    assert not list(backup_dir.iterdir())
+
+
 @pytest.mark.asyncio
 async def test_build_updated_frontend_uses_current_install_root_and_region_mirror(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- keep the existing direct tar.gz backup as the primary path
- fall back to archiving a filtered temporary source snapshot when direct backup fails
- write backups through a partial file and clean up failed archives and temporary snapshots
- keep runtime data, Python environments, and Node dependencies out of fallback backups

## Root cause
The updater can archive the live source tree while files are changing on Windows. Python tarfile records a file size before reading it, so a file that shrinks during the read can raise unexpected end of data and abort the upgrade.

## Tests
- uv run ruff check flocks/updater/updater.py tests/updater/test_updater.py
- uv run pytest -q tests/updater/test_updater.py tests/updater/test_restart_handoff.py