### PR TITLE
fix(provider): map global reasoning effort by model capability

### DIFF
--- a/flocks/provider/catalog.json
+++ b/flocks/provider/catalog.json
@@ -57,6 +57,14 @@
         "family": "deepseek-v4",
         "capabilities": {
           "supports_tools": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max",
+            "max": "max"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -84,6 +92,9 @@
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -110,6 +121,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "adaptive"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -134,6 +148,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -157,6 +174,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -179,6 +199,9 @@
             "field": "reasoning_content",
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
+          },
+          "thinking_level_map": {
+            "high": "enabled"
           },
           "supports_streaming": true
         },
@@ -204,6 +227,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -226,6 +252,9 @@
             "field": "reasoning_content",
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
+          },
+          "thinking_level_map": {
+            "high": "enabled"
           },
           "supports_streaming": true
         },
@@ -252,6 +281,9 @@
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -271,6 +303,14 @@
         "family": "deepseek-v4",
         "capabilities": {
           "supports_tools": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max",
+            "max": "max"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -313,6 +353,14 @@
         "family": "deepseek-v4",
         "capabilities": {
           "supports_tools": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max",
+            "max": "max"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -340,6 +388,9 @@
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -365,6 +416,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "adaptive"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -389,6 +443,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -412,6 +469,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -434,6 +494,9 @@
             "field": "reasoning_content",
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
+          },
+          "thinking_level_map": {
+            "high": "enabled"
           },
           "supports_streaming": true
         },
@@ -459,6 +522,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -482,6 +548,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -499,6 +568,14 @@
         "family": "deepseek-v4",
         "capabilities": {
           "supports_tools": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max",
+            "max": "max"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -653,6 +730,14 @@
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": "xhigh",
+            "max": null
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -670,6 +755,14 @@
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": "xhigh",
+            "max": null
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -687,6 +780,14 @@
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": "xhigh",
+            "max": null
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -704,6 +805,14 @@
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": "minimal",
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": null,
+            "max": null
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -767,6 +876,14 @@
           "supports_tools": true,
           "supports_vision": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": null,
+            "max": "max"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -785,6 +902,14 @@
           "supports_tools": true,
           "supports_vision": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": null,
+            "max": "max"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1014,6 +1139,14 @@
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": "xhigh",
+            "max": null
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1031,6 +1164,14 @@
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": "xhigh",
+            "max": null
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1048,6 +1189,14 @@
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": "xhigh",
+            "max": null
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1065,6 +1214,14 @@
         "capabilities": {
           "supports_tools": true,
           "supports_reasoning": true,
+          "thinking_level_map": {
+            "minimal": "minimal",
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "xhigh": null,
+            "max": null
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1120,6 +1277,14 @@
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
           },
+          "thinking_level_map": {
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max",
+            "max": "max"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1143,6 +1308,14 @@
             "echo": "tool_calls",
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
+          },
+          "thinking_level_map": {
+            "minimal": null,
+            "low": null,
+            "medium": null,
+            "high": "high",
+            "xhigh": "max",
+            "max": "max"
           },
           "supports_streaming": true
         },
@@ -1200,6 +1373,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1222,6 +1398,9 @@
             "field": "reasoning_content",
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
+          },
+          "thinking_level_map": {
+            "high": "enabled"
           },
           "supports_streaming": true
         },
@@ -1280,6 +1459,14 @@
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
           },
+          "thinking_level_map": {
+            "minimal": null,
+            "low": "low",
+            "medium": null,
+            "high": "high",
+            "xhigh": null,
+            "max": "max"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1305,6 +1492,9 @@
             "echo": "tool_calls",
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
+          },
+          "thinking_level_map": {
+            "high": "enabled"
           },
           "supports_streaming": true
         },
@@ -1332,6 +1522,9 @@
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1357,6 +1550,9 @@
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1381,6 +1577,9 @@
             "echo": "tool_calls",
             "placeholder": " ",
             "cross_provider_policy": "placeholder"
+          },
+          "thinking_level_map": {
+            "high": "enabled"
           },
           "supports_streaming": true
         },
@@ -1439,6 +1638,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1462,6 +1664,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1484,6 +1689,9 @@
             "field": "reasoning_content",
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
+          },
+          "thinking_level_map": {
+            "high": "enabled"
           },
           "supports_streaming": true
         },
@@ -1540,6 +1748,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "adaptive"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1564,6 +1775,9 @@
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
           },
+          "thinking_level_map": {
+            "high": "enabled"
+          },
           "supports_streaming": true
         },
         "limits": {
@@ -1586,6 +1800,9 @@
             "field": "reasoning_details",
             "echo": "tool_calls",
             "cross_provider_policy": "promote"
+          },
+          "thinking_level_map": {
+            "high": "enabled"
           },
           "supports_streaming": true
         },

--- a/flocks/provider/model_catalog.py
+++ b/flocks/provider/model_catalog.py
@@ -141,6 +141,7 @@ def _parse_model_definitions(
             supports_vision=caps_raw.get("supports_vision", False),
             supports_reasoning=caps_raw.get("supports_reasoning", True),
             interleaved=caps_raw.get("interleaved"),
+            thinking_level_map=caps_raw.get("thinking_level_map"),
             supports_streaming=caps_raw.get("supports_streaming", True),
         )
 

