### PR TITLE
fix(workflow): prevent isolated RPC memory growth

### DIFF
--- a/flocks/workflow/engine.py
+++ b/flocks/workflow/engine.py
@@ -195,6 +195,8 @@ class WorkflowEngine:
                 cancel_checker=self.runtime.cancel_checker,
                 cleanup_globals_after_execute=self.runtime.cleanup_globals_after_execute,
                 enable_cancel_trace=self.runtime.enable_cancel_trace,
+                isolated_rpc_max_bytes=self.runtime.isolated_rpc_max_bytes,
+                isolated_rpc_max_workers=self.runtime.isolated_rpc_max_workers,
             )
         return self.runtime
 
@@ -854,6 +856,8 @@ class WorkflowEngine:
                     cancel_checker=_rt.cancel_checker,
                     inherited_fd_keys=tuple(node.process_inherit_fd_keys),
                     retained_fd_keys=tuple(node.process_retain_fd_keys),
+                    rpc_max_bytes=_rt.isolated_rpc_max_bytes,
+                    rpc_max_workers=_rt.isolated_rpc_max_workers,
                 )
             return _rt.execute(node.code, inputs)
         if node.type == "logic":
@@ -875,6 +879,8 @@ class WorkflowEngine:
                     cancel_checker=_rt.cancel_checker,
                     inherited_fd_keys=tuple(node.process_inherit_fd_keys),
                     retained_fd_keys=tuple(node.process_retain_fd_keys),
+                    rpc_max_bytes=_rt.isolated_rpc_max_bytes,
+                    rpc_max_workers=_rt.isolated_rpc_max_workers,
                 )
             return _rt.execute(code, inputs)
         if node.type in {"branch", "loop"}:

--- a/flocks/workflow/engine.py
+++ b/flocks/workflow/engine.py
@@ -196,6 +196,8 @@ class WorkflowEngine:
                 cleanup_globals_after_execute=self.runtime.cleanup_globals_after_execute,
                 enable_cancel_trace=self.runtime.enable_cancel_trace,
                 isolated_rpc_max_bytes=self.runtime.isolated_rpc_max_bytes,
+                isolated_rpc_max_inflight_bytes=self.runtime.isolated_rpc_max_inflight_bytes,
+                isolated_rpc_max_response_bytes=self.runtime.isolated_rpc_max_response_bytes,
                 isolated_rpc_max_workers=self.runtime.isolated_rpc_max_workers,
             )
         return self.runtime
@@ -857,6 +859,8 @@ class WorkflowEngine:
                     inherited_fd_keys=tuple(node.process_inherit_fd_keys),
                     retained_fd_keys=tuple(node.process_retain_fd_keys),
                     rpc_max_bytes=_rt.isolated_rpc_max_bytes,
+                    rpc_max_inflight_bytes=_rt.isolated_rpc_max_inflight_bytes,
+                    rpc_max_response_bytes=_rt.isolated_rpc_max_response_bytes,
                     rpc_max_workers=_rt.isolated_rpc_max_workers,
                 )
             return _rt.execute(node.code, inputs)
@@ -880,6 +884,8 @@ class WorkflowEngine:
                     inherited_fd_keys=tuple(node.process_inherit_fd_keys),
                     retained_fd_keys=tuple(node.process_retain_fd_keys),
                     rpc_max_bytes=_rt.isolated_rpc_max_bytes,
+                    rpc_max_inflight_bytes=_rt.isolated_rpc_max_inflight_bytes,
+                    rpc_max_response_bytes=_rt.isolated_rpc_max_response_bytes,
                     rpc_max_workers=_rt.isolated_rpc_max_workers,
                 )
             return _rt.execute(code, inputs)

--- a/flocks/workflow/repl_runtime.py
+++ b/flocks/workflow/repl_runtime.py
@@ -15,6 +15,7 @@ import tempfile
 import threading
 import traceback
 import uuid
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
 from concurrent.futures import TimeoutError as _FuturesTimeoutError
 from dataclasses import dataclass, field
@@ -35,20 +36,140 @@ class Runtime:
 
 _RPC_MAX_BYTES = 4 * 1024 * 1024
 _HOST_PROCESS_RPC_MAX_BYTES = 64 * 1024 * 1024
+_HOST_PROCESS_RPC_MAX_INFLIGHT_BYTES = 64 * 1024 * 1024
+_HOST_PROCESS_RPC_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 _HOST_PROCESS_RPC_MAX_WORKERS = 32
+_HOST_PROCESS_RPC_MIN_FRAME_BYTES = 512
+_HOST_PROCESS_RPC_QUEUE_SIZE = 4
+_HOST_PROCESS_STDERR_MAX_BYTES = 1024 * 1024
 _WORKFLOW_SITE_PACKAGES = "/workspace/.flocks/workflow/site-packages"
 _TOOL_CANCEL_CHECKER_INSTALL_LOCK = threading.Lock()
 
 
-def _drain_text_stream(stream: TextIO, chunks: list[str]) -> None:
+class _RPCFrameTooLarge(ValueError):
+    pass
+
+
+class _InflightByteBudget:
+    def __init__(self, limit: Optional[int]):
+        self._limit = limit
+        self._used = 0
+        self._condition = threading.Condition()
+
+    def acquire(self, size: int, stop: threading.Event) -> bool:
+        if self._limit is None:
+            return True
+        if size > self._limit:
+            return False
+        with self._condition:
+            while self._used + size > self._limit:
+                if stop.is_set():
+                    return False
+                self._condition.wait(timeout=0.05)
+            self._used += size
+            return True
+
+    def release(self, size: int) -> None:
+        if self._limit is None:
+            return
+        with self._condition:
+            self._used = max(0, self._used - size)
+            self._condition.notify_all()
+
+    def wake(self) -> None:
+        with self._condition:
+            self._condition.notify_all()
+
+
+def _utf8_size_exceeds(text: str, limit: int) -> bool:
+    if len(text) > limit:
+        return True
+    if text.isascii():
+        return False
+    size = 0
+    for char in text:
+        codepoint = ord(char)
+        size += 1 if codepoint < 0x80 else 2 if codepoint < 0x800 else 3 if codepoint < 0x10000 else 4
+        if size > limit:
+            return True
+    return False
+
+
+def _contains_oversized_scalar(value: Any, limit: int, seen: Optional[set[int]] = None) -> bool:
+    if isinstance(value, str):
+        return _utf8_size_exceeds(value, limit)
+    if isinstance(value, (bytes, bytearray)):
+        return len(value) > limit
+    if isinstance(value, dict):
+        seen = seen or set()
+        marker = id(value)
+        if marker in seen:
+            return False
+        seen.add(marker)
+        try:
+            return any(
+                _contains_oversized_scalar(key, limit, seen)
+                or _contains_oversized_scalar(item, limit, seen)
+                for key, item in value.items()
+            )
+        finally:
+            seen.remove(marker)
+    if isinstance(value, (list, tuple)):
+        seen = seen or set()
+        marker = id(value)
+        if marker in seen:
+            return False
+        seen.add(marker)
+        try:
+            return any(_contains_oversized_scalar(item, limit, seen) for item in value)
+        finally:
+            seen.remove(marker)
+    return False
+
+
+def _json_line_with_limit(payload: Dict[str, Any], max_bytes: Optional[int]) -> str:
+    if max_bytes is None:
+        return json.dumps(payload, ensure_ascii=False, default=str) + "\n"
+    if _contains_oversized_scalar(payload, max_bytes):
+        raise _RPCFrameTooLarge(f"RPC message exceeds configured limit ({max_bytes} bytes)")
+    buffer = io.StringIO()
+    size = 1  # trailing newline
+    encoder = json.JSONEncoder(ensure_ascii=False, default=str)
+    for chunk in encoder.iterencode(payload):
+        remaining = max_bytes - size
+        if remaining < 0 or _utf8_size_exceeds(chunk, remaining):
+            raise _RPCFrameTooLarge(f"RPC message exceeds configured limit ({max_bytes} bytes)")
+        buffer.write(chunk)
+        size += len(chunk) if chunk.isascii() else len(chunk.encode("utf-8"))
+    buffer.write("\n")
+    return buffer.getvalue()
+
+
+def _drain_text_stream(
+    stream: TextIO,
+    chunks: list[str],
+    max_bytes: int = _HOST_PROCESS_STDERR_MAX_BYTES,
+) -> None:
+    tail: deque[tuple[str, int]] = deque()
+    retained_bytes = 0
+    truncated = False
     try:
         while True:
-            line = stream.readline()
-            if line == "":
+            chunk = stream.read(8192)
+            if chunk == "":
                 break
-            chunks.append(line)
+            chunk_bytes = len(chunk.encode("utf-8", errors="replace"))
+            tail.append((chunk, chunk_bytes))
+            retained_bytes += chunk_bytes
+            while retained_bytes > max_bytes and tail:
+                _, removed_bytes = tail.popleft()
+                retained_bytes -= removed_bytes
+                truncated = True
     except Exception:
-        return
+        pass
+    if truncated:
+        chunks.append(f"[stderr truncated to last {max_bytes} bytes]\n")
+    chunks.extend(chunk for chunk, _ in tail)
 
 
 class _ThreadScopedCancelChecker:
