### PR TITLE
fix(webui): exclude fixed prompt costs from context usage

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ContextUsageSnapshot } from '@/api/session';
 import type { Message } from '@/types';
 
 import {
@@ -75,7 +76,6 @@ const tMock = (key: string, options?: Record<string, unknown>) => {
   'chat.contextUsage.close': 'Close',
   'chat.contextUsage.full': '13% Full',
   'chat.contextUsage.tokens': '~13 / 100 Tokens',
-  'chat.contextUsage.excludedTokens': '100 excluded',
   'chat.contextUsage.noAttributedSegments': 'No attributed breakdown',
   'chat.contextUsage.breakdown.systemPrompt': 'System prompt',
   'chat.contextUsage.breakdown.toolDefinitions': 'Tool definitions',
@@ -303,6 +303,16 @@ function makeMessage(overrides: Partial<Message> & { id: string }): Message {
   } as Message;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 type FetchedMessageFixture = {
   info: {
     id: string;
@@ -380,9 +390,9 @@ async function startFallbackPolling(onStreamingDone: () => void) {
   });
 }
 
-function mockStatefulSessionMessages() {
+function mockStatefulSessionMessages(initialMessages: Message[] = []) {
   useSessionMessagesMock.mockImplementation(() => {
-    const [messages, setMessages] = React.useState<Message[]>([]);
+    const [messages, setMessages] = React.useState<Message[]>(initialMessages);
     const upsertMessage = (messageInfo: Partial<Message> & { id: string }) => setMessages((prev) => {
       const existingIndex = prev.findIndex((message) => message.id === messageInfo.id);
       if (existingIndex >= 0) {
@@ -420,7 +430,18 @@ function mockStatefulSessionMessages() {
         (message) => message.id !== messageId,
       )),
       clearMessages: () => setMessages([]),
-      replaceMessageText: vi.fn(),
+      replaceMessageText: (messageId: string, partId: string, text: string) => setMessages((prev) => (
+        prev.map((message) => (
+          message.id === messageId
+            ? {
+                ...message,
+                parts: message.parts.map((part) => (
+                  part.id === partId ? { ...part, text } : part
+                )),
+              }
+            : message
+        ))
+      )),
       markMessageStopped: (messageId: string) => setMessages((prev) => prev.map(
         (message) => (message.id === messageId ? { ...message, finish: 'stop' } : message),
       )),
@@ -628,6 +649,8 @@ describe('buildContextUsageBreakdown', () => {
       ['skillLoad', 0],
       ['agentDelegation', 0],
     ]);
+    expect(breakdown.segments.find((segment) => segment.key === 'systemPrompt')?.included).toBe(false);
+    expect(breakdown.segments.find((segment) => segment.key === 'toolDefinitions')?.included).toBe(false);
     expect(breakdown.excludedSegments).toEqual([]);
   });
 
@@ -678,18 +701,85 @@ describe('buildContextUsageBreakdown', () => {
       ],
     });
 
-    expect(breakdown.usedTokens).toBe(140);
+    expect(breakdown.usedTokens).toBe(85);
     expect(breakdown.compactedTokens).toBe(50);
-    expect(breakdown.segments.map((segment) => [segment.key, segment.tokens])).toEqual([
-      ['systemPrompt', 15],
-      ['toolDefinitions', 10],
-      ['conversation', 40],
-      ['reasoning', 5],
-      ['tools', 40],
-      ['skillLoad', 20],
-      ['agentDelegation', 10],
+    expect(breakdown.segments.map((segment) => [segment.key, segment.tokens, segment.included])).toEqual([
+      ['systemPrompt', 15, false],
+      ['toolDefinitions', 10, false],
+      ['conversation', 10, true],
+      ['reasoning', 5, true],
+      ['tools', 40, true],
+      ['skillLoad', 20, true],
+      ['agentDelegation', 10, true],
     ]);
     expect(breakdown.excludedSegments).toEqual([]);
+  });
+
+  it('applies and clamps pending removals by attributed segment', () => {
+    const breakdown = buildContextUsageBreakdown([], '', {
+      sessionID: 'sess-1',
+      usedTokens: 260,
+      contextWindow: 1000,
+      percent: 26,
+      source: 'estimated',
+      estimatedTokens: 260,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+        { key: 'conversation', tokens: 100, included: true, source: 'estimated' },
+        { key: 'reasoning', tokens: 50, included: true, source: 'estimated' },
+        { key: 'tools', tokens: 30, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    }, {
+      pendingTokenDeltas: { reasoning: -50, tools: -300 },
+    });
+
+    expect(breakdown.usedTokens).toBe(100);
+    expect(breakdown.segments.find((segment) => segment.key === 'conversation')?.tokens).toBe(100);
+    expect(breakdown.segments.find((segment) => segment.key === 'reasoning')?.tokens).toBe(0);
+    expect(breakdown.segments.find((segment) => segment.key === 'tools')?.tokens).toBe(0);
+  });
+
+  it('uses snapshot fixed costs with local messages and explicit pending removals', () => {
+    const breakdown = buildContextUsageBreakdown([
+      makeMessage({
+        id: 'edited-user',
+        role: 'user',
+        parts: [{ id: 'edited-user-text', type: 'text', text: 'x'.repeat(400) }],
+      }),
+      makeMessage({
+        id: 'discarded-assistant',
+        parts: [
+          { id: 'discarded-text', type: 'text', text: 'y'.repeat(400) },
+          { id: 'discarded-reasoning', type: 'reasoning', text: 'z'.repeat(400) },
+        ],
+      }),
+    ], '', {
+      sessionID: 'sess-1',
+      usedTokens: 330,
+      contextWindow: 1000,
+      percent: 33,
+      source: 'observed',
+      estimatedTokens: 320,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+        { key: 'toolDefinitions', tokens: 40, included: true, source: 'estimated' },
+        { key: 'conversation', tokens: 110, included: true, source: 'estimated' },
+        { key: 'reasoning', tokens: 100, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    }, {
+      pendingTokenDeltas: { conversation: -100, reasoning: -100 },
+      useLocalMessageUsage: true,
+    });
+
+    expect(breakdown.usedTokens).toBe(100);
+    expect(breakdown.segments.find((segment) => segment.key === 'toolDefinitions')?.tokens).toBe(40);
+    expect(breakdown.segments.find((segment) => segment.key === 'toolDefinitions')?.included).toBe(false);
+    expect(breakdown.segments.find((segment) => segment.key === 'conversation')?.tokens).toBe(100);
+    expect(breakdown.segments.find((segment) => segment.key === 'reasoning')?.tokens).toBe(0);
   });
 });
 
@@ -3767,8 +3857,9 @@ describe('ChatToolPart question result rendering', () => {
 });
 
 describe('SessionChat context usage popover', () => {
-  it('always shows fixed usage rows and hides compacted history', async () => {
-    const user = userEvent.setup();
+  it('counts a first prompt handed off as an optimistic new-session message', async () => {
+    const prompt = 'x'.repeat(400);
+    mockStatefulSessionMessages();
     sessionApiGetContextUsageMock.mockResolvedValue({
       sessionID: 'sess-1',
       usedTokens: 120,
@@ -3779,11 +3870,553 @@ describe('SessionChat context usage popover', () => {
       compactedTokens: 0,
       segments: [
         { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+        { key: 'toolDefinitions', tokens: 40, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    });
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      contextWindowTokens: 1000,
+      initialOptimisticMessage: makeMessage({
+        id: 'optimistic-user-1',
+        sessionID: 'sess-1',
+        role: 'user',
+        parts: [{
+          id: 'optimistic-part-1',
+          type: 'text',
+          text: prompt,
+          metadata: { displayText: 'Visible label' },
+        }],
+      }),
+    }));
+
+    const contextButton = screen.getByRole('button', { name: 'chat.contextUsageTitle' });
+    await waitFor(() => {
+      expect(contextButton).toHaveTextContent('10%');
+    });
+    expect(screen.getByText('Visible label')).toBeInTheDocument();
+    expect(screen.queryByText(prompt)).not.toBeInTheDocument();
+  });
+
+  it('counts only the current draft before the first user prompt', async () => {
+    const user = userEvent.setup();
+    sessionApiGetContextUsageMock.mockResolvedValue({
+      sessionID: 'sess-1',
+      usedTokens: 120,
+      contextWindow: 1000,
+      percent: 12,
+      source: 'estimated',
+      estimatedTokens: 120,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 120, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    });
+
+    render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
+    expect(contextButton).toHaveTextContent('0%');
+
+    fireEvent.change(screen.getByPlaceholderText('请输入消息'), {
+      target: { value: 'x'.repeat(400) },
+    });
+    expect(contextButton).toHaveTextContent('10%');
+
+    await user.click(contextButton);
+    const conversationRow = screen.getByText('Conversation').closest('[role="menuitem"]');
+    expect(conversationRow).not.toBeNull();
+    expect(screen.queryByText('System prompt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tool definitions')).not.toBeInTheDocument();
+    expect(within(conversationRow as HTMLElement).getByText('100')).toBeInTheDocument();
+  });
+
+  it('keeps the submitted prompt in usage while the first model call is running', async () => {
+    mockStatefulSessionMessages();
+    sessionApiGetContextUsageMock.mockResolvedValue({
+      sessionID: 'sess-1',
+      usedTokens: 80,
+      contextWindow: 1000,
+      percent: 8,
+      source: 'estimated',
+      estimatedTokens: 80,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    });
+
+    render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+    const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
+    const textarea = screen.getByPlaceholderText('请输入消息');
+    fireEvent.change(textarea, { target: { value: 'x'.repeat(400) } });
+    expect(contextButton).toHaveTextContent('10%');
+
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledWith(
+        '/api/session/sess-1/prompt_async',
+        expect.any(Object),
+      );
+    });
+    expect(contextButton).toHaveTextContent('10%');
+
+    const user = userEvent.setup();
+    await user.click(contextButton);
+    const conversationRow = screen.getByText('Conversation').closest('[role="menuitem"]');
+    expect(screen.queryByText('System prompt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tool definitions')).not.toBeInTheDocument();
+    expect(within(conversationRow as HTMLElement).getByText('100')).toBeInTheDocument();
+  });
+
+  it('keeps draft usage frozen during the automatic-model preflight', async () => {
+    const modelUpdate = deferred<unknown>();
+    mockStatefulSessionMessages();
+    sessionApiUpdateMock.mockReturnValue(modelUpdate.promise);
+    sessionApiGetContextUsageMock.mockResolvedValue({
+      sessionID: 'sess-1',
+      usedTokens: 80,
+      contextWindow: 1000,
+      percent: 8,
+      source: 'estimated',
+      estimatedTokens: 80,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    });
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      contextWindowTokens: 1000,
+      modelAuto: true,
+    }));
+
+    const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
+    const textarea = screen.getByPlaceholderText('请输入消息');
+    fireEvent.change(textarea, { target: { value: 'x'.repeat(400) } });
+    expect(contextButton).toHaveTextContent('10%');
+
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => {
+      expect(sessionApiUpdateMock).toHaveBeenCalledWith('sess-1', {
+        model_auto: true,
+        model_pinned: false,
+      });
+    });
+    expect(clientPostMock).not.toHaveBeenCalledWith(
+      '/api/session/sess-1/prompt_async',
+      expect.any(Object),
+    );
+    expect(contextButton).toHaveTextContent('10%');
+
+    await act(async () => {
+      modelUpdate.resolve({});
+      await modelUpdate.promise;
+    });
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledWith(
+        '/api/session/sess-1/prompt_async',
+        expect.any(Object),
+      );
+    });
+    expect(contextButton).toHaveTextContent('10%');
+  });
+
+  it('counts the real prompt instead of its shorter display label while submitting', async () => {
+    const prompt = 'x'.repeat(400);
+    mockStatefulSessionMessages();
+    sessionApiGetContextUsageMock.mockResolvedValue({
+      sessionID: 'sess-1',
+      usedTokens: 80,
+      contextWindow: 1000,
+      percent: 8,
+      source: 'estimated',
+      estimatedTokens: 80,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    });
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      initialMessage: prompt,
+      initialDisplayText: 'Visible label',
+      contextWindowTokens: 1000,
+    }));
+
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledWith(
+        '/api/session/sess-1/prompt_async',
+        expect.objectContaining({ displayText: 'Visible label' }),
+      );
+      expect(screen.getByRole('button', { name: 'chat.contextUsageTitle' })).toHaveTextContent('10%');
+    });
+    expect(screen.getByText('Visible label')).toBeInTheDocument();
+    expect(screen.queryByText(prompt)).not.toBeInTheDocument();
+  });
+
+  it('does not double-count a prompt when the initial snapshot resolves after submission', async () => {
+    const request = deferred<ContextUsageSnapshot>();
+    mockStatefulSessionMessages();
+    sessionApiGetContextUsageMock.mockReturnValue(request.promise);
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      contextWindowTokens: 1000,
+    }));
+
+    const contextButton = screen.getByRole('button', { name: 'chat.contextUsageTitle' });
+    const textarea = screen.getByPlaceholderText('请输入消息');
+    fireEvent.change(textarea, { target: { value: 'x'.repeat(400) } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledWith(
+        '/api/session/sess-1/prompt_async',
+        expect.any(Object),
+      );
+      expect(sessionApiGetContextUsageMock).toHaveBeenCalledTimes(1);
+    });
+    expect(contextButton).toHaveTextContent('10%');
+
+    await act(async () => {
+      request.resolve({
+        sessionID: 'sess-1',
+        usedTokens: 220,
+        contextWindow: 1000,
+        percent: 22,
+        source: 'estimated',
+        estimatedTokens: 220,
+        compactedTokens: 0,
+        segments: [
+          { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+          { key: 'toolDefinitions', tokens: 40, included: true, source: 'estimated' },
+          { key: 'conversation', tokens: 100, included: true, source: 'estimated' },
+        ],
+        excludedSegments: [],
+      });
+      await request.promise;
+    });
+
+    expect(contextButton).toHaveTextContent('10%');
+  });
+
+  it('keeps a newer prompt pending when the previous turn refresh resolves', async () => {
+    const previousTurnRefresh = deferred<ContextUsageSnapshot>();
+    mockStatefulSessionMessages();
+    sessionApiGetContextUsageMock
+      .mockResolvedValueOnce({
+        sessionID: 'sess-1',
+        usedTokens: 80,
+        contextWindow: 1000,
+        percent: 8,
+        source: 'estimated',
+        estimatedTokens: 80,
+        compactedTokens: 0,
+        segments: [
+          { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+        ],
+        excludedSegments: [],
+      })
+      .mockReturnValueOnce(previousTurnRefresh.promise);
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      contextWindowTokens: 1000,
+    }));
+
+    const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
+    await waitFor(() => expect(sessionApiGetContextUsageMock).toHaveBeenCalledTimes(1));
+    const textarea = screen.getByPlaceholderText('请输入消息');
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(400) } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(contextButton).toHaveTextContent('10%'));
+
+    act(() => {
+      useSSEOptionsRef.current.onEvent({
+        type: 'message.updated',
+        properties: {
+          info: {
+            id: 'assistant-turn-1',
+            sessionID: 'sess-1',
+            role: 'assistant',
+            providerID: 'openai',
+            modelID: 'gpt-test',
+            time: { completed: Date.now() },
+            finish: 'stop',
+          },
+        },
+      });
+    });
+    await waitFor(() => expect(sessionApiGetContextUsageMock).toHaveBeenCalledTimes(2));
+
+    fireEvent.change(textarea, { target: { value: 'b'.repeat(400) } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledTimes(2);
+      expect(contextButton).toHaveTextContent('20%');
+    });
+
+    await act(async () => {
+      previousTurnRefresh.resolve({
+        sessionID: 'sess-1',
+        usedTokens: 180,
+        contextWindow: 1000,
+        percent: 18,
+        source: 'estimated',
+        estimatedTokens: 180,
+        compactedTokens: 0,
+        segments: [
+          { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+          { key: 'conversation', tokens: 100, included: true, source: 'estimated' },
+        ],
+        excludedSegments: [],
+      });
+      await previousTurnRefresh.promise;
+    });
+
+    await waitFor(() => expect(contextButton).toHaveTextContent('20%'));
+  });
+
+  it('drops pending usage during the first render of a different session', async () => {
+    const layoutPercentages: string[] = [];
+    const firstSnapshot: ContextUsageSnapshot = {
+      sessionID: 'sess-1',
+      usedTokens: 580,
+      contextWindow: 1000,
+      percent: 58,
+      source: 'estimated',
+      estimatedTokens: 580,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+        { key: 'conversation', tokens: 500, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    };
+    mockStatefulSessionMessages([
+      makeMessage({
+        id: 'existing-user-1',
+        sessionID: 'sess-1',
+        role: 'user',
+        model: 'openai/gpt-test',
+        parts: [{ id: 'existing-user-part-1', type: 'text', text: 'x'.repeat(2000) }],
+      }),
+    ]);
+    sessionApiGetContextUsageMock.mockImplementation((activeSessionId: string) => (
+      activeSessionId === 'sess-1'
+        ? Promise.resolve(firstSnapshot)
+        : new Promise(() => {})
+    ));
+
+    function SessionSwitchProbe({ activeSessionId }: { activeSessionId: string }) {
+      React.useLayoutEffect(() => {
+        const contextButton = document.querySelector<HTMLButtonElement>(
+          'button[aria-label="chat.contextUsageTitle"]',
+        );
+        layoutPercentages.push(contextButton?.textContent || '');
+      }, [activeSessionId]);
+
+      return React.createElement(SessionChat, {
+        sessionId: activeSessionId,
+        contextWindowTokens: 1000,
+      });
+    }
+
+    const rendered = render(React.createElement(SessionSwitchProbe, {
+      activeSessionId: 'sess-1',
+    }));
+    const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
+    await waitFor(() => expect(contextButton).toHaveTextContent('50%'));
+
+    const textarea = screen.getByPlaceholderText('请输入消息');
+    fireEvent.change(textarea, { target: { value: 'x'.repeat(400) } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(contextButton).toHaveTextContent('60%'));
+
+    rendered.rerender(React.createElement(SessionSwitchProbe, {
+      activeSessionId: 'sess-2',
+    }));
+
+    expect(layoutPercentages[layoutPercentages.length - 1]).toBe('0%');
+    expect(contextButton).toHaveTextContent('0%');
+  });
+
+  it('retains pending prompt usage when the completion refresh fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const failedRefresh = deferred<ContextUsageSnapshot>();
+    mockStatefulSessionMessages();
+    sessionApiGetContextUsageMock
+      .mockResolvedValueOnce({
+        sessionID: 'sess-1',
+        usedTokens: 80,
+        contextWindow: 1000,
+        percent: 8,
+        source: 'estimated',
+        estimatedTokens: 80,
+        compactedTokens: 0,
+        segments: [
+          { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+        ],
+        excludedSegments: [],
+      })
+      .mockReturnValueOnce(failedRefresh.promise);
+
+    try {
+      render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
+
+      const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
+      const textarea = screen.getByPlaceholderText('请输入消息');
+      fireEvent.change(textarea, { target: { value: 'x'.repeat(400) } });
+      fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+      await waitFor(() => {
+        expect(contextButton).toHaveTextContent('10%');
+      });
+
+      act(() => {
+        useSSEOptionsRef.current.onEvent({
+          type: 'message.updated',
+          properties: {
+            info: {
+              id: 'assistant-1',
+              sessionID: 'sess-1',
+              role: 'assistant',
+              time: { completed: Date.now() },
+              finish: 'stop',
+            },
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(sessionApiGetContextUsageMock).toHaveBeenCalledTimes(2);
+      });
+      await act(async () => {
+        failedRefresh.reject(new Error('context usage unavailable'));
+        await failedRefresh.promise.catch(() => undefined);
+      });
+      await waitFor(() => {
+        expect(warnSpy).toHaveBeenCalled();
+      });
+      expect(contextButton).toHaveTextContent('10%');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not activate model context for a built-in slash command', async () => {
+    mockStatefulSessionMessages();
+    sessionApiGetContextUsageMock.mockResolvedValue({
+      sessionID: 'sess-1',
+      usedTokens: 100,
+      contextWindow: 100,
+      percent: 100,
+      source: 'estimated',
+      estimatedTokens: 100,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 60, included: true, source: 'estimated' },
+        { key: 'toolDefinitions', tokens: 40, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    });
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      contextWindowTokens: 100,
+    }));
+
+    const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
+    const textarea = screen.getByPlaceholderText('请输入消息');
+    fireEvent.change(textarea, { target: { value: '/tools' } });
+    expect(contextButton).toHaveTextContent('1%');
+
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(clientPostMock).toHaveBeenCalledWith(
+        '/api/session/sess-1/command',
+        expect.any(Object),
+      );
+    });
+    expect(contextButton).toHaveTextContent('0%');
+  });
+
+  it('ignores command-only history before a context snapshot is available', () => {
+    mockStatefulSessionMessages([
+      makeMessage({
+        id: 'command-user',
+        role: 'user',
+        model: 'openai/gpt-test',
+        parts: [{ id: 'command-part', type: 'text', text: 'x'.repeat(400), ignored: true }],
+      }),
+    ]);
+    sessionApiGetContextUsageMock.mockReturnValue(new Promise(() => {}));
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      contextWindowTokens: 1000,
+    }));
+
+    expect(screen.getByRole('button', { name: 'chat.contextUsageTitle' })).toHaveTextContent('0%');
+  });
+
+  it('does not attribute observed fixed-cost drift to a short model conversation', async () => {
+    const user = userEvent.setup();
+    sessionApiGetContextUsageMock.mockResolvedValue({
+      sessionID: 'sess-1',
+      usedTokens: 23210,
+      contextWindow: 1000000,
+      percent: 2,
+      source: 'observed',
+      observedTokens: 23210,
+      estimatedTokens: 20010,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 8000, included: true, source: 'estimated' },
+        { key: 'toolDefinitions', tokens: 12000, included: true, source: 'estimated' },
+        { key: 'conversation', tokens: 3210, included: true, source: 'estimated' },
         { key: 'agentDelegation', tokens: 0, included: true, source: 'estimated' },
       ],
       excludedSegments: [
         { key: 'compactedHistory', tokens: 12000, included: false, source: 'estimated' },
       ],
+    });
+    useSessionMessagesMock.mockReturnValue({
+      messages: [
+        makeMessage({
+          id: 'user-1',
+          role: 'user',
+          parts: [{ id: 'user-part-1', type: 'text', text: 'prompt' }],
+        }),
+        makeMessage({
+          id: 'assistant-1',
+          role: 'assistant',
+          providerID: 'openai',
+          modelID: 'gpt-test',
+          parts: [{ id: 'assistant-part-1', type: 'text', text: 'response' }],
+        }),
+      ],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      removeMessage: vi.fn(),
+      clearMessages: vi.fn(),
+      replaceMessageText: vi.fn(),
+      markMessageStopped: vi.fn(),
+      truncateAfterMessage: vi.fn(),
     });
 
     render(React.createElement(SessionChat, { sessionId: 'sess-1' }));
