### PR TITLE
fix(compaction): account for post-call tool results

### DIFF
--- a/flocks/session/prompt.py
+++ b/flocks/session/prompt.py
@@ -545,6 +545,50 @@ class SessionPrompt:
         return total
 
     @classmethod
+    async def estimate_tool_result_tokens(
+        cls,
+        session_id: str,
+        message_id: str,
+    ) -> int:
+        """Estimate tool-result tokens added after an assistant model call."""
+        from flocks.session.message import Message
+
+        try:
+            parts = await Message.parts(message_id, session_id)
+        except Exception as exc:
+            log.debug("prompt.tool_result_estimate.parts_failed", {
+                "message_id": message_id,
+                "error": str(exc),
+            })
+            return 0
+
+        total = 0
+        for part in parts:
+            if getattr(part, "type", None) != "tool":
+                continue
+            state = getattr(part, "state", None)
+            if state is None:
+                continue
+            time_info = getattr(state, "time", None)
+            if isinstance(time_info, dict) and time_info.get("compacted"):
+                total += 10
+                continue
+
+            status = getattr(state, "status", None)
+            if status == "completed":
+                output = getattr(state, "output", None)
+                if output:
+                    total += cls.count_tokens(
+                        output if isinstance(output, str) else str(output)
+                    )
+            elif status == "error":
+                error = getattr(state, "error", "Unknown error")
+                total += cls.count_tokens(f"Error: {error}")
+            elif status == "running":
+                total += cls.count_tokens("Error: Tool execution was interrupted")
+        return total
+
+    @classmethod
     async def _tokens_for_message(cls, session_id: str, msg: Any) -> int:
         """Return the token contribution of a single message (E6).
 

--- a/flocks/session/session_loop.py
+++ b/flocks/session/session_loop.py
@@ -100,11 +100,10 @@ class LoopContext:
     # Cooldown window to prefer cheap cleanup over repeated full compaction.
     last_compaction_step: Optional[int] = None
     last_cleanup_step: Optional[int] = None
-    # ``input + cache.read + output`` reported by the provider on the most
-    # recent finished assistant turn.  When non-zero this beats the
-    # synthetic estimate from ``estimate_full_context_tokens`` because it
-    # is what the upstream will actually bill us for on the next turn
-    # (matches the "observed value wins" rule from docs/design/context-compaction-v2.md §B3).
+    # ``input + cache.read + output + reasoning`` reported by the provider on
+    # the most recent finished assistant turn.  Overflow decisions compare it
+    # with a current message estimate so tool output produced after that model
+    # call cannot be missed.
     last_observed_prompt_tokens: int = 0
     auto_failover: bool = False
     # Entrypoint authorization is separate from persisted model_auto. Only a
@@ -1743,40 +1742,79 @@ class SessionLoop:
                     _cache = tokens_dict.get("cache") or {}
                     cache_read = _cache.get("read", 0) if isinstance(_cache, dict) else 0
                     output_tokens = tokens_dict.get("output", 0)
-                    reported_total = input_tokens + cache_read + output_tokens
+                    reasoning_tokens = tokens_dict.get("reasoning", 0)
+                    observed_prompt_tokens = input_tokens + cache_read
+                    reported_total = observed_prompt_tokens + output_tokens + reasoning_tokens
 
-                    # B3 — Observed-value-first token decision.  Always prefer
-                    # the provider's actual usage figure (input + cache_read)
-                    # over our synthetic estimate, because that is what the
-                    # next turn's prompt will be billed against.  Cache it on
-                    # the LoopContext so subsequent turns can reuse it as a
-                    # baseline.  Estimation only kicks in when the provider
-                    # genuinely reports no usage (all zero) — we feed the
-                    # compaction policy into ``estimate_full_context_tokens``
-                    # so it includes system-prompt + tool-schema overhead
-                    # and applies the 1.2 safety margin.
+                    # Provider usage describes the prompt before the latest
+                    # assistant response and its tool results.  Always compare
+                    # it with a lightweight estimate of the current messages
+                    # so newly produced tool output cannot be missed.
                     if reported_total > 0:
-                        ctx.last_observed_prompt_tokens = input_tokens + cache_read + output_tokens
-                        log.info("loop.tokens_decision", {
-                            "session_id": ctx.session.id,
-                            "source": "observed",
-                            "effective_tokens": input_tokens + cache_read,
-                            "overflow_threshold": compaction_policy.overflow_threshold,
-                        })
-                    else:
-                        estimated_tokens = await SessionPrompt.estimate_full_context_tokens(
-                            ctx.session.id,
-                            messages,
-                            policy=compaction_policy,
+                        ctx.last_observed_prompt_tokens = reported_total
+                    # The assistant is marked ``tool-calls`` before its tools
+                    # finish, so a concurrent UI estimate may have cached this
+                    # message without the completed tool output.
+                    SessionPrompt.invalidate_message_cache(last_finished.id)
+                    last_finished_index = next(
+                        (
+                            index
+                            for index, message in enumerate(messages)
+                            if message.id == last_finished.id
+                        ),
+                        len(messages) - 1,
+                    )
+
+                    async def _estimate_effective_tokens() -> tuple[int, int, str]:
+                        if observed_prompt_tokens > 0:
+                            tool_result_tokens = (
+                                await SessionPrompt.estimate_tool_result_tokens(
+                                    ctx.session.id,
+                                    last_finished.id,
+                                )
+                            )
+                            later_tokens = (
+                                await SessionPrompt.estimate_full_context_tokens(
+                                    ctx.session.id,
+                                    messages[last_finished_index + 1:],
+                                    policy=compaction_policy,
+                                )
+                            )
+                            delta_tokens = tool_result_tokens + later_tokens
+                            return (
+                                reported_total + delta_tokens,
+                                delta_tokens,
+                                "observed+estimated_delta",
+                            )
+
+                        estimated_tokens = (
+                            await SessionPrompt.estimate_full_context_tokens(
+                                ctx.session.id,
+                                messages,
+                                policy=compaction_policy,
+                            )
                         )
-                        tokens_dict = {"input": estimated_tokens, "output": 0, "cache": {"read": 0, "write": 0}}
-                        log.info("loop.tokens_decision", {
-                            "session_id": ctx.session.id,
-                            "source": "estimated",
-                            "effective_tokens": estimated_tokens,
-                            "message_count": len(messages),
-                            "overflow_threshold": compaction_policy.overflow_threshold,
-                        })
+                        return max(reported_total, estimated_tokens), estimated_tokens, "estimated"
+
+                    (
+                        effective_tokens,
+                        estimated_component_tokens,
+                        decision_source,
+                    ) = await _estimate_effective_tokens()
+                    tokens_dict = {
+                        "input": effective_tokens,
+                        "output": 0,
+                        "cache": {"read": 0, "write": 0},
+                    }
+                    log.info("loop.tokens_decision", {
+                        "session_id": ctx.session.id,
+                        "source": decision_source,
+                        "effective_tokens": effective_tokens,
+                        "observed_tokens": reported_total,
+                        "estimated_component_tokens": estimated_component_tokens,
+                        "message_count": len(messages),
+                        "overflow_threshold": compaction_policy.overflow_threshold,
+                    })
                     
                     try:
                         _tok_cache = tokens_dict.get("cache") or {}
@@ -1789,6 +1827,13 @@ class SessionLoop:
 
                         if near_overflow and ctx.last_cleanup_step != ctx.step:
                             try:
+                                message_tokens_before_cleanup = (
+                                    await SessionPrompt.estimate_full_context_tokens(
+                                        ctx.session.id,
+                                        messages,
+                                        policy=compaction_policy,
+                                    )
+                                )
                                 trunc_count = await SessionCompaction.truncate_oversized_tool_outputs(
                                     ctx.session.id,
                                     context_window_tokens=model_context,
@@ -1816,19 +1861,45 @@ class SessionLoop:
                                         "input_tokens": current_input_tokens,
                                         "cooldown_active": recent_compaction,
                                     })
-                                    turn_state = set_turn_state(
-                                        ctx.session.id,
-                                        step=ctx.step,
-                                        status="continued",
-                                        continue_reason="pre_compact_cleanup",
-                                        queued_message_detected=False,
+                                    message_tokens_after_cleanup = (
+                                        await SessionPrompt.estimate_full_context_tokens(
+                                            ctx.session.id,
+                                            messages,
+                                            policy=compaction_policy,
+                                        )
                                     )
-                                    await cls._publish_runtime_event(
-                                        callbacks,
-                                        "turn.continued",
-                                        turn_state.model_dump(by_alias=True),
+                                    baseline_offset_tokens = max(
+                                        0,
+                                        effective_tokens - message_tokens_before_cleanup,
                                     )
-                                    continue
+                                    effective_tokens = (
+                                        message_tokens_after_cleanup + baseline_offset_tokens
+                                    )
+                                    tokens_dict["input"] = effective_tokens
+                                    current_input_tokens = effective_tokens
+                                    log.info("loop.pre_compact_cleanup_rechecked", {
+                                        "session_id": ctx.session.id,
+                                        "effective_tokens": effective_tokens,
+                                        "message_tokens": message_tokens_after_cleanup,
+                                        "baseline_offset_tokens": baseline_offset_tokens,
+                                        "overflow_threshold": (
+                                            compaction_policy.overflow_threshold
+                                        ),
+                                    })
+                                    if effective_tokens <= compaction_policy.overflow_threshold:
+                                        turn_state = set_turn_state(
+                                            ctx.session.id,
+                                            step=ctx.step,
+                                            status="continued",
+                                            continue_reason="pre_compact_cleanup",
+                                            queued_message_detected=False,
+                                        )
+                                        await cls._publish_runtime_event(
+                                            callbacks,
+                                            "turn.continued",
+                                            turn_state.model_dump(by_alias=True),
+                                        )
+                                        continue
                             except Exception as trunc_err:
                                 log.warn("loop.pre_compact_cleanup_error", {
                                     "session_id": ctx.session.id,
@@ -1937,6 +2008,13 @@ class SessionLoop:
                             if not ctx.tool_result_truncation_attempted:
                                 ctx.tool_result_truncation_attempted = True
                                 try:
+                                    message_tokens_before_cleanup = (
+                                        await SessionPrompt.estimate_full_context_tokens(
+                                            ctx.session.id,
+                                            messages,
+                                            policy=compaction_policy,
+                                        )
+                                    )
                                     trunc_count = await SessionCompaction.truncate_oversized_tool_outputs(
                                         ctx.session.id,
                                         context_window_tokens=model_context,
@@ -1947,15 +2025,26 @@ class SessionLoop:
                                             "truncated": trunc_count,
                                         })
                                         # Re-check overflow after truncation
-                                        # (B3) Reuse the active v2 policy so the
-                                        # re-estimate includes the same overhead
-                                        # + safety margin as the first decision.
-                                        re_est = await SessionPrompt.estimate_full_context_tokens(
-                                            ctx.session.id,
-                                            messages,
-                                            policy=compaction_policy,
+                                        message_tokens_after_cleanup = (
+                                            await SessionPrompt.estimate_full_context_tokens(
+                                                ctx.session.id,
+                                                messages,
+                                                policy=compaction_policy,
+                                            )
                                         )
-                                        re_tokens = {"input": re_est, "output": 0, "cache": {"read": 0, "write": 0}}
+                                        baseline_offset_tokens = max(
+                                            0,
+                                            effective_tokens - message_tokens_before_cleanup,
+                                        )
+                                        re_est = (
+                                            message_tokens_after_cleanup
+                                            + baseline_offset_tokens
+                                        )
+                                        re_tokens = {
+                                            "input": re_est,
+                                            "output": 0,
+                                            "cache": {"read": 0, "write": 0},
+                                        }
                                         still_overflow = await SessionCompaction.is_overflow(
                                             tokens=re_tokens,
                                             model_context=model_context,

--- a/tests/session/test_prompt_tokens.py
+++ b/tests/session/test_prompt_tokens.py
@@ -490,3 +490,56 @@ class TestEstimateFullContextTokens:
         )
 
         assert result == 0
+
+
+class TestEstimateToolResultTokens:
+    @pytest.mark.asyncio
+    async def test_counts_only_results_added_after_model_call(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from flocks.session import message as message_mod
+
+        parts = [
+            SimpleNamespace(
+                type="tool",
+                state=SimpleNamespace(
+                    status="completed",
+                    input={"query": "i" * 400},
+                    output="o" * 400,
+                    time={},
+                ),
+            ),
+            SimpleNamespace(
+                type="tool",
+                state=SimpleNamespace(
+                    status="completed",
+                    input={},
+                    output="ignored after compaction",
+                    time={"compacted": 1},
+                ),
+            ),
+            SimpleNamespace(
+                type="tool",
+                state=SimpleNamespace(status="error", error="boom", time={}),
+            ),
+            SimpleNamespace(
+                type="tool",
+                state=SimpleNamespace(status="running", time={}),
+            ),
+            SimpleNamespace(type="text", text="not a tool result"),
+        ]
+
+        async def _parts(message_id, session_id):  # noqa: ARG001
+            return parts
+
+        monkeypatch.setattr(message_mod.Message, "parts", staticmethod(_parts))
+
+        result = await SessionPrompt.estimate_tool_result_tokens("ses_x", "msg_x")
+
+        assert result == (
+            SessionPrompt.count_tokens("o" * 400)
+            + 10
+            + SessionPrompt.count_tokens("Error: boom")
+            + SessionPrompt.count_tokens("Error: Tool execution was interrupted")
+        )

--- a/tests/session/test_session_abort_inject.py
+++ b/tests/session/test_session_abort_inject.py
@@ -16,6 +16,7 @@ import pytest
 
 from flocks.session.message import ToolPart, ToolStateCompleted
 from flocks.session.goal import GoalDecision
+from flocks.session.prompt import SessionPrompt
 from flocks.session.session_loop import SessionLoop, LoopCallbacks, LoopContext, LoopResult
 from flocks.session.runner import SessionRunner, StepResult
 from flocks.session.session import SessionInfo
@@ -707,7 +708,7 @@ class TestTurnLifecycle:
             AsyncMock(return_value=1),
         ), patch(
             "flocks.session.session_loop.SessionPrompt.estimate_full_context_tokens",
-            AsyncMock(return_value=0),
+            AsyncMock(side_effect=[0, 50_000, 0, 0]),
         ), patch(
             "flocks.session.runner.SessionRunner._process_step",
             AsyncMock(return_value=StepResult(action="stop")),
@@ -726,6 +727,100 @@ class TestTurnLifecycle:
         cleanup_turn = event_callback.await_args_list[2].args[1]
         assert cleanup_turn["continue_reason"] == "pre_compact_cleanup"
         assert cleanup_turn["status"] == "continued"
+
+    @pytest.mark.asyncio
+    async def test_post_observation_tool_delta_combines_with_observed_prompt(self):
+        session = SimpleNamespace(
+            id="turn_stale_usage_session",
+            agent="rex",
+            directory="/tmp",
+            memory_enabled=False,
+        )
+        ctx = LoopContext(
+            session=session,
+            provider_id="test-provider",
+            model_id="test-model",
+            agent_name="rex",
+        )
+        messages = [
+            self._make_msg("stale_usage_user", "user"),
+            self._make_msg(
+                "stale_usage_assistant",
+                "assistant",
+                finish="tool-calls",
+                tokens={"input": 95_000, "output": 0, "cache": {"read": 0, "write": 0}},
+            ),
+        ]
+        messages[0].content = "h" * 260_000
+        ctx.session_ctx = SimpleNamespace(get_messages=AsyncMock(return_value=messages))
+        tool_parts = [
+            ToolPart(
+                sessionID=session.id,
+                messageID="stale_usage_assistant",
+                callID=f"call_delta_{index}",
+                tool="bash",
+                state=ToolStateCompleted(
+                    input={"command": f"produce output {index}"},
+                    output="x" * 80_000,
+                    title="bash",
+                    metadata={},
+                    time={"start": index, "end": index + 1},
+                ),
+            )
+            for index in range(2)
+        ]
+        run_compaction = AsyncMock(return_value="stop")
+        parts_by_message = {"stale_usage_assistant": []}
+        truncation_calls = 0
+
+        async def truncate_one_tool_result(*args, **kwargs):  # noqa: ARG001
+            nonlocal truncation_calls
+            truncation_calls += 1
+            if truncation_calls == 1:
+                tool_parts[0].state.time["compacted"] = 1
+                return 1
+            return 0
+
+        with patch(
+            "flocks.session.session_loop.Provider.resolve_model_info",
+            return_value=(128_000, 8_192, None),
+        ), patch(
+            "flocks.session.session_loop.Message.parts",
+            AsyncMock(
+                side_effect=lambda message_id, _session_id: (
+                    list(parts_by_message.get(message_id, []))
+                ),
+            ),
+        ), patch(
+            "flocks.session.session_loop.SessionCompaction.truncate_oversized_tool_outputs",
+            AsyncMock(side_effect=truncate_one_tool_result),
+        ), patch(
+            "flocks.session.session_loop.SessionCompaction.prune",
+            AsyncMock(),
+        ), patch(
+            "flocks.session.session_loop.run_compaction",
+            run_compaction,
+        ), patch(
+            "flocks.session.runner.SessionRunner._process_step",
+            AsyncMock(return_value=StepResult(action="stop")),
+        ):
+            estimated_tokens = await SessionPrompt.estimate_full_context_tokens(
+                session.id,
+                messages,
+            )
+            parts_by_message["stale_usage_assistant"] = tool_parts
+            result = await SessionLoop._run_loop(ctx, LoopCallbacks())
+            current_message_tokens = await SessionPrompt.estimate_full_context_tokens(
+                session.id,
+                messages,
+            )
+
+        assert estimated_tokens < int(128_000 * 0.85)
+        assert current_message_tokens < int(128_000 * 0.85)
+        assert result.action == "stop"
+        run_compaction.assert_awaited_once()
+        assert truncation_calls == 2
+        assert ctx.last_observed_prompt_tokens == 95_000
 
     @pytest.mark.asyncio
     async def test_run_loop_skips_exit_condition_when_assistant_has_tool_parts(self):


### PR DESCRIPTION
Combine provider-reported usage with tool-result and later-message deltas so proactive compaction cannot miss context added after a model call. Recheck the effective context after tool-output cleanup and fall through to full compaction when cleanup is insufficient.