@@ -104,6 +225,8 @@ class PythonExecRuntime(Runtime):
     cleanup_globals_after_execute: bool = False
     enable_cancel_trace: bool = True
     isolated_rpc_max_bytes: Optional[int] = _HOST_PROCESS_RPC_MAX_BYTES
+    isolated_rpc_max_inflight_bytes: Optional[int] = _HOST_PROCESS_RPC_MAX_INFLIGHT_BYTES
+    isolated_rpc_max_response_bytes: Optional[int] = _HOST_PROCESS_RPC_MAX_RESPONSE_BYTES
     isolated_rpc_max_workers: int = _HOST_PROCESS_RPC_MAX_WORKERS
 
     _RUNTIME_GLOBAL_KEYS: ClassVar[frozenset[str]] = frozenset(
@@ -330,6 +453,7 @@ class SandboxPythonExecRuntime(Runtime):
                 stderr=subprocess.PIPE,
                 text=True,
                 encoding="utf-8",
+                errors="replace",
                 bufsize=1,
                 env={**os.environ, "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
             )
@@ -685,8 +809,14 @@ sys.stdout.flush()
         )
         return f"{shlex.quote(python_executable)} -I -c {shlex.quote(wrapped)}"
 
-    def _write_json_line(self, stream: TextIO, payload: Dict[str, Any]) -> None:
-        stream.write(json.dumps(payload, ensure_ascii=False, default=str) + "\n")
+    def _write_json_line(
+        self,
+        stream: TextIO,
+        payload: Dict[str, Any],
+        *,
+        max_bytes: Optional[int] = None,
+    ) -> None:
+        stream.write(_json_line_with_limit(payload, max_bytes))
         stream.flush()
 
     def _parse_json_line(self, raw_line: str) -> Optional[Dict[str, Any]]:
@@ -808,6 +938,8 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
     inherited_fd_keys: Tuple[str, ...] = ()
     retained_fd_keys: Tuple[str, ...] = ()
     rpc_max_bytes: Optional[int] = _HOST_PROCESS_RPC_MAX_BYTES