@@ -3791,18 +4424,156 @@ describe('SessionChat context usage popover', () => {
     const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
     expect(contextButton).toHaveClass('h-6');
     expect(contextButton).not.toHaveClass('w-6');
-    expect(contextButton).toHaveTextContent('12%');
+    expect(contextButton).toHaveTextContent('0%');
     await user.click(contextButton);
 
-    expect(screen.getByText('System prompt')).toBeInTheDocument();
-    expect(screen.getByText('Tool definitions')).toBeInTheDocument();
-    expect(screen.getByText('Conversation')).toBeInTheDocument();
+    expect(screen.queryByText('System prompt')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tool definitions')).not.toBeInTheDocument();
+    const conversationRow = screen.getByText('Conversation').closest('[role="menuitem"]');
+    expect(within(conversationRow as HTMLElement).getByText('10')).toBeInTheDocument();
     expect(screen.getByText('Reasoning')).toBeInTheDocument();
     expect(screen.getByText('Tool calls')).toBeInTheDocument();
     expect(screen.getByText('Skill loads')).toBeInTheDocument();
     expect(screen.getByText('Agent delegation')).toBeInTheDocument();
-    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(4);
     expect(screen.queryByText('Compacted history')).not.toBeInTheDocument();
+  });
+
+  it('tracks the token delta while an edited user message is being resent', async () => {
+    const user = userEvent.setup();
+    const originalText = 'x'.repeat(40);
+    const editedText = 'x'.repeat(400);
+    mockStatefulSessionMessages([
+      makeMessage({
+        id: 'user-1',
+        role: 'user',
+        model: 'openai/gpt-test',
+        parts: [{ id: 'user-part-1', type: 'text', text: originalText }],
+      }),
+      makeMessage({
+        id: 'assistant-1',
+        role: 'assistant',
+        providerID: 'openai',
+        modelID: 'gpt-test',
+        parentID: 'user-1',
+        parts: [
+          { id: 'assistant-part-1', type: 'text', text: 'y'.repeat(400) },
+          { id: 'assistant-reasoning-1', type: 'reasoning', text: 'z'.repeat(400) },
+        ],
+      }),
+    ]);
+    sessionApiGetContextUsageMock.mockResolvedValue({
+      sessionID: 'sess-1',
+      usedTokens: 290,
+      contextWindow: 1000,
+      percent: 29,
+      source: 'estimated',
+      estimatedTokens: 290,
+      compactedTokens: 0,
+      segments: [
+        { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+        { key: 'conversation', tokens: 110, included: true, source: 'estimated' },
+        { key: 'reasoning', tokens: 100, included: true, source: 'estimated' },
+      ],
+      excludedSegments: [],
+    });
+    sessionApiResendMessageMock.mockReturnValue(new Promise(() => {}));
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      display: { compact: false, showActions: true },
+    }));
+
+    const contextButton = await screen.findByRole('button', { name: 'chat.contextUsageTitle' });
+    expect(contextButton).toHaveTextContent('21%');
+
+    await user.click(screen.getByLabelText('chat.edit'));
+    fireEvent.change(screen.getByDisplayValue(originalText), { target: { value: editedText } });
+    await user.click(screen.getByLabelText('chat.sendEdited'));
+
+    await waitFor(() => {
+      expect(sessionApiResendMessageMock).toHaveBeenCalledWith(
+        'sess-1',
+        'user-1',
+        'user-part-1',
+        editedText,
+      );
+    });
+    expect(contextButton).toHaveTextContent('10%');
+
+    await user.click(contextButton);
+    const conversationRow = screen.getByText('Conversation').closest('[role="menuitem"]');
+    const reasoningRow = screen.getByText('Reasoning').closest('[role="menuitem"]');
+    expect(within(conversationRow as HTMLElement).getByText('100')).toBeInTheDocument();
+    expect(within(reasoningRow as HTMLElement).getByText('0')).toBeInTheDocument();
+  });
+
+  it('preserves edit removals when the initial context snapshot resolves late', async () => {
+    const request = deferred<ContextUsageSnapshot>();
+    const user = userEvent.setup();
+    const originalText = 'x'.repeat(40);
+    const editedText = 'x'.repeat(400);
+    mockStatefulSessionMessages([
+      makeMessage({
+        id: 'user-late-snapshot',
+        role: 'user',
+        model: 'openai/gpt-test',
+        parts: [{ id: 'user-late-part', type: 'text', text: originalText }],
+      }),
+      makeMessage({
+        id: 'assistant-late-snapshot',
+        role: 'assistant',
+        providerID: 'openai',
+        modelID: 'gpt-test',
+        parentID: 'user-late-snapshot',
+        parts: [
+          { id: 'assistant-late-text', type: 'text', text: 'y'.repeat(400) },
+          { id: 'assistant-late-reasoning', type: 'reasoning', text: 'z'.repeat(400) },
+        ],
+      }),
+    ]);
+    sessionApiGetContextUsageMock.mockReturnValue(request.promise);
+    sessionApiResendMessageMock.mockReturnValue(new Promise(() => {}));
+
+    render(React.createElement(SessionChat, {
+      sessionId: 'sess-1',
+      contextWindowTokens: 1000,
+      display: { compact: false, showActions: true },
+    }));
+
+    await waitFor(() => expect(sessionApiGetContextUsageMock).toHaveBeenCalledTimes(1));
+    const contextButton = screen.getByRole('button', { name: 'chat.contextUsageTitle' });
+    await user.click(screen.getByLabelText('chat.edit'));
+    fireEvent.change(screen.getByDisplayValue(originalText), { target: { value: editedText } });
+    await user.click(screen.getByLabelText('chat.sendEdited'));
+
+    await waitFor(() => expect(contextButton).toHaveTextContent('10%'));
+
+    await act(async () => {
+      request.resolve({
+        sessionID: 'sess-1',
+        usedTokens: 330,
+        contextWindow: 1000,
+        percent: 33,
+        source: 'observed',
+        estimatedTokens: 320,
+        compactedTokens: 0,
+        segments: [
+          { key: 'systemPrompt', tokens: 80, included: true, source: 'estimated' },
+          { key: 'toolDefinitions', tokens: 40, included: true, source: 'estimated' },
+          { key: 'conversation', tokens: 110, included: true, source: 'estimated' },
+          { key: 'reasoning', tokens: 100, included: true, source: 'estimated' },
+        ],
+        excludedSegments: [],
+      });
+      await request.promise;
+    });
+
+    await waitFor(() => expect(contextButton).toHaveTextContent('10%'));
+    await user.click(contextButton);
+    const conversationRow = screen.getByText('Conversation').closest('[role="menuitem"]');
+    const reasoningRow = screen.getByText('Reasoning').closest('[role="menuitem"]');
+    expect(within(conversationRow as HTMLElement).getByText('100')).toBeInTheDocument();
+    expect(within(reasoningRow as HTMLElement).getByText('0')).toBeInTheDocument();
   });
 
   it('keeps usage visible while recalculating after compaction succeeds', async () => {
@@ -3839,6 +4610,7 @@ describe('SessionChat context usage popover', () => {
         makeMessage({
           id: 'stale-user',
           role: 'user',
+          model: 'openai/gpt-test',
           parts: [{ id: 'stale-user-part', type: 'text', text: 'x'.repeat(4000) }] as Message['parts'],
         }),
       ],
@@ -3902,6 +4674,25 @@ describe('SessionChat context usage popover', () => {
         ],
         excludedSegments: [],
       });
+    useSessionMessagesMock.mockReturnValue({
+      messages: [makeMessage({
+        id: 'user-1',
+        role: 'user',
+        model: 'openai/gpt-test',
+        parts: [{ id: 'user-part-1', type: 'text', text: 'prompt' }],
+      })],
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+      addMessage: vi.fn(),
+      updateMessage: vi.fn(),
+      updateMessagePart: vi.fn(),
+      removeMessage: vi.fn(),
+      clearMessages: vi.fn(),
+      replaceMessageText: vi.fn(),
+      markMessageStopped: vi.fn(),
+      truncateAfterMessage: vi.fn(),
+    });
 
     render(React.createElement(SessionChat, { sessionId: 'sess-1', live: true, onError }));
 

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -371,6 +371,7 @@ function stringifyToolPayload(value: unknown): string {
 }
 
 function estimatePartTokens(part: MessagePart): number {
+  if (part.ignored) return 0;
   if (part.type === 'text') {
     return countTokensLikeCompaction(part.text);
   }
@@ -411,6 +412,25 @@ export interface ContextUsageBreakdown {
   excludedSegments: ContextUsageBreakdownSegment[];
 }
 
+interface ContextUsageBreakdownOptions {
+  includeSnapshotUsage?: boolean;
+  pendingTokenDeltas?: ContextUsageTokenDeltas;
+  useLocalMessageUsage?: boolean;
+}
+
+type ContextUsageTokenDeltas = Partial<Record<ContextUsageBreakdownSegment['key'], number>>;
+
+interface PendingContextUsageEntry {
+  snapshotTokenDeltas: ContextUsageTokenDeltas;
+  localTokenDeltas: ContextUsageTokenDeltas;
+}
+
+interface PendingContextUsageState {
+  sessionId: string | null;
+  baselineSnapshot: ContextUsageSnapshot | null;
+  entries: Record<string, PendingContextUsageEntry>;
+}
+
 const CONTEXT_SEGMENT_COLORS: Record<ContextUsageBreakdownSegment['key'], string> = {
   systemPrompt: 'bg-zinc-400',
   toolDefinitions: 'bg-violet-400',
@@ -441,9 +461,23 @@ function estimateMessageTokens(message: Message): number {
   return message.parts.reduce((sum, part) => sum + estimatePartTokens(part), 0);
 }
 
+function isModelInvocationMessage(message: Message): boolean {
+  if (message.role === 'user') {
+    return Boolean(message.model)
+      && message.parts.some((part) => part.ignored !== true);
+  }
+  return message.role === 'assistant'
+    && message.providerID !== 'builtin'
+    && message.modelID !== 'command'
+    && Boolean(message.providerID || message.modelID);
+}
+
 function estimateActiveMessageBreakdown(messages: Message[]): Pick<ContextUsageBreakdown, 'segments' | 'usedTokens'> {
   let conversationTokens = 0;
   let reasoningTokens = 0;
+  let toolTokens = 0;
+  let skillLoadTokens = 0;
+  let agentDelegationTokens = 0;
 
   messages.forEach((message) => {
     if (message.compacted) return;
@@ -451,6 +485,14 @@ function estimateActiveMessageBreakdown(messages: Message[]): Pick<ContextUsageB
       const tokens = estimatePartTokens(part);
       if (part.type === 'reasoning' || part.type === 'thinking') {
         reasoningTokens += tokens;
+      } else if (part.type === 'tool') {
+        if (part.tool === 'skill_load') {
+          skillLoadTokens += tokens;
+        } else if (isDelegateTool(part.tool || '')) {
+          agentDelegationTokens += tokens;
+        } else {
+          toolTokens += tokens;
+        }
       } else {
         conversationTokens += tokens;
       }
@@ -474,11 +516,48 @@ function estimateActiveMessageBreakdown(messages: Message[]): Pick<ContextUsageB
       included: true,
     });
   }
+  if (toolTokens > 0) {
+    segments.push({
+      key: 'tools',
+      tokens: toolTokens,
+      colorClass: CONTEXT_SEGMENT_COLORS.tools,
+      included: true,
+    });
+  }
+  if (skillLoadTokens > 0) {
+    segments.push({
+      key: 'skillLoad',
+      tokens: skillLoadTokens,
+      colorClass: CONTEXT_SEGMENT_COLORS.skillLoad,
+      included: true,
+    });
+  }
+  if (agentDelegationTokens > 0) {
+    segments.push({
+      key: 'agentDelegation',
+      tokens: agentDelegationTokens,
+      colorClass: CONTEXT_SEGMENT_COLORS.agentDelegation,
+      included: true,
+    });
+  }
 
   return {
-    usedTokens: conversationTokens + reasoningTokens,
+    usedTokens: conversationTokens
+      + reasoningTokens
+      + toolTokens
+      + skillLoadTokens
+      + agentDelegationTokens,
     segments,
   };
+}
+
+function addContextTokenDelta(
+  deltas: ContextUsageTokenDeltas,
+  key: ContextUsageBreakdownSegment['key'],
+  tokenDelta: number,
+): void {
+  if (tokenDelta === 0) return;
+  deltas[key] = (deltas[key] || 0) + tokenDelta;
 }
 
 function normalizeContextSegment(segment: {
@@ -518,6 +597,24 @@ function addContextSegmentTokens(
   });
 }
 
+function adjustContextSegmentTokens(
+  segments: ContextUsageBreakdownSegment[],
+  key: ContextUsageBreakdownSegment['key'],
+  tokenDelta: number,
+): number {
+  if (tokenDelta === 0) return 0;
+  const existing = segments.find((segment) => segment.key === key);
+  if (existing) {
+    const previousTokens = existing.tokens;
+    existing.tokens = Math.max(0, previousTokens + tokenDelta);
+    return existing.tokens - previousTokens;
+  } else if (tokenDelta > 0) {
+    addContextSegmentTokens(segments, key, tokenDelta);
+    return tokenDelta;
+  }
+  return 0;
+}
+
 function normalizeFixedContextSegments(
   segments: ContextUsageBreakdownSegment[],
 ): ContextUsageBreakdownSegment[] {
@@ -552,6 +649,7 @@ export function buildContextUsageBreakdown(
   messages: Message[],
   draft: string,
   snapshot?: ContextUsageSnapshot | null,
+  options?: ContextUsageBreakdownOptions,
 ): ContextUsageBreakdown {
   const compactedTokens = messages.reduce((total, message) => (
     message.compacted ? total + estimateMessageTokens(message) : total
@@ -562,27 +660,94 @@ export function buildContextUsageBreakdown(
     const serverSegments = (snapshot.segments || [])
       .map(normalizeContextSegment)
       .filter((segment): segment is ContextUsageBreakdownSegment => Boolean(segment));
-    const segments = [...serverSegments];
+    const includeSnapshotUsage = options?.includeSnapshotUsage !== false;
+    const useLocalMessageUsage = includeSnapshotUsage && options?.useLocalMessageUsage === true;
+    const activeBreakdown = useLocalMessageUsage
+      ? estimateActiveMessageBreakdown(messages)
+      : null;
+    const segments = includeSnapshotUsage
+      ? useLocalMessageUsage
+        ? serverSegments.filter((segment) => (
+            segment.key === 'systemPrompt' || segment.key === 'toolDefinitions'
+          ))
+        : [...serverSegments]
+      : serverSegments.filter((segment) => segment.key === 'systemPrompt');
+    activeBreakdown?.segments.forEach((segment) => {
+      addContextSegmentTokens(segments, segment.key, segment.tokens);
+    });
+    const includedSystemPromptTokens = serverSegments.reduce((total, segment) => (
+      segment.key === 'systemPrompt' && segment.included ? total + segment.tokens : total
+    ), 0);
+    const includedToolDefinitionTokens = serverSegments.reduce((total, segment) => (
+      segment.key === 'toolDefinitions' && segment.included ? total + segment.tokens : total
+    ), 0);
+    const estimatedSnapshotTokens = snapshot.estimatedTokens > 0
+      ? snapshot.estimatedTokens
+      : snapshot.usedTokens || 0;
+    if (includeSnapshotUsage && !useLocalMessageUsage) {
+      adjustContextSegmentTokens(
+        segments,
+        'conversation',
+        -Math.max(0, (snapshot.usedTokens || 0) - estimatedSnapshotTokens),
+      );
+    }
+    const pendingTokenDeltas = includeSnapshotUsage ? options?.pendingTokenDeltas || {} : {};
+    const pendingTokenDeltaTotal = Object.entries(pendingTokenDeltas).reduce(
+      (total, [key, tokenDelta]) => total + adjustContextSegmentTokens(
+        segments,
+        key as ContextUsageBreakdownSegment['key'],
+        tokenDelta || 0,
+      ),
+      0,
+    );
 
     addContextSegmentTokens(segments, 'conversation', draftTokens);
 
     return {
-      usedTokens: Math.max(0, snapshot.usedTokens || 0) + draftTokens,
+      usedTokens: (
+        includeSnapshotUsage
+          ? Math.max(
+              0,
+              (
+                useLocalMessageUsage
+                  ? activeBreakdown?.usedTokens || 0
+                  : estimatedSnapshotTokens - includedSystemPromptTokens - includedToolDefinitionTokens
+              ) + pendingTokenDeltaTotal,
+            )
+          : 0
+      ) + draftTokens,
       compactedTokens: Math.max(0, snapshot.compactedTokens || 0),
-      segments: normalizeFixedContextSegments(segments),
+      segments: normalizeFixedContextSegments(segments).map((segment) => (
+        segment.key === 'systemPrompt' || segment.key === 'toolDefinitions'
+          ? { ...segment, included: false }
+          : segment
+      )),
       excludedSegments: [],
     };
   }
 
   const activeBreakdown = estimateActiveMessageBreakdown(messages);
   const segments: ContextUsageBreakdownSegment[] = [...activeBreakdown.segments];
+  const pendingTokenDeltas = options?.pendingTokenDeltas || {};
+  const pendingTokenDeltaTotal = Object.entries(pendingTokenDeltas).reduce(
+    (total, [key, tokenDelta]) => total + adjustContextSegmentTokens(
+      segments,
+      key as ContextUsageBreakdownSegment['key'],
+      tokenDelta || 0,
+    ),
+    0,
+  );
 
   addContextSegmentTokens(segments, 'conversation', draftTokens);
 
   return {
-    usedTokens: activeBreakdown.usedTokens + draftTokens,
+    usedTokens: Math.max(0, activeBreakdown.usedTokens + pendingTokenDeltaTotal) + draftTokens,
     compactedTokens,
-    segments: normalizeFixedContextSegments(segments),
+    segments: normalizeFixedContextSegments(segments).map((segment) => (
+      segment.key === 'systemPrompt' || segment.key === 'toolDefinitions'
+        ? { ...segment, included: false }
+        : segment
+    )),
     excludedSegments: [],
   };
 }
@@ -640,8 +805,10 @@ function ContextUsageRing({
       : clamped >= 50
         ? 'stroke-sky-500'
         : 'stroke-zinc-400';
-  const rows = breakdown.segments;
-  const activeSegments = breakdown.segments.filter((segment) => segment.tokens > 0);
+  const rows = breakdown.segments.filter((segment) => (
+    segment.key !== 'systemPrompt' && segment.key !== 'toolDefinitions'
+  ));
+  const activeSegments = breakdown.segments.filter((segment) => segment.included && segment.tokens > 0);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -750,9 +917,7 @@ function ContextUsageRing({
                   </span>
                 </div>
                 <span className={segment.included ? 'shrink-0 text-zinc-600 dark:text-zinc-300' : 'shrink-0 text-zinc-400 dark:text-zinc-500'}>
-                  {segment.included
-                    ? formatTokenCount(segment.tokens)
-                    : t('chat.contextUsage.excludedTokens', { tokens: formatTokenCount(segment.tokens) })}
+                  {formatTokenCount(segment.included ? segment.tokens : 0)}
                 </span>
               </div>
             ))}
@@ -1654,6 +1819,25 @@ export default function SessionChat({
   // sidebar → Agents → back to Sessions) doesn't wipe the user's half-typed
   // message. Subsequent session changes are re-hydrated by the effect below.
   const [input, setInput] = useState<string>(() => readChatDraft(sessionId));
+  const [submittedModelPromptSessionId, setSubmittedModelPromptSessionId] = useState<string | null>(null);
+  const [pendingContextUsage, setPendingContextUsage] = useState<PendingContextUsageState>({
+    sessionId: null,
+    baselineSnapshot: null,
+    entries: {},
+  });
+  const pendingContextUsageRef = useRef(pendingContextUsage);
+  pendingContextUsageRef.current = pendingContextUsage;
+  const pendingContextSnapshotKeysRef = useRef<{
+    sessionId: string;
+    keys: string[];
+  } | null>(null);
+  const updatePendingContextUsage = useCallback((
+    updater: (current: PendingContextUsageState) => PendingContextUsageState,
+  ) => {
+    const next = updater(pendingContextUsageRef.current);
+    pendingContextUsageRef.current = next;
+    setPendingContextUsage(next);
+  }, []);
   const [composerReferences, setComposerReferences] = useState<ComposerReference[]>([]);
   const [sending, setSending] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
@@ -1756,6 +1940,80 @@ export default function SessionChat({
     applyPushSnapshot: applyContextUsagePushSnapshot,
     stopRefreshing: stopContextUsageRefreshing,
   } = useSessionContextUsage(sessionId);
+  const activeContextUsageSnapshot = contextUsageSnapshot?.sessionID === sessionId
+    ? contextUsageSnapshot
+    : null;
+  const beginPendingContextUsage = useCallback((
+    key: string,
+    snapshotTokenDeltas: ContextUsageTokenDeltas,
+    baselineSnapshot: ContextUsageSnapshot | null = activeContextUsageSnapshot,
+    localTokenDeltas: ContextUsageTokenDeltas = {},
+  ) => {
+    updatePendingContextUsage((current) => {
+      const continueCurrent = current.sessionId === sessionId
+        && Object.keys(current.entries).length > 0;
+      return {
+        sessionId: sessionId || null,
+        baselineSnapshot: continueCurrent ? current.baselineSnapshot : baselineSnapshot,
+        entries: {
+          ...(continueCurrent ? current.entries : {}),
+          [key]: { snapshotTokenDeltas, localTokenDeltas },
+        },
+      };
+    });
+  }, [activeContextUsageSnapshot, sessionId, updatePendingContextUsage]);
+  const resolvePendingContextUsage = useCallback((
+    keys: string[],
+    expectedSessionId: string,
+    nextBaselineSnapshot?: ContextUsageSnapshot | null,
+  ) => {
+    if (keys.length === 0) return;
+    updatePendingContextUsage((current) => {
+      if (current.sessionId !== expectedSessionId) return current;
+      const entries = { ...current.entries };
+      keys.forEach((key) => delete entries[key]);
+      const hasEntries = Object.keys(entries).length > 0;
+      return {
+        sessionId: hasEntries ? current.sessionId : null,
+        baselineSnapshot: hasEntries
+          ? nextBaselineSnapshot ?? current.baselineSnapshot
+          : null,
+        entries,
+      };
+    });
+  }, [updatePendingContextUsage]);
+  const removePendingContextUsage = useCallback((key: string) => {
+    resolvePendingContextUsage([key], sessionId || '');
+  }, [resolvePendingContextUsage, sessionId]);
+  const clearPendingContextUsage = useCallback(() => {
+    pendingContextSnapshotKeysRef.current = null;
+    updatePendingContextUsage(() => ({ sessionId: null, baselineSnapshot: null, entries: {} }));
+  }, [updatePendingContextUsage]);
+  const refreshContextUsageAfterTurn = useCallback((options?: Parameters<typeof refreshContextUsage>[0]) => {
+    if (!sessionId) return;
+    const pendingAtStart = pendingContextUsageRef.current;
+    const pendingKeys = pendingAtStart.sessionId === sessionId
+      ? Object.keys(pendingAtStart.entries)
+      : [];
+    const capturedPending = pendingKeys.length > 0
+      ? { sessionId, keys: pendingKeys }
+      : null;
+    if (capturedPending) pendingContextSnapshotKeysRef.current = capturedPending;
+    const request = refreshContextUsage({ ...options, force: true });
+    if (request) {
+      void request.then((snapshot) => {
+        if (!snapshot || !capturedPending) return;
+        resolvePendingContextUsage(
+          capturedPending.keys,
+          capturedPending.sessionId,
+          snapshot,
+        );
+        if (pendingContextSnapshotKeysRef.current === capturedPending) {
+          pendingContextSnapshotKeysRef.current = null;
+        }
+      });
+    }
+  }, [refreshContextUsage, resolvePendingContextUsage, sessionId]);
   const isCompactingRef = useRef(false);
   const prevStreamingRef = useRef(false);
   // Tracks "sessionId::message" key to prevent double-send in React StrictMode
@@ -1910,6 +2168,11 @@ export default function SessionChat({
   } =
     useSessionMessages(sessionId || undefined);
 
+  useEffect(() => {
+    setSubmittedModelPromptSessionId(null);
+    clearPendingContextUsage();
+  }, [sessionId, clearPendingContextUsage]);
+
   const seededOptimisticMessageIdRef = useRef('');
   useEffect(() => {
     if (
@@ -1919,10 +2182,17 @@ export default function SessionChat({
     ) return;
 
     seededOptimisticMessageIdRef.current = initialOptimisticMessage.id;
+    setSubmittedModelPromptSessionId(sessionId || null);
+    beginPendingContextUsage(
+      initialOptimisticMessage.id,
+      { conversation: estimateMessageTokens(initialOptimisticMessage) },
+      null,
+    );
     addMessage(initialOptimisticMessage);
     onInitialOptimisticMessageConsumed?.(initialOptimisticMessage.id);
   }, [
     addMessage,
+    beginPendingContextUsage,
     initialOptimisticMessage,
     onInitialOptimisticMessageConsumed,
     sessionId,
@@ -1949,15 +2219,94 @@ export default function SessionChat({
     onFocusMessageConsumed?.();
   }, [focusMessageId, loading, messages.length, onFocusMessageConsumed]);
 
-  const contextUsageMessages = contextUsageRefreshing && !contextUsageSnapshot ? [] : messages;
+  const sessionMessagesForContextUsage = useMemo(
+    () => messages.filter((message) => !message.sessionID || message.sessionID === sessionId),
+    [messages, sessionId],
+  );
+  const hasUserMessage = useMemo(
+    () => sessionMessagesForContextUsage.some((message) => message.role === 'user'),
+    [sessionMessagesForContextUsage],
+  );
+  const hasPersistedModelInvocation = useMemo(
+    () => sessionMessagesForContextUsage.some(isModelInvocationMessage),
+    [sessionMessagesForContextUsage],
+  );
+  const pendingContextSnapshotTokenDeltas = useMemo(
+    () => Object.values(pendingContextUsage.entries).reduce<ContextUsageTokenDeltas>(
+      (totals, entry) => {
+        Object.entries(entry.snapshotTokenDeltas).forEach(([key, tokenDelta]) => {
+          addContextTokenDelta(
+            totals,
+            key as ContextUsageBreakdownSegment['key'],
+            tokenDelta || 0,
+          );
+        });
+        return totals;
+      },
+      {},
+    ),
+    [pendingContextUsage.entries],
+  );
+  const pendingContextLocalTokenDeltas = useMemo(
+    () => Object.values(pendingContextUsage.entries).reduce<ContextUsageTokenDeltas>(
+      (totals, entry) => {
+        Object.entries(entry.localTokenDeltas).forEach(([key, tokenDelta]) => {
+          addContextTokenDelta(
+            totals,
+            key as ContextUsageBreakdownSegment['key'],
+            tokenDelta || 0,
+          );
+        });
+        return totals;
+      },
+      {},
+    ),
+    [pendingContextUsage.entries],
+  );
+  const hasPendingContextUsage = pendingContextUsage.sessionId === sessionId
+    && Object.keys(pendingContextUsage.entries).length > 0;
+  const hasModelInvocation = submittedModelPromptSessionId === sessionId
+    || hasPersistedModelInvocation
+    || hasPendingContextUsage;
+  const canReconcilePendingWithLiveSnapshot = hasPendingContextUsage
+    && !pendingContextUsage.baselineSnapshot
+    && Boolean(activeContextUsageSnapshot);
+  const contextUsageSnapshotForBreakdown = hasPendingContextUsage
+    ? canReconcilePendingWithLiveSnapshot
+      ? activeContextUsageSnapshot
+      : pendingContextUsage.baselineSnapshot
+    : activeContextUsageSnapshot;
+  const pendingTokenDeltasForBreakdown = canReconcilePendingWithLiveSnapshot
+    ? pendingContextLocalTokenDeltas
+    : hasPendingContextUsage
+      ? pendingContextUsage.baselineSnapshot
+        ? pendingContextSnapshotTokenDeltas
+        : pendingContextLocalTokenDeltas
+      : {};
+  const contextUsageMessages = !hasModelInvocation
+    ? []
+    : contextUsageRefreshing && !contextUsageSnapshotForBreakdown && !hasPendingContextUsage
+      ? []
+      : sessionMessagesForContextUsage;
   const contextUsageBreakdown = useMemo(
-    () => buildContextUsageBreakdown(contextUsageMessages, input, contextUsageSnapshot),
-    [contextUsageMessages, input, contextUsageSnapshot],
+    () => buildContextUsageBreakdown(contextUsageMessages, input, contextUsageSnapshotForBreakdown, {
+      includeSnapshotUsage: hasModelInvocation,
+      pendingTokenDeltas: pendingTokenDeltasForBreakdown,
+      useLocalMessageUsage: canReconcilePendingWithLiveSnapshot,
+    }),
+    [
+      contextUsageMessages,
+      contextUsageSnapshotForBreakdown,
+      hasModelInvocation,
+      input,
+      pendingTokenDeltasForBreakdown,
+      canReconcilePendingWithLiveSnapshot,
+    ],
   );
   const estimatedContextTokens = contextUsageBreakdown.usedTokens;
-  const resolvedContextWindowTokens = contextUsageSnapshot?.contextWindow && contextUsageSnapshot.contextWindow > 0
-    ? contextUsageSnapshot.contextWindow
-    : contextUsageWindowTokens > 0
+  const resolvedContextWindowTokens = activeContextUsageSnapshot?.contextWindow && activeContextUsageSnapshot.contextWindow > 0
+    ? activeContextUsageSnapshot.contextWindow
+    : activeContextUsageSnapshot && contextUsageWindowTokens > 0
       ? contextUsageWindowTokens
     : (contextWindowTokens || 0);
   const contextUsagePercent = resolvedContextWindowTokens > 0
@@ -1976,8 +2325,6 @@ export default function SessionChat({
   useEffect(() => { messagesRef.current = messages; }, [messages]);
   const pendingQuestionsRef = useRef(pendingQuestions);
   useEffect(() => { pendingQuestionsRef.current = pendingQuestions; }, [pendingQuestions]);
-
-  const hasUserMessage = useMemo(() => messages.some((m) => m.role === 'user'), [messages]);
 
   const sseEnabled = Boolean(sessionId) && (live || isStreaming || !hideInput);
 
@@ -2027,6 +2374,8 @@ export default function SessionChat({
           setIsStreaming(false);
           setGoalBanner(null);
           setDismissedGoalKey('');
+          setSubmittedModelPromptSessionId(null);
+          clearPendingContextUsage();
           clearMessages();
           void refreshContextUsage({ clear: true });
           return;
@@ -2062,7 +2411,7 @@ export default function SessionChat({
             setCompactingMessage('');
             setCompactionStages([]);
             refetch();
-            void refreshContextUsage({ skipIfFreshMs: 500 });
+            refreshContextUsageAfterTurn({ skipIfFreshMs: 500 });
           }
           return;
         case 'message-updated': {
@@ -2079,7 +2428,7 @@ export default function SessionChat({
             setIsStreaming(false);
             setSending(false);
             if (info.finish || info.time?.completed) {
-              void refreshContextUsage();
+              refreshContextUsageAfterTurn();
             }
           } else if (info.finish || info.time?.completed) {
             const shouldRefetch = shouldRefetchFinishedMessage({
@@ -2095,7 +2444,7 @@ export default function SessionChat({
                 setIsStreaming(false);
               }
             }
-            void refreshContextUsage();
+            refreshContextUsageAfterTurn();
             abortingRef.current = false;
             abortedMessageIdRef.current = null;
           } else if (
@@ -2115,6 +2464,8 @@ export default function SessionChat({
           if (abortedMessageIdRef.current === action.messageID) {
             abortedMessageIdRef.current = null;
           }
+          removePendingContextUsage(action.messageID);
+          removePendingContextUsage(`edit:${action.messageID}`);
           removeMessage(action.messageID);
           return;
         }
@@ -2175,15 +2526,25 @@ export default function SessionChat({
         case 'context-compacted':
           void refreshContextUsage({ skipIfFreshMs: 500 });
           return;
-        case 'context-usage-updated':
+        case 'context-usage-updated': {
+          const capturedPending = pendingContextSnapshotKeysRef.current;
+          if (capturedPending?.sessionId === action.snapshot.sessionID) {
+            resolvePendingContextUsage(
+              capturedPending.keys,
+              capturedPending.sessionId,
+              action.snapshot,
+            );
+            pendingContextSnapshotKeysRef.current = null;
+          }
           applyContextUsagePushSnapshot(action.snapshot);
           return;
+        }
         case 'session-error':
           setIsStreaming(false);
           setIsCompacting(false);
           setCompactionStages([]);
           stopContextUsageRefreshing();
-          void refreshContextUsage({ skipIfFreshMs: 500 });
+          refreshContextUsageAfterTurn({ skipIfFreshMs: 500 });
           abortingRef.current = false;
           sessionBusyRef.current = false;
           activeToolPartIdsRef.current.clear();
@@ -2199,8 +2560,12 @@ export default function SessionChat({
       clearMessages,
       refetch,
       refreshContextUsage,
+      refreshContextUsageAfterTurn,
       applyContextUsagePushSnapshot,
       stopContextUsageRefreshing,
+      clearPendingContextUsage,
+      resolvePendingContextUsage,
+      removePendingContextUsage,
       handleQuestionAsked,
       removeByRequestId,
       applyPromptQueueItems,
@@ -2290,7 +2655,7 @@ export default function SessionChat({
       if (!sessionId) return;
       void reconcileSessionStatusAfterReconnect();
       refetch();
-      refreshContextUsage();
+      void refreshContextUsage();
       fetchPromptQueue();
       fetchPendingQuestions(sessionId).catch((err) => {
         console.warn('[SessionChat] Failed to recover pending questions after reconnect:', err);
@@ -2776,9 +3141,7 @@ export default function SessionChat({
     options?: PromptDisplayOptions,
   ) => {
     if (!sessionId) return;
-    await ensureAutoModelSession();
     const effectiveAgent = agentOverride || agentName;
-    const visibleText = options?.displayText || text;
     // Clear abort state immediately so SSE events for the new stream are not suppressed
     abortingRef.current = false;
     abortedMessageIdRef.current = null;
@@ -2791,21 +3154,33 @@ export default function SessionChat({
 
     const messageId = createMessageId();
     const tempParts: MessagePart[] = [];
-    if (visibleText) tempParts.push({ id: `temp-${messageId}-text`, type: 'text', text: visibleText });
+    const optimisticTextPart: MessagePart = {
+      id: `temp-${messageId}-text`,
+      type: 'text',
+      text,
+      ...(options?.displayText ? { metadata: { displayText: options.displayText } } : {}),
+    };
+    if (text || options?.displayText) tempParts.push(optimisticTextPart);
     imageParts.forEach((img, i) => {
       tempParts.push({ id: `temp-${messageId}-img-${i}`, type: 'file', url: img.url, mime: img.mime, filename: img.filename });
     });
 
-    addMessage({
+    const optimisticMessage = {
       id: messageId,
       sessionID: sessionId,
       role: 'user',
-      parts: tempParts.length > 0 ? tempParts : [{ id: `temp-${messageId}-part`, type: 'text', text: visibleText }],
+      parts: tempParts.length > 0 ? tempParts : [optimisticTextPart],
       timestamp: Date.now(),
       agent: effectiveAgent,
-    } as Message);
+    } as Message;
+    setSubmittedModelPromptSessionId(sessionId);
+    beginPendingContextUsage(messageId, {
+      conversation: estimateMessageTokens(optimisticMessage),
+    });
+    addMessage(optimisticMessage);
 
     try {
+      await ensureAutoModelSession();
       const payload: Record<string, unknown> = {
         parts: buildPromptParts(text, imageParts),
         messageID: messageId,
@@ -2826,6 +3201,12 @@ export default function SessionChat({
     } catch (err: unknown) {
       setIsStreaming(false);
       removeMessage(messageId);
+      removePendingContextUsage(messageId);
+      if (!hasPersistedModelInvocation) {
+        setSubmittedModelPromptSessionId((currentSessionId) => (
+          currentSessionId === sessionId ? null : currentSessionId
+        ));
+      }
       const axiosErr = err as any;
       if (axiosErr?.response?.status === 404) {
         onError?.(`Session not found. Please start a new session.`);
@@ -3410,13 +3791,50 @@ export default function SessionChat({
     suppressStreamingUntilIdleRef.current = false;
     isAtBottomRef.current = true;
     setActionMessageId(editingMessageId);
+    const sourceMessage = messagesRef.current.find((message) => message.id === editingMessageId);
+    const sourceMessageIndex = messagesRef.current.findIndex((message) => message.id === editingMessageId);
+    const sourcePart = sourceMessage?.parts.find((part) => part.id === editingPartId);
+    const originalText = sourcePart?.text || '';
+    const pendingContextKey = `edit:${editingMessageId}`;
+    const editedMessageTokenDelta = sourceMessage
+      ? estimateMessageTokens({
+          ...sourceMessage,
+          parts: sourceMessage.parts.map((part) => (
+            part.id === editingPartId ? { ...part, text } : part
+          )),
+        }) - estimateMessageTokens(sourceMessage)
+      : countTokensLikeCompaction(text) - countTokensLikeCompaction(originalText);
+    const snapshotTokenDeltas: ContextUsageTokenDeltas = { conversation: editedMessageTokenDelta };
+    const localTokenDeltas: ContextUsageTokenDeltas = {};
+    if (sourceMessageIndex >= 0) {
+      estimateActiveMessageBreakdown(
+        messagesRef.current.slice(sourceMessageIndex + 1),
+      ).segments.forEach((segment) => {
+        addContextTokenDelta(snapshotTokenDeltas, segment.key, -segment.tokens);
+        addContextTokenDelta(localTokenDeltas, segment.key, -segment.tokens);
+      });
+    }
+    setSubmittedModelPromptSessionId(sessionId);
+    beginPendingContextUsage(
+      pendingContextKey,
+      snapshotTokenDeltas,
+      activeContextUsageSnapshot,
+      localTokenDeltas,
+    );
+    replaceMessageText(editingMessageId, editingPartId, text);
     try {
       await sessionApi.resendMessage(sessionId, editingMessageId, editingPartId, text);
-      replaceMessageText(editingMessageId, editingPartId, text);
       truncateAfterMessage(editingMessageId);
       setIsStreaming(true);
       resetEditingState();
     } catch (err) {
+      replaceMessageText(editingMessageId, editingPartId, originalText);
+      removePendingContextUsage(pendingContextKey);
+      if (!hasPersistedModelInvocation) {
+        setSubmittedModelPromptSessionId((currentSessionId) => (
+          currentSessionId === sessionId ? null : currentSessionId
+        ));
+      }
       reportActionError(t('chat.errors.resendFailed'), err);
     } finally {
       setActionMessageId(null);
@@ -3426,7 +3844,11 @@ export default function SessionChat({
     editingPartId,
     editingRole,
     editingText,
+    activeContextUsageSnapshot,
+    beginPendingContextUsage,
+    hasPersistedModelInvocation,
     replaceMessageText,
+    removePendingContextUsage,
     reportActionError,
     resetEditingState,
     sessionId,

--- a/webui/src/features/session-chat/useSessionContextUsage.test.ts
+++ b/webui/src/features/session-chat/useSessionContextUsage.test.ts
@@ -97,4 +97,79 @@ describe('useSessionContextUsage', () => {
 
     expect(result.current.snapshot?.usedTokens).toBe(420);
   });
+
+  it('forces a new request and reports whether its snapshot was applied', async () => {
+    const firstRequest = deferred<ContextUsageSnapshot>();
+    const forcedRequest = deferred<ContextUsageSnapshot>();
+    getContextUsageMock
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(forcedRequest.promise);
+    const { result } = renderHook(() => useSessionContextUsage('sess-1'));
+
+    let appliedPromise: Promise<ContextUsageSnapshot | null> | undefined;
+    act(() => {
+      result.current.refresh();
+      appliedPromise = result.current.refresh({ force: true });
+    });
+
+    expect(getContextUsageMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      firstRequest.resolve(buildSnapshot({ usedTokens: 900 }));
+      await firstRequest.promise;
+    });
+    expect(result.current.snapshot).toBeNull();
+
+    let applied: ContextUsageSnapshot | null = null;
+    await act(async () => {
+      forcedRequest.resolve(buildSnapshot({ usedTokens: 420 }));
+      applied = await appliedPromise!;
+    });
+
+    expect(applied?.usedTokens).toBe(420);
+    expect(result.current.snapshot?.usedTokens).toBe(420);
+  });
+
+  it('reports a failed refresh without applying a snapshot', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    getContextUsageMock.mockRejectedValueOnce(new Error('unavailable'));
+    const { result } = renderHook(() => useSessionContextUsage('sess-1'));
+
+    try {
+      let applied: ContextUsageSnapshot | null = buildSnapshot();
+      await act(async () => {
+        applied = await result.current.refresh({ force: true })!;
+      });
+
+      expect(applied).toBeNull();
+      expect(result.current.snapshot).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('rejects a response from the previously rendered session immediately', async () => {
+    const request = deferred<ContextUsageSnapshot>();
+    getContextUsageMock.mockReturnValue(request.promise);
+    const { result, rerender } = renderHook(
+      ({ sessionId }) => useSessionContextUsage(sessionId),
+      { initialProps: { sessionId: 'sess-1' } },
+    );
+
+    let appliedPromise: Promise<ContextUsageSnapshot | null> | undefined;
+    act(() => {
+      appliedPromise = result.current.refresh({ force: true });
+    });
+    rerender({ sessionId: 'sess-2' });
+
+    let applied: ContextUsageSnapshot | null = buildSnapshot();
+    await act(async () => {
+      request.resolve(buildSnapshot({ sessionID: 'sess-1', usedTokens: 900 }));
+      applied = await appliedPromise!;
+    });
+
+    expect(applied).toBeNull();
+    expect(result.current.snapshot).toBeNull();
+  });
 });

--- a/webui/src/features/session-chat/useSessionContextUsage.ts
+++ b/webui/src/features/session-chat/useSessionContextUsage.ts
@@ -4,6 +4,7 @@ import { sessionApi, type ContextUsageSnapshot } from '@/api/session';
 
 export interface RefreshContextUsageOptions {
   clear?: boolean;
+  force?: boolean;
   skipIfFreshMs?: number;
 }
 
@@ -11,9 +12,14 @@ export function useSessionContextUsage(sessionId?: string | null) {
   const [snapshot, setSnapshot] = useState<ContextUsageSnapshot | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [contextWindowTokens, setContextWindowTokens] = useState(0);
-  const requestRef = useRef<{ sessionId: string; promise: Promise<void> } | null>(null);
+  const requestRef = useRef<{
+    sessionId: string;
+    promise: Promise<ContextUsageSnapshot | null>;
+  } | null>(null);
   const requestSeqRef = useRef(0);
   const lastPushAtRef = useRef(0);
+  const activeSessionIdRef = useRef(sessionId);
+  activeSessionIdRef.current = sessionId;
 
   const reset = useCallback((nextRefreshing = false) => {
     setSnapshot(null);
@@ -37,6 +43,9 @@ export function useSessionContextUsage(sessionId?: string | null) {
       Date.now() - lastPushAtRef.current < options.skipIfFreshMs
     ) {
       return;
+    } else if (options?.force) {
+      requestSeqRef.current += 1;
+      requestRef.current = null;
     }
 
     const existingRequest = requestRef.current;
@@ -47,16 +56,28 @@ export function useSessionContextUsage(sessionId?: string | null) {
     const requestSessionId = sessionId;
     const requestSeq = requestSeqRef.current;
     const request = sessionApi.getContextUsage(requestSessionId).then((nextSnapshot) => {
-      if (requestSeq === requestSeqRef.current && nextSnapshot.sessionID === sessionId) {
+      if (
+        requestSeq === requestSeqRef.current
+        && requestSessionId === activeSessionIdRef.current
+        && nextSnapshot.sessionID === activeSessionIdRef.current
+      ) {
         setSnapshot(nextSnapshot);
         if (nextSnapshot.contextWindow && nextSnapshot.contextWindow > 0) {
           setContextWindowTokens(nextSnapshot.contextWindow);
         }
         setRefreshing(false);
+        return nextSnapshot;
       }
+      return null;
     }).catch((err) => {
-      setRefreshing(false);
+      if (
+        requestSeq === requestSeqRef.current
+        && requestSessionId === activeSessionIdRef.current
+      ) {
+        setRefreshing(false);
+      }
       console.warn('[SessionChat] Failed to fetch context usage:', err);
+      return null;
     }).finally(() => {
       if (requestRef.current?.promise === request) {
         requestRef.current = null;

--- a/webui/src/hooks/useSessionChat.test.ts
+++ b/webui/src/hooks/useSessionChat.test.ts
@@ -194,7 +194,11 @@ describe('useSessionChat.createAndSend — image forwarding', () => {
       id: messageId,
       sessionID: SESSION_ID,
       agent: 'rex',
-      parts: [expect.objectContaining({ type: 'text', text: 'visible prompt' })],
+      parts: [expect.objectContaining({
+        type: 'text',
+        text: 'internal prompt',
+        metadata: { displayText: 'visible prompt' },
+      })],
     });
 
     act(() => {

--- a/webui/src/hooks/useSessionChat.ts
+++ b/webui/src/hooks/useSessionChat.ts
@@ -169,13 +169,13 @@ export function useSessionChat({
       await client.post(`/api/session/${sid}/prompt_async`, payload);
 
       if (!resumedExistingSession) {
-        const visibleText = displayText || text;
         const optimisticParts: Message['parts'] = [];
-        if (visibleText) {
+        if (text || displayText) {
           optimisticParts.push({
             id: `temp-${messageId}-text`,
             type: 'text',
-            text: visibleText,
+            text,
+            ...(displayText ? { metadata: { displayText } } : {}),
           });
         }
         imageParts?.forEach((image, index) => {
@@ -193,7 +193,7 @@ export function useSessionChat({
           role: 'user',
           parts: optimisticParts.length > 0
             ? optimisticParts
-            : [{ id: `temp-${messageId}-part`, type: 'text', text: visibleText }],
+            : [{ id: `temp-${messageId}-part`, type: 'text', text }],
           timestamp: Date.now(),
           agent,
         });

--- a/webui/src/locales/en-US/session.json
+++ b/webui/src/locales/en-US/session.json
@@ -183,7 +183,6 @@
       "close": "Close",
       "full": "{{percent}}% Full",
       "tokens": "~{{used}} / {{total}} Tokens",
-      "excludedTokens": "{{tokens}} excluded",
       "noAttributedSegments": "No attributed breakdown",
       "breakdown": {
         "systemPrompt": "System prompt",

--- a/webui/src/locales/zh-CN/session.json
+++ b/webui/src/locales/zh-CN/session.json
@@ -183,7 +183,6 @@
       "close": "关闭",
       "full": "{{percent}}% 已用",
       "tokens": "~{{used}} / {{total}} Tokens",
-      "excludedTokens": "已排除 {{tokens}}",
       "noAttributedSegments": "暂无可归因明细",
       "breakdown": {
         "systemPrompt": "系统提示词",

--- a/webui/src/pages/Session/index.test.tsx
+++ b/webui/src/pages/Session/index.test.tsx
@@ -185,7 +185,11 @@ vi.mock('@/components/common/SessionChat', () => ({
     initialOptimisticMessage?: {
       id: string;
       sessionID: string;
-      parts: Array<{ type: string; text?: string }>;
+      parts: Array<{
+        type: string;
+        text?: string;
+        metadata?: { displayText?: string };
+      }>;
     } | null;
     focusMessageId?: string | null;
     model?: { providerID: string; modelID: string } | null;
@@ -230,6 +234,7 @@ vi.mock('@/components/common/SessionChat', () => ({
         data-initial-display={initialDisplayText ?? ''}
         data-optimistic-id={initialOptimisticMessage?.id ?? ''}
         data-optimistic-text={initialOptimisticMessage?.parts.find((part) => part.type === 'text')?.text ?? ''}
+        data-optimistic-display={initialOptimisticMessage?.parts.find((part) => part.type === 'text')?.metadata?.displayText ?? ''}
         data-focus-message={focusMessageId ?? ''}
       >
         {sessionId ?? 'no-session'}
@@ -2024,6 +2029,16 @@ describe('SessionPage session actions menu', () => {
             }),
           ]),
         }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('session-chat')).toHaveAttribute(
+        'data-optimistic-text',
+        'welcome.alertOperationsSuggestion',
+      );
+      expect(screen.getByTestId('session-chat')).toHaveAttribute(
+        'data-optimistic-display',
+        '@@flocks-instruction:welcome.alertOperations',
       );
     });
     expect(screen.getByTestId('mock-chat-input')).toHaveTextContent('');

--- a/webui/src/pages/Session/index.tsx
+++ b/webui/src/pages/Session/index.tsx
@@ -1618,14 +1618,14 @@ export default function SessionPage() {
       });
       const newSessionId = response.data.id;
       const messageId = createMessageId();
-      const visibleText = options?.displayText || text;
       const effectiveAgent = agentOverride || selectedAgent || 'rex';
       const optimisticParts: Message['parts'] = [];
-      if (visibleText) {
+      if (text || options?.displayText) {
         optimisticParts.push({
           id: `temp-${messageId}-text`,
           type: 'text',
-          text: visibleText,
+          text,
+          ...(options?.displayText ? { metadata: { displayText: options.displayText } } : {}),
         });
       }
       imageParts?.forEach((image, index) => {
@@ -1674,7 +1674,7 @@ export default function SessionPage() {
         role: 'user',
         parts: optimisticParts.length > 0
           ? optimisticParts
-          : [{ id: `temp-${messageId}-part`, type: 'text', text: visibleText }],
+          : [{ id: `temp-${messageId}-part`, type: 'text', text }],
         timestamp: Date.now(),
         agent: effectiveAgent,
       });


### PR DESCRIPTION
Start the meter from user-visible conversation content and keep optimistic usage stable across refreshes and session switches.

Exclude and hide system prompt and tool definition costs, and prevent provider attribution drift from inflating conversation tokens.