### PR TITLE
refactor(task): rename scheduled task manager

### DIFF
--- a/flocks/cli/commands/task.py
+++ b/flocks/cli/commands/task.py
@@ -45,11 +45,11 @@ def task_dashboard():
 
 async def _dashboard():
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.store import TaskStore
     await TaskStore.init()
 
-    counts = await TaskManager.dashboard()
+    counts = await ScheduleTaskManager.dashboard()
 
     panel_lines = [
         f"🟢 Running:             {counts.get('running', 0)}",
@@ -63,7 +63,7 @@ async def _dashboard():
 
     console.print(Panel("\n".join(panel_lines), title="📋 Task Center", border_style="cyan"))
 
-    unviewed = await TaskManager.get_unviewed_results()
+    unviewed = await ScheduleTaskManager.get_unviewed_results()
     if unviewed:
         console.print()
         console.print("[bold]Unviewed completed tasks:[/bold]")
@@ -88,7 +88,7 @@ def task_list(
 
 async def _list_tasks(status_val, type_val, limit, fmt):
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.models import SchedulerStatus, TaskStatus
     from flocks.task.store import TaskStore
     await TaskStore.init()
@@ -99,7 +99,7 @@ async def _list_tasks(status_val, type_val, limit, fmt):
             scheduler_status = SchedulerStatus.ACTIVE
         elif status_val in ("paused", "disabled"):
             scheduler_status = SchedulerStatus.DISABLED
-        tasks, total = await TaskManager.list_schedulers(status=scheduler_status, limit=limit)
+        tasks, total = await ScheduleTaskManager.list_schedulers(status=scheduler_status, limit=limit)
     else:
         task_status = None
         if status_val:
@@ -108,7 +108,7 @@ async def _list_tasks(status_val, type_val, limit, fmt):
                 task_status = TaskStatus(mapped_status)
             except ValueError as exc:
                 raise typer.BadParameter(f"Invalid execution status: {status_val}") from exc
-        tasks, total = await TaskManager.list_executions(
+        tasks, total = await ScheduleTaskManager.list_executions(
             status=task_status,
             limit=limit,
         )
@@ -160,13 +160,13 @@ def task_show(task_id: str = typer.Argument(..., help="Task ID")):
 
 async def _show_task(task_id: str):
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.store import TaskStore
     await TaskStore.init()
 
-    task = await TaskManager.get_execution(task_id)
+    task = await ScheduleTaskManager.get_execution(task_id)
     if task is None:
-        task = await TaskManager.get_scheduler(task_id)
+        task = await ScheduleTaskManager.get_scheduler(task_id)
     if not task:
         console.print(f"[red]Task {task_id} not found[/red]")
         raise typer.Exit(1)
@@ -243,7 +243,7 @@ def task_create(
 
 async def _create_task(title, description, task_type, priority, mode, agent, workflow, skills, cron, prompt):
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.models import (
         ExecutionMode,
         SchedulerMode,
@@ -270,7 +270,7 @@ async def _create_task(title, description, task_type, priority, mode, agent, wor
 
     source = TaskSource(user_prompt=prompt) if prompt else None
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title=title,
         description=description,
         mode=scheduler_mode,
@@ -284,7 +284,7 @@ async def _create_task(title, description, task_type, priority, mode, agent, wor
     )
     console.print(f"[green]✅ Created scheduler:[/green] {scheduler.id}  {scheduler.title}")
     if trigger.run_immediately:
-        executions, _ = await TaskManager.list_scheduler_executions(scheduler.id, limit=1)
+        executions, _ = await ScheduleTaskManager.list_scheduler_executions(scheduler.id, limit=1)
         if executions:
             console.print(
                 f"[green]↳ execution:[/green] {executions[0].id}  ({executions[0].status.value})"
@@ -306,20 +306,20 @@ def task_queue(
 
 async def _queue(pause: bool, resume: bool):
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.store import TaskStore
     await TaskStore.init()
 
     if pause:
-        TaskManager.pause_queue()
+        ScheduleTaskManager.pause_queue()
         console.print("[yellow]Queue paused[/yellow]")
         return
     if resume:
-        TaskManager.resume_queue()
+        ScheduleTaskManager.resume_queue()
         console.print("[green]Queue resumed[/green]")
         return
 
-    qs = await TaskManager.queue_status()
+    qs = await ScheduleTaskManager.queue_status()
     console.print(Panel(
         f"Paused:         {qs['paused']}\n"
         f"Max concurrent: {qs['max_concurrent']}\n"
@@ -342,11 +342,11 @@ def task_scheduled():
 
 async def _scheduled():
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.store import TaskStore
     await TaskStore.init()
 
-    tasks, _ = await TaskManager.list_schedulers(scheduled_only=True, limit=100)
+    tasks, _ = await ScheduleTaskManager.list_schedulers(scheduled_only=True, limit=100)
     if not tasks:
         console.print("[dim]No scheduled tasks[/dim]")
         return
@@ -384,11 +384,11 @@ def task_cancel(task_id: str = typer.Argument(..., help="Task ID")):
 
 async def _cancel(task_id: str):
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.store import TaskStore
     await TaskStore.init()
 
-    task = await TaskManager.cancel_execution(task_id)
+    task = await ScheduleTaskManager.cancel_execution(task_id)
     if not task:
         console.print(f"[red]Task {task_id} not found[/red]")
         raise typer.Exit(1)
@@ -403,11 +403,11 @@ def task_retry(task_id: str = typer.Argument(..., help="Task ID")):
 
 async def _retry(task_id: str):
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.store import TaskStore
     await TaskStore.init()
 
-    task = await TaskManager.retry_execution(task_id)
+    task = await ScheduleTaskManager.retry_execution(task_id)
     if not task:
         console.print(f"[red]Task {task_id} not found or not failed[/red]")
         raise typer.Exit(1)
@@ -422,13 +422,13 @@ def task_rerun(task_id: str = typer.Argument(..., help="Task ID")):
 
 async def _rerun(task_id: str):
     await Storage.init()
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.store import TaskStore
     await TaskStore.init()
 
-    task = await TaskManager.rerun_execution(task_id)
+    task = await ScheduleTaskManager.rerun_execution(task_id)
     if task is None:
-        task = await TaskManager.rerun_scheduler(task_id)
+        task = await ScheduleTaskManager.rerun_scheduler(task_id)
     if not task:
         console.print(f"[red]Task {task_id} not found[/red]")
         raise typer.Exit(1)

--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -350,17 +350,17 @@ async def lifespan(app: FastAPI):
 
     # Start Task Center (scheduler + queue executor)
     try:
-        from flocks.task.manager import TaskManager
+        from flocks.task.schedule_task_manager import ScheduleTaskManager
         await _run_startup_phase(
             log,
-            "task_manager.start",
-            TaskManager.start,
+            "schedule_task_manager.start",
+            ScheduleTaskManager.start,
         )
-        log.info("task_manager.started")
+        log.info("schedule_task_manager.started")
     except Exception as e:
-        from flocks.task.manager import TaskManager
-        TaskManager.mark_start_failed(e)
-        log.warning("task_manager.start.failed", {"error": str(e)})
+        from flocks.task.schedule_task_manager import ScheduleTaskManager
+        ScheduleTaskManager.mark_start_failed(e)
+        log.warning("schedule_task_manager.start.failed", {"error": str(e)})
 
     # Seed built-in scheduled tasks from .flocks/plugins/tasks/*.json (idempotent)
     try:
@@ -538,13 +538,13 @@ async def lifespan(app: FastAPI):
 
     # Stop Task Center
     try:
-        from flocks.task.manager import TaskManager
+        from flocks.task.schedule_task_manager import ScheduleTaskManager
         from flocks.task.store import TaskStore
-        await TaskManager.stop()
+        await ScheduleTaskManager.stop()
         await TaskStore.close()
-        log.info("task_manager.stopped")
+        log.info("schedule_task_manager.stopped")
     except Exception as e:
-        log.warning("task_manager.stop.failed", {"error": str(e)})
+        log.warning("schedule_task_manager.stop.failed", {"error": str(e)})
     
     # Stop Skill file watcher
     try:

--- a/flocks/server/routes/stats.py
+++ b/flocks/server/routes/stats.py
@@ -19,7 +19,7 @@ from flocks.provider.provider import Provider
 from flocks.server.routes.provider import list_providers
 from flocks.server.routes.workflow import _list_workflows_from_fs, _migrate_storage_to_filesystem
 from flocks.skill.skill import Skill
-from flocks.task.manager import TaskManager
+from flocks.task.schedule_task_manager import ScheduleTaskManager
 from flocks.tool.registry import ToolRegistry
 from flocks.utils.log import Log
 
@@ -70,7 +70,7 @@ def _should_count_agent(agent: Any) -> bool:
 
 
 async def _task_dashboard() -> dict[str, Any]:
-    return await TaskManager.dashboard()
+    return await ScheduleTaskManager.dashboard()
 
 
 async def _safe_dashboard(failures: list[str]) -> dict[str, Any]:

--- a/flocks/server/routes/task_entities.py
+++ b/flocks/server/routes/task_entities.py
@@ -145,10 +145,10 @@ def _parse_task_type(task_type: str) -> str:
 
 @router.get("/task-system/notice")
 async def get_task_system_notice():
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
     started_at = time.perf_counter()
-    notice = await TaskManager.get_task_page_notice()
+    notice = await ScheduleTaskManager.get_task_page_notice()
     log_route_timing(log, "task.notice.complete", started_at=started_at, extra={
         "has_notice": bool(notice),
     })
@@ -157,10 +157,10 @@ async def get_task_system_notice():
 
 @router.get("/task-system/dashboard")
 async def task_dashboard():
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
     started_at = time.perf_counter()
-    payload = await TaskManager.dashboard()
+    payload = await ScheduleTaskManager.dashboard()
     log_route_timing(log, "task.dashboard.complete", started_at=started_at, extra={
         "running": payload.get("running"),
         "queued": payload.get("queued"),
@@ -171,10 +171,10 @@ async def task_dashboard():
 
 @router.get("/task-system/queue/status")
 async def task_queue_status():
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
     started_at = time.perf_counter()
-    payload = await TaskManager.queue_status()
+    payload = await ScheduleTaskManager.queue_status()
     log_route_timing(log, "task.queue_status.complete", started_at=started_at, extra={
         "queued": payload.get("queued"),
         "running": payload.get("running"),
@@ -185,17 +185,17 @@ async def task_queue_status():
 
 @router.post("/task-system/queue/pause")
 async def pause_task_queue():
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    TaskManager.pause_queue()
+    ScheduleTaskManager.pause_queue()
     return {"paused": True}
 
 
 @router.post("/task-system/queue/resume")
 async def resume_task_queue():
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    TaskManager.resume_queue()
+    ScheduleTaskManager.resume_queue()
     return {"paused": False}
 
 
@@ -209,9 +209,9 @@ async def list_schedulers(
     offset: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=100),
 ):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    items, total = await TaskManager.list_schedulers(
+    items, total = await ScheduleTaskManager.list_schedulers(
         status=_parse_scheduler_status_filter(status_filter),
         priority=_parse_priority(priority),
         scheduled_only=scheduled_only,
@@ -230,7 +230,7 @@ async def list_schedulers(
 
 @router.post("/task-schedulers", status_code=status.HTTP_201_CREATED)
 async def create_scheduler(req: SchedulerCreateRequest):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.models import (
         SchedulerMode,
         TaskSource,
@@ -268,7 +268,7 @@ async def create_scheduler(req: SchedulerCreateRequest):
             detail=str(exc),
         ) from exc
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title=req.title,
         description=req.description,
         mode=mode,
@@ -289,9 +289,9 @@ async def create_scheduler(req: SchedulerCreateRequest):
 
 @router.get("/task-schedulers/{scheduler_id}")
 async def get_scheduler(scheduler_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    scheduler = await TaskManager.get_scheduler(scheduler_id)
+    scheduler = await ScheduleTaskManager.get_scheduler(scheduler_id)
     if not scheduler:
         raise HTTPException(404, "Task scheduler not found")
     return scheduler.model_dump(mode="json", by_alias=True)
@@ -299,7 +299,7 @@ async def get_scheduler(scheduler_id: str):
 
 @router.put("/task-schedulers/{scheduler_id}")
 async def update_scheduler(scheduler_id: str, req: SchedulerUpdateRequest):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
     fields = {k: v for k, v in req.model_dump(exclude_none=True).items()}
     if "priority" in fields:
@@ -313,7 +313,7 @@ async def update_scheduler(scheduler_id: str, req: SchedulerUpdateRequest):
     run_at = fields.pop("run_at", None)
     user_prompt = fields.pop("user_prompt", None)
     try:
-        scheduler = await TaskManager.update_scheduler_with_trigger(
+        scheduler = await ScheduleTaskManager.update_scheduler_with_trigger(
             scheduler_id,
             fields=fields,
             cron=cron,
@@ -335,18 +335,18 @@ async def update_scheduler(scheduler_id: str, req: SchedulerUpdateRequest):
 
 @router.delete("/task-schedulers/{scheduler_id}")
 async def delete_scheduler(scheduler_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    if not await TaskManager.delete_scheduler(scheduler_id):
+    if not await ScheduleTaskManager.delete_scheduler(scheduler_id):
         raise HTTPException(404, "Task scheduler not found")
     return {"ok": True}
 
 
 @router.post("/task-schedulers/{scheduler_id}/enable")
 async def enable_scheduler(scheduler_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    scheduler = await TaskManager.enable_scheduler(scheduler_id)
+    scheduler = await ScheduleTaskManager.enable_scheduler(scheduler_id)
     if not scheduler:
         raise HTTPException(404, "Task scheduler not found")
     return scheduler.model_dump(mode="json", by_alias=True)
@@ -354,9 +354,9 @@ async def enable_scheduler(scheduler_id: str):
 
 @router.post("/task-schedulers/{scheduler_id}/disable")
 async def disable_scheduler(scheduler_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    scheduler = await TaskManager.disable_scheduler(scheduler_id)
+    scheduler = await ScheduleTaskManager.disable_scheduler(scheduler_id)
     if not scheduler:
         raise HTTPException(404, "Task scheduler not found")
     return scheduler.model_dump(mode="json", by_alias=True)
@@ -368,9 +368,9 @@ async def list_scheduler_executions(
     offset: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=100),
 ):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    items, total = await TaskManager.list_scheduler_executions(
+    items, total = await ScheduleTaskManager.list_scheduler_executions(
         scheduler_id, offset=offset, limit=limit
     )
     return PaginatedResponse(
@@ -383,9 +383,9 @@ async def list_scheduler_executions(
 
 @router.post("/task-schedulers/{scheduler_id}/run")
 async def run_scheduler(scheduler_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    execution = await TaskManager.rerun_scheduler(scheduler_id)
+    execution = await ScheduleTaskManager.rerun_scheduler(scheduler_id)
     if not execution:
         raise HTTPException(404, "Task scheduler not found")
     return execution.model_dump(mode="json", by_alias=True)
@@ -402,9 +402,9 @@ async def list_executions(
     offset: int = Query(0, ge=0),
     limit: int = Query(20, ge=1, le=100),
 ):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    items, total = await TaskManager.list_executions(
+    items, total = await ScheduleTaskManager.list_executions(
         scheduler_id=scheduler_id,
         status=_parse_execution_status_filter(status_filter),
         priority=_parse_priority(priority),
@@ -424,23 +424,23 @@ async def list_executions(
 
 @router.post("/task-executions/batch/cancel")
 async def batch_cancel(req: BatchRequest):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    return {"cancelled": await TaskManager.batch_cancel(req.execution_ids)}
+    return {"cancelled": await ScheduleTaskManager.batch_cancel(req.execution_ids)}
 
 
 @router.post("/task-executions/batch/delete")
 async def batch_delete(req: BatchRequest):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    return {"deleted": await TaskManager.batch_delete(req.execution_ids)}
+    return {"deleted": await ScheduleTaskManager.batch_delete(req.execution_ids)}
 
 
 @router.get("/task-executions/{execution_id}")
 async def get_execution(execution_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    execution = await TaskManager.get_execution(execution_id)
+    execution = await ScheduleTaskManager.get_execution(execution_id)
     if not execution:
         raise HTTPException(404, "Task execution not found")
     return execution.model_dump(mode="json", by_alias=True)
@@ -448,9 +448,9 @@ async def get_execution(execution_id: str):
 
 @router.post("/task-executions/{execution_id}/viewed")
 async def mark_execution_viewed(execution_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    execution = await TaskManager.mark_viewed(execution_id)
+    execution = await ScheduleTaskManager.mark_viewed(execution_id)
     if not execution:
         raise HTTPException(404, "Task execution not found")
     return execution.model_dump(mode="json", by_alias=True)
@@ -458,18 +458,18 @@ async def mark_execution_viewed(execution_id: str):
 
 @router.post("/task-executions/{execution_id}/cancel")
 async def cancel_execution(execution_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    execution = await TaskManager.cancel_execution(execution_id)
+    execution = await ScheduleTaskManager.cancel_execution(execution_id)
     if not execution:
         raise HTTPException(404, "Task execution not found")
     return execution.model_dump(mode="json", by_alias=True)
 
 @router.post("/task-executions/{execution_id}/retry")
 async def retry_execution(execution_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    execution = await TaskManager.retry_execution(execution_id)
+    execution = await ScheduleTaskManager.retry_execution(execution_id)
     if not execution:
         raise HTTPException(404, "Task execution not found")
     return execution.model_dump(mode="json", by_alias=True)
@@ -477,9 +477,9 @@ async def retry_execution(execution_id: str):
 
 @router.post("/task-executions/{execution_id}/rerun")
 async def rerun_execution(execution_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    execution = await TaskManager.rerun_execution(execution_id)
+    execution = await ScheduleTaskManager.rerun_execution(execution_id)
     if not execution:
         raise HTTPException(404, "Task execution not found")
     return execution.model_dump(mode="json", by_alias=True)
@@ -487,9 +487,9 @@ async def rerun_execution(execution_id: str):
 
 @router.delete("/task-executions/{execution_id}")
 async def delete_execution(execution_id: str):
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
-    if not await TaskManager.delete_execution(execution_id):
+    if not await ScheduleTaskManager.delete_execution(execution_id):
         raise HTTPException(404, "Task execution not found")
     return {"ok": True}
 

--- a/flocks/task/__init__.py
+++ b/flocks/task/__init__.py
@@ -20,7 +20,7 @@ from .models import (
     SchedulerStatus,
     build_schedule,
 )
-from .manager import TaskManager
+from .schedule_task_manager import ScheduleTaskManager
 from .store import TaskStore
 
 __all__ = [
@@ -30,7 +30,7 @@ __all__ = [
     "RetryConfig",
     "TaskExecution",
     "TaskExecutionQueueRef",
-    "TaskManager",
+    "ScheduleTaskManager",
     "TaskPriority",
     "TaskScheduler",
     "TaskTrigger",

--- a/flocks/task/plugin_sync.py
+++ b/flocks/task/plugin_sync.py
@@ -12,7 +12,7 @@ log = Log.create(service="task.plugin.sync")
 
 
 async def upsert_task_specs(specs: Sequence[TaskSpec]) -> int:
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.models import (
         ExecutionMode,
         SchedulerMode,
@@ -89,7 +89,7 @@ async def upsert_task_specs(specs: Sequence[TaskSpec]) -> int:
             log.warn("task.plugin.missing_cron", {"dedup_key": spec.dedup_key})
             continue
 
-        await TaskManager.create_scheduler(
+        await ScheduleTaskManager.create_scheduler(
             title=spec.title,
             description=spec.description,
             mode=SchedulerMode.CRON,

--- a/flocks/task/schedule_task_manager.py
+++ b/flocks/task/schedule_task_manager.py
@@ -1,4 +1,4 @@
-"""Task Manager for scheduler/execution domain."""
+"""Schedule task manager for the scheduler/execution domain."""
 
 import asyncio
 import json
@@ -32,7 +32,7 @@ from .queue import TaskQueue
 from .scheduler import TaskScheduler as SchedulerLoop
 from .store import TaskStore
 
-log = Log.create(service="task.manager")
+log = Log.create(service="task.schedule_manager")
 
 _TASK_EXPIRY_HOURS: int = 24
 _CLEANUP_INTERVAL_S: int = 3600
@@ -49,8 +49,8 @@ class _TaskEventProps(_BaseModel):
     title: str
 
 
-class TaskManager:
-    _instance: Optional["TaskManager"] = None
+class ScheduleTaskManager:
+    _instance: Optional["ScheduleTaskManager"] = None
     _startup_error: Optional[str] = None
 
     def __init__(
@@ -83,7 +83,7 @@ class TaskManager:
         max_concurrent: int = 4,
         poll_interval: int = 5,
         scheduler_interval: int = 30,
-    ) -> "TaskManager":
+    ) -> "ScheduleTaskManager":
         if cls._instance and cls._instance._running:
             return cls._instance
         await TaskStore.init()
@@ -128,7 +128,7 @@ class TaskManager:
         log.info("manager.stopped")
 
     @classmethod
-    def get(cls) -> Optional["TaskManager"]:
+    def get(cls) -> Optional["ScheduleTaskManager"]:
         return cls._instance
 
     @classmethod

--- a/flocks/task/scheduler.py
+++ b/flocks/task/scheduler.py
@@ -60,7 +60,7 @@ class TaskScheduler:
             await asyncio.sleep(self._check_interval)
 
     async def _tick(self) -> None:
-        from .manager import TaskManager
+        from .schedule_task_manager import ScheduleTaskManager
 
         now = datetime.now(timezone.utc)
         schedulers = await TaskStore.list_due_schedulers()
@@ -77,7 +77,7 @@ class TaskScheduler:
                 if scheduler.mode == SchedulerMode.ONCE
                 else ExecutionTriggerType.SCHEDULED
             )
-            await TaskManager.create_execution_from_scheduler(
+            await ScheduleTaskManager.create_execution_from_scheduler(
                 scheduler,
                 trigger_type=trigger_type,
                 enqueue=True,

--- a/flocks/tool/task/schedule_task_center.py
+++ b/flocks/tool/task/schedule_task_center.py
@@ -128,7 +128,7 @@ async def schedule_task_create(
     enabled: Optional[bool] = None,
     action: Optional[str] = None,
 ) -> ToolResult:
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.models import (
         SchedulerMode,
         TaskPriority,
@@ -178,7 +178,7 @@ async def schedule_task_create(
         user_prompt=user_prompt,
     )
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title=title,
         description=description,
         mode=mode,
@@ -187,7 +187,7 @@ async def schedule_task_create(
         trigger=trigger,
     )
     if enabled is False:
-        scheduler = await TaskManager.disable_scheduler(scheduler.id) or scheduler
+        scheduler = await ScheduleTaskManager.disable_scheduler(scheduler.id) or scheduler
 
     display_tz = resolve_task_timezone_name(scheduler)
     output_lines = [
@@ -198,7 +198,7 @@ async def schedule_task_create(
         f"Priority: {scheduler.priority.value}",
     ]
     if scheduler.trigger.run_immediately:
-        executions, _ = await TaskManager.list_scheduler_executions(
+        executions, _ = await ScheduleTaskManager.list_scheduler_executions(
             scheduler.id,
             limit=1,
         )
@@ -238,7 +238,7 @@ async def schedule_task_list(
     type: Optional[str] = None,
     limit: int = 10,
 ) -> ToolResult:
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.models import SchedulerStatus, TaskStatus
 
     if type is not None and type not in _VALID_TYPES:
@@ -286,7 +286,7 @@ async def schedule_task_list(
             scheduler_status = SchedulerStatus.ACTIVE
         elif status in ("disabled", "paused"):
             scheduler_status = SchedulerStatus.DISABLED
-        tasks, total = await TaskManager.list_schedulers(
+        tasks, total = await ScheduleTaskManager.list_schedulers(
             status=scheduler_status,
             scheduled_only=type != "scheduler",
             limit=limit,
@@ -304,7 +304,7 @@ async def schedule_task_list(
                     f"Valid values: {', '.join(s.value for s in TaskStatus)}."
                 ),
             )
-        tasks, total = await TaskManager.list_executions(
+        tasks, total = await ScheduleTaskManager.list_executions(
             status=task_status,
             limit=limit,
         )
@@ -322,22 +322,22 @@ async def schedule_task_status(
     task_id: str,
     resource_type: Optional[str] = None,
 ) -> ToolResult:
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
     if resource_type == "scheduler":
-        task = await TaskManager.get_scheduler(task_id)
+        task = await ScheduleTaskManager.get_scheduler(task_id)
     elif resource_type == "execution":
-        task = await TaskManager.get_execution(task_id)
+        task = await ScheduleTaskManager.get_execution(task_id)
     else:
-        task = await TaskManager.get_execution(task_id)
+        task = await ScheduleTaskManager.get_execution(task_id)
         if task is None:
-            task = await TaskManager.get_scheduler(task_id)
+            task = await ScheduleTaskManager.get_scheduler(task_id)
     if (
         resource_type != "scheduler"
         and task
         and getattr(getattr(task, "delivery_status", None), "value", None) == "unread"
     ):
-        await TaskManager.mark_notified(task_id)
+        await ScheduleTaskManager.mark_notified(task_id)
     if task is None:
         return ToolResult(success=False, error=f"Task {task_id} not found")
 
@@ -363,7 +363,7 @@ async def schedule_task_update(
     user_prompt: Optional[str] = None,
     enabled: Optional[bool] = None,
 ) -> ToolResult:
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
     from flocks.task.models import TaskPriority
 
     normalized_action = (action or "update").lower()
@@ -373,13 +373,13 @@ async def schedule_task_update(
         normalized_action = "enable"
 
     if normalized_action == "cancel":
-        task = await TaskManager.cancel_execution(task_id)
+        task = await ScheduleTaskManager.cancel_execution(task_id)
     elif normalized_action == "retry":
-        task = await TaskManager.retry_execution(task_id)
+        task = await ScheduleTaskManager.retry_execution(task_id)
     elif normalized_action == "disable":
-        task = await TaskManager.disable_scheduler(task_id)
+        task = await ScheduleTaskManager.disable_scheduler(task_id)
     elif normalized_action == "enable":
-        task = await TaskManager.enable_scheduler(task_id)
+        task = await ScheduleTaskManager.enable_scheduler(task_id)
     elif normalized_action == "update":
         fields = {}
         if priority:
@@ -389,7 +389,7 @@ async def schedule_task_update(
         if description is not None:
             fields["description"] = description
         try:
-            task = await TaskManager.update_scheduler_with_trigger(
+            task = await ScheduleTaskManager.update_scheduler_with_trigger(
                 task_id,
                 fields=fields,
                 cron=cron,
@@ -402,10 +402,10 @@ async def schedule_task_update(
         except ValueError as exc:
             return ToolResult(success=False, error=str(exc))
         if enabled is False:
-            task = await TaskManager.disable_scheduler(task_id) or task
+            task = await ScheduleTaskManager.disable_scheduler(task_id) or task
             normalized_action = "disable"
         elif enabled is True:
-            task = await TaskManager.enable_scheduler(task_id) or task
+            task = await ScheduleTaskManager.enable_scheduler(task_id) or task
             normalized_action = "enable"
     else:
         return ToolResult(success=False, error=f"Unknown action: {action}")
@@ -425,18 +425,18 @@ async def schedule_task_delete(
     task_id: str,
     resource_type: Optional[str] = None,
 ) -> ToolResult:
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
     if resource_type == "execution":
-        ok = await TaskManager.delete_execution(task_id)
+        ok = await ScheduleTaskManager.delete_execution(task_id)
     elif resource_type == "scheduler":
-        ok = await TaskManager.delete_scheduler(task_id)
+        ok = await ScheduleTaskManager.delete_scheduler(task_id)
     else:
-        execution = await TaskManager.get_execution(task_id)
+        execution = await ScheduleTaskManager.get_execution(task_id)
         if execution is not None:
-            ok = await TaskManager.delete_execution(task_id)
+            ok = await ScheduleTaskManager.delete_execution(task_id)
         else:
-            ok = await TaskManager.delete_scheduler(task_id)
+            ok = await ScheduleTaskManager.delete_scheduler(task_id)
     if not ok:
         return ToolResult(success=False, error=f"Task {task_id} not found")
     return ToolResult(success=True, output=f"Task {task_id} deleted.")
@@ -447,16 +447,16 @@ async def schedule_task_rerun(
     task_id: str,
     resource_type: Optional[str] = None,
 ) -> ToolResult:
-    from flocks.task.manager import TaskManager
+    from flocks.task.schedule_task_manager import ScheduleTaskManager
 
     if resource_type == "execution":
-        task = await TaskManager.rerun_execution(task_id)
+        task = await ScheduleTaskManager.rerun_execution(task_id)
     elif resource_type == "scheduler":
-        task = await TaskManager.rerun_scheduler(task_id)
+        task = await ScheduleTaskManager.rerun_scheduler(task_id)
     else:
-        task = await TaskManager.rerun_execution(task_id)
+        task = await ScheduleTaskManager.rerun_execution(task_id)
         if task is None:
-            task = await TaskManager.rerun_scheduler(task_id)
+            task = await ScheduleTaskManager.rerun_scheduler(task_id)
     if not task:
         return ToolResult(success=False, error=f"Task {task_id} not found")
 

--- a/tests/integration/test_task_queue_integration.py
+++ b/tests/integration/test_task_queue_integration.py
@@ -8,12 +8,12 @@ from pathlib import Path
 
 import pytest
 
-import flocks.task.manager as task_manager_module
+import flocks.task.schedule_task_manager as task_manager_module
 from flocks.task.models import ExecutionMode
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
 from flocks.task.executor import TaskExecutor
-from flocks.task.manager import TaskManager
+from flocks.task.schedule_task_manager import ScheduleTaskManager
 from flocks.task.models import (
     ExecutionTriggerType,
     SchedulerMode,
@@ -34,8 +34,8 @@ async def isolated_task_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     Config._cached_config = None
     Storage._db_path = None
     Storage._initialized = False
-    TaskManager._instance = None
-    TaskManager._startup_error = None
+    ScheduleTaskManager._instance = None
+    ScheduleTaskManager._startup_error = None
     TaskStore._initialized = False
     TaskStore._conn = None
 
@@ -44,14 +44,14 @@ async def isolated_task_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     yield
 
-    await TaskManager.stop()
+    await ScheduleTaskManager.stop()
     await TaskStore.close()
     Config._global_config = None
     Config._cached_config = None
     Storage._db_path = None
     Storage._initialized = False
-    TaskManager._instance = None
-    TaskManager._startup_error = None
+    ScheduleTaskManager._instance = None
+    ScheduleTaskManager._startup_error = None
     TaskStore._initialized = False
     TaskStore._conn = None
 
@@ -59,7 +59,7 @@ async def isolated_task_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 async def _wait_for_execution(execution_id: str, *, status: TaskStatus, timeout: float = 2.0):
     deadline = asyncio.get_running_loop().time() + timeout
     while asyncio.get_running_loop().time() < deadline:
-        execution = await TaskManager.get_execution(execution_id)
+        execution = await ScheduleTaskManager.get_execution(execution_id)
         if execution is not None and execution.status == status:
             return execution
         await asyncio.sleep(0.02)
@@ -77,15 +77,15 @@ async def test_immediate_scheduler_runs_through_queue(monkeypatch: pytest.Monkey
         return await TaskStore.update_execution(execution)
 
     monkeypatch.setattr(TaskExecutor, "dispatch", fake_dispatch)
-    await TaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="立即执行链路",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    executions, total = await TaskManager.list_scheduler_executions(scheduler.id)
+    executions, total = await ScheduleTaskManager.list_scheduler_executions(scheduler.id)
 
     assert total == 1
     completed = await _wait_for_execution(executions[0].id, status=TaskStatus.COMPLETED)
@@ -108,18 +108,18 @@ async def test_rerun_execution_creates_new_execution_with_same_scheduler(monkeyp
         return await TaskStore.update_execution(execution)
 
     monkeypatch.setattr(TaskExecutor, "dispatch", fake_dispatch)
-    await TaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="重复执行",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    first = (await TaskManager.list_scheduler_executions(scheduler.id))[0][0]
+    first = (await ScheduleTaskManager.list_scheduler_executions(scheduler.id))[0][0]
     first = await _wait_for_execution(first.id, status=TaskStatus.COMPLETED)
 
-    rerun = await TaskManager.rerun_execution(first.id)
+    rerun = await ScheduleTaskManager.rerun_execution(first.id)
     assert rerun is not None
     rerun = await _wait_for_execution(rerun.id, status=TaskStatus.COMPLETED)
 
@@ -152,23 +152,23 @@ async def test_dispatch_timeout_releases_queue_for_following_execution(
 
     monkeypatch.setattr(TaskExecutor, "dispatch", fake_dispatch)
     monkeypatch.setattr(task_manager_module, "_DISPATCH_GUARD_TIMEOUT_S", 0.05)
-    await TaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
 
-    first_scheduler = await TaskManager.create_scheduler(
+    first_scheduler = await ScheduleTaskManager.create_scheduler(
         title="超时任务",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
         workspace_directory=str(tmp_path / "workspace-1"),
     )
-    second_scheduler = await TaskManager.create_scheduler(
+    second_scheduler = await ScheduleTaskManager.create_scheduler(
         title="后续任务",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
         workspace_directory=str(tmp_path / "workspace-2"),
     )
 
-    first = (await TaskManager.list_scheduler_executions(first_scheduler.id))[0][0]
-    second = (await TaskManager.list_scheduler_executions(second_scheduler.id))[0][0]
+    first = (await ScheduleTaskManager.list_scheduler_executions(first_scheduler.id))[0][0]
+    second = (await ScheduleTaskManager.list_scheduler_executions(second_scheduler.id))[0][0]
 
     failed = await _wait_for_execution(first.id, status=TaskStatus.FAILED, timeout=1.0)
     completed = await _wait_for_execution(second.id, status=TaskStatus.COMPLETED, timeout=1.0)
@@ -179,21 +179,21 @@ async def test_dispatch_timeout_releases_queue_for_following_execution(
 
 @pytest.mark.asyncio
 async def test_delete_scheduler_releases_claimed_queue_slot(tmp_path: Path):
-    await TaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="删除释放槽位",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace-1"),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
     )
 
-    manager = TaskManager.get()
+    manager = ScheduleTaskManager.get()
     assert manager is not None
 
     claimed = await manager.queue.dequeue()
@@ -202,20 +202,20 @@ async def test_delete_scheduler_releases_claimed_queue_slot(tmp_path: Path):
     assert claimed.id == execution.id
     assert execution.id in manager.queue._running_ids
 
-    deleted = await TaskManager.delete_scheduler(scheduler.id)
+    deleted = await ScheduleTaskManager.delete_scheduler(scheduler.id)
 
     assert deleted is True
     assert execution.id not in manager.queue._running_ids
-    assert await TaskManager.get_execution(execution.id) is None
+    assert await ScheduleTaskManager.get_execution(execution.id) is None
     assert await TaskStore.get_queue_ref(execution.id) is None
 
-    next_scheduler = await TaskManager.create_scheduler(
+    next_scheduler = await ScheduleTaskManager.create_scheduler(
         title="后续可领取",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace-2"),
     )
-    next_execution = await TaskManager.create_execution_from_scheduler(
+    next_execution = await ScheduleTaskManager.create_execution_from_scheduler(
         next_scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
@@ -236,21 +236,21 @@ async def test_cancelled_worker_requeues_execution_instead_of_losing_queue_ref(
         raise asyncio.CancelledError()
 
     monkeypatch.setattr(TaskExecutor, "dispatch", fake_dispatch)
-    await TaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="取消后回队",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
     )
 
-    manager = TaskManager.get()
+    manager = ScheduleTaskManager.get()
     assert manager is not None
 
     claimed = await manager.queue.dequeue()
@@ -260,7 +260,7 @@ async def test_cancelled_worker_requeues_execution_instead_of_losing_queue_ref(
     with pytest.raises(asyncio.CancelledError):
         await manager._run_execution(claimed)
 
-    refreshed = await TaskManager.get_execution(execution.id)
+    refreshed = await ScheduleTaskManager.get_execution(execution.id)
     queue_ref = await TaskStore.get_queue_ref(execution.id)
 
     assert refreshed is not None
@@ -310,9 +310,9 @@ async def test_workflow_timeout_signals_cancel_and_stops_before_next_node(
         lambda workflow_id: {"workflowJson": workflow_json} if workflow_id == "wf_slow_cancel" else None,
     )
     monkeypatch.setattr(task_manager_module, "_DISPATCH_GUARD_TIMEOUT_S", 0.01)
-    await TaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=0.01, scheduler_interval=999)
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="可取消 workflow",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
@@ -321,7 +321,7 @@ async def test_workflow_timeout_signals_cancel_and_stops_before_next_node(
         workspace_directory=str(tmp_path / "workspace"),
     )
 
-    execution = (await TaskManager.list_scheduler_executions(scheduler.id))[0][0]
+    execution = (await ScheduleTaskManager.list_scheduler_executions(scheduler.id))[0][0]
     failed = await _wait_for_execution(execution.id, status=TaskStatus.FAILED, timeout=1.0)
     await asyncio.sleep(0.15)
 
@@ -466,8 +466,8 @@ async def test_standalone_legacy_migration_script_migrates_existing_tables(tmp_p
     stdout, stderr = await proc.communicate()
     assert proc.returncode == 0, (stdout or b"").decode() + (stderr or b"").decode()
 
-    scheduler = await TaskManager.get_scheduler("task_legacy_1")
-    execution = await TaskManager.get_execution("texec_legacy_1")
+    scheduler = await ScheduleTaskManager.get_scheduler("task_legacy_1")
+    execution = await ScheduleTaskManager.get_execution("texec_legacy_1")
 
     assert scheduler is not None
     assert scheduler.mode == SchedulerMode.ONCE
@@ -475,7 +475,7 @@ async def test_standalone_legacy_migration_script_migrates_existing_tables(tmp_p
     assert execution.scheduler_id == "task_legacy_1"
     assert execution.status == TaskStatus.COMPLETED
     assert execution.session_id == "ses_123"
-    assert TaskManager._legacy_tables_exist() is False
+    assert ScheduleTaskManager._legacy_tables_exist() is False
     assert state_path.exists() is False
 
 
@@ -581,8 +581,8 @@ async def test_standalone_legacy_migration_preserves_paused_scheduled_task_histo
     stdout, stderr = await proc.communicate()
     assert proc.returncode == 0, (stdout or b"").decode() + (stderr or b"").decode()
 
-    scheduler = await TaskManager.get_scheduler("task_paused_sched")
-    execution = await TaskManager.get_execution("legacy_exec_task_paused_sched")
+    scheduler = await ScheduleTaskManager.get_scheduler("task_paused_sched")
+    execution = await ScheduleTaskManager.get_execution("legacy_exec_task_paused_sched")
 
     assert scheduler is not None
     assert scheduler.status in (SchedulerStatus.ACTIVE, SchedulerStatus.DISABLED)

--- a/tests/server/routes/test_task_scheduler_context_route.py
+++ b/tests/server/routes/test_task_scheduler_context_route.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from flocks.task.manager import TaskManager
+from flocks.task.schedule_task_manager import ScheduleTaskManager
 from flocks.task.models import ExecutionMode, ExecutionTriggerType, SchedulerMode, TaskTrigger
 
 
 @pytest.mark.asyncio
 async def test_update_scheduler_accepts_context_for_workflow_inputs(client):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="工作流定时任务",
         mode=SchedulerMode.CRON,
         trigger=TaskTrigger(cron="0 9 * * *", timezone="Asia/Shanghai"),
@@ -28,11 +28,11 @@ async def test_update_scheduler_accepts_context_for_workflow_inputs(client):
     assert response.status_code == 200
     assert response.json()["context"] == {"keyword": "after", "limit": 5}
 
-    updated = await TaskManager.get_scheduler(scheduler.id)
+    updated = await ScheduleTaskManager.get_scheduler(scheduler.id)
     assert updated is not None
     assert updated.context == {"keyword": "after", "limit": 5}
 
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         updated,
         trigger_type=ExecutionTriggerType.SCHEDULED,
         enqueue=False,

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -93,8 +93,8 @@ async def test_lifespan_cleans_replaced_files_without_upgrade_recovery(
     )
     monkeypatch.setitem(
         sys.modules,
-        "flocks.task.manager",
-        types.SimpleNamespace(TaskManager=types.SimpleNamespace(start=fake_async_noop, stop=fake_async_noop)),
+        "flocks.task.schedule_task_manager",
+        types.SimpleNamespace(ScheduleTaskManager=types.SimpleNamespace(start=fake_async_noop, stop=fake_async_noop)),
     )
     monkeypatch.setitem(
         sys.modules,

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient, ASGITransport
 from fastapi import status
 
 from flocks.server.app import app
+from flocks.task.schedule_task_manager import ScheduleTaskManager
 from flocks.task.store import TaskStore
 from flocks.task.models import (
     DeliveryStatus,
@@ -132,12 +133,12 @@ async def test_list_executions_invalid_priority_returns_422(client):
 
 @pytest.mark.asyncio
 async def test_task_schedulers_scheduled_only_excludes_immediate_queue_templates(client):
-    await TaskManager.create_scheduler(
+    await ScheduleTaskManager.create_scheduler(
         title="立即任务",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
     )
-    scheduled = await TaskManager.create_scheduler(
+    scheduled = await ScheduleTaskManager.create_scheduler(
         title="单次计划",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
@@ -154,12 +155,12 @@ async def test_task_schedulers_scheduled_only_excludes_immediate_queue_templates
 
 @pytest.mark.asyncio
 async def test_task_scheduler_list_accepts_legacy_paused_status_query(client):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="兼容旧 paused 调度查询",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
     )
-    await TaskManager.disable_scheduler(scheduler.id)
+    await ScheduleTaskManager.disable_scheduler(scheduler.id)
 
     response = await client.get("/api/task-schedulers", params={"status": "paused"})
 
@@ -170,13 +171,13 @@ async def test_task_scheduler_list_accepts_legacy_paused_status_query(client):
 
 @pytest.mark.asyncio
 async def test_task_schedulers_list_excludes_archived_builtin_after_delete(client):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="内置计划任务",
         mode=SchedulerMode.CRON,
         trigger=TaskTrigger(cron="*/5 * * * *", timezone="Asia/Shanghai"),
         dedup_key="builtin:test-scheduled-task",
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.SCHEDULED,
         enqueue=True,
@@ -191,8 +192,8 @@ async def test_task_schedulers_list_excludes_archived_builtin_after_delete(clien
     ids = {item["id"] for item in data["items"]}
 
     assert scheduler.id not in ids
-    archived = await TaskManager.get_scheduler(scheduler.id)
-    cancelled_execution = await TaskManager.get_execution(execution.id)
+    archived = await ScheduleTaskManager.get_scheduler(scheduler.id)
+    cancelled_execution = await ScheduleTaskManager.get_execution(execution.id)
     assert archived is not None
     assert archived.status == SchedulerStatus.ARCHIVED
     assert cancelled_execution is not None
@@ -201,13 +202,13 @@ async def test_task_schedulers_list_excludes_archived_builtin_after_delete(clien
 
 @pytest.mark.asyncio
 async def test_delete_scheduler_cleans_queue_state_for_non_builtin(client):
-    await TaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
-    scheduler = await TaskManager.create_scheduler(
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="普通计划任务",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
@@ -233,12 +234,12 @@ async def test_delete_scheduler_cleans_queue_state_for_non_builtin(client):
 
 @pytest.mark.asyncio
 async def test_task_execution_list_accepts_legacy_paused_status_query(client):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="兼容旧 paused 执行查询",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -256,17 +257,17 @@ async def test_task_execution_list_accepts_legacy_paused_status_query(client):
 
 @pytest.mark.asyncio
 async def test_batch_cancel_endpoint_cancels_selected_executions(client):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="批量取消接口",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
     )
-    cancellable = await TaskManager.create_execution_from_scheduler(
+    cancellable = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
     )
-    completed = await TaskManager.create_execution_from_scheduler(
+    completed = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -283,19 +284,19 @@ async def test_batch_cancel_endpoint_cancels_selected_executions(client):
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["cancelled"] == 1
 
-    cancelled_execution = await TaskManager.get_execution(cancellable.id)
+    cancelled_execution = await ScheduleTaskManager.get_execution(cancellable.id)
     assert cancelled_execution is not None
     assert cancelled_execution.status == TaskStatus.CANCELLED
 
 
 @pytest.mark.asyncio
 async def test_execution_pause_and_resume_endpoints_are_removed(client):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="旧暂停接口",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
@@ -310,12 +311,12 @@ async def test_execution_pause_and_resume_endpoints_are_removed(client):
 
 @pytest.mark.asyncio
 async def test_mark_execution_viewed_endpoint_updates_delivery_status(client):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="标记已读",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
     )
-    execution = (await TaskManager.list_scheduler_executions(scheduler.id, limit=1))[0][0]
+    execution = (await ScheduleTaskManager.list_scheduler_executions(scheduler.id, limit=1))[0][0]
     execution.status = TaskStatus.COMPLETED
     execution.delivery_status = DeliveryStatus.UNREAD
     await TaskStore.update_execution(execution)

--- a/tests/storage/test_sqlite_connection_config.py
+++ b/tests/storage/test_sqlite_connection_config.py
@@ -5,7 +5,7 @@ import pytest
 
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
-from flocks.task.manager import TaskManager
+from flocks.task.schedule_task_manager import ScheduleTaskManager
 
 
 @pytest.fixture(autouse=True)
@@ -76,7 +76,7 @@ def test_storage_connect_sync_applies_runtime_sqlite_pragmas() -> None:
 async def test_task_manager_sync_connection_uses_storage_sqlite_contract() -> None:
     await Storage.init()
 
-    with TaskManager._with_db_connection() as db:
+    with ScheduleTaskManager._with_db_connection() as db:
         row = db.execute(
             "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'storage'"
         ).fetchone()

--- a/tests/task/test_task.py
+++ b/tests/task/test_task.py
@@ -10,7 +10,7 @@ import pytest
 
 from flocks.cli.commands import task as task_cli_commands
 import flocks.task.background as background_module
-import flocks.task.manager as task_manager_module
+import flocks.task.schedule_task_manager as task_manager_module
 import flocks.task.plugin_sync as plugin_sync_module
 from flocks.server.routes import question as question_routes
 from flocks.config.config import Config
@@ -19,7 +19,7 @@ from flocks.storage.storage import Storage
 from flocks.task.background import BackgroundManager, BackgroundTask, LaunchInput
 from flocks.task.executor import TaskExecutor
 from flocks.task.formatting import format_task_datetime
-from flocks.task.manager import TaskManager
+from flocks.task.schedule_task_manager import ScheduleTaskManager
 from flocks.task.models import (
     DeliveryStatus,
     ExecutionMode,
@@ -49,8 +49,8 @@ async def isolated_task_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     Config._cached_config = None
     Storage._db_path = None
     Storage._initialized = False
-    TaskManager._instance = None
-    TaskManager._startup_error = None
+    ScheduleTaskManager._instance = None
+    ScheduleTaskManager._startup_error = None
     TaskStore._initialized = False
     TaskStore._conn = None
 
@@ -59,21 +59,21 @@ async def isolated_task_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     yield
 
-    await TaskManager.stop()
+    await ScheduleTaskManager.stop()
     await TaskStore.close()
     Config._global_config = None
     Config._cached_config = None
     Storage._db_path = None
     Storage._initialized = False
-    TaskManager._instance = None
-    TaskManager._startup_error = None
+    ScheduleTaskManager._instance = None
+    ScheduleTaskManager._startup_error = None
     TaskStore._initialized = False
     TaskStore._conn = None
 
 
 @pytest.mark.asyncio
 async def test_immediate_scheduler_creates_single_queued_execution(tmp_path: Path):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="立即执行",
         description="创建后立刻入队",
         mode=SchedulerMode.ONCE,
@@ -82,7 +82,7 @@ async def test_immediate_scheduler_creates_single_queued_execution(tmp_path: Pat
         workspace_directory=str(tmp_path / "workspace"),
     )
 
-    executions, total = await TaskManager.list_scheduler_executions(scheduler.id)
+    executions, total = await ScheduleTaskManager.list_scheduler_executions(scheduler.id)
 
     assert total == 1
     execution = executions[0]
@@ -99,7 +99,7 @@ async def test_list_executions_tolerates_legacy_non_utf8_description(
     tmp_path: Path,
 ):
     legacy_description = "扫描 Windows 主机 192.168.254.1"
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="legacy encoding",
         description="placeholder",
         mode=SchedulerMode.ONCE,
@@ -107,7 +107,7 @@ async def test_list_executions_tolerates_legacy_non_utf8_description(
         trigger=TaskTrigger(run_immediately=True),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    executions, _ = await TaskManager.list_scheduler_executions(scheduler.id)
+    executions, _ = await ScheduleTaskManager.list_scheduler_executions(scheduler.id)
     execution_id = executions[0].id
 
     db = await TaskStore.raw_db()
@@ -121,7 +121,7 @@ async def test_list_executions_tolerates_legacy_non_utf8_description(
     )
     await db.commit()
 
-    executions, total = await TaskManager.list_executions(limit=20)
+    executions, total = await ScheduleTaskManager.list_executions(limit=20)
 
     assert total == 1
     assert executions[0].description == legacy_description
@@ -129,7 +129,7 @@ async def test_list_executions_tolerates_legacy_non_utf8_description(
 
 @pytest.mark.asyncio
 async def test_once_scheduler_tick_creates_execution_and_disables_scheduler(tmp_path: Path):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="单次定时",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(
@@ -142,8 +142,8 @@ async def test_once_scheduler_tick_creates_execution_and_disables_scheduler(tmp_
     loop = SchedulerLoop()
     await loop._tick()
 
-    updated = await TaskManager.get_scheduler(scheduler.id)
-    executions, total = await TaskManager.list_scheduler_executions(scheduler.id)
+    updated = await ScheduleTaskManager.get_scheduler(scheduler.id)
+    executions, total = await ScheduleTaskManager.list_scheduler_executions(scheduler.id)
 
     assert updated is not None
     assert updated.status == SchedulerStatus.DISABLED
@@ -154,7 +154,7 @@ async def test_once_scheduler_tick_creates_execution_and_disables_scheduler(tmp_
 
 @pytest.mark.asyncio
 async def test_cron_scheduler_does_not_spawn_second_active_execution(tmp_path: Path):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="循环任务",
         mode=SchedulerMode.CRON,
         trigger=TaskTrigger(
@@ -172,7 +172,7 @@ async def test_cron_scheduler_does_not_spawn_second_active_execution(tmp_path: P
     await loop._tick()
     await loop._tick()
 
-    executions, total = await TaskManager.list_scheduler_executions(scheduler.id, limit=10)
+    executions, total = await ScheduleTaskManager.list_scheduler_executions(scheduler.id, limit=10)
 
     assert total == 1
     assert executions[0].status == TaskStatus.QUEUED
@@ -182,7 +182,7 @@ async def test_cron_scheduler_does_not_spawn_second_active_execution(tmp_path: P
 @pytest.mark.asyncio
 async def test_create_scheduler_rejects_six_field_cron(tmp_path: Path):
     with pytest.raises(ValueError, match="only 5-field cron is supported"):
-        await TaskManager.create_scheduler(
+        await ScheduleTaskManager.create_scheduler(
             title="非法 cron",
             mode=SchedulerMode.CRON,
             trigger=TaskTrigger(
@@ -196,7 +196,7 @@ async def test_create_scheduler_rejects_six_field_cron(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_create_scheduler_rejects_out_of_range_five_field_cron(tmp_path: Path):
     with pytest.raises(ValueError, match="not a valid 5-field cron"):
-        await TaskManager.create_scheduler(
+        await ScheduleTaskManager.create_scheduler(
             title="越界 cron",
             mode=SchedulerMode.CRON,
             trigger=TaskTrigger(
@@ -214,7 +214,7 @@ async def test_create_scheduler_does_not_mutate_trigger_argument(tmp_path: Path)
         timezone="Asia/Shanghai",
     )
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="不修改调用方 trigger",
         mode=SchedulerMode.CRON,
         trigger=trigger,
@@ -276,7 +276,7 @@ async def test_plugin_sync_skips_new_scheduler_with_invalid_six_field_cron(
 async def test_plugin_sync_does_not_overwrite_existing_scheduler_with_invalid_six_field_cron(
     tmp_path: Path,
 ):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="原始内置任务",
         mode=SchedulerMode.CRON,
         trigger=TaskTrigger(
@@ -299,7 +299,7 @@ async def test_plugin_sync_does_not_overwrite_existing_scheduler_with_invalid_si
         ]
     )
 
-    unchanged = await TaskManager.get_scheduler(scheduler.id)
+    unchanged = await ScheduleTaskManager.get_scheduler(scheduler.id)
 
     assert created == 0
     assert unchanged is not None
@@ -312,7 +312,7 @@ async def test_plugin_sync_does_not_overwrite_existing_scheduler_with_invalid_si
 async def test_update_scheduler_with_trigger_run_once_preserves_existing_cron_when_omitted(
     tmp_path: Path,
 ):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="切成单次任务时保留旧 cron",
         mode=SchedulerMode.CRON,
         trigger=TaskTrigger(
@@ -322,7 +322,7 @@ async def test_update_scheduler_with_trigger_run_once_preserves_existing_cron_wh
         workspace_directory=str(tmp_path / "workspace"),
     )
 
-    updated = await TaskManager.update_scheduler_with_trigger(
+    updated = await ScheduleTaskManager.update_scheduler_with_trigger(
         scheduler.id,
         fields={},
         run_once=True,
@@ -338,8 +338,8 @@ async def test_update_scheduler_with_trigger_run_once_preserves_existing_cron_wh
 
 @pytest.mark.asyncio
 async def test_recover_stale_running_execution_unblocks_scheduler(tmp_path: Path):
-    manager = TaskManager(max_concurrent=1, poll_interval=999, scheduler_interval=999)
-    scheduler = await TaskManager.create_scheduler(
+    manager = ScheduleTaskManager(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="恢复阻塞循环任务",
         mode=SchedulerMode.CRON,
         trigger=TaskTrigger(cron="*/5 * * * *", timezone="Asia/Shanghai"),
@@ -348,7 +348,7 @@ async def test_recover_stale_running_execution_unblocks_scheduler(tmp_path: Path
     scheduler.trigger.next_run = datetime.now(timezone.utc) - timedelta(seconds=1)
     await TaskStore.update_scheduler(scheduler)
 
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.SCHEDULED,
         enqueue=False,
@@ -366,7 +366,7 @@ async def test_recover_stale_running_execution_unblocks_scheduler(tmp_path: Path
     recovered = await manager._recover_stale_active_executions()
 
     assert recovered == 1
-    failed = await TaskManager.get_execution(execution.id)
+    failed = await ScheduleTaskManager.get_execution(execution.id)
     assert failed is not None
     assert failed.status == TaskStatus.FAILED
     assert "recovery threshold" in (failed.error or "")
@@ -374,7 +374,7 @@ async def test_recover_stale_running_execution_unblocks_scheduler(tmp_path: Path
 
     loop = SchedulerLoop()
     await loop._tick()
-    executions, total = await TaskManager.list_scheduler_executions(scheduler.id, limit=10)
+    executions, total = await ScheduleTaskManager.list_scheduler_executions(scheduler.id, limit=10)
 
     assert total == 2
     assert any(item.id == execution.id and item.status == TaskStatus.FAILED for item in executions)
@@ -383,29 +383,29 @@ async def test_recover_stale_running_execution_unblocks_scheduler(tmp_path: Path
 
 @pytest.mark.asyncio
 async def test_recover_orphaned_queued_execution_restores_queue_ref(tmp_path: Path):
-    await TaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
     # Pause the execution loop so it cannot race the test by claiming the
     # execution before we manually simulate the orphan state (queued row
     # with no queue ref).
-    TaskManager.pause_queue()
-    scheduler = await TaskManager.create_scheduler(
+    ScheduleTaskManager.pause_queue()
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="恢复孤儿排队任务",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
     )
     await TaskStore.finish_queue_ref(execution.id)
 
-    manager = TaskManager.get()
+    manager = ScheduleTaskManager.get()
     assert manager is not None
 
     recovered = await manager._recover_orphaned_queued_executions()
-    refreshed = await TaskManager.get_execution(execution.id)
+    refreshed = await ScheduleTaskManager.get_execution(execution.id)
 
     assert recovered == 1
     assert refreshed is not None
@@ -420,14 +420,14 @@ async def test_recover_orphaned_queued_execution_restores_queue_ref(tmp_path: Pa
 
 @pytest.mark.asyncio
 async def test_queue_status_reports_stale_running_execution(tmp_path: Path):
-    await TaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
-    scheduler = await TaskManager.create_scheduler(
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="阻塞诊断",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -440,7 +440,7 @@ async def test_queue_status_reports_stale_running_execution(tmp_path: Path):
     execution.queued_at = started_at
     await TaskStore.update_execution(execution)
 
-    status = await TaskManager.queue_status()
+    status = await ScheduleTaskManager.queue_status()
 
     assert status["stale_running"] == 1
     assert isinstance(status["oldest_running_seconds"], int)
@@ -449,19 +449,19 @@ async def test_queue_status_reports_stale_running_execution(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_queue_status_uses_largest_elapsed_running_time(tmp_path: Path):
-    await TaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
-    scheduler = await TaskManager.create_scheduler(
+    await ScheduleTaskManager.start(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="阻塞诊断-多任务",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    older_execution = await TaskManager.create_execution_from_scheduler(
+    older_execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
     )
-    newer_execution = await TaskManager.create_execution_from_scheduler(
+    newer_execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -479,7 +479,7 @@ async def test_queue_status_uses_largest_elapsed_running_time(tmp_path: Path):
     await TaskStore.update_execution(older_execution)
     await TaskStore.update_execution(newer_execution)
 
-    status = await TaskManager.queue_status()
+    status = await ScheduleTaskManager.queue_status()
 
     assert status["stale_running"] == 1
     assert isinstance(status["oldest_running_seconds"], int)
@@ -739,15 +739,15 @@ async def test_trigger_workflow_resolves_workflow_id_from_filesystem(
 
 @pytest.mark.asyncio
 async def test_retry_queue_requeues_failed_execution(tmp_path: Path):
-    manager = TaskManager(max_concurrent=1, poll_interval=999, scheduler_interval=999)
+    manager = ScheduleTaskManager(max_concurrent=1, poll_interval=999, scheduler_interval=999)
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="失败重试",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -761,7 +761,7 @@ async def test_retry_queue_requeues_failed_execution(tmp_path: Path):
 
     await manager._process_retry_queue()
 
-    reloaded = await TaskManager.get_execution(execution.id)
+    reloaded = await ScheduleTaskManager.get_execution(execution.id)
     assert reloaded is not None
     assert reloaded.status == TaskStatus.QUEUED
     assert reloaded.retry.retry_after is None
@@ -773,18 +773,18 @@ async def test_retry_queue_requeues_failed_execution(tmp_path: Path):
 @pytest.mark.asyncio
 async def test_queue_dequeue_respects_claimed_slots_before_running_status(tmp_path: Path):
     queue = TaskQueue(max_concurrent=1)
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="并发控制",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    first = await TaskManager.create_execution_from_scheduler(
+    first = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
     )
-    second = await TaskManager.create_execution_from_scheduler(
+    second = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
@@ -806,14 +806,14 @@ async def test_queue_dequeue_respects_claimed_slots_before_running_status(tmp_pa
 
 @pytest.mark.asyncio
 async def test_immediate_scheduler_dedup_does_not_create_duplicate_execution(tmp_path: Path):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="去重立即执行",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
         workspace_directory=str(tmp_path / "workspace"),
         dedup_key="dup-immediate",
     )
-    duplicate = await TaskManager.create_scheduler(
+    duplicate = await ScheduleTaskManager.create_scheduler(
         title="去重立即执行",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
@@ -821,7 +821,7 @@ async def test_immediate_scheduler_dedup_does_not_create_duplicate_execution(tmp
         dedup_key="dup-immediate",
     )
 
-    executions, total = await TaskManager.list_scheduler_executions(scheduler.id, limit=10)
+    executions, total = await ScheduleTaskManager.list_scheduler_executions(scheduler.id, limit=10)
 
     assert duplicate.id == scheduler.id
     assert total == 1
@@ -830,18 +830,18 @@ async def test_immediate_scheduler_dedup_does_not_create_duplicate_execution(tmp
 
 @pytest.mark.asyncio
 async def test_batch_cancel_counts_only_actual_cancellations(tmp_path: Path):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="批量取消",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    cancellable = await TaskManager.create_execution_from_scheduler(
+    cancellable = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
     )
-    completed = await TaskManager.create_execution_from_scheduler(
+    completed = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -850,7 +850,7 @@ async def test_batch_cancel_counts_only_actual_cancellations(tmp_path: Path):
     completed.completed_at = datetime.now(timezone.utc)
     await TaskStore.update_execution(completed)
 
-    cancelled = await TaskManager.batch_cancel([cancellable.id, completed.id])
+    cancelled = await ScheduleTaskManager.batch_cancel([cancellable.id, completed.id])
 
     assert cancelled == 1
 
@@ -866,28 +866,28 @@ async def test_delete_scheduler_cleans_active_executions_before_cascade(
         cancelled_runtime_ids.append(execution.id)
 
     monkeypatch.setattr(
-        TaskManager,
+        ScheduleTaskManager,
         "_cancel_execution_runtime",
         classmethod(fake_cancel_runtime),
     )
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="删除前清理普通计划",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    pending = await TaskManager.create_execution_from_scheduler(
+    pending = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
     )
-    queued = await TaskManager.create_execution_from_scheduler(
+    queued = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
     )
-    running = await TaskManager.create_execution_from_scheduler(
+    running = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -898,7 +898,7 @@ async def test_delete_scheduler_cleans_active_executions_before_cascade(
     running.session_id = "ses_delete_running"
     await TaskStore.update_execution(running)
     await TaskStore.enqueue_execution_ref(running.id)
-    completed = await TaskManager.create_execution_from_scheduler(
+    completed = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -907,7 +907,7 @@ async def test_delete_scheduler_cleans_active_executions_before_cascade(
     completed.completed_at = datetime.now(timezone.utc)
     await TaskStore.update_execution(completed)
 
-    deleted = await TaskManager.delete_scheduler(scheduler.id)
+    deleted = await ScheduleTaskManager.delete_scheduler(scheduler.id)
 
     assert deleted is True
     assert set(cancelled_runtime_ids) == {
@@ -916,7 +916,7 @@ async def test_delete_scheduler_cleans_active_executions_before_cascade(
         running.id,
     }
     for execution_id in (pending.id, queued.id, running.id, completed.id):
-        assert await TaskManager.get_execution(execution_id) is None
+        assert await ScheduleTaskManager.get_execution(execution_id) is None
     assert await TaskStore.get_queue_ref(queued.id) is None
     assert await TaskStore.get_queue_ref(running.id) is None
 
@@ -938,13 +938,13 @@ async def test_delete_scheduler_cleans_active_executions_before_cascade(
 
 @pytest.mark.asyncio
 async def test_store_init_normalizes_legacy_paused_execution(tmp_path: Path):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="兼容旧 paused 状态",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=True,
@@ -966,7 +966,7 @@ async def test_store_init_normalizes_legacy_paused_execution(tmp_path: Path):
     await TaskStore.close()
     await TaskStore.init()
 
-    normalized = await TaskManager.get_execution(execution.id)
+    normalized = await ScheduleTaskManager.get_execution(execution.id)
 
     assert normalized is not None
     assert normalized.status == TaskStatus.CANCELLED
@@ -977,12 +977,12 @@ async def test_store_init_normalizes_legacy_paused_execution(tmp_path: Path):
 
 @pytest.mark.asyncio
 async def test_cli_list_tasks_accepts_legacy_paused_status(monkeypatch: pytest.MonkeyPatch):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="CLI 兼容 paused 查询",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
     )
-    execution = await TaskManager.create_execution_from_scheduler(
+    execution = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -990,7 +990,7 @@ async def test_cli_list_tasks_accepts_legacy_paused_status(monkeypatch: pytest.M
     execution.status = TaskStatus.CANCELLED
     execution.completed_at = datetime.now(timezone.utc)
     await TaskStore.update_execution(execution)
-    await TaskManager.disable_scheduler(scheduler.id)
+    await ScheduleTaskManager.disable_scheduler(scheduler.id)
 
     printed: list[object] = []
     monkeypatch.setattr(task_cli_commands.console, "print", lambda *args, **kwargs: printed.append(args))
@@ -1049,24 +1049,24 @@ async def test_delete_builtin_scheduler_archives_and_cancels_active_executions(
         cancelled_runtime_ids.append(execution.id)
 
     monkeypatch.setattr(
-        TaskManager,
+        ScheduleTaskManager,
         "_cancel_execution_runtime",
         classmethod(fake_cancel_runtime),
     )
 
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="删除前清理内置计划",
         mode=SchedulerMode.CRON,
         trigger=TaskTrigger(cron="*/5 * * * *", timezone="Asia/Shanghai"),
         workspace_directory=str(tmp_path / "workspace"),
         dedup_key="builtin:test-delete-cleanup",
     )
-    queued = await TaskManager.create_execution_from_scheduler(
+    queued = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.SCHEDULED,
         enqueue=True,
     )
-    running = await TaskManager.create_execution_from_scheduler(
+    running = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.SCHEDULED,
         enqueue=False,
@@ -1077,7 +1077,7 @@ async def test_delete_builtin_scheduler_archives_and_cancels_active_executions(
     running.session_id = "ses_builtin_running"
     await TaskStore.update_execution(running)
     await TaskStore.enqueue_execution_ref(running.id)
-    completed = await TaskManager.create_execution_from_scheduler(
+    completed = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.SCHEDULED,
         enqueue=False,
@@ -1086,11 +1086,11 @@ async def test_delete_builtin_scheduler_archives_and_cancels_active_executions(
     completed.completed_at = datetime.now(timezone.utc)
     await TaskStore.update_execution(completed)
 
-    deleted = await TaskManager.delete_scheduler(scheduler.id)
-    archived = await TaskManager.get_scheduler(scheduler.id)
-    queued_execution = await TaskManager.get_execution(queued.id)
-    running_execution = await TaskManager.get_execution(running.id)
-    completed_execution = await TaskManager.get_execution(completed.id)
+    deleted = await ScheduleTaskManager.delete_scheduler(scheduler.id)
+    archived = await ScheduleTaskManager.get_scheduler(scheduler.id)
+    queued_execution = await ScheduleTaskManager.get_execution(queued.id)
+    running_execution = await ScheduleTaskManager.get_execution(running.id)
+    completed_execution = await ScheduleTaskManager.get_execution(completed.id)
 
     assert deleted is True
     assert archived is not None
@@ -1108,39 +1108,39 @@ async def test_delete_builtin_scheduler_archives_and_cancels_active_executions(
 
 @pytest.mark.asyncio
 async def test_dashboard_counts_exclude_immediate_once_schedulers(tmp_path: Path):
-    await TaskManager.create_scheduler(
+    await ScheduleTaskManager.create_scheduler(
         title="队列任务模板",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=True),
         workspace_directory=str(tmp_path / "workspace-1"),
     )
-    await TaskManager.create_scheduler(
+    await ScheduleTaskManager.create_scheduler(
         title="单次计划任务",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False, run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
         workspace_directory=str(tmp_path / "workspace-2"),
     )
-    await TaskManager.create_scheduler(
+    await ScheduleTaskManager.create_scheduler(
         title="循环计划任务",
         mode=SchedulerMode.CRON,
         trigger=TaskTrigger(cron="*/5 * * * *", timezone="Asia/Shanghai"),
         workspace_directory=str(tmp_path / "workspace-3"),
     )
 
-    counts = await TaskManager.dashboard()
+    counts = await ScheduleTaskManager.dashboard()
 
     assert counts["scheduled_active"] == 2
 
 
 @pytest.mark.asyncio
 async def test_get_unviewed_results_includes_unread_and_notified_only(tmp_path: Path):
-    scheduler = await TaskManager.create_scheduler(
+    scheduler = await ScheduleTaskManager.create_scheduler(
         title="未读结果",
         mode=SchedulerMode.ONCE,
         trigger=TaskTrigger(run_immediately=False),
         workspace_directory=str(tmp_path / "workspace"),
     )
-    unread = await TaskManager.create_execution_from_scheduler(
+    unread = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -1150,7 +1150,7 @@ async def test_get_unviewed_results_includes_unread_and_notified_only(tmp_path: 
     unread.delivery_status = DeliveryStatus.UNREAD
     await TaskStore.update_execution(unread)
 
-    notified = await TaskManager.create_execution_from_scheduler(
+    notified = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -1160,7 +1160,7 @@ async def test_get_unviewed_results_includes_unread_and_notified_only(tmp_path: 
     notified.delivery_status = DeliveryStatus.NOTIFIED
     await TaskStore.update_execution(notified)
 
-    viewed = await TaskManager.create_execution_from_scheduler(
+    viewed = await ScheduleTaskManager.create_execution_from_scheduler(
         scheduler,
         trigger_type=ExecutionTriggerType.RUN_ONCE,
         enqueue=False,
@@ -1170,7 +1170,7 @@ async def test_get_unviewed_results_includes_unread_and_notified_only(tmp_path: 
     viewed.delivery_status = DeliveryStatus.VIEWED
     await TaskStore.update_execution(viewed)
 
-    results = await TaskManager.get_unviewed_results()
+    results = await ScheduleTaskManager.get_unviewed_results()
     result_ids = {item.id for item in results}
 
     assert unread.id in result_ids
@@ -1183,11 +1183,11 @@ async def test_task_page_notice_drops_legacy_tables_after_third_display():
     db = await TaskStore.raw_db()
     await db.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY)")
     await db.commit()
-    TaskManager._write_migration_state({"failed": True, "notice_count": 0})
+    ScheduleTaskManager._write_migration_state({"failed": True, "notice_count": 0})
 
-    first = await TaskManager.get_task_page_notice()
-    second = await TaskManager.get_task_page_notice()
-    third = await TaskManager.get_task_page_notice()
+    first = await ScheduleTaskManager.get_task_page_notice()
+    second = await ScheduleTaskManager.get_task_page_notice()
+    third = await ScheduleTaskManager.get_task_page_notice()
 
     assert first == {
         "message": "系统更新了任务表的存储，旧表自动迁移失败，请手动重建任务 scheduler",
@@ -1195,4 +1195,4 @@ async def test_task_page_notice_drops_legacy_tables_after_third_display():
     }
     assert second is not None and second["displayCount"] == 2
     assert third is not None and third["displayCount"] == 3
-    assert TaskManager._legacy_tables_exist() is False
+    assert ScheduleTaskManager._legacy_tables_exist() is False

--- a/tests/tool/test_task_center_compat.py
+++ b/tests/tool/test_task_center_compat.py
@@ -7,7 +7,7 @@ import pytest
 import flocks.tool.task.schedule_task_center  # noqa: F401
 from flocks.config.config import Config
 from flocks.storage.storage import Storage
-from flocks.task.manager import TaskManager
+from flocks.task.schedule_task_manager import ScheduleTaskManager
 from flocks.task.models import SchedulerMode, TaskPriority, TaskScheduler, TaskTrigger
 from flocks.task.store import TaskStore
 from flocks.tool.registry import ToolContext, ToolRegistry
@@ -27,8 +27,8 @@ async def isolated_task_env(tmp_path: pytest.TempPathFactory, monkeypatch: pytes
     Config._cached_config = None
     Storage._db_path = None
     Storage._initialized = False
-    TaskManager._instance = None
-    TaskManager._startup_error = None
+    ScheduleTaskManager._instance = None
+    ScheduleTaskManager._startup_error = None
     TaskStore._initialized = False
     TaskStore._conn = None
 
@@ -37,14 +37,14 @@ async def isolated_task_env(tmp_path: pytest.TempPathFactory, monkeypatch: pytes
 
     yield
 
-    await TaskManager.stop()
+    await ScheduleTaskManager.stop()
     await TaskStore.close()
     Config._global_config = None
     Config._cached_config = None
     Storage._db_path = None
     Storage._initialized = False
-    TaskManager._instance = None
-    TaskManager._startup_error = None
+    ScheduleTaskManager._instance = None
+    ScheduleTaskManager._startup_error = None
     TaskStore._initialized = False
     TaskStore._conn = None
 
@@ -107,7 +107,7 @@ class TestTaskCenterCompatibility:
 
         assert result.success is True
 
-        schedulers, total = await TaskManager.list_schedulers(limit=10)
+        schedulers, total = await ScheduleTaskManager.list_schedulers(limit=10)
         assert total == 1
         scheduler = schedulers[0]
         assert scheduler.mode == SchedulerMode.CRON
@@ -130,7 +130,7 @@ class TestTaskCenterCompatibility:
 
         assert result.success is True
 
-        schedulers, total = await TaskManager.list_schedulers(limit=10)
+        schedulers, total = await ScheduleTaskManager.list_schedulers(limit=10)
         assert total == 1
         scheduler = schedulers[0]
         assert scheduler.mode == SchedulerMode.CRON
@@ -152,7 +152,7 @@ class TestTaskCenterCompatibility:
 
         assert result.success is True
 
-        schedulers, total = await TaskManager.list_schedulers(limit=10)
+        schedulers, total = await ScheduleTaskManager.list_schedulers(limit=10)
         assert total == 1
         scheduler = schedulers[0]
         assert scheduler.mode == SchedulerMode.CRON
@@ -161,7 +161,7 @@ class TestTaskCenterCompatibility:
 
     @pytest.mark.asyncio
     async def test_task_update_accepts_schedule_fields(self):
-        scheduler = await TaskManager.create_scheduler(
+        scheduler = await ScheduleTaskManager.create_scheduler(
             title="原始任务",
             description="原始描述",
             mode=SchedulerMode.ONCE,
@@ -187,7 +187,7 @@ class TestTaskCenterCompatibility:
 
         assert result.success is True
 
-        updated = await TaskManager.get_scheduler(scheduler.id)
+        updated = await ScheduleTaskManager.get_scheduler(scheduler.id)
         assert updated is not None
         assert updated.mode == SchedulerMode.CRON
         assert updated.description == "更新后的描述"
@@ -218,7 +218,7 @@ class TestTaskCenterCompatibility:
         assert result.error is not None
         assert "run_at" in result.error or "cron" in result.error
 
-        _, total = await TaskManager.list_schedulers(limit=10)
+        _, total = await ScheduleTaskManager.list_schedulers(limit=10)
         assert total == 0
 
     @pytest.mark.asyncio
@@ -238,7 +238,7 @@ class TestTaskCenterCompatibility:
 
         assert result.success is True
 
-        schedulers, total = await TaskManager.list_schedulers(limit=10)
+        schedulers, total = await ScheduleTaskManager.list_schedulers(limit=10)
         assert total == 1
         scheduler = schedulers[0]
         assert scheduler.mode == SchedulerMode.CRON
@@ -263,12 +263,12 @@ class TestTaskCenterCompatibility:
         assert "only 5-field cron is supported" in result.error
         assert "`0 6 * * *`" in result.error
 
-        _, total = await TaskManager.list_schedulers(limit=10)
+        _, total = await ScheduleTaskManager.list_schedulers(limit=10)
         assert total == 0
 
     @pytest.mark.asyncio
     async def test_task_update_rejects_six_field_cron_with_hint(self):
-        scheduler = await TaskManager.create_scheduler(
+        scheduler = await ScheduleTaskManager.create_scheduler(
             title="待更新的定时任务",
             mode=SchedulerMode.CRON,
             trigger=TaskTrigger(
@@ -292,7 +292,7 @@ class TestTaskCenterCompatibility:
         assert "only 5-field cron is supported" in result.error
         assert "`0 6 * * *`" in result.error
 
-        unchanged = await TaskManager.get_scheduler(scheduler.id)
+        unchanged = await ScheduleTaskManager.get_scheduler(scheduler.id)
         assert unchanged is not None
         assert unchanged.trigger.cron == "*/5 * * * *"
 
@@ -327,7 +327,7 @@ class TestTaskCenterCompatibility:
 
     @pytest.mark.asyncio
     async def test_task_update_can_disable_and_enable_scheduled_task(self):
-        scheduler = await TaskManager.create_scheduler(
+        scheduler = await ScheduleTaskManager.create_scheduler(
             title="可停止的定时任务",
             mode=SchedulerMode.CRON,
             trigger=TaskTrigger(
@@ -345,7 +345,7 @@ class TestTaskCenterCompatibility:
         )
 
         assert disable_result.success is True
-        disabled = await TaskManager.get_scheduler(scheduler.id)
+        disabled = await ScheduleTaskManager.get_scheduler(scheduler.id)
         assert disabled is not None
         assert disabled.status.value == "disabled"
 
@@ -359,6 +359,6 @@ class TestTaskCenterCompatibility:
         )
 
         assert enable_result.success is True
-        enabled = await TaskManager.get_scheduler(scheduler.id)
+        enabled = await ScheduleTaskManager.get_scheduler(scheduler.id)
         assert enabled is not None
         assert enabled.status.value == "active"

--- a/tests/tool/test_task_list_routing.py
+++ b/tests/tool/test_task_list_routing.py
@@ -15,7 +15,7 @@ import pytest
 from flocks.tool.registry import ToolContext, ToolRegistry, ToolResult
 from flocks.tool.task.schedule_task_center import schedule_task, schedule_task_list
 
-_TM_PATH = "flocks.task.manager.TaskManager"
+_TM_PATH = "flocks.task.schedule_task_manager.ScheduleTaskManager"
 
 
 def _ctx() -> ToolContext:


### PR DESCRIPTION
## Summary

- Rename the generic TaskManager type and module to ScheduleTaskManager.
- Update scheduler, CLI, server, tool, and existing test references.
- Keep runtime behavior and storage schemas unchanged.

## Validation

- 73 scheduled-task regression tests passed.
- Ruff passed for all changed Python files.

## Database

- No schema or migration changes.