--- a/flocks/provider/options.py
+++ b/flocks/provider/options.py
@@ -9,7 +9,7 @@ Both ``SessionRunner`` (session/runner.py) and ``AgentExecutor``
 so that provider rules are maintained in exactly one place.
 """
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 from flocks.provider.interleaved import (
     REASONING_TRANSPORT_ANTHROPIC_MESSAGES,
@@ -30,8 +30,16 @@ log = Log.create(service="provider.options")
 DEFAULT_THINKING_BUDGET = 16000
 DEFAULT_OUTPUT_BUFFER = 8192
 DEFAULT_REASONING_EFFORT = "high"
-DEFAULT_KIMI_K3_REASONING_EFFORT = DEFAULT_REASONING_EFFORT
-KIMI_K3_REASONING_EFFORTS = frozenset({"low", "high", "max"})
+
+# ``enable_thinking`` controls off; this tuple orders provider-agnostic levels.
+_REASONING_EFFORT_LEVELS = (
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
 
 _GENERIC_CHAT_REASONING_EXTRA_BODY_KEYS = {
     "reasoning_content": "enable_thinking",
@@ -94,6 +102,130 @@ def _resolve_reasoning_effort(provider_id: str, model_id: str) -> Optional[str]:
             "error": str(exc),
         })
         return None
+
+
+def _get_reasoning_effort_map(
+    provider_id: str,
+    model_id: str,
+) -> Optional[Mapping[str, Optional[str]]]:
+    """Return the model-declared semantic-to-provider effort mapping."""
+    model = _lookup_raw_model_metadata(provider_id, model_id)
+    metadata_provider_id = getattr(model, "provider_id", None) if model else None
+    accepted_provider_ids = {provider_id.strip().lower()}
+    if "azure" in accepted_provider_ids:
+        accepted_provider_ids.add("azure-openai")
+    elif "azure-openai" in accepted_provider_ids:
+        accepted_provider_ids.add("azure")
+    if (
+        isinstance(metadata_provider_id, str)
+        and metadata_provider_id.strip().lower() not in accepted_provider_ids
+    ):
+        model = None
+    capabilities = getattr(model, "capabilities", None) if model else None
+    effort_map = (
+        getattr(capabilities, "thinking_level_map", None)
+        if capabilities
+        else None
+    )
+
+    if not effort_map:
+        try:
+            from flocks.provider.model_catalog import get_provider_model_definitions
+
+            catalog_provider_id = (
+                "azure-openai" if provider_id.strip().lower() == "azure" else provider_id
+            )
+            definitions = get_provider_model_definitions(catalog_provider_id) or []
+            catalog_model = next(
+                (model for model in definitions if model.id == model_id),
+                None,
+            )
+            catalog_capabilities = (
+                getattr(catalog_model, "capabilities", None)
+                if catalog_model
+                else None
+            )
+            effort_map = (
+                getattr(catalog_capabilities, "thinking_level_map", None)
+                if catalog_capabilities
+                else None
+            )
+        except Exception as exc:
+            log.debug("options.reasoning_effort.catalog_lookup_failed", {
+                "provider_id": provider_id,
+                "model_id": model_id,
+                "error": str(exc),
+            })
+
+    if not isinstance(effort_map, Mapping):
+        return None
+
+    normalized: Dict[str, Optional[str]] = {}
+    for semantic_level, provider_level in effort_map.items():
+        if not isinstance(semantic_level, str):
+            continue
+        if provider_level is not None and not isinstance(provider_level, str):
+            continue
+        normalized[semantic_level.strip().lower()] = provider_level
+    return normalized or None
+
+
+def _map_reasoning_effort(
+    provider_id: str,
+    model_id: str,
+    reasoning_effort: Optional[str],
+) -> Optional[str]:
+    """Clamp a semantic reasoning level and map it to the provider value."""
+    effort_map = _get_reasoning_effort_map(provider_id, model_id)
+    if not effort_map:
+        return None
+
+    requested = reasoning_effort or DEFAULT_REASONING_EFFORT
+    if effort_map.get(requested) is not None:
+        return effort_map[requested]
+
+    supported_levels = {
+        level: provider_level
+        for level, provider_level in effort_map.items()
+        if provider_level is not None
+    }
+    if not supported_levels:
+        return None
+
+    fallback = supported_levels.get(DEFAULT_REASONING_EFFORT) or next(
+        iter(supported_levels.values())
+    )
+    if requested not in _REASONING_EFFORT_LEVELS:
+        log.warning(
+            "options.reasoning_effort.invalid",
+            {
+                "provider_id": provider_id,
+                "model_id": model_id,
+                "reasoning_effort": requested,
+                "fallback": fallback,
+            },
+        )
+        return fallback
+
+    requested_index = _REASONING_EFFORT_LEVELS.index(requested)
+    higher_levels = _REASONING_EFFORT_LEVELS[requested_index + 1 :]
+    lower_levels = reversed(_REASONING_EFFORT_LEVELS[:requested_index])
+    for candidate in (*higher_levels, *lower_levels):
+        mapped_effort = effort_map.get(candidate)
+        if mapped_effort is not None:
+            log.warning(
+                "options.reasoning_effort.clamped",
+                {
+                    "provider_id": provider_id,
+                    "model_id": model_id,
+                    "reasoning_effort": requested,
+                    "resolved_reasoning_effort": candidate,
+                    "provider_reasoning_effort": mapped_effort,
+                },
+            )
+            return mapped_effort
+
+    return fallback
 
 
 def _resolve_default_extra_body(provider_id: str, model_id: str) -> Optional[Dict[str, Any]]:
@@ -234,27 +366,26 @@ def _build_generic_chat_extra_body(
     enabled = reasoning_enabled is not False
 
     if is_kimi_k3_model(model_id):
-        effort = reasoning_effort or DEFAULT_KIMI_K3_REASONING_EFFORT
-        if effort not in KIMI_K3_REASONING_EFFORTS:
-            log.warning(
-                "options.kimi_k3.invalid_reasoning_effort",
-                {
-                    "model_id": model_id,
-                    "reasoning_effort": effort,
-                    "fallback": DEFAULT_KIMI_K3_REASONING_EFFORT,
-                },
-            )
-            effort = DEFAULT_KIMI_K3_REASONING_EFFORT
-        return {"reasoning_effort": effort}
+        effort = _map_reasoning_effort(provider_id, model_id, reasoning_effort)
+        return {"reasoning_effort": effort} if effort else None
 
     if "deepseek" in model_lower or provider_lower == "deepseek":
-        return {
+        extra_body = {
             "thinking": (
                 {"type": "enabled"}
                 if enabled
                 else {"type": "disabled"}
             )
         }
+        if enabled and model_lower.startswith("deepseek-v4"):
+            effort = _map_reasoning_effort(
+                provider_id,
+                model_id,
+                reasoning_effort,
+            )
+            if effort:
+                extra_body["reasoning_effort"] = effort
+        return extra_body
 
     if "glm" in model_lower or provider_lower == "zhipu":
         return {
@@ -320,7 +451,8 @@ def build_provider_options(
     thinking_budget:
         Token budget for extended-thinking / reasoning where applicable.
     reasoning_effort:
-        Kimi K3 reasoning effort (``low``, ``high``, or ``max``).
+        Provider-agnostic reasoning effort. Unsupported levels are clamped to
+        the nearest model-supported level, preferring higher levels.
     resolve_max_tokens:
         If *True*, fall back to the model's configured ``max_tokens`` when
         no provider-specific logic has already set it.
@@ -367,11 +499,24 @@ def build_provider_options(
                 "budget_tokens": effective_budget,
             }
             options["max_tokens"] = api_limit if api_limit else (thinking_budget + DEFAULT_OUTPUT_BUFFER)
+            effort = _map_reasoning_effort(
+                provider_id,
+                model_id,
+                reasoning_effort,
+            )
+            if effort:
+                options["output_config"] = {"effort": effort}
 
     # -- OpenAI reasoning (o1 / o3 / gpt-5) --------------------------------
-    elif provider_id == "openai":
+    elif provider_id in {"openai", "azure", "azure-openai"}:
         if reasoning_enabled is not False and any(tag in model_lower for tag in ("o1", "o3", "gpt-5")):
-            options["reasoningEffort"] = reasoning_effort or DEFAULT_REASONING_EFFORT
+            effort = _map_reasoning_effort(
+                provider_id,
+                model_id,
+                reasoning_effort,
+            )
+            if effort:
+                options["reasoningEffort"] = effort
 
     # -- Google Gemini thinking ---------------------------------------------
     elif provider_id == "google":
@@ -413,22 +558,38 @@ def build_provider_options(
             reasoning_effort,
         )
         extra_body = dict(configured_extra_body or automatic_extra_body or {})
+        if configured_extra_body and (
+            "deepseek" in model_lower or provider_id.lower() == "deepseek"
+        ):
+            extra_body = dict(automatic_extra_body or {})
+            extra_body.update(configured_extra_body)
         if is_kimi_k3_model(model_id):
             # K3 is always a reasoning model and uses the top-level
             # reasoning_effort field instead of the K2.x thinking object.
             extra_body.pop("thinking", None)
             if reasoning_effort_explicit:
-                extra_body["reasoning_effort"] = (automatic_extra_body or {}).get(
-                    "reasoning_effort",
-                    DEFAULT_KIMI_K3_REASONING_EFFORT,
+                resolved_effort = (automatic_extra_body or {}).get(
+                    "reasoning_effort"
                 )
+                if resolved_effort:
+                    extra_body["reasoning_effort"] = resolved_effort
+                else:
+                    extra_body.pop("reasoning_effort", None)
             else:
                 configured_effort = extra_body.get("reasoning_effort")
-                if configured_effort not in KIMI_K3_REASONING_EFFORTS:
-                    extra_body["reasoning_effort"] = (automatic_extra_body or {}).get(
-                        "reasoning_effort",
-                        DEFAULT_KIMI_K3_REASONING_EFFORT,
+                supported_efforts = {
+                    value
+                    for value in (_get_reasoning_effort_map(provider_id, model_id) or {}).values()
+                    if value is not None
+                }
+                if supported_efforts and configured_effort not in supported_efforts:
+                    resolved_effort = (automatic_extra_body or {}).get(
+                        "reasoning_effort"
                     )
+                    if resolved_effort:
+                        extra_body["reasoning_effort"] = resolved_effort
+                    else:
+                        extra_body.pop("reasoning_effort", None)
         elif is_kimi_k27_code_model(model_id):
             # K2.7 rejects disabled thinking. Normalize configured values so
             # direct and gateway-backed endpoints always request reasoning.

--- a/flocks/provider/provider.py
+++ b/flocks/provider/provider.py
@@ -38,6 +38,11 @@ def _model_info_signature(model: "ModelInfo") -> tuple:
             getattr(cap, "supports_vision", None),
             getattr(cap, "supports_reasoning", None),
             getattr(cap, "interleaved", None),
+            json.dumps(
+                getattr(cap, "thinking_level_map", None),
+                default=str,
+                sort_keys=True,
+            ),
             getattr(cap, "max_tokens", None),
             getattr(cap, "context_window", None),
         )
@@ -123,6 +128,7 @@ class ModelCapabilities(BaseModel):
     supports_vision: bool = False
     supports_reasoning: bool = True
     interleaved: Optional[Dict[str, Any]] = None
+    thinking_level_map: Optional[Dict[str, Optional[str]]] = None
     max_tokens: Optional[int] = None
     context_window: Optional[int] = None
 
@@ -875,6 +881,7 @@ class Provider:
                                     supports_vision=model_dict.get("supports_vision", False),
                                     supports_reasoning=model_dict.get("supports_reasoning", True),
                                     interleaved=model_dict.get("interleaved"),
+                                    thinking_level_map=model_dict.get("thinking_level_map"),
                                     max_tokens=model_dict.get("max_output_tokens") or model_dict.get("max_tokens"),
                                     context_window=model_dict.get("context_window"),
                                 ),
@@ -1258,6 +1265,11 @@ class BaseProvider:
                 supports_vision=model.capabilities.supports_vision,
                 supports_reasoning=getattr(model.capabilities, "supports_reasoning", True),
                 interleaved=getattr(model.capabilities, "interleaved", None),
+                thinking_level_map=getattr(
+                    model.capabilities,
+                    "thinking_level_map",
+                    None,
+                ),
             ),
             limits=ModelLimits(
                 context_window=model.capabilities.context_window or 128000,
@@ -1323,6 +1335,12 @@ class BaseProvider:
         if "interleaved" in keys:
             overridden.capabilities.interleaved = getattr(
                 model.capabilities, "interleaved", None
+            )
+        if "thinking_level_map" in keys:
+            overridden.capabilities.thinking_level_map = getattr(
+                model.capabilities,
+                "thinking_level_map",
+                None,
             )
 
         # Limits — only override when explicitly stored

--- a/flocks/provider/sdk/anthropic.py
+++ b/flocks/provider/sdk/anthropic.py
@@ -355,6 +355,8 @@ class AnthropicProvider(BaseProvider):
                 request_params["max_tokens"] = kwargs["max_tokens"]
         else:
             request_params["temperature"] = kwargs.get("temperature", 0.7)
+        if kwargs.get("output_config"):
+            request_params["output_config"] = kwargs["output_config"]
         
         if system_message:
             request_params["system"] = system_message
@@ -456,6 +458,8 @@ class AnthropicProvider(BaseProvider):
         else:
             # Only set temperature when thinking is NOT enabled
             request_params["temperature"] = kwargs.get("temperature", 0.7)
+        if kwargs.get("output_config"):
+            request_params["output_config"] = kwargs["output_config"]
         
         if system_message:
             request_params["system"] = system_message

--- a/flocks/provider/sdk/azure.py
+++ b/flocks/provider/sdk/azure.py
@@ -139,6 +139,8 @@ class AzureProvider(BaseProvider):
             request_params["max_completion_tokens"] = max_tokens
         if tools:
             request_params["tools"] = tools
+        if kwargs.get("reasoningEffort"):
+            request_params["reasoning_effort"] = kwargs["reasoningEffort"]
         
         try:
             response = await client.chat.completions.create(**request_params)
@@ -192,6 +194,8 @@ class AzureProvider(BaseProvider):
             request_params["max_completion_tokens"] = max_tokens
         if tools:
             request_params["tools"] = tools
+        if kwargs.get("reasoningEffort"):
+            request_params["reasoning_effort"] = kwargs["reasoningEffort"]
         
         try:
             stream = await client.chat.completions.create(**request_params)

--- a/flocks/provider/sdk/azure.py
+++ b/flocks/provider/sdk/azure.py
@@ -21,43 +21,41 @@ log = Log.create(service="provider.azure")
 
 class AzureProvider(BaseProvider):
     """Azure OpenAI provider"""
-    
+
     def __init__(self):
         super().__init__(provider_id="azure", name="Azure OpenAI")
         self._api_key = os.getenv("AZURE_OPENAI_API_KEY")
         self._endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
         self._client = None
-    
+
     def _get_client(self):
         """Get or create Azure OpenAI client"""
         if self._client is None:
             try:
                 from openai import AsyncAzureOpenAI
-                
+
                 # Get API key
                 api_key = self._config.api_key if self._config else self._api_key
                 if not api_key:
                     api_key = os.getenv("AZURE_OPENAI_API_KEY")
                 if not api_key:
                     raise ValueError("Azure OpenAI API key not configured")
-                
+
                 # Get endpoint
                 endpoint = None
                 if self._config and self._config.base_url:
                     endpoint = self._config.base_url
                 else:
                     endpoint = self._endpoint or os.getenv("AZURE_OPENAI_ENDPOINT")
-                
+
                 if not endpoint:
                     raise ValueError("Azure OpenAI endpoint not configured")
-                
+
                 # Get API version
-                api_version = (
-                    self._config.custom_settings.get("api_version") 
-                    if self._config 
-                    else None
-                ) or os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
-                
+                api_version = (self._config.custom_settings.get("api_version") if self._config else None) or os.getenv(
+                    "AZURE_OPENAI_API_VERSION", "2025-04-01-preview"
+                )
+
                 # Create client
                 self._client = AsyncAzureOpenAI(
                     api_key=api_key,
@@ -65,11 +63,11 @@ class AzureProvider(BaseProvider):
                     api_version=api_version,
                 )
                 self.log.info("azure.client.created", {"endpoint": endpoint})
-                    
+
             except ImportError:
                 raise ImportError("openai package not installed. Install with: pip install openai")
         return self._client
-    
+
     def get_models(self) -> List[ModelInfo]:
         """Get list of Azure OpenAI models.
 
