### PR TITLE
fix(release): gate Gitee release on matching tag SHA

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,31 @@ jobs:
           echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
           echo "release_tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
+      - name: Set up QEMU (attempt 1)
+        id: qemu_attempt_1
+        continue-on-error: true
+        uses: docker/setup-qemu-action@v3
+
+      - name: Wait before QEMU retry 2
+        if: steps.qemu_attempt_1.outcome == 'failure'
+        run: sleep 10
+
+      - name: Set up QEMU (attempt 2)
+        id: qemu_attempt_2
+        if: steps.qemu_attempt_1.outcome == 'failure'
+        continue-on-error: true
+        uses: docker/setup-qemu-action@v3
+
+      - name: Wait before QEMU retry 3
+        if: >-
+          steps.qemu_attempt_1.outcome == 'failure' &&
+          steps.qemu_attempt_2.outcome == 'failure'
+        run: sleep 30
+
+      - name: Set up QEMU (attempt 3)
+        if: >-
+          steps.qemu_attempt_1.outcome == 'failure' &&
+          steps.qemu_attempt_2.outcome == 'failure'
         uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker Buildx

--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -4,17 +4,238 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-gitee-release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  GITEE_OWNER: flocks
+  GITEE_REPO: flocks
+  GITEE_GIT_URL: https://gitee.com/flocks/flocks.git
+  GITEE_API_BASE_URL: https://gitee.com/api/v5
+
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Sync GitHub Release to Gitee
-        uses: trustedinster/sync-release-gitee@v1.3
+      - name: Check out the published GitHub tag
+        uses: actions/checkout@v6
         with:
