### PR TITLE
fix(task): serialize background completion handoff

### DIFF
--- a/flocks/task/background.py
+++ b/flocks/task/background.py
@@ -237,21 +237,27 @@ class BackgroundManager:
             "</task>"
         )
         try:
-            await Message.create(
-                session_id=task.parent_session_id,
-                role=MessageRole.USER,
-                content=content,
-                agent=task.parent_agent or "rex",
-                model=task.parent_model,
-                synthetic=True,
-                part_metadata={
-                    "kind": "background_task_result",
-                    "task_id": task.id,
-                    "session_id": task.session_id,
-                    "status": state,
-                },
+            async def _persist_completion() -> None:
+                await Message.create(
+                    session_id=task.parent_session_id,
+                    role=MessageRole.USER,
+                    content=content,
+                    agent=task.parent_agent or "rex",
+                    model=task.parent_model,
+                    synthetic=True,
+                    part_metadata={
+                        "kind": "background_task_result",
+                        "task_id": task.id,
+                        "session_id": task.session_id,
+                        "status": state,
+                    },
+                )
+                await self._update_parent_tool_part(task)
+
+            await Session.run_active_write(
+                task.parent_session_id,
+                _persist_completion,
             )
-            await self._update_parent_tool_part(task)
             task.completion_injected = True
             self._schedule_parent_resume(task)
         except Exception as exc:
@@ -265,15 +271,6 @@ class BackgroundManager:
         """Kick the parent session so Rex consumes injected background results."""
         if not task.parent_session_id:
             return
-        if task.status not in ("completed", "error"):
-            return
-        if SessionLoop.is_running(task.parent_session_id):
-            log.info("background.parent_resume.already_running", {
-                "task_id": task.id,
-                "parent_session_id": task.parent_session_id,
-            })
-            return
-
         async def _run_parent() -> None:
             try:
                 from flocks.server.routes.event import publish_event

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -624,6 +624,12 @@ async def test_background_task_completion_injects_parent_context(
     monkeypatch.setattr(background_module.Message, "update_part", update_part)
     monkeypatch.setattr(background_module.SessionLoop, "run", parent_loop_run)
 
+    async def run_active_write(_session_id, operation, **_kwargs):
+        return await operation()
+
+    active_write = AsyncMock(side_effect=run_active_write)
+    monkeypatch.setattr(background_module.Session, "run_active_write", active_write)
+
     manager = BackgroundManager()
     task = BackgroundTask(
         id="bg_parent_inject",
@@ -642,6 +648,8 @@ async def test_background_task_completion_injects_parent_context(
 
     await manager._inject_parent_completion(task)
 
+    active_write.assert_awaited_once()
+    assert active_write.await_args.args[0] == "ses-parent"
     create_message.assert_awaited_once()
     kwargs = create_message.await_args.kwargs
     assert kwargs["session_id"] == "ses-parent"
@@ -662,12 +670,11 @@ async def test_background_task_completion_injects_parent_context(
 
 
 @pytest.mark.asyncio
-async def test_background_task_completion_does_not_resume_running_parent(
+async def test_background_task_completion_always_attempts_parent_resume(
     monkeypatch: pytest.MonkeyPatch,
 ):
     parent_loop_run = AsyncMock(return_value=SimpleNamespace(action="stop"))
     monkeypatch.setattr(background_module.SessionLoop, "run", parent_loop_run)
-    monkeypatch.setattr(background_module.SessionLoop, "is_running", lambda _session_id: True)
 
     manager = BackgroundManager()
     task = BackgroundTask(
@@ -685,7 +692,8 @@ async def test_background_task_completion_does_not_resume_running_parent(
     manager._schedule_parent_resume(task)
     await asyncio.sleep(0)
 
-    parent_loop_run.assert_not_awaited()
+    parent_loop_run.assert_awaited_once()
+    assert parent_loop_run.await_args.kwargs["session_id"] == "ses-parent"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Serialize the injected completion message and parent tool-part update with the session active-write boundary.
- Always hand terminal background results to SessionLoop so an active parent queues the continuation instead of dropping it.

## Validation

- 2 focused background-completion regression tests passed.
- Ruff passed for both changed Python files.