@@ -109,30 +107,24 @@ class AzureProvider(BaseProvider):
                 ),
             ),
         ]
-    
-    async def chat(
-        self,
-        model_id: str,
-        messages: List[ChatMessage],
-        **kwargs
-    ) -> ChatResponse:
+
+    async def chat(self, model_id: str, messages: List[ChatMessage], **kwargs) -> ChatResponse:
         """Send chat completion request to Azure OpenAI"""
         client = self._get_client()
-        
+
         formatted_messages = format_openai_messages(messages)
-        
+
         # Extract parameters
         temperature = kwargs.get("temperature", 0.7)
         max_tokens = kwargs.get("max_tokens")
         tools = kwargs.get("tools")
-        
+
         # Make request
         request_params = {
             "model": model_id,
             "messages": formatted_messages,
-            "temperature": temperature,
         }
-        
+
         if max_tokens:
             # Newer Azure models (GPT-4o, GPT-5.x) require max_completion_tokens;
             # try that first and fall back to max_tokens for older deployments.
@@ -141,7 +133,9 @@ class AzureProvider(BaseProvider):
             request_params["tools"] = tools
         if kwargs.get("reasoningEffort"):
             request_params["reasoning_effort"] = kwargs["reasoningEffort"]
-        
+        else:
+            request_params["temperature"] = temperature
+
         try:
             response = await client.chat.completions.create(**request_params)
         except Exception as e:
@@ -151,7 +145,7 @@ class AzureProvider(BaseProvider):
                 response = await client.chat.completions.create(**request_params)
             else:
                 raise
-        
+
         # Format response
         choice = response.choices[0]
         return ChatResponse(
@@ -163,40 +157,36 @@ class AzureProvider(BaseProvider):
                 "prompt_tokens": response.usage.prompt_tokens,
                 "completion_tokens": response.usage.completion_tokens,
                 "total_tokens": response.usage.total_tokens,
-            }
+            },
         )
-    
-    async def chat_stream(
-        self,
-        model_id: str,
-        messages: List[ChatMessage],
-        **kwargs
-    ) -> AsyncIterator[StreamChunk]:
+
+    async def chat_stream(self, model_id: str, messages: List[ChatMessage], **kwargs) -> AsyncIterator[StreamChunk]:
         """Send streaming chat completion request to Azure OpenAI"""
         client = self._get_client()
-        
+
         formatted_messages = format_openai_messages(messages)
-        
+
         # Extract parameters
         temperature = kwargs.get("temperature", 0.7)
         max_tokens = kwargs.get("max_tokens")
         tools = kwargs.get("tools")
-        
+
         # Make streaming request
         request_params = {
             "model": model_id,
             "messages": formatted_messages,
-            "temperature": temperature,
             "stream": True,
         }