+    rpc_max_inflight_bytes: Optional[int] = _HOST_PROCESS_RPC_MAX_INFLIGHT_BYTES
+    rpc_max_response_bytes: Optional[int] = _HOST_PROCESS_RPC_MAX_RESPONSE_BYTES
     rpc_max_workers: int = _HOST_PROCESS_RPC_MAX_WORKERS
 
     def execute(self, code: str, inputs: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
@@ -828,9 +960,55 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
         if rpc_max_bytes is not None:
             if type(rpc_max_bytes) is not int or rpc_max_bytes <= 0:
                 raise NodeExecutionError(node_id="<runtime>", message="rpc_max_bytes must be None or a positive integer")
+        rpc_max_inflight_bytes = self.rpc_max_inflight_bytes
+        if rpc_max_inflight_bytes is not None:
+            if type(rpc_max_inflight_bytes) is not int or rpc_max_inflight_bytes <= 0:
+                raise NodeExecutionError(
+                    node_id="<runtime>",
+                    message="rpc_max_inflight_bytes must be None or a positive integer",
+                )
+            if rpc_max_bytes is not None and rpc_max_bytes > rpc_max_inflight_bytes:
+                raise NodeExecutionError(
+                    node_id="<runtime>",
+                    message="rpc_max_bytes cannot exceed rpc_max_inflight_bytes",
+                )
         rpc_max_workers = self.rpc_max_workers
-        if type(rpc_max_workers) is not int or rpc_max_workers <= 0:
-            raise NodeExecutionError(node_id="<runtime>", message="rpc_max_workers must be a positive integer")
+        if type(rpc_max_workers) is not int or not 1 <= rpc_max_workers <= _HOST_PROCESS_RPC_MAX_WORKERS:
+            raise NodeExecutionError(
+                node_id="<runtime>",
+                message=f"rpc_max_workers must be an integer between 1 and {_HOST_PROCESS_RPC_MAX_WORKERS}",
+            )
+        rpc_frame_limit = rpc_max_bytes if rpc_max_bytes is not None else rpc_max_inflight_bytes
+        if rpc_frame_limit is not None and rpc_frame_limit < _HOST_PROCESS_RPC_MIN_FRAME_BYTES:
+            raise NodeExecutionError(
+                node_id="<runtime>",
+                message=f"effective RPC frame limit must be at least {_HOST_PROCESS_RPC_MIN_FRAME_BYTES} bytes",
+            )
+        rpc_max_response_bytes = self.rpc_max_response_bytes
+        if rpc_max_response_bytes is not None:
+            if type(rpc_max_response_bytes) is not int or rpc_max_response_bytes <= 0:
+                raise NodeExecutionError(
+                    node_id="<runtime>",
+                    message="rpc_max_response_bytes must be None or a positive integer",
+                )
+        response_limits = [limit for limit in (rpc_frame_limit, rpc_max_response_bytes) if limit is not None]
+        rpc_response_limit = min(response_limits) if response_limits else None
+        if rpc_response_limit is not None and rpc_response_limit < _HOST_PROCESS_RPC_MIN_FRAME_BYTES:
+            raise NodeExecutionError(
+                node_id="<runtime>",
+                message=f"effective RPC response limit must be at least {_HOST_PROCESS_RPC_MIN_FRAME_BYTES} bytes",
+            )
+        if rpc_max_inflight_bytes is not None:
+            if rpc_response_limit is None:
+                raise NodeExecutionError(
+                    node_id="<runtime>",
+                    message="RPC responses must have a size limit when rpc_max_inflight_bytes is configured",
+                )
+            if rpc_response_limit * rpc_max_workers > rpc_max_inflight_bytes:
+                raise NodeExecutionError(
+                    node_id="<runtime>",
+                    message="rpc_max_response_bytes and rpc_max_workers exceed rpc_max_inflight_bytes",
+                )
 
         inherited_fds = self._resolve_inherited_fds(inputs)
         retained_fds = self._resolve_retained_fds(inputs)
@@ -888,6 +1066,7 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
                 stderr=subprocess.PIPE,
                 text=True,
                 encoding="utf-8",
+                errors="replace",
                 bufsize=1,
                 env={**os.environ, "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
                 start_new_session=(os.name != "nt"),
@@ -919,9 +1098,13 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
         bridge_closed = threading.Event()
         stdout_reader_stop = threading.Event()
         bridge_errors: list[str] = []
-        stdout_lines: queue.Queue[Optional[str]] = queue.Queue(maxsize=rpc_max_workers)
+        inflight_budget = _InflightByteBudget(rpc_max_inflight_bytes)
+        response_budget = _InflightByteBudget(rpc_max_inflight_bytes)
+        stdout_lines: queue.Queue[Optional[tuple[bytes, int]]] = queue.Queue(
+            maxsize=min(rpc_max_workers, _HOST_PROCESS_RPC_QUEUE_SIZE)
+        )
 
-        def _queue_stdout_line(line: Optional[str]) -> bool:
+        def _queue_stdout_line(line: Optional[tuple[bytes, int]]) -> bool:
             while not stdout_reader_stop.is_set():
                 try:
                     stdout_lines.put(line, timeout=0.05)
@@ -933,19 +1116,22 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
         def _read_stdout() -> None:
             try:
                 while True:
-                    if rpc_max_bytes is None:
+                    if rpc_frame_limit is None:
                         raw_line = proc.stdout.buffer.readline()
                     else:
-                        raw_line = proc.stdout.buffer.readline(rpc_max_bytes + 1)
+                        raw_line = proc.stdout.buffer.readline(rpc_frame_limit + 1)
                     if raw_line == b"":
                         break
-                    if rpc_max_bytes is not None and len(raw_line) > rpc_max_bytes:
+                    frame_bytes = len(raw_line)
+                    if rpc_frame_limit is not None and frame_bytes > rpc_frame_limit:
                         bridge_errors.append(
-                            f"Isolated host RPC message exceeds configured limit ({rpc_max_bytes} bytes)"
+                            f"Isolated host RPC message exceeds configured limit ({rpc_frame_limit} bytes)"
                         )
                         break
-                    line = raw_line.decode(proc.stdout.encoding or "utf-8")
-                    if not _queue_stdout_line(line):
+                    if not inflight_budget.acquire(frame_bytes, stdout_reader_stop):
+                        return
+                    if not _queue_stdout_line((raw_line, frame_bytes)):
+                        inflight_budget.release(frame_bytes)
                         return
             except Exception as exc:
                 bridge_errors.append(f"Isolated host RPC bridge read failed: {exc}")
@@ -972,72 +1158,122 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
         def _rpc_cancel_requested() -> bool:
             return bridge_closed.is_set() or self._cancel_requested()
 
-        def _handle_rpc(message: Dict[str, Any]) -> None:
+        def _handle_rpc(message: Dict[str, Any], request_bytes: int) -> None:
+            response_reservation = rpc_response_limit or 0
+            response_reserved = False
             try:
+                if not response_budget.acquire(response_reservation, bridge_closed):
+                    return
+                response_reserved = True
                 response = self._handle_rpc_request(
                     msg=message,
                     token=token,
                     cancel_checker=_rpc_cancel_requested,
                 )
+                response_error: Optional[str] = None
+                try:
+                    response_line = _json_line_with_limit(response, rpc_response_limit)
+                except _RPCFrameTooLarge:
+                    response_error = "RPC response exceeds configured limit"
+                except Exception as exc:
+                    response_error = f"RPC response serialization failed ({type(exc).__name__})"
+                finally:
+                    response = None
+                if response_error is not None:
+                    try:
+                        response_line = _json_line_with_limit(
+                            {
+                                "type": "rpc_result",
+                                "token": token,
+                                "id": str(message.get("id") or ""),
+                                "ok": False,
+                                "error": response_error,
+                            },
+                            rpc_response_limit,
+                        )
+                    except ValueError:
+                        return
                 try:
                     with stdin_lock:
                         if not bridge_closed.is_set() and proc.poll() is None:
-                            self._write_json_line(proc.stdin, response)
+                            proc.stdin.write(response_line)
+                            proc.stdin.flush()
                 except (BrokenPipeError, OSError, ValueError):
                     return
             finally:
+                if response_reserved:
+                    response_budget.release(response_reservation)
+                inflight_budget.release(request_bytes)
                 rpc_slots.release()
 
         try:
-            self._write_json_line(proc.stdin, {"type": "init", "token": token, "inputs": child_inputs})
+            try:
+                self._write_json_line(
+                    proc.stdin,
+                    {"type": "init", "token": token, "inputs": child_inputs},
+                    max_bytes=rpc_frame_limit,
+                )
+            except _RPCFrameTooLarge as exc:
+                bridge_errors.append(str(exc))
+                self._terminate_process(proc)
             while True:
                 if self._cancel_requested():
                     cancelled = True
                     self._terminate_process(proc)
                     break
                 try:
-                    line = stdout_lines.get(timeout=0.05)
+                    item = stdout_lines.get(timeout=0.05)
                 except queue.Empty:
                     continue
-                if line is None:
+                if item is None:
                     break
-                msg = self._parse_json_line(line)
-                if msg is None:
-                    continue
-                msg_type = str(msg.get("type") or "").strip().lower()
-                if msg_type == "rpc":
-                    slot_acquired = False
-                    while not slot_acquired:
-                        slot_acquired = rpc_slots.acquire(timeout=0.05)
-                        if slot_acquired:
+                raw_line, frame_bytes = item
+                release_frame = True
+                try:
+                    line = raw_line.decode(proc.stdout.encoding or "utf-8")
+                    msg = self._parse_json_line(line)
+                    if msg is None:
+                        continue
+                    msg_type = str(msg.get("type") or "").strip().lower()
+                    if msg_type == "rpc":
+                        slot_acquired = False
+                        while not slot_acquired:
+                            slot_acquired = rpc_slots.acquire(timeout=0.05)
+                            if slot_acquired:
+                                break
+                            if self._cancel_requested():
+                                cancelled = True
+                                self._terminate_process(proc)
+                                break
+                            if proc.poll() is not None:
+                                bridge_closed.set()
+                                break
+                            if bridge_closed.is_set():
+                                break
+                        if cancelled:
                             break
-                        if self._cancel_requested():
-                            cancelled = True
-                            self._terminate_process(proc)
-                            break
-                        if proc.poll() is not None:
-                            bridge_closed.set()
-                            break
+                        if not slot_acquired:
+                            continue
                         if bridge_closed.is_set():
-                            break
-                    if cancelled:
-                        break
-                    if not slot_acquired:
-                        continue
-                    if bridge_closed.is_set():
-                        rpc_slots.release()
-                        continue
-                    try:
-                        rpc_pool.submit(_handle_rpc, msg)
-                    except Exception:
-                        rpc_slots.release()
-                        raise
-                elif msg_type == "final" and msg.get("token") == token:
-                    payload = msg.get("payload")
-                    final_payload = payload if isinstance(payload, dict) else {}
+                            rpc_slots.release()
+                            continue
+                        try:
+                            rpc_pool.submit(_handle_rpc, msg, frame_bytes)
+                            release_frame = False
+                        except Exception:
+                            rpc_slots.release()
+                            raise
+                    elif msg_type == "final" and msg.get("token") == token:
+                        payload = msg.get("payload")
+                        final_payload = payload if isinstance(payload, dict) else {}
+                finally:
+                    if release_frame:
+                        inflight_budget.release(frame_bytes)
         finally:
             bridge_closed.set()
             stdout_reader_stop.set()
+            inflight_budget.wake()
+            response_budget.wake()
             rpc_pool.shutdown(
                 wait=final_payload is not None and not cancelled,
                 cancel_futures=True,

--- a/flocks/workflow/repl_runtime.py
+++ b/flocks/workflow/repl_runtime.py
@@ -34,7 +34,10 @@ class Runtime:
 
 
 _RPC_MAX_BYTES = 4 * 1024 * 1024
+_HOST_PROCESS_RPC_MAX_BYTES = 64 * 1024 * 1024
+_HOST_PROCESS_RPC_MAX_WORKERS = 32
 _WORKFLOW_SITE_PACKAGES = "/workspace/.flocks/workflow/site-packages"
+_TOOL_CANCEL_CHECKER_INSTALL_LOCK = threading.Lock()
 
 
 def _drain_text_stream(stream: TextIO, chunks: list[str]) -> None:
@@ -46,6 +49,45 @@ def _drain_text_stream(stream: TextIO, chunks: list[str]) -> None:
             chunks.append(line)
     except Exception:
         return
+
+
+class _ThreadScopedCancelChecker:
+    def __init__(self, fallback: Optional[Callable[[], bool]]):
+        self._fallback = fallback
+        self._local = threading.local()
+
+    def __call__(self) -> bool:
+        stack = getattr(self._local, "stack", None)
+        checker = stack[-1] if stack else self._fallback
+        return bool(checker and checker())
+
+    @contextlib.contextmanager
+    def scope(self, checker: Optional[Callable[[], bool]]):
+        stack = getattr(self._local, "stack", None)
+        if stack is None:
+            stack = []
+            self._local.stack = stack
+        stack.append(checker)
+        try:
+            yield
+        finally:
+            stack.pop()
+            if not stack:
+                del self._local.stack
+
+
+def _legacy_registry_cancel_scope(registry: Any, checker: Optional[Callable[[], bool]]):
+    if not hasattr(registry, "cancel_checker"):
+        return contextlib.nullcontext()
+    try:
+        with _TOOL_CANCEL_CHECKER_INSTALL_LOCK:
+            scoped_checker = getattr(registry, "cancel_checker", None)
+            if not isinstance(scoped_checker, _ThreadScopedCancelChecker):
+                scoped_checker = _ThreadScopedCancelChecker(scoped_checker)
+                registry.cancel_checker = scoped_checker
+        return scoped_checker.scope(checker)
+    except Exception:
+        return contextlib.nullcontext()
 
 
 @dataclass
@@ -61,6 +103,8 @@ class PythonExecRuntime(Runtime):
     cancel_checker: Optional[Callable[[], bool]] = None
     cleanup_globals_after_execute: bool = False
     enable_cancel_trace: bool = True
+    isolated_rpc_max_bytes: Optional[int] = _HOST_PROCESS_RPC_MAX_BYTES
+    isolated_rpc_max_workers: int = _HOST_PROCESS_RPC_MAX_WORKERS
 
     _RUNTIME_GLOBAL_KEYS: ClassVar[frozenset[str]] = frozenset(
         {
@@ -285,6 +329,7 @@ class SandboxPythonExecRuntime(Runtime):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
                 bufsize=1,
                 env={**os.environ, "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
             )
@@ -398,16 +443,38 @@ import sys
 import threading
 import traceback
 
+for _stream in (sys.stdin, sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, OSError):
+        pass
+
 outputs = {{}}
 _MAX = {rpc_max_bytes!r}
 _TOKEN = {json.dumps(bridge_token, ensure_ascii=False)}
+_stdin_pending = bytearray()
 
 def _read_json_line():
-    line = sys.stdin.readline()
-    if not line:
-        raise RuntimeError("Bridge channel closed")
-    if _MAX is not None and len(line) > _MAX:
-        raise RuntimeError("Bridge payload too large")
+    if _MAX is None:
+        line = sys.stdin.readline()
+        if not line:
+            raise RuntimeError("Bridge channel closed")
+    else:
+        while True:
+            newline = _stdin_pending.find(b"\\n")
+            if newline >= 0:
+                if newline + 1 > _MAX:
+                    raise RuntimeError("Bridge payload too large")
+                raw_line = bytes(_stdin_pending[: newline + 1])
+                del _stdin_pending[: newline + 1]
+                break
+            if len(_stdin_pending) > _MAX:
+                raise RuntimeError("Bridge payload too large")
+            chunk = os.read(sys.stdin.fileno(), 65536)
+            if not chunk:
+                raise RuntimeError("Bridge channel closed")
+            _stdin_pending.extend(chunk)
+        line = raw_line.decode("utf-8")
     obj = json.loads(line)
     if not isinstance(obj, dict):
         raise RuntimeError("Bridge payload must be an object")
@@ -415,10 +482,12 @@ def _read_json_line():
 
 def _fail_rpc_waiters(message):
     with _rpc_waiters_lock:
-        waiters = list(_rpc_waiters.values())
-    for waiter in waiters:
+        waiters = list(_rpc_waiters.items())
+    for req_id, waiter in waiters:
         waiter["response"] = {{
             "type": "rpc_result",
+            "token": _TOKEN,
+            "id": req_id,
             "ok": False,
             "error": message,
         }}
@@ -630,7 +699,13 @@ sys.stdout.flush()
             return None
         return obj if isinstance(obj, dict) else None
 
-    def _handle_rpc_request(self, *, msg: Dict[str, Any], token: str) -> Dict[str, Any]:
+    def _handle_rpc_request(
+        self,
+        *,
+        msg: Dict[str, Any],
+        token: str,
+        cancel_checker: Optional[Callable[[], bool]] = None,
+    ) -> Dict[str, Any]:
         req_id = str(msg.get("id") or "")
         if msg.get("token") != token:
             return {"type": "rpc_result", "token": token, "id": req_id, "ok": False, "error": "Invalid bridge token"}
@@ -639,9 +714,10 @@ sys.stdout.flush()
             return {"type": "rpc_result", "token": token, "id": req_id, "ok": False, "error": "Invalid RPC payload"}
 
         kind = str(rpc.get("kind") or "").strip().lower()
+        effective_cancel_checker = self.cancel_checker if cancel_checker is None else cancel_checker
         try:
             if kind == "cancelled":
-                output = bool(self.cancel_checker and self.cancel_checker())
+                output = bool(effective_cancel_checker and effective_cancel_checker())
                 return {"type": "rpc_result", "token": token, "id": req_id, "ok": True, "output": output}
 
             if kind in ("tool", "tool_safe"):
@@ -654,15 +730,20 @@ sys.stdout.flush()
                 if not isinstance(kwargs, dict):
                     raise RuntimeError("Tool kwargs must be an object")
                 registry = self.tool_registry or get_tool_registry()
-                if hasattr(registry, "cancel_checker"):
+                cancel_scope = contextlib.nullcontext()
+                with_cancel_checker = getattr(registry, "with_cancel_checker", None)
+                if callable(with_cancel_checker):
                     try:
-                        registry.cancel_checker = self.cancel_checker
+                        registry = with_cancel_checker(effective_cancel_checker)
                     except Exception:
-                        pass
-                if kind == "tool_safe":
-                    output = registry.run_safe(name, **kwargs)
+                        cancel_scope = _legacy_registry_cancel_scope(registry, effective_cancel_checker)
                 else:
-                    output = registry.run(name, **kwargs)
+                    cancel_scope = _legacy_registry_cancel_scope(registry, effective_cancel_checker)
+                with cancel_scope:
+                    if kind == "tool_safe":
+                        output = registry.run_safe(name, **kwargs)
+                    else:
+                        output = registry.run(name, **kwargs)
                 return {"type": "rpc_result", "token": token, "id": req_id, "ok": True, "output": output}
 
             if kind == "llm":
@@ -697,7 +778,7 @@ sys.stdout.flush()
                     retry_delay_s = float(retry_delay_raw)
                 except Exception as exc:
                     raise RuntimeError("LLM retry_delay_s must be a number when provided") from exc
-                output = get_lazy_llm(cancel_checker=self.cancel_checker).ask(
+                output = get_lazy_llm(cancel_checker=effective_cancel_checker).ask(
                     prompt,
                     temperature=temperature,
                     model=model,
@@ -726,6 +807,8 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
     sandbox: Dict[str, Any] = field(default_factory=dict)
     inherited_fd_keys: Tuple[str, ...] = ()
     retained_fd_keys: Tuple[str, ...] = ()
+    rpc_max_bytes: Optional[int] = _HOST_PROCESS_RPC_MAX_BYTES
+    rpc_max_workers: int = _HOST_PROCESS_RPC_MAX_WORKERS
 
     def execute(self, code: str, inputs: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
         if not isinstance(code, str):
@@ -740,6 +823,14 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
                 node_id="<runtime>",
                 message=f"Inputs must be a dict, got {type(inputs).__name__}",
             )
+
+        rpc_max_bytes = self.rpc_max_bytes
+        if rpc_max_bytes is not None:
+            if type(rpc_max_bytes) is not int or rpc_max_bytes <= 0:
+                raise NodeExecutionError(node_id="<runtime>", message="rpc_max_bytes must be None or a positive integer")
+        rpc_max_workers = self.rpc_max_workers
+        if type(rpc_max_workers) is not int or rpc_max_workers <= 0:
+            raise NodeExecutionError(node_id="<runtime>", message="rpc_max_workers must be a positive integer")
 
         inherited_fds = self._resolve_inherited_fds(inputs)
         retained_fds = self._resolve_retained_fds(inputs)
@@ -767,7 +858,7 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
             python_source = self._build_python_source(
                 code=code,
                 bridge_token=token,
-                rpc_max_bytes=None,
+                rpc_max_bytes=rpc_max_bytes,
                 extra_site_packages=package_root,
             )
             with tempfile.NamedTemporaryFile(
@@ -783,7 +874,7 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
             python_cmd = self._build_python_cmd(
                 code=code,
                 bridge_token=token,
-                rpc_max_bytes=None,
+                rpc_max_bytes=rpc_max_bytes,
                 extra_site_packages=package_root,
                 python_executable=sys.executable,
             )
@@ -796,6 +887,7 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
                 bufsize=1,
                 env={**os.environ, "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
                 start_new_session=(os.name != "nt"),
@@ -824,17 +916,42 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
         )
         stderr_thread.start()
 
-        stdout_lines: queue.Queue[Optional[str]] = queue.Queue()
+        bridge_closed = threading.Event()
+        stdout_reader_stop = threading.Event()
+        bridge_errors: list[str] = []
+        stdout_lines: queue.Queue[Optional[str]] = queue.Queue(maxsize=rpc_max_workers)
+
+        def _queue_stdout_line(line: Optional[str]) -> bool:
+            while not stdout_reader_stop.is_set():
+                try:
+                    stdout_lines.put(line, timeout=0.05)
+                    return True
+                except queue.Full:
+                    continue
+            return False
 
         def _read_stdout() -> None:
             try:
                 while True:
-                    line = proc.stdout.readline()
-                    if line == "":
+                    if rpc_max_bytes is None:
+                        raw_line = proc.stdout.buffer.readline()
+                    else:
+                        raw_line = proc.stdout.buffer.readline(rpc_max_bytes + 1)
+                    if raw_line == b"":
                         break
-                    stdout_lines.put(line)
+                    if rpc_max_bytes is not None and len(raw_line) > rpc_max_bytes:
+                        bridge_errors.append(
+                            f"Isolated host RPC message exceeds configured limit ({rpc_max_bytes} bytes)"
+                        )
+                        break
+                    line = raw_line.decode(proc.stdout.encoding or "utf-8")
+                    if not _queue_stdout_line(line):
+                        return
+            except Exception as exc:
+                bridge_errors.append(f"Isolated host RPC bridge read failed: {exc}")
             finally:
-                stdout_lines.put(None)
+                bridge_closed.set()
+                _queue_stdout_line(None)
 
         stdout_thread = threading.Thread(
             target=_read_stdout,
@@ -846,16 +963,30 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
         final_payload: Optional[Dict[str, Any]] = None
         cancelled = False
         stdin_lock = threading.Lock()
-        rpc_pool = _ThreadPoolExecutor(max_workers=32, thread_name_prefix="wf-process-rpc")
+        rpc_slots = threading.BoundedSemaphore(rpc_max_workers)
+        rpc_pool = _ThreadPoolExecutor(
+            max_workers=rpc_max_workers,
+            thread_name_prefix="wf-process-rpc",
+        )
+
+        def _rpc_cancel_requested() -> bool:
+            return bridge_closed.is_set() or self._cancel_requested()
 
         def _handle_rpc(message: Dict[str, Any]) -> None:
-            response = self._handle_rpc_request(msg=message, token=token)
             try:
-                with stdin_lock:
-                    if proc.poll() is None:
-                        self._write_json_line(proc.stdin, response)
-            except (BrokenPipeError, OSError, ValueError):
-                return
+                response = self._handle_rpc_request(
+                    msg=message,
+                    token=token,
+                    cancel_checker=_rpc_cancel_requested,
+                )
+                try:
+                    with stdin_lock:
+                        if not bridge_closed.is_set() and proc.poll() is None:
+                            self._write_json_line(proc.stdin, response)
+                except (BrokenPipeError, OSError, ValueError):
+                    return
+            finally:
+                rpc_slots.release()
 
         try:
             self._write_json_line(proc.stdin, {"type": "init", "token": token, "inputs": child_inputs})
@@ -875,11 +1006,38 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
                     continue
                 msg_type = str(msg.get("type") or "").strip().lower()
                 if msg_type == "rpc":
-                    rpc_pool.submit(_handle_rpc, msg)
+                    slot_acquired = False
+                    while not slot_acquired:
+                        slot_acquired = rpc_slots.acquire(timeout=0.05)
+                        if slot_acquired:
+                            break
+                        if self._cancel_requested():
+                            cancelled = True
+                            self._terminate_process(proc)
+                            break
+                        if proc.poll() is not None:
+                            bridge_closed.set()
+                            break
+                        if bridge_closed.is_set():
+                            break
+                    if cancelled:
+                        break
+                    if not slot_acquired:
+                        continue
+                    if bridge_closed.is_set():
+                        rpc_slots.release()
+                        continue
+                    try:
+                        rpc_pool.submit(_handle_rpc, msg)
+                    except Exception:
+                        rpc_slots.release()
+                        raise
                 elif msg_type == "final" and msg.get("token") == token:
                     payload = msg.get("payload")
                     final_payload = payload if isinstance(payload, dict) else {}
         finally:
+            bridge_closed.set()
+            stdout_reader_stop.set()
             rpc_pool.shutdown(
                 wait=final_payload is not None and not cancelled,
                 cancel_futures=True,
@@ -908,6 +1066,13 @@ class HostProcessPythonExecRuntime(SandboxPythonExecRuntime):
         if cancelled:
             self._close_parent_fds(managed_fds)
             raise RunCancelledError("<runtime>")
+        if bridge_errors:
+            self._close_parent_fds(managed_fds)
+            raise NodeExecutionError(
+                node_id="<runtime>",
+                message=bridge_errors[0],
+                traceback=stderr_text,
+            )
         if exit_code != 0:
             self._close_parent_fds(managed_fds)
             message = stderr_text.strip() or f"Isolated command exited with code {exit_code}"

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import logging
 import os
 import threading
@@ -446,6 +447,13 @@ def run_workflow(
     registry = tool_registry or get_tool_registry(tool_context=tool_context)
     sandbox_payload = _extract_sandbox_runtime_payload(tool_context)
     runtime_preference = _resolve_workflow_runtime_preference(tool_context)
+    isolated_runtime_options: Dict[str, Any] = {}
+    runtime_metadata = wf.metadata.get("runtime") if isinstance(wf.metadata, dict) else None
+    if isinstance(runtime_metadata, dict):
+        if "process_rpc_max_bytes" in runtime_metadata:
+            isolated_runtime_options["isolated_rpc_max_bytes"] = runtime_metadata["process_rpc_max_bytes"]
+        if "process_rpc_max_workers" in runtime_metadata:
+            isolated_runtime_options["isolated_rpc_max_workers"] = runtime_metadata["process_rpc_max_workers"]
 
     if runtime_preference == "host":
         sandbox_payload = None
@@ -472,6 +480,7 @@ def run_workflow(
         rt = PythonExecRuntime(
             tool_registry=registry,
             cleanup_globals_after_execute=(history_mode == "summary"),
+            **isolated_runtime_options,
         )
 
     _logger.debug(
@@ -557,6 +566,9 @@ def run_workflow(
             outputs=last_outputs,
             history=history_from_error,
         )
+    finally:
+        if execution_profile != "high_frequency":
+            gc.collect(0)
 
     history = [s.model_dump(mode="json") for s in result.history] if result.history else []
     last_outputs = result.outputs if result.outputs else {}

--- a/flocks/workflow/runner.py
+++ b/flocks/workflow/runner.py
@@ -452,6 +452,14 @@ def run_workflow(
     if isinstance(runtime_metadata, dict):
         if "process_rpc_max_bytes" in runtime_metadata:
             isolated_runtime_options["isolated_rpc_max_bytes"] = runtime_metadata["process_rpc_max_bytes"]
+        if "process_rpc_max_inflight_bytes" in runtime_metadata:
+            isolated_runtime_options["isolated_rpc_max_inflight_bytes"] = runtime_metadata[
+                "process_rpc_max_inflight_bytes"
+            ]
+        if "process_rpc_max_response_bytes" in runtime_metadata:
+            isolated_runtime_options["isolated_rpc_max_response_bytes"] = runtime_metadata[
+                "process_rpc_max_response_bytes"
+            ]
         if "process_rpc_max_workers" in runtime_metadata:
             isolated_runtime_options["isolated_rpc_max_workers"] = runtime_metadata["process_rpc_max_workers"]
 

--- a/flocks/workflow/tools_adapter.py
+++ b/flocks/workflow/tools_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json as _json
 from concurrent.futures import TimeoutError as _FuturesTimeoutError
 from typing import Any, Callable, Dict, List, Optional
@@ -36,6 +37,14 @@ class FlocksToolAdapter:
 
     def _blocked(self, name: str) -> bool:
         return (name or "").strip() in WORKFLOW_TOOL_BLOCKLIST
+
+    def with_cancel_checker(
+        self,
+        cancel_checker: Optional[Callable[[], bool]],
+    ) -> "FlocksToolAdapter":
+        scoped = copy.copy(self)
+        scoped.cancel_checker = cancel_checker
+        return scoped
 
     def _execute_tool_async(self, name: str, ctx: ToolContext, kwargs: Dict[str, Any]) -> ToolResult:
         """

--- a/tests/sandbox/test_workflow_sandbox_runtime.py
+++ b/tests/sandbox/test_workflow_sandbox_runtime.py
@@ -27,6 +27,7 @@ def test_sandbox_runtime_success_payload(monkeypatch: pytest.MonkeyPatch) -> Non
         def __init__(self, *args, **kwargs):
             _ = args
             assert kwargs["encoding"] == "utf-8"
+            assert kwargs["errors"] == "replace"
             self.stdin = io.StringIO()
             self.stdout = io.StringIO(
                 '{"type":"final","token":"tok","payload":{"outputs":{"result":1},"stdout":"ok","error":null}}\n'

--- a/tests/sandbox/test_workflow_sandbox_runtime.py
+++ b/tests/sandbox/test_workflow_sandbox_runtime.py
@@ -26,7 +26,7 @@ def test_sandbox_runtime_success_payload(monkeypatch: pytest.MonkeyPatch) -> Non
     class FakePopen:
         def __init__(self, *args, **kwargs):
             _ = args
-            _ = kwargs
+            assert kwargs["encoding"] == "utf-8"
             self.stdin = io.StringIO()
             self.stdout = io.StringIO(
                 '{"type":"final","token":"tok","payload":{"outputs":{"result":1},"stdout":"ok","error":null}}\n'
@@ -85,18 +85,19 @@ def test_run_workflow_uses_sandbox_runtime_when_context_has_sandbox(
             self.tool_registry = tool_registry
 
     class FakeHostRuntime:
-        def __init__(self, tool_registry):
+        def __init__(self, tool_registry, **_kwargs):
             self.tool_registry = tool_registry
 
     class FakeEngine:
         def __init__(self, _wf, runtime=None, **_kwargs):
             captured["runtime_class"] = type(runtime).__name__
 
-        def run(self, initial_inputs=None, timeout_s=None):
+        def run(self, initial_inputs=None, timeout_s=None, **_kwargs):
             _ = initial_inputs
             _ = timeout_s
             return SimpleNamespace(
                 history=[],
+                outputs={},
                 steps=0,
                 last_node_id=None,
                 run_id="sandbox-run",
@@ -152,17 +153,17 @@ def test_run_workflow_uses_host_runtime_when_sandbox_mode_off(
             _ = tool_registry
 
     class FakeHostRuntime:
-        def __init__(self, tool_registry):
+        def __init__(self, tool_registry, **_kwargs):
             _ = tool_registry
 
     class FakeEngine:
         def __init__(self, _wf, runtime=None, **_kwargs):
             captured["runtime_class"] = type(runtime).__name__
 
-        def run(self, initial_inputs=None, timeout_s=None):
+        def run(self, initial_inputs=None, timeout_s=None, **_kwargs):
             _ = initial_inputs
             _ = timeout_s
-            return SimpleNamespace(history=[], steps=0, last_node_id=None, run_id="host-run")
+            return SimpleNamespace(history=[], outputs={}, steps=0, last_node_id=None, run_id="host-run")
 
     monkeypatch.setattr("flocks.workflow.runner.SandboxPythonExecRuntime", FakeSandboxRuntime)
     monkeypatch.setattr("flocks.workflow.runner.PythonExecRuntime", FakeHostRuntime)
@@ -211,17 +212,17 @@ def test_run_workflow_uses_sandbox_runtime_when_sandbox_mode_on(
             self.tool_registry = tool_registry
 
     class FakeHostRuntime:
-        def __init__(self, tool_registry):
+        def __init__(self, tool_registry, **_kwargs):
             _ = tool_registry
 
     class FakeEngine:
         def __init__(self, _wf, runtime=None, **_kwargs):
             captured["runtime_class"] = type(runtime).__name__
 
-        def run(self, initial_inputs=None, timeout_s=None):
+        def run(self, initial_inputs=None, timeout_s=None, **_kwargs):
             _ = initial_inputs
             _ = timeout_s
-            return SimpleNamespace(history=[], steps=0, last_node_id=None, run_id="sandbox-default-run")
+            return SimpleNamespace(history=[], outputs={}, steps=0, last_node_id=None, run_id="sandbox-default-run")
 
     async def fake_resolve_sandbox_context(**kwargs):
         _ = kwargs
@@ -270,17 +271,17 @@ def test_run_workflow_installs_requirements_in_sandbox_runtime(
             _ = tool_registry
 
     class FakeHostRuntime:
-        def __init__(self, tool_registry):
+        def __init__(self, tool_registry, **_kwargs):
             _ = tool_registry
 
     class FakeEngine:
         def __init__(self, _wf, runtime=None, **_kwargs):
             _ = runtime
 
-        def run(self, initial_inputs=None, timeout_s=None):
+        def run(self, initial_inputs=None, timeout_s=None, **_kwargs):
             _ = initial_inputs
             _ = timeout_s
-            return SimpleNamespace(history=[], steps=0, last_node_id=None, run_id="sandbox-req-run")
+            return SimpleNamespace(history=[], outputs={}, steps=0, last_node_id=None, run_id="sandbox-req-run")
 
     class FakeHostInstaller:
         def __init__(self, installer="auto"):
@@ -350,17 +351,17 @@ def test_run_workflow_installs_requirements_in_host_runtime(
             _ = tool_registry
 
     class FakeHostRuntime:
-        def __init__(self, tool_registry):
+        def __init__(self, tool_registry, **_kwargs):
             _ = tool_registry
 
     class FakeEngine:
         def __init__(self, _wf, runtime=None, **_kwargs):
             _ = runtime
 
-        def run(self, initial_inputs=None, timeout_s=None):
+        def run(self, initial_inputs=None, timeout_s=None, **_kwargs):
             _ = initial_inputs
             _ = timeout_s
-            return SimpleNamespace(history=[], steps=0, last_node_id=None, run_id="host-req-run")
+            return SimpleNamespace(history=[], outputs={}, steps=0, last_node_id=None, run_id="host-req-run")
 
     class FakeHostInstaller:
         def __init__(self, installer="auto"):
@@ -491,17 +492,17 @@ def test_run_workflow_injects_workflow_file_context_inputs(
     captured = {"initial_inputs": None}
 
     class FakeHostRuntime:
-        def __init__(self, tool_registry):
+        def __init__(self, tool_registry, **_kwargs):
             _ = tool_registry
 
     class FakeEngine:
         def __init__(self, _wf, runtime=None, **_kwargs):
             _ = runtime
 
-        def run(self, initial_inputs=None, timeout_s=None):
+        def run(self, initial_inputs=None, timeout_s=None, **_kwargs):
             _ = timeout_s
             captured["initial_inputs"] = dict(initial_inputs or {})
-            return SimpleNamespace(history=[], steps=0, last_node_id=None, run_id="wf-input-inject")
+            return SimpleNamespace(history=[], outputs={}, steps=0, last_node_id=None, run_id="wf-input-inject")
 
     monkeypatch.setattr("flocks.workflow.runner.PythonExecRuntime", FakeHostRuntime)
     monkeypatch.setattr("flocks.workflow.runner.WorkflowEngine", FakeEngine)

--- a/tests/workflow/test_workflow_execution_plan.py
+++ b/tests/workflow/test_workflow_execution_plan.py
@@ -85,3 +85,38 @@ def test_high_frequency_profile_uses_lightweight_runtime_options(monkeypatch) ->
     assert isinstance(captured_init["execution_plan"], WorkflowExecutionPlan)
     assert captured_run["retain_history"] is False
     assert captured_run["run_id"] == "exec-1"
+
+
+def test_workflow_metadata_configures_process_rpc_limits(monkeypatch) -> None:
+    captured_init: dict[str, Any] = {}
+
+    class FakeEngine:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            captured_init.update(kwargs)
+
+        def run(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            return SimpleNamespace(
+                run_id="rpc-config",
+                steps=1,
+                last_node_id="start",
+                outputs={"ok": True},
+                history=[],
+            )
+
+    workflow = _workflow()
+    workflow.metadata = {
+        "runtime": {
+            "process_rpc_max_bytes": None,
+            "process_rpc_max_workers": 3,
+        }
+    }
+    monkeypatch.setattr(runner_module, "WorkflowEngine", FakeEngine)
+    monkeypatch.setattr(runner_module, "_resolve_workflow_runtime_preference", lambda _ctx: "host")
+    monkeypatch.setattr(runner_module, "get_tool_registry", lambda tool_context=None: None)
+
+    result = run_workflow(workflow=workflow, ensure_requirements=False)
+
+    assert result.status == "SUCCEEDED"
+    runtime = captured_init["runtime"]
+    assert runtime.isolated_rpc_max_bytes is None
+    assert runtime.isolated_rpc_max_workers == 3

--- a/tests/workflow/test_workflow_execution_plan.py
+++ b/tests/workflow/test_workflow_execution_plan.py
@@ -107,6 +107,8 @@ def test_workflow_metadata_configures_process_rpc_limits(monkeypatch) -> None:
     workflow.metadata = {
         "runtime": {
             "process_rpc_max_bytes": None,
+            "process_rpc_max_inflight_bytes": 1024 * 1024,
+            "process_rpc_max_response_bytes": 100_000,
             "process_rpc_max_workers": 3,
         }
     }
@@ -119,4 +121,6 @@ def test_workflow_metadata_configures_process_rpc_limits(monkeypatch) -> None:
     assert result.status == "SUCCEEDED"
     runtime = captured_init["runtime"]
     assert runtime.isolated_rpc_max_bytes is None
+    assert runtime.isolated_rpc_max_inflight_bytes == 1024 * 1024
+    assert runtime.isolated_rpc_max_response_bytes == 100_000
     assert runtime.isolated_rpc_max_workers == 3

--- a/tests/workflow/test_workflow_history_mode.py
+++ b/tests/workflow/test_workflow_history_mode.py
@@ -1,3 +1,4 @@
+import flocks.workflow.runner as workflow_runner_module
 from flocks.workflow.runner import run_workflow
 from flocks.workflow.repl_runtime import PythonExecRuntime
 
@@ -139,6 +140,59 @@ def test_python_runtime_can_cleanup_node_globals_after_execute() -> None:
     assert "temporary_payload" not in runtime.globals
     assert "inputs" not in runtime.globals
     assert "outputs" not in runtime.globals
+
+
+def test_low_frequency_workflow_boundary_collects_gc_once_on_success_and_failure(monkeypatch) -> None:
+    collect_calls = []
+    monkeypatch.setattr(
+        workflow_runner_module.gc,
+        "collect",
+        lambda generation: collect_calls.append(generation) or 0,
+    )
+
+    success = run_workflow(
+        workflow={
+            "start": "done",
+            "nodes": [{"id": "done", "type": "python", "code": "outputs['ok'] = True"}],
+            "edges": [],
+        },
+        ensure_requirements=False,
+    )
+    assert success.status == "SUCCEEDED"
+    assert collect_calls == [0]
+
+    failure = run_workflow(
+        workflow={
+            "start": "fail",
+            "nodes": [{"id": "fail", "type": "python", "code": "raise RuntimeError('boom')"}],
+            "edges": [],
+        },
+        ensure_requirements=False,
+    )
+    assert failure.status == "FAILED"
+    assert collect_calls == [0, 0]
+
+
+def test_high_frequency_workflow_boundary_skips_gc(monkeypatch) -> None:
+    collect_calls = []
+    monkeypatch.setattr(
+        workflow_runner_module.gc,
+        "collect",
+        lambda generation: collect_calls.append(generation) or 0,
+    )
+
+    result = run_workflow(
+        workflow={
+            "start": "done",
+            "nodes": [{"id": "done", "type": "python", "code": "outputs['ok'] = True"}],
+            "edges": [],
+        },
+        ensure_requirements=False,
+        execution_profile="high_frequency",
+    )
+
+    assert result.status == "SUCCEEDED"
+    assert collect_calls == []
 
 
 def test_mapped_payload_is_not_retained_for_remaining_run() -> None:

--- a/tests/workflow/test_workflow_node_timeout.py
+++ b/tests/workflow/test_workflow_node_timeout.py
@@ -1,8 +1,10 @@
 """Regression tests for isolated and compatibility node timeouts."""
 
+import io
 import os
 import threading
 import time
+import tracemalloc
 
 import pytest
 
@@ -172,7 +174,11 @@ def test_process_rpc_bridge_matches_concurrent_responses_by_request_id():
 
 def test_process_rpc_bridge_defaults_to_32_workers():
     assert PythonExecRuntime().isolated_rpc_max_workers == 32
+    assert PythonExecRuntime().isolated_rpc_max_inflight_bytes == 64 * 1024 * 1024
+    assert PythonExecRuntime().isolated_rpc_max_response_bytes == 2 * 1024 * 1024
     assert HostProcessPythonExecRuntime().rpc_max_workers == 32
+    assert HostProcessPythonExecRuntime().rpc_max_inflight_bytes == 64 * 1024 * 1024
+    assert HostProcessPythonExecRuntime().rpc_max_response_bytes == 2 * 1024 * 1024
 
 
 @pytest.mark.parametrize("rpc_max_workers", [3, 8])
@@ -296,7 +302,7 @@ def test_process_rpc_bridge_rejects_oversized_parent_response(monkeypatch):
 
     monkeypatch.setattr(repl_runtime_module, "get_lazy_llm", lambda **_kwargs: LLM())
 
-    with pytest.raises(NodeExecutionError, match="Bridge payload too large"):
+    with pytest.raises(NodeExecutionError, match="RPC response exceeds configured limit"):
         HostProcessPythonExecRuntime(rpc_max_bytes=4096).execute(
             "outputs['value'] = llm.ask('small')",
             {},
@@ -304,12 +310,180 @@ def test_process_rpc_bridge_rejects_oversized_parent_response(monkeypatch):
 
 
 def test_process_rpc_bridge_allows_explicitly_unlimited_frames():
-    outputs, _stdout = HostProcessPythonExecRuntime(rpc_max_bytes=None).execute(
+    outputs, _stdout = HostProcessPythonExecRuntime(
+        rpc_max_bytes=None,
+        rpc_max_inflight_bytes=None,
+        rpc_max_response_bytes=None,
+    ).execute(
         "outputs['value'] = 'x' * 2048",
         {},
     )
 
     assert outputs == {"value": "x" * 2048}
+
+
+def test_process_rpc_bridge_bounds_total_inflight_request_bytes():
+    class Registry:
+        cancel_checker = None
+
+        def __init__(self):
+            self.active = 0
+            self.peak = 0
+            self.lock = threading.Lock()
+
+        def run(self, _name, *, value, blob):
+            _ = blob
+            with self.lock:
+                self.active += 1
+                self.peak = max(self.peak, self.active)
+            try:
+                time.sleep(0.03)
+                return value
+            finally:
+                with self.lock:
+                    self.active -= 1
+
+    registry = Registry()
+    outputs, _stdout = HostProcessPythonExecRuntime(
+        tool_registry=registry,
+        rpc_max_bytes=800_000,
+        rpc_max_inflight_bytes=1_000_000,
+        rpc_max_response_bytes=100_000,
+        rpc_max_workers=6,
+    ).execute(
+        (
+            "from concurrent.futures import ThreadPoolExecutor\n"
+            "blob = 'x' * 700_000\n"
+            "def call(value):\n"
+            "    return tool.run('bounded', value=value, blob=blob)\n"
+            "with ThreadPoolExecutor(max_workers=6) as pool:\n"
+            "    outputs['values'] = list(pool.map(call, range(6)))"
+        ),
+        {},
+    )
+
+    assert outputs["values"] == list(range(6))
+    assert registry.peak == 1
+
+
+def test_process_rpc_bridge_bounds_responses_without_reducing_worker_concurrency(monkeypatch):
+    class LLM:
+        def __init__(self):
+            self.barrier = threading.Barrier(4)
+            self.active = 0
+            self.peak = 0
+            self.lock = threading.Lock()
+
+        def ask(self, _prompt, **_kwargs):
+            with self.lock:
+                self.active += 1
+                self.peak = max(self.peak, self.active)
+            try:
+                self.barrier.wait(timeout=1)
+                return "x" * 200_000
+            finally:
+                with self.lock:
+                    self.active -= 1
+
+    llm = LLM()
+    monkeypatch.setattr(repl_runtime_module, "get_lazy_llm", lambda **_kwargs: llm)
+
+    outputs, _stdout = HostProcessPythonExecRuntime(
+        rpc_max_bytes=900_000,
+        rpc_max_inflight_bytes=1_000_000,
+        rpc_max_response_bytes=250_000,
+        rpc_max_workers=4,
+    ).execute(
+        (
+            "from concurrent.futures import ThreadPoolExecutor\n"
+            "with ThreadPoolExecutor(max_workers=4) as pool:\n"
+            "    outputs['values'] = list(pool.map(lambda i: llm.ask(str(i)), range(4)))"
+        ),
+        {},
+    )
+
+    assert [len(value) for value in outputs["values"]] == [200_000] * 4
+    assert llm.peak == 4
+
+
+@pytest.mark.parametrize(
+    ("runtime_kwargs", "message"),
+    [
+        ({"rpc_max_workers": 33}, "between 1 and 32"),
+        (
+            {"rpc_max_bytes": 2048, "rpc_max_inflight_bytes": 1024},
+            "cannot exceed rpc_max_inflight_bytes",
+        ),
+        (
+            {"rpc_max_bytes": None, "rpc_max_inflight_bytes": 128},
+            "must be at least 512 bytes",
+        ),
+        (
+            {
+                "rpc_max_bytes": 900_000,
+                "rpc_max_inflight_bytes": 1_000_000,
+                "rpc_max_response_bytes": 300_000,
+                "rpc_max_workers": 4,
+            },
+            "rpc_max_response_bytes and rpc_max_workers exceed",
+        ),
+    ],
+)
+def test_process_rpc_bridge_validates_memory_limit_combinations(runtime_kwargs, message):
+    with pytest.raises(NodeExecutionError, match=message):
+        HostProcessPythonExecRuntime(**runtime_kwargs).execute("outputs['ok'] = True", {})
+
+
+def test_parent_response_size_check_avoids_full_json_copy():
+    payload = {"output": "x" * (8 * 1024 * 1024)}
+
+    tracemalloc.start()
+    try:
+        with pytest.raises(repl_runtime_module._RPCFrameTooLarge):
+            repl_runtime_module._json_line_with_limit(payload, 1024)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert peak < 512 * 1024
+
+
+def test_parent_response_encoding_bounds_many_small_json_chunks():
+    payload = {"output": [0] * 200_000}
+
+    tracemalloc.start()
+    try:
+        line = repl_runtime_module._json_line_with_limit(payload, 1024 * 1024)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert len(line) < 1024 * 1024
+    assert peak < 3 * 1024 * 1024
+
+
+def test_stderr_drain_retains_only_bounded_tail():
+    chunks = []
+    max_bytes = 16 * 1024
+    repl_runtime_module._drain_text_stream(
+        io.StringIO("prefix\n" + "x" * (64 * 1024) + "stderr-tail"),
+        chunks,
+        max_bytes=max_bytes,
+    )
+
+    stderr = "".join(chunks)
+    assert stderr.startswith("[stderr truncated to last 16384 bytes]\n")
+    assert stderr.endswith("stderr-tail")
+    assert len(stderr.encode("utf-8")) <= max_bytes + 64
+
+
+def test_host_process_drains_invalid_utf8_stderr_without_stalling():
+    outputs, _stdout = HostProcessPythonExecRuntime().execute(
+        "import os\nos.write(2, b'\\xff' * (512 * 1024))\noutputs['ok'] = True",
+        {},
+    )
+
+    assert outputs == {"ok": True}
 
 
 def test_process_isolated_node_inherits_runtime_rpc_limit():
@@ -330,6 +504,33 @@ def test_process_isolated_node_inherits_runtime_rpc_limit():
         WorkflowEngine(
             workflow,
             runtime=PythonExecRuntime(isolated_rpc_max_bytes=1024),
+            node_timeout_s=3,
+        ).run()
+
+
+def test_process_isolated_node_inherits_runtime_response_limit(monkeypatch):
+    class LLM:
+        def ask(self, _prompt, **_kwargs):
+            return "x" * 2048
+
+    monkeypatch.setattr(repl_runtime_module, "get_lazy_llm", lambda **_kwargs: LLM())
+    workflow = Workflow.from_dict({
+        "start": "large_response",
+        "nodes": [
+            {
+                "id": "large_response",
+                "type": "python",
+                "processIsolated": True,
+                "code": "outputs['value'] = llm.ask('small')",
+            }
+        ],
+        "edges": [],
+    })
+
+    with pytest.raises(NodeExecutionError, match="RPC response exceeds configured limit"):
+        WorkflowEngine(
+            workflow,
+            runtime=PythonExecRuntime(isolated_rpc_max_response_bytes=1024),
             node_timeout_s=3,
         ).run()
 
@@ -579,6 +780,7 @@ def test_host_process_windows_launch_does_not_require_posix_shell(monkeypatch):
     def checking_popen(args, *popen_args, **popen_kwargs):
         assert args[0] != "sh"
         assert popen_kwargs["encoding"] == "utf-8"
+        assert popen_kwargs["errors"] == "replace"
         script_paths.append(args[-1])
         return real_popen(args, *popen_args, **popen_kwargs)
 

--- a/tests/workflow/test_workflow_node_timeout.py
+++ b/tests/workflow/test_workflow_node_timeout.py
@@ -170,6 +170,294 @@ def test_process_rpc_bridge_matches_concurrent_responses_by_request_id():
     assert registry.peak > 1
 
 
+def test_process_rpc_bridge_defaults_to_32_workers():
+    assert PythonExecRuntime().isolated_rpc_max_workers == 32
+    assert HostProcessPythonExecRuntime().rpc_max_workers == 32
+
+
+@pytest.mark.parametrize("rpc_max_workers", [3, 8])
+def test_process_rpc_bridge_bounds_concurrent_llm_requests(monkeypatch, rpc_max_workers):
+    real_executor = repl_runtime_module._ThreadPoolExecutor
+    pending = 0
+    pending_peak = 0
+    pending_lock = threading.Lock()
+
+    class TrackingExecutor(real_executor):
+        def submit(self, fn, *args, **kwargs):
+            nonlocal pending, pending_peak
+            with pending_lock:
+                pending += 1
+                pending_peak = max(pending_peak, pending)
+
+            def tracked():
+                nonlocal pending
+                try:
+                    return fn(*args, **kwargs)
+                finally:
+                    with pending_lock:
+                        pending -= 1
+
+            try:
+                return super().submit(tracked)
+            except Exception:
+                with pending_lock:
+                    pending -= 1
+                raise
+
+    class LLM:
+        def __init__(self):
+            self.active = 0
+            self.peak = 0
+            self.lock = threading.Lock()
+
+        def ask(self, prompt, **_kwargs):
+            with self.lock:
+                self.active += 1
+                self.peak = max(self.peak, self.active)
+            try:
+                time.sleep(0.05)
+                return prompt
+            finally:
+                with self.lock:
+                    self.active -= 1
+
+    llm = LLM()
+    monkeypatch.setattr(repl_runtime_module, "_ThreadPoolExecutor", TrackingExecutor)
+    monkeypatch.setattr(repl_runtime_module, "get_lazy_llm", lambda **_kwargs: llm)
+
+    outputs, _stdout = HostProcessPythonExecRuntime(rpc_max_workers=rpc_max_workers).execute(
+        (
+            "from concurrent.futures import ThreadPoolExecutor\n"
+            "def call(value):\n"
+            "    return llm.ask(str(value))\n"
+            "with ThreadPoolExecutor(max_workers=24) as pool:\n"
+            "    outputs['values'] = list(pool.map(call, range(24)))"
+        ),
+        {},
+    )
+
+    assert outputs["values"] == [str(value) for value in range(24)]
+    assert llm.peak <= rpc_max_workers
+    assert pending_peak <= rpc_max_workers
+
+
+def test_process_rpc_tool_cancel_checker_is_scoped_per_request():
+    class Registry:
+        cancel_checker = None
+
+        def __init__(self):
+            self.barrier = threading.Barrier(2)
+
+        def run(self, _name, **_kwargs):
+            self.barrier.wait(timeout=1)
+            return bool(self.cancel_checker and self.cancel_checker())
+
+    registry = Registry()
+    runtime = HostProcessPythonExecRuntime(tool_registry=registry)
+    responses = {}
+
+    def invoke(label, checker):
+        responses[label] = runtime._handle_rpc_request(
+            msg={
+                "type": "rpc",
+                "token": "token",
+                "id": label,
+                "rpc": {"kind": "tool", "name": "check"},
+            },
+            token="token",
+            cancel_checker=checker,
+        )
+
+    first = threading.Thread(target=invoke, args=("first", lambda: False))
+    second = threading.Thread(target=invoke, args=("second", lambda: True))
+    first.start()
+    second.start()
+    first.join(timeout=1)
+    second.join(timeout=1)
+
+    assert responses["first"]["output"] is False
+    assert responses["second"]["output"] is True
+    assert callable(registry.cancel_checker)
+    assert registry.cancel_checker() is False
+
+
+def test_process_rpc_bridge_rejects_oversized_child_frame():
+    with pytest.raises(NodeExecutionError, match="exceeds configured limit"):
+        HostProcessPythonExecRuntime(rpc_max_bytes=1024).execute(
+            "outputs['value'] = 'x' * 2048",
+            {},
+        )
+
+
+def test_process_rpc_bridge_rejects_oversized_parent_response(monkeypatch):
+    class LLM:
+        def ask(self, _prompt, **_kwargs):
+            return "x" * 8192
+
+    monkeypatch.setattr(repl_runtime_module, "get_lazy_llm", lambda **_kwargs: LLM())
+
+    with pytest.raises(NodeExecutionError, match="Bridge payload too large"):
+        HostProcessPythonExecRuntime(rpc_max_bytes=4096).execute(
+            "outputs['value'] = llm.ask('small')",
+            {},
+        )
+
+
+def test_process_rpc_bridge_allows_explicitly_unlimited_frames():
+    outputs, _stdout = HostProcessPythonExecRuntime(rpc_max_bytes=None).execute(
+        "outputs['value'] = 'x' * 2048",
+        {},
+    )
+
+    assert outputs == {"value": "x" * 2048}
+
+
+def test_process_isolated_node_inherits_runtime_rpc_limit():
+    workflow = Workflow.from_dict({
+        "start": "large_output",
+        "nodes": [
+            {
+                "id": "large_output",
+                "type": "python",
+                "processIsolated": True,
+                "code": "outputs['value'] = 'x' * 2048",
+            }
+        ],
+        "edges": [],
+    })
+
+    with pytest.raises(NodeExecutionError, match="exceeds configured limit"):
+        WorkflowEngine(
+            workflow,
+            runtime=PythonExecRuntime(isolated_rpc_max_bytes=1024),
+            node_timeout_s=3,
+        ).run()
+
+
+def test_process_rpc_bridge_cancels_legacy_tool_registry_when_child_exits():
+    class Registry:
+        cancel_checker = None
+
+        def __init__(self):
+            self.started = threading.Event()
+            self.stopped = threading.Event()
+            self.timed_out = threading.Event()
+
+        def run(self, _name, **_kwargs):
+            self.started.set()
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                if self.cancel_checker and self.cancel_checker():
+                    self.stopped.set()
+                    raise RuntimeError("bridge closed")
+                time.sleep(0.01)
+            self.timed_out.set()
+            return "late"
+
+    registry = Registry()
+    with pytest.raises(NodeExecutionError, match="exited with code 17"):
+        HostProcessPythonExecRuntime(tool_registry=registry).execute(
+            (
+                "import os, threading, time\n"
+                "threading.Thread(target=lambda: tool.run('blocked'), daemon=True).start()\n"
+                "time.sleep(0.3)\n"
+                "os._exit(17)"
+            ),
+            {},
+        )
+
+    assert registry.started.wait(0.5)
+    assert registry.stopped.wait(0.5)
+    assert not registry.timed_out.is_set()
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline and any(
+        thread.name.startswith("wf-process-rpc") for thread in threading.enumerate()
+    ):
+        time.sleep(0.01)
+    assert not any(thread.name.startswith("wf-process-rpc") for thread in threading.enumerate())
+
+
+def test_process_rpc_bridge_cancels_llm_when_child_exits(monkeypatch):
+    started = threading.Event()
+    stopped = threading.Event()
+    timed_out = threading.Event()
+    real_bounded_semaphore = threading.BoundedSemaphore
+    tracked_semaphores = []
+
+    class TrackingBoundedSemaphore:
+        def __init__(self, value):
+            self._semaphore = real_bounded_semaphore(value)
+            self._lock = threading.Lock()
+            self.active = 0
+            tracked_semaphores.append(self)
+
+        def acquire(self, *args, **kwargs):
+            acquired = self._semaphore.acquire(*args, **kwargs)
+            if acquired:
+                with self._lock:
+                    self.active += 1
+            return acquired
+
+        def release(self):
+            with self._lock:
+                self.active -= 1
+            self._semaphore.release()
+
+    monkeypatch.setattr(
+        repl_runtime_module.threading,
+        "BoundedSemaphore",
+        TrackingBoundedSemaphore,
+    )
+
+    class LLM:
+        def __init__(self, cancel_checker):
+            self.cancel_checker = cancel_checker
+
+        def ask(self, _prompt, **_kwargs):
+            started.set()
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                if self.cancel_checker and self.cancel_checker():
+                    stopped.set()
+                    raise RuntimeError("bridge closed")
+                time.sleep(0.01)
+            timed_out.set()
+            return "late"
+
+    monkeypatch.setattr(
+        repl_runtime_module,
+        "get_lazy_llm",
+        lambda *, cancel_checker=None: LLM(cancel_checker),
+    )
+
+    with pytest.raises(NodeExecutionError, match="exited with code 17"):
+        HostProcessPythonExecRuntime().execute(
+            (
+                "import os, threading, time\n"
+                "for value in range(24):\n"
+                "    threading.Thread(\n"
+                "        target=lambda item=value: llm.ask(f'blocked-{item}'),\n"
+                "        daemon=True,\n"
+                "    ).start()\n"
+                "time.sleep(0.3)\n"
+                "os._exit(17)"
+            ),
+            {},
+        )
+
+    assert started.wait(0.5)
+    assert stopped.wait(0.5)
+    assert not timed_out.is_set()
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline and any(
+        thread.name.startswith("wf-process-rpc") for thread in threading.enumerate()
+    ):
+        time.sleep(0.01)
+    assert not any(thread.name.startswith("wf-process-rpc") for thread in threading.enumerate())
+    assert len(tracked_semaphores) == 1
+    assert tracked_semaphores[0].active == 0
+
+
 def test_process_isolated_runtime_exposes_cooperative_cancel_hooks():
     workflow = Workflow.from_dict({
         "start": "check_cancel",
@@ -290,6 +578,7 @@ def test_host_process_windows_launch_does_not_require_posix_shell(monkeypatch):
 
     def checking_popen(args, *popen_args, **popen_kwargs):
         assert args[0] != "sh"
+        assert popen_kwargs["encoding"] == "utf-8"
         script_paths.append(args[-1])
         return real_popen(args, *popen_args, **popen_kwargs)
 
@@ -297,11 +586,11 @@ def test_host_process_windows_launch_does_not_require_posix_shell(monkeypatch):
     monkeypatch.setattr(repl_runtime_module.subprocess, "Popen", checking_popen)
 
     outputs, _stdout = HostProcessPythonExecRuntime().execute(
-        "outputs['ok'] = True",
-        {},
+        "outputs['value'] = inputs['value']",
+        {"value": "中文告警"},
     )
 
-    assert outputs == {"ok": True}
+    assert outputs == {"value": "中文告警"}
     assert script_paths
     assert all(not os.path.exists(path) for path in script_paths)
 


### PR DESCRIPTION
Bound host-process RPC buffering while preserving the 32-worker default, and make frame limits configurable.

Cancel pending bridge work on child exit, scope tool cancellation safely, enforce UTF-8 IPC, and collect generation-zero GC at low-frequency workflow boundaries.