### PR TITLE
feat(provider): update Alibaba Qwen model catalog

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -1159,8 +1159,8 @@
     }
   },
   "alibaba": {
-    "name": "阿里云通义 (Alibaba/Qwen)",
-    "description": "通义千问系列大模型 via DashScope",
+    "name": "阿里云百炼 (Alibaba)",
+    "description": "阿里云百炼大模型 via DashScope",
     "npm": "@ai-sdk/openai-compatible",
     "default_base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
     "credential_schemas": [
@@ -1189,11 +1189,12 @@
       "ALIBABA_API_KEY"
     ],
     "models": {
-      "qwen3-235b-a22b-2507": {
-        "name": "Qwen3 235B A22B Instruct 2507",
-        "family": "qwen3",
+      "qwen3.8-max": {
+        "name": "Qwen3.8-Max",
+        "family": "qwen3.8",
         "capabilities": {
           "supports_tools": true,
+          "supports_vision": true,
           "supports_reasoning": true,
           "interleaved": {
             "field": "reasoning_content",
@@ -1203,18 +1204,42 @@
           "supports_streaming": true
         },
         "limits": {
-          "context_window": 262144,
-          "max_output_tokens": 262144
+          "context_window": 1000000,
+          "max_output_tokens": 65536
         },
         "pricing": {
-          "input": 2.0,
-          "output": 20.0,
+          "input": 12.0,
+          "output": 36.0,
           "currency": "CNY"
         }
       },
-      "qwen3.5-flash-02-23": {
-        "name": "Qwen3.5-Flash",
-        "family": "qwen3.5",
+      "qwen3.7-plus": {
+        "name": "Qwen3.7-Plus",
+        "family": "qwen3.7",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_vision": true,
+          "supports_reasoning": true,
+          "interleaved": {
+            "field": "reasoning_content",
+            "echo": "tool_calls",
+            "cross_provider_policy": "promote"
+          },
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 1000000,
+          "max_output_tokens": 65536
+        },
+        "pricing": {
+          "input": 2.0,
+          "output": 8.0,
+          "currency": "CNY"
+        }
+      },
+      "qwen3.7-max": {
+        "name": "Qwen3.7-Max",
+        "family": "qwen3.7",
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
@@ -1227,11 +1252,35 @@
         },
         "limits": {
           "context_window": 1000000,
-          "max_output_tokens": 1000000
+          "max_output_tokens": 65536
         },
         "pricing": {
-          "input": 0.8,
-          "output": 8.0,
+          "input": 12.0,
+          "output": 36.0,
+          "currency": "CNY"
+        }
+      },
+      "qwen3.7-flash": {
+        "name": "Qwen3.7-Flash",
+        "family": "qwen3.7",
+        "capabilities": {
+          "supports_tools": true,
+          "supports_vision": true,
+          "supports_reasoning": true,
+          "interleaved": {
+            "field": "reasoning_content",
+            "echo": "tool_calls",
+            "cross_provider_policy": "promote"
+          },
+          "supports_streaming": true
+        },
+        "limits": {
+          "context_window": 1000000,
+          "max_output_tokens": 65536
+        },
+        "pricing": {
+          "input": 0.2,
+          "output": 0.8,
           "currency": "CNY"
         }
       }

--- a/flocks/provider/sdk/alibaba.py
+++ b/flocks/provider/sdk/alibaba.py
@@ -1,5 +1,5 @@
 """
-Alibaba Cloud / Tongyi Qwen (阿里云 / 通义千问) provider implementation.
+Alibaba Cloud Model Studio (阿里云百炼) provider implementation.
 
 DashScope provides OpenAI-compatible API.
 Docs: https://help.aliyun.com/zh/model-studio/developer-reference/compatibility-of-openai-with-dashscope
@@ -9,7 +9,7 @@ from flocks.provider.sdk.openai_base import OpenAIBaseProvider
 
 
 class AlibabaProvider(OpenAIBaseProvider):
-    """Alibaba Cloud / Tongyi Qwen provider (OpenAI-compatible via DashScope).
+    """Alibaba Cloud Model Studio provider (OpenAI-compatible via DashScope).
 
     Models are loaded from catalog.json (CATALOG_ID = "alibaba") and
     user-added custom models from flocks.json by the parent
@@ -22,4 +22,4 @@ class AlibabaProvider(OpenAIBaseProvider):
     CATALOG_ID = "alibaba"
 
     def __init__(self):
-        super().__init__(provider_id="alibaba", name="阿里云通义 (Alibaba/Qwen)")
+        super().__init__(provider_id="alibaba", name="阿里云百炼 (Alibaba)")

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -155,16 +155,41 @@ class TestCuratedCatalogModels:
         assert v4_pro.capabilities.interleaved["field"] == "reasoning_content"
 
     def test_alibaba_catalog(self):
+        meta = get_provider_meta("alibaba")
+        assert meta is not None
+        assert meta.name == "阿里云百炼 (Alibaba)"
+
         models = get_provider_model_definitions("alibaba")
         assert {m.id for m in models} == {
-            "qwen3-235b-a22b-2507",
-            "qwen3.5-flash-02-23",
+            "qwen3.8-max",
+            "qwen3.7-plus",
+            "qwen3.7-max",
+            "qwen3.7-flash",
         }
 
-        flash = next(m for m in models if m.id == "qwen3.5-flash-02-23")
+        qwen38 = next(m for m in models if m.id == "qwen3.8-max")
+        assert qwen38.capabilities.supports_vision is True
+        assert qwen38.capabilities.supports_reasoning is True
+        assert qwen38.capabilities.interleaved["field"] == "reasoning_content"
+        assert qwen38.limits.context_window == 1000000
+        assert qwen38.limits.max_output_tokens == 65536
+        assert qwen38.pricing.currency == "CNY"
+
+        max_model = next(m for m in models if m.id == "qwen3.7-max")
+        assert max_model.capabilities.supports_reasoning is True
+        assert max_model.capabilities.interleaved["field"] == "reasoning_content"
+        assert max_model.limits.context_window == 1000000
+
+        plus = next(m for m in models if m.id == "qwen3.7-plus")
+        assert plus.capabilities.supports_vision is True
+        assert plus.capabilities.supports_reasoning is True
+
+        flash = next(m for m in models if m.id == "qwen3.7-flash")
+        assert flash.capabilities.supports_vision is True
         assert flash.capabilities.supports_reasoning is True
         assert flash.capabilities.interleaved["field"] == "reasoning_content"
         assert flash.limits.context_window == 1000000
+        assert flash.limits.max_output_tokens == 65536
         assert flash.pricing.currency == "CNY"
 
     def test_moonshot_catalog(self):

--- a/webui/src/hooks/useDefaultModelVision.test.ts
+++ b/webui/src/hooks/useDefaultModelVision.test.ts
@@ -93,6 +93,22 @@ describe('useDefaultModelVision', () => {
     await waitFor(() => expect(result.current).toBe(true));
   });
 
+  it.each(['qwen3.8-max', 'qwen3.7-plus', 'qwen3.7-flash'])(
+    'returns true for the predefined Alibaba vision model %s',
+    async (modelId) => {
+      mockResolved.mockResolvedValue(makeResolvedResp('alibaba', modelId));
+      mockDefinitions.mockResolvedValue(makeDefinitionsResp(
+        { supports_vision: true },
+        'predefined',
+        'alibaba',
+        modelId,
+      ));
+
+      const { result } = renderHook(() => useDefaultModelVision());
+      await waitFor(() => expect(result.current).toBe(true));
+    },
+  );
+
   it('returns true for the predefined kimi-k2.7-code model', async () => {
     mockResolved.mockResolvedValue(makeResolvedResp('threatbook-cn-llm', 'kimi-k2.7-code'));
     mockDefinitions.mockResolvedValue(makeDefinitionsResp(

--- a/webui/src/hooks/useDefaultModelVision.ts
+++ b/webui/src/hooks/useDefaultModelVision.ts
@@ -47,7 +47,10 @@ const subscribers = new Set<(state: VisionState) => void>();
 function allowsBuiltInVision(modelId: string): boolean {
   const lowered = modelId.toLowerCase();
   return (
-    lowered.includes('qwen3.6-plus')
+    lowered.includes('qwen3.8-max')
+    || lowered.includes('qwen3.7-plus')
+    || lowered.includes('qwen3.7-flash')
+    || lowered.includes('qwen3.6-plus')
     || lowered.includes('kimi-k2.6')
     || lowered.includes('kimi-k2.7-code')
   );

--- a/webui/src/pages/Model/index.tsx
+++ b/webui/src/pages/Model/index.tsx
@@ -2289,7 +2289,10 @@ function getDefaultReasoningToggleValue(providerId: string, modelId: string): bo
 function allowsBuiltInVisionToggle(modelId: string): boolean {
   const lowered = modelId.toLowerCase();
   return (
-    lowered.includes('qwen3.6-plus')
+    lowered.includes('qwen3.8-max')
+    || lowered.includes('qwen3.7-plus')
+    || lowered.includes('qwen3.7-flash')
+    || lowered.includes('qwen3.6-plus')
     || lowered.includes('kimi-k2.6')
     || lowered.includes('kimi-k2.7-code')
   );


### PR DESCRIPTION
## Summary

- rename the Alibaba provider to `阿里云百炼 (Alibaba)`
- replace legacy Alibaba catalog entries with Qwen3.8 Max and Qwen3.7 Plus, Max, and Flash
- expose vision support for the new multimodal Qwen models in the web UI
- update provider catalog coverage for the new model set and metadata

## Testing

- `uv run pytest tests/provider/test_chinese_providers.py -q`
- `npm run test:run -- src/hooks/useDefaultModelVision.test.ts`
- `ruff check flocks/provider/sdk/alibaba.py tests/provider/test_chinese_providers.py`
- `npx eslint src/hooks/useDefaultModelVision.ts src/hooks/useDefaultModelVision.test.ts src/pages/Model/index.tsx --report-unused-disable-directives --max-warnings 0`