-        
+
         if max_tokens:
             request_params["max_completion_tokens"] = max_tokens
         if tools:
             request_params["tools"] = tools
         if kwargs.get("reasoningEffort"):
             request_params["reasoning_effort"] = kwargs["reasoningEffort"]
-        
+        else:
+            request_params["temperature"] = temperature
+
         try:
             stream = await client.chat.completions.create(**request_params)
         except Exception as e:
@@ -206,7 +196,7 @@ class AzureProvider(BaseProvider):
                 stream = await client.chat.completions.create(**request_params)
             else:
                 raise
-        
+
         tool_calls: Dict[int, Dict[str, Any]] = {}
 
         async for chunk in stream:

--- a/flocks/provider/types.py
+++ b/flocks/provider/types.py
@@ -246,6 +246,7 @@ class ModelCapabilitiesV2(BaseModel):
     supports_vision: bool = False
     supports_reasoning: bool = True
     interleaved: Optional[Dict[str, Any]] = None
+    thinking_level_map: Optional[Dict[str, Optional[str]]] = None
     supports_temperature: bool = True
     supports_json_mode: bool = False
     supports_structured_output: bool = False

--- a/tests/provider/test_anthropic_interleaved.py
+++ b/tests/provider/test_anthropic_interleaved.py
@@ -195,6 +195,7 @@ async def test_anthropic_stream_uses_beta_interleaved_and_yields_tools_on_block_
                 }
             ],
             thinking={"type": "enabled", "budget_tokens": 2048},
+            output_config={"effort": "max"},
         )
     ]
 
@@ -203,6 +204,7 @@ async def test_anthropic_stream_uses_beta_interleaved_and_yields_tools_on_block_
         "interleaved-thinking-2025-05-14",
         "fine-grained-tool-streaming-2025-05-14",
     ]
+    assert kwargs["output_config"] == {"effort": "max"}
 
     assert chunks[0].event_type == "reasoning-start"
     assert chunks[1].event_type == "reasoning"

--- a/tests/provider/test_azure_provider.py
+++ b/tests/provider/test_azure_provider.py
@@ -175,11 +175,13 @@ async def test_azure_chat_stream_still_emits_text_chunks():
         async for chunk in provider.chat_stream(
             model_id="gpt-5.4-mini",
             messages=[ChatMessage(role="user", content="hi")],
+            reasoningEffort="xhigh",
         )
     ]
 
     assert [chunk.delta for chunk in emitted] == ["hello", ""]
     assert emitted[-1].finish_reason == "stop"
+    assert client.completions.last_request["reasoning_effort"] == "xhigh"
 
 
 @pytest.mark.asyncio

--- a/tests/provider/test_azure_provider.py
+++ b/tests/provider/test_azure_provider.py
@@ -39,6 +39,35 @@ class _FakeAzureClient:
         self.chat = SimpleNamespace(completions=self.completions)
 
 
