### PR TITLE
fix(channel): use runtime server port for message delivery

### DIFF
--- a/flocks/cli/main.py
+++ b/flocks/cli/main.py
@@ -5,6 +5,7 @@ Provides command-line interface for Flocks
 """
 
 import asyncio
+import os
 import secrets as secrets_lib
 import sys
 from pathlib import Path
@@ -362,6 +363,8 @@ def serve(
     Start the Flocks API server
     """
     import uvicorn
+
+    os.environ["_FLOCKS_SERVER_PORT"] = str(port)
 
     console.print(Panel(logo(), border_style="cyan"))
     console.print(f"[cyan]Starting server on:[/cyan] http://{host}:{port}")

--- a/flocks/tool/channel/channel_message.py
+++ b/flocks/tool/channel/channel_message.py
@@ -12,6 +12,8 @@ is bound to multiple channels.
 
 from __future__ import annotations
 
+import os
+
 from flocks.tool.registry import (
     ParameterType,
     ToolCategory,
@@ -31,6 +33,20 @@ _CHANNEL_ALIASES: dict[str, list[str]] = {
     "email": ["email", "mail", "邮件", "imap", "smtp"],
     "slack": ["slack", "sl"],
 }
+
+
+def _get_server_port() -> int:
+    """Return the port of the API server hosting the current process."""
+    try:
+        runtime_port = os.environ.get("_FLOCKS_SERVER_PORT")
+        if runtime_port:
+            return int(runtime_port)
+
+        from flocks.config import Config
+
+        return Config.get_global().server_port
+    except Exception:
+        return 8000
 
 
 def _normalize_channel_type(channel_type: str | None) -> str | None:
@@ -213,12 +229,7 @@ async def channel_message(ctx: ToolContext, **kwargs) -> ToolResult:
     channel_type: str | None = _normalize_channel_type(raw_channel_type)
 
     # Prefer the HTTP endpoint of the running flocks server to reuse its WS connection.
-    try:
-        from flocks.config import Config
-        cfg = await Config.get()
-        port = getattr(cfg, "port", None) or 8000
-    except Exception:
-        port = 8000
+    port = _get_server_port()
 
     result = await _http_session_send(
         port,

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -205,6 +205,7 @@ cleanup() {
 start_backend() {
     echo -e "${GREEN}🔧 启动后端服务: http://${BACKEND_HOST}:${BACKEND_PORT}${NC}"
     cd "${PROJECT_ROOT}"
+    _FLOCKS_SERVER_PORT="${BACKEND_PORT}" \
     _FLOCKS_WEBUI_HOST="${FRONTEND_HOST}" \
     _FLOCKS_WEBUI_PORT="${FRONTEND_PORT}" \
     FLOCKS_CONSOLE_BASE_URL="${FLOCKS_CONSOLE_BASE_URL}" \
@@ -229,6 +230,7 @@ start_frontend() {
 start_all() {
     echo -e "${BLUE}🚀 同时启动前后端开发环境...${NC}"
     cd "${PROJECT_ROOT}"
+    _FLOCKS_SERVER_PORT="${BACKEND_PORT}" \
     _FLOCKS_WEBUI_HOST="${FRONTEND_HOST}" \
     _FLOCKS_WEBUI_PORT="${FRONTEND_PORT}" \
     FLOCKS_CONSOLE_BASE_URL="${FLOCKS_CONSOLE_BASE_URL}" \

--- a/tests/cli/test_service_commands.py
+++ b/tests/cli/test_service_commands.py
@@ -1,3 +1,4 @@
+import os
 import re
 import subprocess
 import time
@@ -101,6 +102,17 @@ def test_hidden_serve_command_is_not_listed_but_still_invocable(monkeypatch, tmp
     assert not _help_contains_command(result.stdout, "serve")
     assert hidden_help.exit_code == 0
     assert "Start the Flocks API server" in hidden_help.stdout
+
+
+def test_serve_exposes_runtime_server_port(monkeypatch) -> None:
+    import uvicorn
+
+    monkeypatch.delenv("_FLOCKS_SERVER_PORT", raising=False)
+    monkeypatch.setattr(uvicorn, "run", lambda *_args, **_kwargs: None)
+
+    cli_main.serve(host="127.0.0.1", port=5173, reload=False)
+
+    assert os.environ["_FLOCKS_SERVER_PORT"] == "5173"
 
 
 def test_tui_starts_hidden_serve_command(monkeypatch, tmp_path) -> None:

--- a/tests/scripts/test_bash_scripts.py
+++ b/tests/scripts/test_bash_scripts.py
@@ -41,3 +41,9 @@ def test_dev_script_sets_console_base_url_default() -> None:
 
     assert 'FLOCKS_CONSOLE_BASE_URL="${FLOCKS_CONSOLE_BASE_URL:-https://portalflocks.threatbook.cn}"' in script
     assert 'FLOCKS_CONSOLE_BASE_URL="${FLOCKS_CONSOLE_BASE_URL}" \\' in script
+
+
+def test_dev_script_exposes_runtime_server_port() -> None:
+    script = (SCRIPT_DIR / "dev.sh").read_text(encoding="utf-8")
+
+    assert script.count('_FLOCKS_SERVER_PORT="${BACKEND_PORT}" \\') == 2

--- a/tests/tool/test_channel_message.py
+++ b/tests/tool/test_channel_message.py
@@ -8,7 +8,7 @@ from flocks.tool.channel.channel_message import (
     _normalize_channel_type,
     channel_message,
 )
-from flocks.tool.registry import ToolContext, ToolRegistry
+from flocks.tool.registry import ToolContext, ToolRegistry, ToolResult
 
 
 def test_channel_message_normalizes_weixin_aliases() -> None:
@@ -61,6 +61,25 @@ def test_channel_message_schema_includes_builtin_channels() -> None:
         "邮件",
     ):
         assert value in channel_enum
+
+
+@pytest.mark.asyncio
+async def test_channel_message_uses_runtime_server_port(monkeypatch) -> None:
+    monkeypatch.setenv("_FLOCKS_SERVER_PORT", "5173")
+    http_send = AsyncMock(return_value=ToolResult(success=True, output="ok"))
+
+    with patch(
+        "flocks.tool.channel.channel_message._http_session_send",
+        http_send,
+    ):
+        result = await channel_message(
+            ToolContext(session_id="ses_current", message_id="msg_1"),
+            session_id="ses_target",
+            message="hello",
+        )
+
+    assert result.success is True
+    assert http_send.await_args.args[0] == 5173
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Expose the active API port from managed and development launch paths so channel_message no longer falls back to the legacy port. Add regression coverage for CLI, dev script, and message delivery port selection.