### PR TITLE
fix(browser): restore current-profile inspect flow

### DIFF
--- a/.flocks/plugins/skills/browser-use/SKILL.md
+++ b/.flocks/plugins/skills/browser-use/SKILL.md
@@ -61,9 +61,9 @@ flocks browser --doctor
 | 结果 | 触发条件 | 一线修复 | 仍失败兜底 |
 |---|---|---|---|
 | **A** | `next action` 以 `ready` 开头 | 立即确定 `CDP 直连`,阅读 `references/cdp-direct.md`,之后不再切到 `agent-browser` | — |
-| **B** | `next action` 以 `attach` 开头 | 不要先反复 `--setup`；按输出执行 `flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'` 触发一次实际连接/观察 | 如果 `-c` 失败或仍无连接，执行 `flocks browser --reload` 清理旧 daemon，再执行 `flocks browser --setup`；若 setup 输出本地 remote debugging 不可达，按 `references/cdp-setup.md` 的固定端口流程处理 |
-| **C** | `next action` 以 `setup` 开头 | 先执行 `flocks browser --setup`（不包短超时），再运行 `--doctor` 确认 | 如提示 remote debugging 不可达、`DevToolsActivePort` 缺失、403 handshake 或 not live yet，按 `references/cdp-setup.md` 指引使用非默认 `--user-data-dir` 启动 Chromium 系浏览器，再访问 `/json/version` 验证 |
-| **D** | `next action` 提示启动浏览器或提供 endpoint | 明确告知需要先用 remote-debugging 参数启动 Chrome/Chromium/Edge/Brave，或提供 CDP endpoint | **不**擅自降级到 curl/webfetch；坚持告知 skill 边界 |
+| **B** | `next action` 以 `attach` 开头 | 不要先反复 `--setup`；按输出执行 `flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'` 触发一次实际连接/观察 | 如果 `-c` 失败或仍无连接，执行 `flocks browser --reload` 清理旧 daemon，再执行 `flocks browser --setup`；按 setup 提示在当前 profile 的 inspect 页面完成 Allow 后重试 |
+| **C** | `next action` 以 `setup` 开头 | 先执行 `flocks browser --setup`（不包短超时），再运行 `--doctor` 确认 | 如提示 remote debugging 未启用、`DevToolsActivePort` 缺失、403 handshake 或 not live yet，按 `references/cdp-setup.md` 先完成当前 profile 的 inspect/Allow；只有该流程重试后仍失败，才使用独立 profile 固定端口兜底 |
+| **D** | `next action` 提示启动浏览器或提供 endpoint | 明确告知需要先启动 Chrome/Chromium/Edge/Brave，或提供 CDP endpoint | **不**擅自降级到 curl/webfetch；坚持告知 skill 边界 |
 
 ### Step 4: 跨模式通用失败
 