+class _FakeAzureChatCompletions:
+    def __init__(self):
+        self.last_request = None
+
+    async def create(self, **kwargs):
+        self.last_request = kwargs
+        return SimpleNamespace(
+            id="response-1",
+            model=kwargs["model"],
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+            ),
+        )
+
+
+class _FakeAzureChatClient:
+    def __init__(self):
+        self.completions = _FakeAzureChatCompletions()
+        self.chat = SimpleNamespace(completions=self.completions)
+
+
 def _chunk(delta=None, finish_reason=None):
     return SimpleNamespace(
         choices=[
@@ -87,6 +116,40 @@ def test_azure_provider_returns_fallback_models_without_config():
 
     assert {m.id for m in models} == {"gpt-5.4", "gpt-5-mini"}
     assert all(m.provider_id == "azure" for m in models)
+
+
+def test_azure_client_defaults_to_reasoning_capable_api_version(monkeypatch):
+    client_args = {}
+
+    class FakeAsyncAzureOpenAI:
+        def __init__(self, **kwargs):
+            client_args.update(kwargs)
+
+    monkeypatch.setattr("openai.AsyncAzureOpenAI", FakeAsyncAzureOpenAI)
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.delenv("AZURE_OPENAI_API_VERSION", raising=False)
+
+    AzureProvider()._get_client()
+
+    assert client_args["api_version"] == "2025-04-01-preview"
+
+
+@pytest.mark.asyncio
+async def test_azure_chat_omits_temperature_for_reasoning_model():
+    client = _FakeAzureChatClient()
+    provider = AzureProvider()
+    provider._get_client = lambda: client
+
+    await provider.chat(
+        model_id="gpt-5.4",
+        messages=[ChatMessage(role="user", content="hi")],
+        temperature=0.2,
+        reasoningEffort="high",
+    )
+
+    assert client.completions.last_request["reasoning_effort"] == "high"
+    assert "temperature" not in client.completions.last_request
 
 
 @pytest.mark.asyncio
@@ -144,6 +207,7 @@ async def test_azure_chat_stream_emits_tool_calls():
     ]
 
     assert client.completions.last_request["tools"]
+    assert client.completions.last_request["temperature"] == 0.7
     assert len(emitted) == 1
     assert emitted[0].finish_reason == "tool_calls"
     assert emitted[0].tool_calls == [
@@ -160,13 +224,15 @@ async def test_azure_chat_stream_emits_tool_calls():
 
 @pytest.mark.asyncio
 async def test_azure_chat_stream_still_emits_text_chunks():
-    client = _FakeAzureClient([
-        _chunk(delta=SimpleNamespace(content="hello", tool_calls=None)),
-        _chunk(
-            delta=SimpleNamespace(content=None, tool_calls=None),
-            finish_reason="stop",
-        ),
-    ])
+    client = _FakeAzureClient(
+        [
+            _chunk(delta=SimpleNamespace(content="hello", tool_calls=None)),
+            _chunk(
+                delta=SimpleNamespace(content=None, tool_calls=None),
+                finish_reason="stop",
+            ),
+        ]
+    )
     provider = AzureProvider()
     provider._get_client = lambda: client
 
@@ -175,6 +241,7 @@ async def test_azure_chat_stream_still_emits_text_chunks():
         async for chunk in provider.chat_stream(
             model_id="gpt-5.4-mini",
             messages=[ChatMessage(role="user", content="hi")],
+            temperature=0.2,
             reasoningEffort="xhigh",
         )
     ]
@@ -182,16 +249,19 @@ async def test_azure_chat_stream_still_emits_text_chunks():
     assert [chunk.delta for chunk in emitted] == ["hello", ""]
     assert emitted[-1].finish_reason == "stop"
     assert client.completions.last_request["reasoning_effort"] == "xhigh"
+    assert "temperature" not in client.completions.last_request
 
 
 @pytest.mark.asyncio
 async def test_azure_chat_stream_preserves_tool_call_history():
-    client = _FakeAzureClient([
-        _chunk(
-            delta=SimpleNamespace(content=None, tool_calls=None),
-            finish_reason="stop",
-        ),
-    ])
+    client = _FakeAzureClient(
+        [
+            _chunk(
+                delta=SimpleNamespace(content=None, tool_calls=None),
+                finish_reason="stop",
+            ),
+        ]
+    )
     provider = AzureProvider()
     provider._get_client = lambda: client
 

--- a/tests/provider/test_chinese_providers.py
+++ b/tests/provider/test_chinese_providers.py
@@ -53,6 +53,28 @@ class TestCuratedCatalogProviders:
 class TestCuratedCatalogModels:
     """Verify key models, pricing, and limits."""
 
+    def test_mainstream_reasoning_models_declare_thinking_level_maps(self):
+        family_prefixes = (
+            "gpt",
+            "claude",
+            "deepseek",
+            "glm",
+            "qwen",
+            "kimi",
+            "minimax",
+        )
+        missing = []
+
+        for provider_id, provider in get_raw_catalog().items():
+            for model_id, model in provider.get("models", {}).items():
+                family = model.get("family", "").lower()
+                if not family.startswith(family_prefixes):
+                    continue
+                if not model.get("capabilities", {}).get("thinking_level_map"):
+                    missing.append(f"{provider_id}/{model_id}")
+
+        assert missing == []
+
     def test_openai_compatible_catalog(self):
         meta = get_provider_meta("openai-compatible")
         assert meta is not None
@@ -89,6 +111,8 @@ class TestCuratedCatalogModels:
 
         gpt54 = next(m for m in models if m.id == "gpt-5.4")
         assert gpt54.capabilities.supports_reasoning is True
+        assert gpt54.capabilities.thinking_level_map["xhigh"] == "xhigh"
+        assert gpt54.capabilities.thinking_level_map["minimal"] is None
         assert gpt54.limits.max_output_tokens == 1050000
         assert gpt54.pricing.input == 2.5
 
@@ -103,6 +127,8 @@ class TestCuratedCatalogModels:
 
         opus = next(m for m in models if m.id == "claude-opus-4-6")
         assert opus.capabilities.supports_vision is True
+        assert opus.capabilities.thinking_level_map["max"] == "max"
+        assert opus.capabilities.thinking_level_map["xhigh"] is None
         assert opus.pricing.output == 25.0
 
     def test_xai_catalog(self):
@@ -149,6 +175,7 @@ class TestCuratedCatalogModels:
         v4_flash = next(m for m in models if m.id == "deepseek-v4-flash")
         assert v4_flash.capabilities.supports_reasoning is True
         assert v4_flash.capabilities.interleaved["field"] == "reasoning_content"
+        assert v4_flash.capabilities.thinking_level_map["xhigh"] == "max"
 
         v4_pro = next(m for m in models if m.id == "deepseek-v4-pro")
         assert v4_pro.capabilities.supports_reasoning is True
@@ -163,6 +190,7 @@ class TestCuratedCatalogModels:
 
         flash = next(m for m in models if m.id == "qwen3.5-flash-02-23")
         assert flash.capabilities.supports_reasoning is True
+        assert flash.capabilities.thinking_level_map == {"high": "enabled"}
         assert flash.capabilities.interleaved["field"] == "reasoning_content"
         assert flash.limits.context_window == 1000000
         assert flash.pricing.currency == "CNY"
@@ -181,6 +209,8 @@ class TestCuratedCatalogModels:
         assert k3.capabilities.supports_vision is True
         assert k3.capabilities.supports_reasoning is True
         assert k3.capabilities.interleaved["field"] == "reasoning_content"
+        assert k3.capabilities.thinking_level_map["low"] == "low"
+        assert k3.capabilities.thinking_level_map["medium"] is None
         assert k3.pricing.input == 20.0
         assert k3.pricing.output == 100.0
         assert k3.pricing.cache_read == 2.0
@@ -235,6 +265,7 @@ class TestCuratedCatalogModels:
         glm47 = next(m for m in models if m.id == "glm-4.7")
         assert glm47.capabilities.supports_reasoning is True
         assert glm47.capabilities.interleaved["field"] == "reasoning_content"
+        assert glm47.capabilities.thinking_level_map == {"high": "enabled"}
 
     def test_minimax_catalog(self):
         models = get_provider_model_definitions("minimax")
@@ -246,6 +277,7 @@ class TestCuratedCatalogModels:
         m3 = next(m for m in models if m.id == "minimax-m3")
         assert m3.capabilities.supports_reasoning is True
         assert m3.capabilities.interleaved["field"] == "reasoning_details"
+        assert m3.capabilities.thinking_level_map == {"high": "adaptive"}
         assert m3.limits.context_window == 1000000
         assert m3.limits.max_output_tokens == 128000
         m27 = next(m for m in models if m.id == "minimax-m2.7")

--- a/tests/provider/test_model_management.py
+++ b/tests/provider/test_model_management.py
@@ -237,6 +237,7 @@ class TestBaseProviderExtensions:
                             supports_streaming=True,
                             supports_tools=True,
                             supports_vision=True,
+                            thinking_level_map={"high": "provider-high"},
                             context_window=100000,
                             max_tokens=8000,
                         ),
