### PR TITLE
fix(webui): render bash tool errors once

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -3818,6 +3818,29 @@ describe('ChatToolPart bash rendering', () => {
     expect(screen.getByText('$').closest('pre')).toHaveClass('max-h-64');
     expect(screen.getByText('tests passed').closest('pre')).toHaveClass('max-h-64');
   });
+
+  it.each([
+    'Tool execution was interrupted',
+    'Command failed with exit code 1',
+  ])('renders the bash error once: %s', (error) => {
+    render(
+      React.createElement(ChatToolPart, {
+        part: {
+          id: 'bash-error-part',
+          type: 'tool',
+          tool: 'bash',
+          callID: 'call-bash-error',
+          state: {
+            status: 'error',
+            input: { command: 'exit 1' },
+            error,
+          },
+        } as any,
+      }),
+    );
+
+    expect(screen.getAllByText(error)).toHaveLength(1);
+  });
 });
 
 describe('ChatToolPart question result rendering', () => {

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -6275,7 +6275,7 @@ export function ChatToolPart({ part, pendingQuestion, onAnswer, onReject, proces
         </details>
       )}
 
-      {status === 'error' && state.error && (
+      {!isBashTool && status === 'error' && state.error && (
         <div className="rounded-md border border-red-100 bg-red-50 px-2.5 py-1.5 text-[11px] text-red-600 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
           {state.error}
         </div>


### PR DESCRIPTION
## Summary

- Avoid rendering the generic tool error block for bash tools.
- Keep bash-specific error output as the single visible error source.

## Validation

- 170 SessionChat component tests passed.
- TypeScript validation passed.