--- a/.flocks/plugins/skills/browser-use/references/cdp-direct.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-direct.md
@@ -350,13 +350,14 @@ print({"cookies": [c["name"] for c in cookies], "localStorage": js("Object.keys(
 
 1. 先运行 `flocks browser --doctor` 看版本、安装模式、daemon 和浏览器状态；不要只看退出码，优先读 `next action`，再看 `browser running`、`daemon alive`、`active browser connections`。
 2. `next action` 为 `attach`，或 `daemon alive` ok 但 `active browser connections` 为 0 时，不要先反复 `--setup`。先用一次实际命令触发连接/观察：`flocks browser -c 'print(page_info())'` 或 `flocks browser -c 'print(list_tabs(include_chrome=False))'`。
-3. 如果上一步失败或仍无连接，再执行 `flocks browser --reload` 清旧 daemon，然后执行 `flocks browser --setup`。若 setup 输出本地 remote debugging 不可达，按 `references/cdp-setup.md` 的固定端口流程处理。
+3. 如果上一步失败或仍无连接，再执行 `flocks browser --reload` 清旧 daemon，然后执行 `flocks browser --setup`；setup 会在需要时打开当前 profile 的 inspect 页面，用户完成 Allow 后会再尝试 attach。
 4. 首次安装、冷启动、daemon 不存在/不通，且浏览器已经运行或配置了 `BU_CDP_URL` / `BU_CDP_WS` 时，优先运行 `flocks browser --setup`。
-5. Chrome / Chromium / Edge / Brave 未运行且没有显式 CDP endpoint 时，按 `references/cdp-setup.md` 提供对应平台的 remote-debugging 启动命令。
-6. 只有在明确提示 remote debugging 不可达、`DevToolsActivePort` 缺失、403 handshake、remote-debugging page 或 not live yet 时，才让用户使用非默认 `--user-data-dir` 和 `--remote-debugging-port=9222` 启动 Chromium 系浏览器，并访问 `http://127.0.0.1:9222/json/version` 验证。
-7. 用户刚按固定端口流程启动浏览器时，不要立刻再次运行 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 daemon attach，再用 `--doctor` 做只读确认。
-8. `connection refused`、`DevTools not live yet`、`/json/version` 404 通常是浏览器正在启动，轮询等待，不要重启。
-9. stale websocket / stale socket 时执行一次：
+5. Chrome / Chromium / Edge / Brave 未运行且没有显式 CDP endpoint 时，只提示用户先启动浏览器，再重新运行 `flocks browser --setup`；不要默认要求关闭浏览器或创建独立 profile。
+6. 只有当前 profile 的 inspect/Allow 流程完成且重试仍失败时，才按 `references/cdp-setup.md` 的可选兜底方案使用非默认 `--user-data-dir` 和 `--remote-debugging-port=9222` 启动独立 Chromium 系浏览器。
+7. `chrome://inspect/#remote-debugging` / `edge://inspect/#remote-debugging` 用于为当前 profile 启用并允许 remote debugging；不要从 inspect 页面查找 `webSocketDebuggerUrl`，Flocks 会通过 `DevToolsActivePort` 和 `/json/version` 自行发现 endpoint。
+8. 用户刚按独立 profile 兜底流程启动浏览器时，不要立刻再次运行 `flocks browser --doctor`；先执行一次 `flocks browser --setup`，或直接执行 `flocks browser -c 'print(page_info())'` 触发 daemon attach，再用 `--doctor` 做只读确认。
+9. `connection refused`、`DevTools not live yet`、`/json/version` 404 通常是浏览器正在启动，轮询等待，不要重启。
+10. stale websocket / stale socket 时执行一次：
 
 ```bash
 flocks browser -c 'restart_daemon()'

--- a/.flocks/plugins/skills/browser-use/references/cdp-setup.md
+++ b/.flocks/plugins/skills/browser-use/references/cdp-setup.md
@@ -1,6 +1,6 @@
 # Flocks browser setup
 
-本地固定端口 CDP 设置：daemon 不存在/不通，active browser connection 不可用，或浏览器尚未以 remote debugging 参数启动。
+本地浏览器连接以复用用户当前 profile 为主。独立 profile 固定端口只用于当前 profile 授权并重试后仍无法连接的兜底场景。
 
 先区分两种情况：
 
@@ -11,13 +11,17 @@
 2. daemon 不存在/不通，且浏览器已运行或配置了 `BU_CDP_URL` / `BU_CDP_WS`：
    - 执行 `flocks browser --setup` 触发 attach，不要用短超时包装该命令。
 
-只有在错误明确指向 remote debugging 不可达、`DevToolsActivePort` 缺失、403 handshake 或 not live yet 时，才提示用户走本地固定端口流程：
+只有在错误明确指向 remote debugging 未启用、`DevToolsActivePort` 缺失、403 handshake 或 not live yet 时，才提示用户完成当前 profile 的授权：
 
 ```text
-不要从 chrome://inspect 查找 webSocketDebuggerUrl。关闭对应 Chromium 系浏览器后，使用非默认 --user-data-dir 和 --remote-debugging-port=9222 启动浏览器，再访问 http://127.0.0.1:9222/json/version 验证。
+打开对应浏览器的 inspect 页面（例如 chrome://inspect/#remote-debugging 或 edge://inspect/#remote-debugging），选择日常使用的 profile，并勾选或点击 Allow remote debugging。不要从 chrome://inspect 查找 webSocketDebuggerUrl；Flocks 会自行发现 endpoint。
 ```
 
-候选命令按平台选择一个即可；如果浏览器安装路径不同，替换可执行文件路径：
+用户完成 Allow 后，`flocks browser --setup` 会再次尝试 attach。不要要求用户先关闭日常浏览器，也不要默认创建独立 profile。
+
+## 独立 profile 兜底
+
+只有当前 profile 的 inspect/Allow 流程重试后仍失败，才提供以下独立 profile 方案。候选命令按平台选择一个即可；如果浏览器安装路径不同，替换可执行文件路径：
 
 Windows PowerShell：
 
@@ -46,7 +50,7 @@ chromium --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/chromium-de
 brave-browser --remote-debugging-port=9222 --user-data-dir="$HOME/.flocks/brave-debug-profile"
 ```
 
-输出命令后等待用户进一步指示，不要占用当前终端盲目重试。
+输出命令后等待用户进一步指示，不要占用当前终端盲目重试。不要把该方案描述成默认设置方式。
 
 当用户确认 `http://127.0.0.1:9222/json/version` 已可访问后:
 1. 执行 `flocks browser --setup` 触发 attach，不要用短超时包装该命令

--- a/flocks/browser/admin.py
+++ b/flocks/browser/admin.py
@@ -20,7 +20,7 @@ from .utils import load_env_file
 VERSION_CACHE = Path(tempfile.gettempdir()) / "flocks-browser-version-cache.json"
 VERSION_CACHE_TTL = 24 * 3600
 DOCTOR_TEXT_LIMIT = 140
-# run_setup retries transient attach failures once, but exits after manual setup guidance.
+# run_setup retries once after the user enables remote debugging for the current profile.
 _SETUP_ATTACH_WAIT = 20.0
 _SETUP_RETRY_WAIT = 30.0
 
@@ -49,7 +49,7 @@ def _log_tail(name: str | None):
 
 
 def _needs_chrome_remote_debugging_prompt(msg: str | None) -> bool:
-    """Return True when a local browser needs remote-debugging setup guidance."""
+    """Return True when a local browser needs the inspect-page permission flow."""
     lower = (msg or "").lower()
     return (
         "devtoolsactiveport not found" in lower
@@ -63,12 +63,13 @@ def _needs_chrome_remote_debugging_prompt(msg: str | None) -> bool:
 
 
 def _local_debugging_setup_lines(system: str | None = None) -> list[str]:
-    """Return concise manual setup guidance for local Chromium-based debugging."""
+    """Return optional isolated-browser fallback guidance."""
     import platform
 
     system = system or platform.system()
     lines = [
-        "Do not look for webSocketDebuggerUrl in chrome://inspect; that page does not reliably show it.",
+        "Fallback only: use this if the current-profile inspect/Allow flow still cannot attach.",
+        "Do not look for webSocketDebuggerUrl in chrome://inspect; Flocks discovers the endpoint itself.",
         "Close the matching Chromium-based browser if it is already open, then run one command below.",
     ]
     if system == "Windows":
@@ -275,7 +276,7 @@ def _doctor_short_text(value, limit: int | None = None) -> str:
 
 
 def ensure_daemon(
-    wait: float = 60.0, name: str | None = None, env: dict | None = None, _show_debugging_guidance: bool = True
+    wait: float = 60.0, name: str | None = None, env: dict | None = None, _open_inspect: bool = True
 ) -> None:
     """Ensure a healthy daemon is running, restarting stale sessions when needed."""
     effective_name = ipc.runtime_paths(name or NAME).name
@@ -328,10 +329,17 @@ def ensure_daemon(
         msg = _log_tail(effective_name) or ""
         if local and attempt == 0 and _needs_chrome_remote_debugging_prompt(msg):
             restart_daemon(effective_name)
-            if _show_debugging_guidance:
-                print(f"{BROWSER_LABEL}: local Chromium-based browser remote debugging is not reachable.", file=sys.stderr)
-                _print_local_debugging_setup(sys.stderr)
-            raise RuntimeError(msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}")
+            if not _open_inspect:
+                raise RuntimeError(
+                    msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}"
+                )
+            _open_browser_inspect()
+            print(
+                f"{BROWSER_LABEL}: click Allow on your browser's inspect page "
+                "(for example chrome://inspect or edge://inspect), and tick the checkbox if shown",
+                file=sys.stderr,
+            )
+            continue
         raise RuntimeError(msg or f"daemon {effective_name} didn't come up -- check {ipc.log_path(effective_name)}")
 
 
@@ -437,6 +445,40 @@ def _chrome_running() -> bool:
         return False
 
 
+def _open_browser_inspect() -> None:
+    import platform
+    import subprocess
+    import webbrowser
+
+    inspect_targets = [
+        ("Google Chrome", "chrome://inspect/#remote-debugging"),
+        ("Microsoft Edge", "edge://inspect/#remote-debugging"),
+    ]
+    if platform.system() == "Darwin":
+        for app_name, url in inspect_targets:
+            try:
+                subprocess.run(
+                    [
+                        "osascript",
+                        "-e",
+                        f'tell application "{app_name}" to activate',
+                        "-e",
+                        f'tell application "{app_name}" to open location "{url}"',
+                    ],
+                    timeout=5,
+                    check=False,
+                )
+                return
+            except Exception:
+                continue
+    for _app_name, url in inspect_targets:
+        try:
+            if webbrowser.open(url, new=2):
+                return
+        except Exception:
+            continue
+
+
 def run_setup() -> int:
     """Interactively attach to the running browser."""
     import sys
@@ -458,33 +500,37 @@ def run_setup() -> int:
             restart_daemon()
     if not endpoint_name and not _chrome_running():
         print("no Chrome/Chromium/Edge/Brave process detected.")
-        print("start a Chromium-based browser with remote debugging, then rerun `flocks browser --setup`.")
-        _print_local_debugging_setup(sys.stdout)
+        print("start Chrome, Chromium, Edge, or Brave and rerun `flocks browser --setup`.")
         return 1
     try:
-        ensure_daemon(wait=_SETUP_ATTACH_WAIT, _show_debugging_guidance=False)
+        ensure_daemon(wait=_SETUP_ATTACH_WAIT, _open_inspect=False)
         print("daemon is up.")
         return 0
     except RuntimeError as error:
         first_err = str(error)
 
-    needs_manual_debugging_setup = _is_local_chrome_mode() and _needs_chrome_remote_debugging_prompt(first_err)
-    if needs_manual_debugging_setup:
-        print("Chromium-based browser remote debugging is not reachable for the current profile.")
-        _print_local_debugging_setup(sys.stdout)
-        return 1
+    needs_inspect = _is_local_chrome_mode() and _needs_chrome_remote_debugging_prompt(first_err)
+    if needs_inspect:
+        print("browser remote debugging is not enabled on the current profile.")
+        print("opening your browser's inspect page -- in the tab that opens:")
+        print("  1. if the browser shows the profile picker, pick your normal profile;")
+        print("  2. tick 'Discover network targets' and click Allow if prompted.")
+        _open_browser_inspect()
     else:
         print(f"attach failed: {first_err}")
         print("retrying once (the browser may still be starting up)...")
 
     try:
-        ensure_daemon(wait=_SETUP_RETRY_WAIT, _show_debugging_guidance=False)
+        ensure_daemon(wait=_SETUP_RETRY_WAIT, _open_inspect=False)
         print("daemon is up.")
         return 0
     except RuntimeError as error:
         last = str(error)
 
     print(f"setup failed: {last}", file=sys.stderr)
+    if needs_inspect and _needs_chrome_remote_debugging_prompt(last):
+        print("current-profile attach still failed; optional isolated-browser fallback:", file=sys.stderr)
+        _print_local_debugging_setup(sys.stderr)
     print("run `flocks browser --doctor` for diagnostics.", file=sys.stderr)
     return 1
 
@@ -550,7 +596,7 @@ def run_doctor() -> int:
         daemon,
         ""
         if daemon
-        else "not running; run `flocks browser --setup` to attach; if setup reports remote debugging is not reachable, follow its debug-browser instructions",
+        else "not running; run `flocks browser --setup` to attach; if setup reports remote debugging is disabled, follow its inspect-page prompt",
     )
     row("active browser connections", bool(connections), str(len(connections)))
     for conn in connections:

--- a/flocks/browser/daemon.py
+++ b/flocks/browser/daemon.py
@@ -63,7 +63,6 @@ def profile_dirs(
     if system == "Darwin":
         support = home / "Library/Application Support"
         return [
-            *flocks_debug_profiles,
             support / "Google/Chrome",
             support / "Google/Chrome Canary",
             support / "Comet",
@@ -74,11 +73,11 @@ def profile_dirs(
             support / "Microsoft Edge Canary",
             support / "BraveSoftware/Brave-Browser",
             support / "Chromium",
+            *flocks_debug_profiles,
         ]
     if system == "Windows":
         local = Path(environ.get("LOCALAPPDATA", str(home / "AppData/Local"))).expanduser()
         return [
-            *flocks_debug_profiles,
             local / "Google/Chrome/User Data",
             local / "Google/Chrome Beta/User Data",
             local / "Google/Chrome Dev/User Data",
@@ -91,9 +90,9 @@ def profile_dirs(
             local / "BraveSoftware/Brave-Browser/User Data",
             local / "BraveSoftware/Brave-Browser-Beta/User Data",
             local / "BraveSoftware/Brave-Browser-Nightly/User Data",
+            *flocks_debug_profiles,
         ]
     return [
-        *flocks_debug_profiles,
         home / ".config/google-chrome",
         home / ".config/google-chrome-beta",
         home / ".config/google-chrome-unstable",
@@ -107,6 +106,7 @@ def profile_dirs(
         home / ".var/app/com.google.Chrome/config/google-chrome",
         home / ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
         home / ".var/app/com.microsoft.Edge/config/microsoft-edge",
+        *flocks_debug_profiles,
     ]
 
 
@@ -210,14 +210,15 @@ def get_ws_url() -> str:
     if profile_errors:
         details = "; ".join(dict.fromkeys(profile_errors))
         raise RuntimeError(
-            "Chromium-based browser remote debugging is not reachable for any detected profile: "
-            f"{details} — for manual setup, start the browser with --remote-debugging-port and a non-default "
-            "--user-data-dir, then verify http://127.0.0.1:9222/json/version"
+            "The browser's remote-debugging page is open, but DevTools is not live yet for any detected profile: "
+            f"{details} — if the browser opened a profile picker, choose your normal profile first, then tick the "
+            "checkbox and click Allow if shown"
         )
     raise RuntimeError(
         "DevToolsActivePort not found in "
-        f"{[str(path) for path in profiles]} — start a Chromium-based browser with --remote-debugging-port and a non-default "
-        "--user-data-dir, or set BU_CDP_WS for a remote browser"
+        f"{[str(path) for path in profiles]} — enable your browser's remote-debugging page "
+        "(for example chrome://inspect/#remote-debugging or edge://inspect/#remote-debugging), "
+        "or set BU_CDP_WS for a remote browser"
     )
 
 
@@ -291,9 +292,7 @@ class Daemon:
                     f"{hint}"
                 ) from error
             raise RuntimeError(
-                f"CDP WS handshake failed: {error} -- restart your Chromium-based browser with "
-                "--remote-debugging-port and a non-default --user-data-dir, then verify "
-                "http://127.0.0.1:9222/json/version"
+                f"CDP WS handshake failed: {error} -- click Allow in your browser if prompted, then retry"
             )
         await self.attach_first_page()
         orig = self.cdp._event_registry.handle_event

--- a/tests/browser/test_admin.py
+++ b/tests/browser/test_admin.py
@@ -74,7 +74,8 @@ def test_local_debugging_setup_lines_use_windows_user_data_dir() -> None:
     lines = "\n".join(admin._local_debugging_setup_lines("Windows"))
 
     assert "chrome://inspect" in lines
-    assert "does not reliably show it" in lines
+    assert "Fallback only" in lines
+    assert "Flocks discovers the endpoint itself" in lines
     assert "--remote-debugging-port=9222" in lines
     assert '--user-data-dir="$env:USERPROFILE\\.flocks\\chrome-debug-profile"' in lines
     assert "msedge.exe" in lines
@@ -97,7 +98,7 @@ def test_local_debugging_setup_lines_list_chromium_browser_candidates() -> None:
     assert "brave-browser" in linux_lines
 
 
-def test_browser_skill_docs_do_not_reintroduce_inspect_allow_setup_flow() -> None:
+def test_browser_skill_docs_keep_inspect_allow_as_primary_setup_flow() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     docs = [
         repo_root / ".flocks/plugins/skills/browser-use/SKILL.md",
@@ -106,9 +107,10 @@ def test_browser_skill_docs_do_not_reintroduce_inspect_allow_setup_flow() -> Non
     ]
     text = "\n".join(path.read_text(encoding="utf-8") for path in docs)
 
-    assert "chrome://inspect/#remote-debugging" not in text
-    assert "edge://inspect/#remote-debugging" not in text
-    assert "Allow remote debugging" not in text
+    assert "chrome://inspect/#remote-debugging" in text
+    assert "edge://inspect/#remote-debugging" in text
+    assert "Allow remote debugging" in text
+    assert "不要从 chrome://inspect 查找 webSocketDebuggerUrl" in text
 
 
 def test_daemon_endpoint_names_discovers_default_and_named_sessions(tmp_path, monkeypatch) -> None:
@@ -243,9 +245,10 @@ def test_ensure_daemon_retries_after_lock_holder_exits_without_endpoint(tmp_path
     assert len(spawned) == 2
 
 
-def test_ensure_daemon_prints_manual_guidance_without_blind_retry(tmp_path, monkeypatch, capsys) -> None:
+def test_ensure_daemon_opens_inspect_and_retries_current_profile(tmp_path, monkeypatch, capsys) -> None:
     spawned = []
     restarted = []
+    open_calls = []
 
     class FakeProcess:
         def poll(self):
@@ -265,16 +268,16 @@ def test_ensure_daemon_prints_manual_guidance_without_blind_retry(tmp_path, monk
         lambda name: "Chromium-based browser remote debugging is not reachable for any detected profile",
     )
     monkeypatch.setattr(admin, "restart_daemon", lambda name=None: restarted.append(name))
-    monkeypatch.setattr(admin, "_local_debugging_setup_lines", lambda: ["debug browser instructions"])
+    monkeypatch.setattr(admin, "_open_browser_inspect", lambda: open_calls.append(True))
 
     with pytest.raises(RuntimeError):
         admin.ensure_daemon(wait=1.0, name="manual-session")
 
     err = capsys.readouterr().err
-    assert "local Chromium-based browser remote debugging is not reachable" in err
-    assert "debug browser instructions" in err
-    assert len(spawned) == 1
+    assert "click Allow on your browser's inspect page" in err
+    assert len(spawned) == 2
     assert restarted == ["manual-session"]
+    assert open_calls == [True]
 
 
 def test_run_doctor_prints_active_browser_connections_and_active_pages(monkeypatch, capsys) -> None:
@@ -363,21 +366,21 @@ def test_run_doctor_suggests_setup_when_target_exists_but_daemon_missing(monkeyp
 def test_run_setup_uses_generic_missing_browser_wording(monkeypatch, capsys) -> None:
     monkeypatch.setattr(admin, "daemon_alive", lambda: False)
     monkeypatch.setattr(admin, "_chrome_running", lambda: False)
-    monkeypatch.setattr(admin, "_local_debugging_setup_lines", lambda: ["debug browser instructions"])
 
     assert admin.run_setup() == 1
 
     out = capsys.readouterr().out
     assert "no Chrome/Chromium/Edge/Brave process detected" in out
-    assert "start a Chromium-based browser with remote debugging" in out
-    assert "debug browser instructions" in out
+    assert "start Chrome, Chromium, Edge, or Brave" in out
+    assert "--remote-debugging-port" not in out
 
 
-def test_run_setup_prints_remote_debugging_guidance_without_blind_retry(monkeypatch, capsys) -> None:
+def test_run_setup_opens_inspect_and_retries_current_profile(monkeypatch, capsys) -> None:
     monkeypatch.setattr(admin, "daemon_alive", lambda: False)
     monkeypatch.setattr(admin, "_chrome_running", lambda: True)
     monkeypatch.setattr(admin, "_is_local_chrome_mode", lambda env=None: True)
-    monkeypatch.setattr(admin, "_local_debugging_setup_lines", lambda: ["debug browser instructions"])
+    open_calls = []
+    monkeypatch.setattr(admin, "_open_browser_inspect", lambda: open_calls.append(True), raising=False)
 
     calls = {"count": 0}
 
@@ -391,13 +394,43 @@ def test_run_setup_prints_remote_debugging_guidance_without_blind_retry(monkeypa
 
     monkeypatch.setattr(admin, "ensure_daemon", fake_ensure_daemon)
 
-    assert admin.run_setup() == 1
+    assert admin.run_setup() == 0
 
     out = capsys.readouterr().out
-    assert "Chromium-based browser remote debugging is not reachable for the current profile." in out
-    assert "debug browser instructions" in out
-    assert "opening your browser's inspect page" not in out
-    assert calls["count"] == 1
+    assert "browser remote debugging is not enabled on the current profile." in out
+    assert "opening your browser's inspect page" in out
+    assert "pick your normal profile" in out
+    assert open_calls == [True]
+    assert calls["count"] == 2
+
+
+def test_run_setup_prints_isolated_fallback_only_after_inspect_retry_fails(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(admin, "daemon_alive", lambda: False)
+    monkeypatch.setattr(admin, "_chrome_running", lambda: True)
+    monkeypatch.setattr(admin, "_is_local_chrome_mode", lambda env=None: True)
+    monkeypatch.setattr(admin, "_local_debugging_setup_lines", lambda: ["isolated fallback instructions"])
+    open_calls = []
+    monkeypatch.setattr(admin, "_open_browser_inspect", lambda: open_calls.append(True))
+    ensure_calls = []
+
+    def fake_ensure_daemon(**kwargs):
+        ensure_calls.append(kwargs)
+        raise RuntimeError("DevToolsActivePort not found")
+
+    monkeypatch.setattr(admin, "ensure_daemon", fake_ensure_daemon)
+
+    assert admin.run_setup() == 1
+
+    output = capsys.readouterr()
+    assert "opening your browser's inspect page" in output.out
+    assert "isolated fallback instructions" not in output.out
+    assert "optional isolated-browser fallback" in output.err
+    assert "isolated fallback instructions" in output.err
+    assert open_calls == [True]
+    assert ensure_calls == [
+        {"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False},
+        {"wait": admin._SETUP_RETRY_WAIT, "_open_inspect": False},
+    ]
 
 
 def test_run_setup_restarts_stale_existing_local_daemon(monkeypatch, capsys) -> None:
@@ -415,7 +448,7 @@ def test_run_setup_restarts_stale_existing_local_daemon(monkeypatch, capsys) -> 
     assert "browser connection is stale; restarting" in out
     assert "daemon is up." in out
     assert restarted == [None]
-    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_show_debugging_guidance": False}]
+    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False}]
 
 
 def test_run_setup_retries_at_most_once(monkeypatch, capsys) -> None:
@@ -435,8 +468,8 @@ def test_run_setup_retries_at_most_once(monkeypatch, capsys) -> None:
     out = capsys.readouterr()
     assert "retrying once" in out.out
     assert ensure_calls == [
-        {"wait": admin._SETUP_ATTACH_WAIT, "_show_debugging_guidance": False},
-        {"wait": admin._SETUP_RETRY_WAIT, "_show_debugging_guidance": False},
+        {"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False},
+        {"wait": admin._SETUP_RETRY_WAIT, "_open_inspect": False},
     ]
 
 
@@ -452,7 +485,7 @@ def test_run_setup_allows_explicit_remote_cdp_without_local_browser(monkeypatch,
     out = capsys.readouterr().out
     assert "attaching via BU_CDP_WS" in out
     assert "daemon is up." in out
-    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_show_debugging_guidance": False}]
+    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False}]
 
 
 def test_run_setup_restarts_existing_daemon_for_explicit_remote_cdp(monkeypatch, capsys) -> None:
@@ -473,7 +506,7 @@ def test_run_setup_restarts_existing_daemon_for_explicit_remote_cdp(monkeypatch,
     assert "restarting to attach via BU_CDP_URL" in out
     assert "daemon is up." in out
     assert restarted == [None]
-    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_show_debugging_guidance": False}]
+    assert ensure_calls == [{"wait": admin._SETUP_ATTACH_WAIT, "_open_inspect": False}]
 
 
 def test_run_doctor_uses_generic_browser_wording_when_missing(monkeypatch, capsys) -> None:
@@ -492,7 +525,7 @@ def test_run_doctor_uses_generic_browser_wording_when_missing(monkeypatch, capsy
     assert "next action       start Chrome/Chromium/Edge/Brave or provide BU_CDP_URL/BU_CDP_WS" in out
 
 
-def test_run_doctor_points_to_debug_browser_instructions_when_daemon_missing(monkeypatch, capsys) -> None:
+def test_run_doctor_points_to_inspect_flow_when_daemon_missing(monkeypatch, capsys) -> None:
     monkeypatch.setattr(admin, "_version", lambda: "0.1.0")
     monkeypatch.setattr(admin, "_install_mode", lambda: "git")
     monkeypatch.setattr(admin, "_chrome_running", lambda: True)
@@ -503,9 +536,8 @@ def test_run_doctor_points_to_debug_browser_instructions_when_daemon_missing(mon
     assert admin.run_doctor() == 1
 
     out = capsys.readouterr().out
-    assert "follow its debug-browser instructions" in out
-    assert "remote debugging is not reachable" in out
-    assert "inspect-page prompt" not in out
+    assert "remote debugging is disabled" in out
+    assert "follow its inspect-page prompt" in out
 
 
 def test_run_doctor_accepts_explicit_remote_cdp_without_local_browser(monkeypatch, capsys) -> None:

--- a/tests/browser/test_daemon.py
+++ b/tests/browser/test_daemon.py
@@ -178,12 +178,12 @@ def test_profile_dirs_only_returns_paths_for_requested_os() -> None:
         environ={"LOCALAPPDATA": str(local_app_data)},
     )
 
-    assert mac_profiles[:4] == flocks_debug_profiles
-    assert linux_profiles[:4] == flocks_debug_profiles
-    assert windows_profiles[:4] == flocks_debug_profiles
-    assert all("Library" in path.parts and "Application Support" in path.parts for path in mac_profiles[4:])
-    assert all(".config" in path.parts or ".var" in path.parts for path in linux_profiles[4:])
-    assert all(path.is_relative_to(local_app_data) for path in windows_profiles[4:])
+    assert mac_profiles[-4:] == flocks_debug_profiles
+    assert linux_profiles[-4:] == flocks_debug_profiles
+    assert windows_profiles[-4:] == flocks_debug_profiles
+    assert all("Library" in path.parts and "Application Support" in path.parts for path in mac_profiles[:-4])
+    assert all(".config" in path.parts or ".var" in path.parts for path in linux_profiles[:-4])
+    assert all(path.is_relative_to(local_app_data) for path in windows_profiles[:-4])
 
 
 def test_get_ws_url_skips_unreachable_profile_and_uses_next_candidate(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- restore the current-profile inspect/Allow flow and retry attachment before offering an isolated browser
- retain the DevToolsActivePort WebSocket-path fallback from #588
- treat isolated debug profiles and fixed-port startup as a final fallback, after normal profiles
- align browser-use guidance and add regression coverage

## Validation

- ============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/rosey/.codex/worktrees/6c8c/flocks
configfile: pyproject.toml
plugins: cov-7.1.0, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 117 items

tests/browser/test_admin.py ............................................ [ 37%]
..                                                                       [ 39%]
tests/browser/test_daemon.py ...............                             [ 52%]
tests/browser/test_helpers.py .....................                      [ 70%]
tests/browser/test_ipc.py ..............                                 [ 82%]
tests/browser/test_lifecycle.py ..........                               [ 90%]
tests/browser/test_run.py .......                                        [ 96%]
tests/browser/test_skill_docs.py .                                       [ 97%]
tests/browser/test_utils.py ...                                          [100%]

============================= 117 passed in 1.02s ==============================
- All checks passed!

Fixes the regression introduced by #588, which made isolated-profile startup the default recovery path and prevented reuse of the user's current browser profile.