@@ -249,6 +250,9 @@ class TestBaseProviderExtensions:
         assert len(defs) == 1
         assert defs[0].id == "dummy-model"
         assert defs[0].capabilities.supports_vision is True
+        assert defs[0].capabilities.thinking_level_map == {
+            "high": "provider-high"
+        }
         assert defs[0].limits.context_window == 100000
         assert defs[0].limits.max_output_tokens == 8000
 
@@ -278,6 +282,36 @@ class TestBaseProviderExtensions:
 
         assert overridden.capabilities.supports_reasoning is False
         assert ModelFeature.REASONING not in overridden.capabilities.features
+
+    def test_config_override_replaces_catalog_thinking_level_map(self):
+        from flocks.provider.provider import BaseProvider, ModelCapabilities, ModelInfo
+
+        catalog_def = ModelDefinition(
+            id="dummy-model",
+            name="Dummy Model",
+            provider_id="dummy",
+            capabilities=ModelCapabilitiesV2(
+                thinking_level_map={"high": "catalog-high"},
+            ),
+        )
+        model = ModelInfo(
+            id="dummy-model",
+            name="Dummy Model",
+            provider_id="dummy",
+            capabilities=ModelCapabilities(
+                thinking_level_map={"low": "custom-low"},
+            ),
+        )
+        model._explicit_keys = {"thinking_level_map"}
+
+        overridden = BaseProvider("dummy", "Dummy")._apply_config_overrides(
+            catalog_def,
+            model,
+        )
+
+        assert overridden.capabilities.thinking_level_map == {
+            "low": "custom-low"
+        }
 
     def test_config_override_preserves_cache_read_pricing(self):
         from flocks.provider.provider import BaseProvider, ModelCapabilities, ModelInfo

--- a/tests/provider/test_provider_options.py
+++ b/tests/provider/test_provider_options.py
@@ -4,7 +4,10 @@ from flocks.provider.interleaved import (
     REASONING_TRANSPORT_GENERIC_CHAT,
 )
 
-DEEPSEEK_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
+DEEPSEEK_THINKING_EXTRA_BODY = {
+    "thinking": {"type": "enabled"},
+    "reasoning_effort": "high",
+}
 GLM_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled", "clear_thinking": False}}
 KIMI_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
 MIMO_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
@@ -121,7 +124,7 @@ class TestBuildProviderOptions:
 
     def test_kimi_k3_uses_reasoning_effort_instead_of_thinking(self):
         options = provider_options.build_provider_options(
-            "openai-compatible",
+            "moonshot",
             "kimi-k3",
             reasoning_enabled=False,
             resolve_max_tokens=False,
@@ -132,7 +135,7 @@ class TestBuildProviderOptions:
 
     def test_kimi_k3_respects_supported_reasoning_effort(self):
         options = provider_options.build_provider_options(
-            "openai-compatible",
+            "moonshot",
             "kimi-k3",
             reasoning_effort="low",
             resolve_max_tokens=False,
@@ -151,7 +154,7 @@ class TestBuildProviderOptions:
         )
 
         options = provider_options.build_provider_options(
-            "openai-compatible",
+            "moonshot",
             "kimi-k3",
             resolve_max_tokens=False,
         )
@@ -169,7 +172,7 @@ class TestBuildProviderOptions:
         )
 
         options = provider_options.build_provider_options(
-            "openai-compatible",
+            "moonshot",
             "kimi-k3",
             reasoning_effort="low",
             resolve_max_tokens=False,
@@ -254,6 +257,42 @@ class TestBuildProviderOptions:
         )
 
         assert options["extra_body"] == DEEPSEEK_THINKING_EXTRA_BODY
+
+    def test_deepseek_v4_maps_xhigh_reasoning_effort_to_max(self):
+        options = provider_options.build_provider_options(
+            "deepseek",
+            "deepseek-v4-flash",
+            reasoning_effort="xhigh",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "max",
+        }
+
+    def test_deepseek_effort_is_merged_with_configured_extra_body(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_default_extra_body",
+            lambda *_args: {"custom_option": True},
+        )
+
+        options = provider_options.build_provider_options(
+            "deepseek",
+            "deepseek-v4-pro",
+            reasoning_effort="xhigh",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "max",
+            "custom_option": True,
+        }
 
     def test_deepseek_models_emit_disabled_thinking_when_reasoning_disabled(
         self,
@@ -467,3 +506,128 @@ class TestBuildProviderOptions:
         )
 
         assert options["reasoningEffort"] == "low"
