### PR TITLE
fix(session): unify retry policy across model modes

### DIFF
--- a/flocks/session/lifecycle/retry.py
+++ b/flocks/session/lifecycle/retry.py
@@ -19,6 +19,7 @@ RETRY_INITIAL_DELAY = 2000  # 2 seconds in milliseconds
 RETRY_BACKOFF_FACTOR = 2
 RETRY_MAX_DELAY_NO_HEADERS = 30_000  # 30 seconds
 RETRY_MAX_DELAY = 2_147_483_647  # max 32-bit signed integer
+MAX_ERROR_RETRIES = 5
 CONNECTION_ERROR_DISPLAY_MESSAGE = (
     "Model is unavailable. Please check the provider connection and model configuration."
 )

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -34,7 +34,11 @@ from flocks.session.core.defaults import (
     DOOM_LOOP_THRESHOLD,
     REPEATED_EXACT_TOOL_CALL_HALT_THRESHOLD,
 )
-from flocks.session.lifecycle.retry import CONNECTION_ERROR_DISPLAY_MESSAGE, SessionRetry
+from flocks.session.lifecycle.retry import (
+    CONNECTION_ERROR_DISPLAY_MESSAGE,
+    MAX_ERROR_RETRIES,
+    SessionRetry,
+)
 from flocks.session.lifecycle.compaction import SessionCompaction, CompactionPolicy
 from flocks.session.streaming.stream_processor import StreamProcessor
 from flocks.session.streaming.stream_events import (
@@ -237,7 +241,6 @@ class FailoverDecision:
 
     eligible: bool
     reason: str
-    same_model_retries: int = 3
 
 
 @dataclass
@@ -1243,53 +1246,53 @@ class SessionRunner:
             reason = "billing" if any(
                 pattern in lowered for pattern in ("billing", "insufficient quota")
             ) else "rate_limit"
-            return FailoverDecision(True, reason, 0)
+            return FailoverDecision(True, reason)
         if status_code in {401, 403}:
-            return FailoverDecision(True, "auth", 0)
+            return FailoverDecision(True, "auth")
         if status_code == 402:
-            return FailoverDecision(True, "billing", 0)
+            return FailoverDecision(True, "billing")
 
         if "model" in lowered and any(pattern in lowered for pattern in (
             "not found", "model_not_found", "unknown model", "no such model",
         )):
-            return FailoverDecision(True, "model_not_found", 0)
+            return FailoverDecision(True, "model_not_found")
 
         if status_code == 404:
             if any(pattern in lowered for pattern in (
                 "model not found", "model_not_found", "unknown model", "no such model",
             )):
-                return FailoverDecision(True, "model_not_found", 0)
-            return FailoverDecision(True, "unknown_api", 3)
+                return FailoverDecision(True, "model_not_found")
+            return FailoverDecision(True, "unknown_api")
 
         if status_code in {408, 504} or data.get("isConnectionError") is True or any(
             pattern in lowered
             for pattern in ("timeout", "timed out", "connection error", "connection reset")
         ):
-            return FailoverDecision(True, "timeout", 1)
+            return FailoverDecision(True, "timeout")
         if status_code in {503, 529} or any(
             pattern in lowered for pattern in ("overloaded", "temporarily unavailable")
         ):
-            return FailoverDecision(True, "overloaded", 1)
+            return FailoverDecision(True, "overloaded")
         if status_code in {500, 502}:
-            return FailoverDecision(True, "server_error", 3)
+            return FailoverDecision(True, "server_error")
 
         if any(pattern in lowered for pattern in (
             "content policy", "content filter", "content_filter", "safety policy",
             "policy violation",
         )):
-            return FailoverDecision(True, "content_policy", 0)
+            return FailoverDecision(True, "content_policy")
         if error_name == "JSONDecodeError" or any(
             pattern in lowered for pattern in (
                 "malformed response", "invalid response", "empty choices",
                 "returned choice with null", "null message",
             )
         ):
-            return FailoverDecision(True, "invalid_response", 0)
+            return FailoverDecision(True, "invalid_response")
 
         if status_code is not None and 400 <= status_code < 500:
-            return FailoverDecision(True, "provider_request", 0)
+            return FailoverDecision(True, "provider_request")
         if error_name == "APIError" or data.get("isRetryable") is True:
-            return FailoverDecision(True, "unknown_api", 3)
+            return FailoverDecision(True, "unknown_api")
         return FailoverDecision(False, "local_error")
 
     def _deferred_failure_result(
@@ -1636,7 +1639,6 @@ class SessionRunner:
         # The two counters are independent: empty-response retries (transient
         # model quirk) and exception retries (API errors) track separately so
         # that one kind of failure doesn't eat the other's budget.
-        MAX_ERROR_RETRIES = 3
         MAX_EMPTY_RETRIES = 3
         error_attempt = 0
         empty_attempt = 0
@@ -1812,18 +1814,7 @@ class SessionRunner:
                 retry_message = SessionRetry.retryable(error_dict)
                 failover_decision = self.classify_failover_error(error_dict)
                 retry_limit = MAX_ERROR_RETRIES
-                if (
-                    self._defer_step_errors
-                    and failover_decision.eligible
-                ):
-                    retry_limit = failover_decision.same_model_retries
-                    will_retry = error_attempt <= retry_limit
-                    if will_retry and retry_message is None:
-                        retry_message = (
-                            f"Provider error ({failover_decision.reason}), retrying..."
-                        )
-                else:
-                    will_retry = retry_message is not None and error_attempt <= retry_limit
+                will_retry = retry_message is not None and error_attempt <= retry_limit
                 retry_blocked_by_tool_execution = (
                     self._attempt_state.tool_execution_started
                 )

--- a/tests/session/test_auto_model_failover.py
+++ b/tests/session/test_auto_model_failover.py
@@ -97,25 +97,24 @@ def _clear_cooldowns():
 
 
 @pytest.mark.parametrize(
-    ("status_code", "message", "reason", "same_model_retries"),
+    ("status_code", "message", "reason"),
     [
-        (401, "Unauthorized", "auth", 0),
-        (402, "Payment required", "billing", 0),
-        (429, "Too many requests", "rate_limit", 0),
-        (403, "Quota exceeded", "rate_limit", 0),
-        (403, "Insufficient quota", "billing", 0),
-        (408, "Request timeout", "timeout", 1),
-        (404, "Route not found", "unknown_api", 3),
-        (500, "Internal server error", "server_error", 3),
-        (502, "Bad gateway", "server_error", 3),
-        (529, "Provider overloaded", "overloaded", 1),
+        (401, "Unauthorized", "auth"),
+        (402, "Payment required", "billing"),
+        (429, "Too many requests", "rate_limit"),
+        (403, "Quota exceeded", "rate_limit"),
+        (403, "Insufficient quota", "billing"),
+        (408, "Request timeout", "timeout"),
+        (404, "Route not found", "unknown_api"),
+        (500, "Internal server error", "server_error"),
+        (502, "Bad gateway", "server_error"),
+        (529, "Provider overloaded", "overloaded"),
     ],
 )
-def test_failover_classifier_retry_thresholds(
+def test_failover_classifier(
     status_code: int,
     message: str,
     reason: str,
-    same_model_retries: int,
 ):
     decision = SessionRunner.classify_failover_error({
         "name": "APIError",
@@ -124,7 +123,6 @@ def test_failover_classifier_retry_thresholds(
 
     assert decision.eligible is True
     assert decision.reason == reason
-    assert decision.same_model_retries == same_model_retries
 
 
 @pytest.mark.asyncio
@@ -133,15 +131,15 @@ def test_failover_classifier_retry_thresholds(
     [
         (401, 1),
         (402, 1),
-        (429, 1),
-        (408, 2),
-        (404, 4),
-        (500, 4),
-        (502, 4),
-        (529, 2),
+        (429, 6),
+        (408, 1),
+        (404, 1),
+        (500, 6),
+        (502, 6),
+        (529, 1),
     ],
 )
-async def test_runner_applies_failover_retry_thresholds(
+async def test_auto_runner_uses_standard_retry_policy(
     monkeypatch,
     status_code: int,
     expected_calls: int,
@@ -200,16 +198,16 @@ async def test_runner_applies_failover_retry_thresholds(
 @pytest.mark.parametrize(
     ("status_code", "expected_calls"),
     [
-        (429, 1),
-        (503, 2),
+        (429, 6),
+        (503, 6),
     ],
 )
-async def test_last_auto_candidate_keeps_hermes_retry_thresholds(
+async def test_last_auto_candidate_uses_standard_retry_policy(
     monkeypatch,
     status_code: int,
     expected_calls: int,
 ):
-    """The last candidate still has Auto's per-model retry budget."""
+    """The last candidate uses the same retry policy as every other mode."""
     runner = SessionRunner(
         session=_session(),
         provider_id="fallback",
@@ -339,7 +337,6 @@ def test_model_not_found_without_status_fails_over():
 
     assert decision.eligible is True
     assert decision.reason == "model_not_found"
-    assert decision.same_model_retries == 0
 
 
 def test_content_filter_error_fails_over_immediately():
@@ -350,7 +347,6 @@ def test_content_filter_error_fails_over_immediately():
 
     assert decision.eligible is True
     assert decision.reason == "content_policy"
-    assert decision.same_model_retries == 0
 
 
 def test_candidate_switch_keeps_tool_loop_guard_only():

--- a/tests/session/test_retry.py
+++ b/tests/session/test_retry.py
@@ -130,6 +130,15 @@ class TestRetryable:
 # ---------------------------------------------------------------------------
 
 class TestDelay:
+    def test_five_retry_schedule(self):
+        assert [SessionRetry.delay(attempt) for attempt in range(1, 6)] == [
+            2_000,
+            4_000,
+            8_000,
+            16_000,
+            30_000,
+        ]
+
     def test_attempt_1_returns_initial_delay(self):
         result = SessionRetry.delay(1)
         assert result == RETRY_INITIAL_DELAY

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -2368,7 +2368,7 @@ async def test_process_step_limits_connection_error_retries(monkeypatch):
 
     result = await runner._process_step([last_user], last_user)
 
-    assert call_count == 4
+    assert call_count == 6
     assert result.action == "stop"
     assert result.error == runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE
     runner.callbacks.on_error.assert_awaited_with(runner_mod.CONNECTION_ERROR_DISPLAY_MESSAGE)
@@ -2386,7 +2386,7 @@ async def test_process_step_limits_connection_error_retries(monkeypatch):
         call for call in error_log.call_args_list
         if call.args and call.args[0] == "runner.step.max_retries_exceeded"
     ]
-    assert len(retry_logs) == 3
+    assert len(retry_logs) == 5
     assert len(max_retry_logs) == 1
     assert not any(
         call.args and call.args[0] == "runner.step.error"


### PR DESCRIPTION
## Summary

- use one retry policy for standard and Auto model modes
- retry transient provider errors five times before Auto failover
- apply the 2s, 4s, 8s, 16s, and 30s backoff schedule
- keep non-retryable errors and replay-safety guards unchanged

## Testing

- uv run pytest tests/session/test_retry.py tests/session/test_auto_model_failover.py tests/session/test_runner_step.py -q
- uv run ruff check flocks/session/lifecycle/retry.py flocks/session/runner.py tests/session/test_retry.py tests/session/test_auto_model_failover.py tests/session/test_runner_step.py