-          gitee_owner: flocks
-          gitee_repo: flocks
-          gitee_token: ${{ secrets.GITEE_TOKEN }}
-          github_owner: AgentFlocks
-          github_repo: flocks
-          gitee_upload_retry_times: 3
-          debug: false
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Resolve the exact GitHub tag commit
+        id: source
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${TAG_NAME}" ]]; then
+            echo "::error title=Missing release tag::The release event does not contain a tag name."
+            exit 1
+          fi
+
+          git show-ref --verify --quiet "refs/tags/${TAG_NAME}" || {
+            echo "::error title=GitHub tag not found::refs/tags/${TAG_NAME} is missing after checkout."
+            exit 1
+          }
+
+          github_tag_sha="$(git rev-parse "${TAG_NAME}^{commit}")"
+          echo "tag_name=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "github_tag_sha=${github_tag_sha}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved GitHub ${TAG_NAME} to ${github_tag_sha}."
+
+      - name: Sync the exact GitHub tag to Gitee
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          TAG_NAME: ${{ steps.source.outputs.tag_name }}
+          EXPECTED_SHA: ${{ steps.source.outputs.github_tag_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GITEE_TOKEN}" ]]; then
+            echo "::error title=Missing Gitee token::Repository secret GITEE_TOKEN is not configured."
+            exit 1
+          fi
+
+          remote_ref="refs/tags/${TAG_NAME}"
+          gitee_tag_sha="$(
+            git ls-remote --tags "${GITEE_GIT_URL}" "${remote_ref}" "${remote_ref}^{}" |
+              awk -v direct="${remote_ref}" -v peeled="${remote_ref}^{}" '
+                $2 == direct { direct_sha = $1 }
+                $2 == peeled { peeled_sha = $1 }
+                END {
+                  if (peeled_sha != "") {
+                    print peeled_sha
+                  } else {
+                    print direct_sha
+                  }
+                }
+              '
+          )"
+
+          if [[ -n "${gitee_tag_sha}" && "${gitee_tag_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error title=Gitee tag conflict::${TAG_NAME} points to ${gitee_tag_sha}, expected ${EXPECTED_SHA}. The workflow will not move an existing release tag."
+            exit 1
+          fi
+
+          if [[ "${gitee_tag_sha}" == "${EXPECTED_SHA}" ]]; then
+            echo "Gitee ${TAG_NAME} already points to ${EXPECTED_SHA}; no push is needed."
+            exit 0
+          fi
+
+          gitee_user="$(
+            curl --fail-with-body --silent --show-error --retry 3 \
+              --get \
+              --data-urlencode "access_token=${GITEE_TOKEN}" \
+              "${GITEE_API_BASE_URL}/user" |
+              jq -er '.login'
+          )"
+
+          askpass_script="${RUNNER_TEMP}/gitee-askpass-${GITHUB_RUN_ID}.sh"
+          trap 'rm -f "${askpass_script}"' EXIT
+          {
+            echo '#!/bin/sh'
+            echo 'case "$1" in'
+            echo '  *Username*) printf "%s\n" "$GITEE_USERNAME" ;;'
+            echo '  *Password*) printf "%s\n" "$GITEE_TOKEN" ;;'
+            echo 'esac'
+          } > "${askpass_script}"
+          chmod 700 "${askpass_script}"
+
+          export GIT_ASKPASS="${askpass_script}"
+          export GIT_TERMINAL_PROMPT=0
+          export GITEE_USERNAME="${gitee_user}"
+
+          git push "${GITEE_GIT_URL}" "${remote_ref}:${remote_ref}"
+          echo "Pushed ${TAG_NAME} to Gitee from the exact GitHub tag object."
+
+      - name: Gate Gitee Release creation on matching tag SHA
+        env:
+          TAG_NAME: ${{ steps.source.outputs.tag_name }}
+          EXPECTED_SHA: ${{ steps.source.outputs.github_tag_sha }}
+        run: |
+          set -euo pipefail
+
+          remote_ref="refs/tags/${TAG_NAME}"
+          gitee_tag_sha=""
+
+          for attempt in {1..12}; do
+            gitee_tag_sha="$(
+              git ls-remote --tags "${GITEE_GIT_URL}" "${remote_ref}" "${remote_ref}^{}" |
+                awk -v direct="${remote_ref}" -v peeled="${remote_ref}^{}" '
+                  $2 == direct { direct_sha = $1 }
+                  $2 == peeled { peeled_sha = $1 }
+                  END {
+                    if (peeled_sha != "") {
+                      print peeled_sha
+                    } else {
+                      print direct_sha
+                    }
+                  }
+                '
+            )"
+
+            if [[ "${gitee_tag_sha}" == "${EXPECTED_SHA}" ]]; then
+              echo "SHA gate passed: GitHub and Gitee ${TAG_NAME} both point to ${EXPECTED_SHA}."
+              break
+            fi
+
+            if [[ -n "${gitee_tag_sha}" ]]; then
+              echo "::error title=Gitee SHA gate failed::${TAG_NAME} points to ${gitee_tag_sha}, expected ${EXPECTED_SHA}."
+              exit 1
+            fi
+
+            echo "Gitee ${TAG_NAME} is not visible yet (attempt ${attempt}/12); retrying."
+            sleep 5
+          done
+
+          if [[ "${gitee_tag_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error title=Gitee SHA gate timed out::${TAG_NAME} did not become visible at ${EXPECTED_SHA}."
+            exit 1
+          fi
+
+      - name: Create or update only the current Gitee Release
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          TAG_NAME: ${{ steps.source.outputs.tag_name }}
+          VERIFIED_SHA: ${{ steps.source.outputs.github_tag_sha }}
+        run: |
+          set -euo pipefail
+
+          release_name="$(jq -r '.release.name // empty' "${GITHUB_EVENT_PATH}")"
+          release_body="$(jq -r '.release.body // empty' "${GITHUB_EVENT_PATH}")"
+          prerelease="$(jq -r '.release.prerelease // false' "${GITHUB_EVENT_PATH}")"
+          [[ -n "${release_name}" ]] || release_name="${TAG_NAME}"
+          [[ -n "${release_body}" ]] || release_body="-"
+
+          encoded_tag="$(jq -rn --arg value "${TAG_NAME}" '$value | @uri')"
+          release_lookup="${RUNNER_TEMP}/gitee-release-lookup.json"
+          release_response="${RUNNER_TEMP}/gitee-release-response.json"
+          lookup_status="$(
+            curl --silent --show-error --retry 3 \
+              --output "${release_lookup}" \
+              --write-out '%{http_code}' \
+              --get \
+              --data-urlencode "access_token=${GITEE_TOKEN}" \
+              "${GITEE_API_BASE_URL}/repos/${GITEE_OWNER}/${GITEE_REPO}/releases/tags/${encoded_tag}"
+          )"
+
+          common_fields=(
+            --data-urlencode "access_token=${GITEE_TOKEN}"
+            --data-urlencode "tag_name=${TAG_NAME}"
+            --data-urlencode "name=${release_name}"
+            --data-urlencode "body=${release_body}"
+            --data-urlencode "prerelease=${prerelease}"
+          )
+
+          if [[ "${lookup_status}" == "200" ]]; then
+            release_id="$(jq -er '.id' "${release_lookup}")"
+            sync_method="PATCH"
+            sync_url="${GITEE_API_BASE_URL}/repos/${GITEE_OWNER}/${GITEE_REPO}/releases/${release_id}"
+            echo "Gitee Release ${TAG_NAME} already exists; updating its metadata only."
+          elif [[ "${lookup_status}" == "404" ]]; then
+            sync_method="POST"
+            sync_url="${GITEE_API_BASE_URL}/repos/${GITEE_OWNER}/${GITEE_REPO}/releases"
+            common_fields+=(--data-urlencode "target_commitish=${VERIFIED_SHA}")
+            echo "Creating Gitee Release ${TAG_NAME} at verified commit ${VERIFIED_SHA}."
+          else
+            message="$(jq -r '.message // "unknown Gitee API error"' "${release_lookup}" 2>/dev/null || true)"
+            echo "::error title=Gitee Release lookup failed::HTTP ${lookup_status}: ${message}"
+            exit 1
+          fi
+
+          sync_status="$(
+            curl --silent --show-error --retry 3 \
+              --output "${release_response}" \
+              --write-out '%{http_code}' \
+              --request "${sync_method}" \
+              "${common_fields[@]}" \
+              "${sync_url}"
+          )"
+
+          if [[ ! "${sync_status}" =~ ^2[0-9][0-9]$ ]]; then
+            message="$(jq -r '.message // "unknown Gitee API error"' "${release_response}" 2>/dev/null || true)"
+            echo "::error title=Gitee Release sync failed::HTTP ${sync_status}: ${message}"
+            exit 1
+          fi
+
+          synced_tag="$(jq -er '.tag_name' "${release_response}")"
+          synced_release_id="$(jq -er '.id' "${release_response}")"
+          if [[ "${synced_tag}" != "${TAG_NAME}" ]]; then
+            echo "::error title=Unexpected Gitee Release tag::Gitee returned ${synced_tag}, expected ${TAG_NAME}."
+            exit 1
+          fi
+
+          {
+            echo "### Gitee Release sync"
+            echo
+            echo "- Tag: \`${TAG_NAME}\`"
+            echo "- Verified commit: \`${VERIFIED_SHA}\`"
+            echo "- Gitee Release ID: \`${synced_release_id}\`"
+            echo "- Result: tag SHA gate passed before Release ${sync_method}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -1,14 +1,22 @@
 name: Sync GitHub Release to Gitee
 
+run-name: Sync ${{ github.event.release.tag_name || inputs.release_tag }} to Gitee
+
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: GitHub Release tag to retry, for example v2026.8.4
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: sync-gitee-release-${{ github.event.release.tag_name }}
+  group: sync-gitee-release-${{ github.event.release.tag_name || inputs.release_tag }}
   cancel-in-progress: false
 
 env:
@@ -24,18 +32,18 @@ jobs:
       - name: Check out the published GitHub tag
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
           fetch-depth: 0
 
       - name: Resolve the exact GitHub tag commit
         id: source
         env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           set -euo pipefail
 
           if [[ -z "${TAG_NAME}" ]]; then
-            echo "::error title=Missing release tag::The release event does not contain a tag name."
+            echo "::error title=Missing release tag::No tag name was provided by the release event or manual input."
             exit 1
           fi
 
@@ -48,6 +56,39 @@ jobs:
           echo "tag_name=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
           echo "github_tag_sha=${github_tag_sha}" >> "${GITHUB_OUTPUT}"
           echo "Resolved GitHub ${TAG_NAME} to ${github_tag_sha}."
+
+      - name: Resolve the published GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.source.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+
+          encoded_tag="$(jq -rn --arg value "${TAG_NAME}" '$value | @uri')"
+          release_metadata="${RUNNER_TEMP}/github-release.json"
+
+          gh api \
+            --method GET \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}" \
+            > "${release_metadata}"
+
+          resolved_tag="$(jq -er '.tag_name' "${release_metadata}")"
+          is_draft="$(jq -er '.draft' "${release_metadata}")"
+          published_at="$(jq -r '.published_at // empty' "${release_metadata}")"
+
+          if [[ "${resolved_tag}" != "${TAG_NAME}" ]]; then
+            echo "::error title=Unexpected GitHub Release tag::GitHub returned ${resolved_tag}, expected ${TAG_NAME}."
+            exit 1
+          fi
+
+          if [[ "${is_draft}" == "true" || -z "${published_at}" ]]; then
+            echo "::error title=GitHub Release is not published::${TAG_NAME} must be published before it can be synchronized to Gitee."
+            exit 1
+          fi
+
+          echo "Resolved published GitHub Release ${TAG_NAME}."
 
       - name: Sync the exact GitHub tag to Gitee
         env:
@@ -167,9 +208,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          release_name="$(jq -r '.release.name // empty' "${GITHUB_EVENT_PATH}")"
-          release_body="$(jq -r '.release.body // empty' "${GITHUB_EVENT_PATH}")"
-          prerelease="$(jq -r '.release.prerelease // false' "${GITHUB_EVENT_PATH}")"
+          release_metadata="${RUNNER_TEMP}/github-release.json"
+          release_name="$(jq -r '.name // empty' "${release_metadata}")"
+          release_body="$(jq -r '.body // empty' "${release_metadata}")"
+          prerelease="$(jq -r '.prerelease // false' "${release_metadata}")"
           [[ -n "${release_name}" ]] || release_name="${TAG_NAME}"
           [[ -n "${release_body}" ]] || release_body="-"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flocks"
-version = "v2026.8.4"
+version = "v2026.8.12"
 description = "AI-Native SecOps platform with multi-agent collaboration"
 authors = [
     {name = "Flocks Team", email = "team@example.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -553,7 +553,7 @@ wheels = [
 
 [[package]]
 name = "flocks"
-version = "2026.8.4"
+version = "2026.8.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- resolve the exact commit behind the published GitHub release tag
- create the same tag on Gitee by pushing the exact Git tag object
- fail safely when an existing Gitee tag points to a different commit
- verify GitHub and Gitee tag SHAs match before creating or updating the Gitee Release
- process only the current release instead of scanning historical releases and attachments

## Root cause

The previous third-party release sync created the Gitee Release before repository source synchronization had completed. Because it forwarded `target_commitish=main`, Gitee could create the new version tag from a stale `main`, causing the new tag archive to contain old source code.

## Impact

China-region upgrades that consume Gitee tag archives are now protected by an explicit SHA gate. A Gitee Release cannot be created when its tag is missing or points to a different commit, and existing release tags are never force-moved.

## Validation

- `actionlint .github/workflows/sync-gitee.yml`
- YAML parsing
- Bash syntax validation for every workflow `run` block
- `git diff --check`

## Notes

- the existing `GITEE_TOKEN` secret must have both Release API access and repository tag push permission
- this workflow no longer copies custom GitHub Release attachments; Gitee tag-derived source archives remain available