+
+    def test_openai_clamps_unsupported_global_reasoning_effort_for_model(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_reasoning_effort",
+            lambda *_args: "max",
+        )
+
+        options = provider_options.build_provider_options(
+            "openai",
+            "gpt-5.4",
+            resolve_max_tokens=False,
+        )
+
+        assert options["reasoningEffort"] == "xhigh"
+
+    def test_openai_unknown_reasoning_model_omits_unverified_effort(self):
+        options = provider_options.build_provider_options(
+            "openai",
+            "o3",
+            reasoning_effort="max",
+            resolve_max_tokens=False,
+        )
+
+        assert "reasoningEffort" not in options
+
+    def test_openai_clamps_minimal_up_to_low_for_gpt_54(self):
+        options = provider_options.build_provider_options(
+            "openai",
+            "gpt-5.4",
+            reasoning_effort="minimal",
+            resolve_max_tokens=False,
+        )
+
+        assert options["reasoningEffort"] == "low"
+
+    def test_azure_openai_uses_catalog_effort_map(self):
+        options = provider_options.build_provider_options(
+            "azure-openai",
+            "gpt-5.4",
+            reasoning_effort="max",
+            resolve_max_tokens=False,
+        )
+
+        assert options["reasoningEffort"] == "xhigh"
+
+    def test_claude_clamps_xhigh_up_to_max(self):
+        options = provider_options.build_provider_options(
+            "anthropic",
+            "claude-sonnet-4-6",
+            reasoning_effort="xhigh",
+            resolve_max_tokens=False,
+        )
+
+        assert options["output_config"] == {"effort": "max"}
+
+    def test_invalid_global_effort_falls_back_to_model_high(self):
+        options = provider_options.build_provider_options(
+            "openai",
+            "gpt-5.4",
+            reasoning_effort="turbo",
+            resolve_max_tokens=False,
+        )
+
+        assert options["reasoningEffort"] == "high"
+
+    def test_unknown_kimi_k3_gateway_omits_unverified_effort(self):
+        options = provider_options.build_provider_options(
+            "openai-compatible",
+            "kimi-k3",
+            reasoning_effort="max",
+            resolve_max_tokens=False,
+        )
+
+        assert "extra_body" not in options
+
+    def test_toggle_only_models_accept_all_global_efforts(self):
+        cases = (
+            ("zhipu", "glm-5", GLM_THINKING_EXTRA_BODY),
+            ("alibaba", "qwen3.5-flash-02-23", {"enable_thinking": True}),
+            ("minimax", "minimax-m3", {"reasoning_split": True}),
+            ("moonshot", "kimi-k2.6", KIMI_THINKING_EXTRA_BODY),
+        )
+
+        for provider_id, model_id, expected_extra_body in cases:
+            for effort in ("minimal", "low", "medium", "high", "xhigh", "max"):
+                options = provider_options.build_provider_options(
+                    provider_id,
+                    model_id,
+                    reasoning_effort=effort,
+                    resolve_max_tokens=False,
+                )
+
+                assert options["extra_body"] == expected_extra_body
+
+    def test_kimi_k3_clamps_reasoning_effort_up_before_down(self):
+        options = provider_options.build_provider_options(
+            "moonshot",
+            "kimi-k3",
+            reasoning_effort="xhigh",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {"reasoning_effort": "max"}
+
+    def test_kimi_k3_clamps_unsupported_global_medium_to_high(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            provider_options,
+            "_resolve_reasoning_effort",
+            lambda *_args: "medium",
+        )
+
+        options = provider_options.build_provider_options(
+            "moonshot",
+            "kimi-k3",
+            resolve_max_tokens=False,
+        )
+
+        assert options["extra_body"] == {"reasoning_effort": "high"}

--- a/tests/provider/test_thinking_params.py
+++ b/tests/provider/test_thinking_params.py
@@ -41,7 +41,7 @@ These tests verify four properties of the new path:
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterator, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 import pytest
 
@@ -49,7 +49,10 @@ from flocks.provider import model_catalog
 from flocks.provider import options as provider_options
 from flocks.provider.interleaved import is_kimi_k27_code_model, is_kimi_k3_model
 
-DEEPSEEK_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
+DEEPSEEK_THINKING_EXTRA_BODY = {
+    "thinking": {"type": "enabled"},
+    "reasoning_effort": "high",
+}
 GLM_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled", "clear_thinking": False}}
 KIMI_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
 MIMO_THINKING_EXTRA_BODY = {"thinking": {"type": "enabled"}}
@@ -444,7 +447,7 @@ class TestDispatchShape:
             ("kimi-k2.6-uncatalogued", KIMI_THINKING_EXTRA_BODY),
             ("kimi-k2.7-code", KIMI_THINKING_EXTRA_BODY),
             ("kimi-k2.7-code-highspeed", KIMI_THINKING_EXTRA_BODY),
-            ("kimi-k3", {"reasoning_effort": "high"}),
+            ("kimi-k3", None),
             ("mimo-v2.5-pro-uncatalogued", MIMO_THINKING_EXTRA_BODY),
             ("minimax-m4-uncatalogued", {"reasoning_split": True}),
             ("step-3.5-flash-uncatalogued", {"enable_thinking": True}),
@@ -453,11 +456,12 @@ class TestDispatchShape:
     def test_series_token_fallback_emits_expected_extra_body(
         self,
         model_id: str,
-        expected_extra_body: Dict[str, Any],
+        expected_extra_body: Optional[Dict[str, Any]],
     ) -> None:
         """Models matching a known series token in
-        ``infer_interleaved_capability`` get the expected extra_body on the wire
-        even when the catalog has no explicit declaration for them.
+        ``infer_interleaved_capability`` get the safe extra_body on the wire even
+        when the catalog has no explicit declaration for them. Effort-only models
+        omit the effort when no model capability map is available.
 
         This is the regression net for the design choice that the dispatch
         is *not* provider-keyed: a user-configured openai-compatible


### PR DESCRIPTION
## Summary

- add model-level `thinking_level_map` metadata and resolve the global semantic reasoning effort against the active provider and model
- clamp unsupported levels upward before downward, while omitting unverified effort values for unknown models
- support GPT, Claude, DeepSeek, GLM, MiniMax, Kimi, and Qwen across built-in and ThreatBook catalog entries
- forward validated native effort parameters through OpenAI/Azure, Anthropic, DeepSeek, and Kimi request paths
- keep toggle-only models on their safe enabled/adaptive behavior without inventing unsupported effort values

## Default behavior

With no configuration, the global semantic level is `high`. Native effort models receive their validated high-equivalent value. Toggle-only models enable thinking and use the provider/model default depth. Models without a capability map omit the effort parameter.

## Testing

- `uv run ruff check` on all changed Python files
- 195 focused provider capability and request-shape tests passed
- full provider/config suite: 564 passed, 14 skipped, 11 pre-existing environment/mock failures
- `git diff --check`
- `jq empty flocks/provider/catalog.json`