### PR TITLE
feat: link SOC workflows to execution details

### DIFF
--- a/.flocks/flockshub/plugins/webuis/soc_ui/soc_dashboard/src/Page.tsx
+++ b/.flocks/flockshub/plugins/webuis/soc_ui/soc_dashboard/src/Page.tsx
@@ -194,12 +194,17 @@ function createActivityState() {
 
 function createMockActivityEvent(overrides) {
   const now = new Date();
+  const workflowId = overrides.workflowId || (overrides.stage === 'triage' ? 'stream_alert_triage' : 'stream_alert_denoise');
+  const executionId = overrides.executionId || `${workflowId}-mock-execution`;
   return {
-    eventId: overrides.eventId || `mock-${overrides.stage}-${overrides.alert?.id || Math.random().toString(36).slice(2)}`,
+    eventId: overrides.eventId || `workflow-execution:${executionId}`,
     stage: overrides.stage,
     status: overrides.status || 'running',
     occurredAt: overrides.occurredAt || now.toISOString(),
-    triggerSource: overrides.triggerSource || 'mock',
+    triggerSource: overrides.triggerSource || 'workflow_execution',
+    workflowId,
+    sessionId: overrides.sessionId || '',
+    messageId: overrides.messageId || '',
     playbackMode: overrides.playbackMode || 'normal',
     playbackStartedAt: overrides.playbackStartedAt || Date.now() - 4200,
     sampleCount: overrides.sampleCount || 1,
@@ -234,7 +239,8 @@ function createMockActivityState() {
   const now = Date.now();
   const denoiseCurrent = createMockActivityEvent({
     stage: 'denoise',
-    eventId: 'mock-denoise-current',
+    workflowId: 'stream_alert_denoise',
+    executionId: 'mock-denoise-run-001',
     playbackMode: 'burst',
     playbackStartedAt: now - 3600,
     sampleCount: 6,
@@ -259,7 +265,8 @@ function createMockActivityState() {
   });
   const triageCurrent = createMockActivityEvent({
     stage: 'triage',
-    eventId: 'mock-triage-current',
+    workflowId: 'stream_alert_triage',
+    executionId: 'mock-triage-run-002',
     playbackStartedAt: now - 6200,
     alert: {
       id: 'mock-alert-rce',
@@ -280,7 +287,8 @@ function createMockActivityState() {
   const triageWaiting = createMockActivityEvent({
     stage: 'triage',
     status: 'queued',
-    eventId: 'mock-triage-waiting',
+    workflowId: 'stream_alert_triage',
+    executionId: 'mock-triage-run-003',
     occurredAt: new Date(now - 18000).toISOString(),
     playbackStartedAt: now - 18000,
     alert: {
@@ -300,7 +308,8 @@ function createMockActivityState() {
   const denoiseWaiting = createMockActivityEvent({
     stage: 'denoise',
     status: 'queued',
-    eventId: 'mock-denoise-waiting',
+    workflowId: 'stream_alert_denoise',
+    executionId: 'mock-denoise-run-004',
     occurredAt: new Date(now - 26000).toISOString(),
     playbackStartedAt: now - 26000,
     sampleCount: 4,
@@ -440,7 +449,7 @@ function createMockTaskCenterState() {
         latestAlertName: '异常登录爆发（Mock）',
         progressPercent: 0.58,
         progressLabel: '第 4/7 步',
-        currentPhase: '聚类降噪',
+        currentPhase: 'running',
         sessionId: '',
         messageId: '',
       },
@@ -458,7 +467,7 @@ function createMockTaskCenterState() {
         latestAlertName: '远程命令执行攻击（Mock）',
         progressPercent: 0.67,
         progressLabel: '第 2/3 步',
-        currentPhase: '证据汇总',
+        currentPhase: 'running',
         sessionId: '',
         messageId: '',
       },
@@ -2177,24 +2186,51 @@ function taskCenterProgressLabel(item) {
   return String(item?.progressLabel || '').trim() || '待执行';
 }
 
-function openTaskCenterConversation(item) {
-  const sessionId = String(item?.sessionId || item?.sessionID || '').trim();
-  if (!sessionId || typeof window === 'undefined') return false;
-  const messageId = String(item?.messageId || item?.messageID || '').trim();
-  const params = new URLSearchParams({ session: sessionId });
-  if (messageId) params.set('focusMessage', messageId);
-  window.location.href = `/sessions?${params.toString()}`;
+function workflowIdFromTaskCenterItem(item) {
+  return String(item?.id || item?.workflowId || item?.workflowID || '').trim();
+}
+
+function executionIdFromTaskCenterItem(item) {
+  return String(item?.latestExecutionHash || item?.executionId || item?.executionID || '').trim();
+}
+
+function executionIdFromWorkflowEvent(event) {
+  const directId = String(event?.executionId || event?.executionID || '').trim();
+  if (directId) return directId;
+  const eventId = String(event?.eventId || event?.id || '').trim();
+  const match = eventId.match(/^workflow-execution:(.+)$/);
+  return match ? match[1].trim() : '';
+}
+
+function workflowIdFromEvent(event) {
+  return String(event?.workflowId || event?.workflowID || '').trim();
+}
+
+function openWorkflowExecution(workflowId, executionId) {
+  if (!workflowId || !executionId || typeof window === 'undefined') return false;
+  const params = new URLSearchParams({ tab: 'run', execId: executionId });
+  try {
+    const currentParams = new URLSearchParams(window.location.search || '');
+    if (currentParams.has('mockDashboard') || currentParams.has('mockActivity') || currentParams.has('mockTaskCenter')) {
+      params.set('mockDashboard', '1');
+    } else if (isMockSwitchEnabled(window.localStorage?.getItem(SOC_MOCK_DASHBOARD_KEY))
+      || isMockSwitchEnabled(window.localStorage?.getItem(SOC_MOCK_ACTIVITY_KEY))
+      || isMockSwitchEnabled(window.localStorage?.getItem(SOC_MOCK_TASK_CENTER_KEY))) {
+      params.set('mockDashboard', '1');
+    }
+  } catch {
+    // Mock switch propagation is best-effort; navigation must still work without localStorage.
+  }
+  window.location.href = `/workflows/${encodeURIComponent(workflowId)}?${params.toString()}`;
   return true;
 }
 
-function openConversationFromEvent(event) {
-  const sessionId = String(event?.sessionId || event?.sessionID || '').trim();
-  if (!sessionId || typeof window === 'undefined') return false;
-  const messageId = String(event?.messageId || event?.messageID || '').trim();
-  const params = new URLSearchParams({ session: sessionId });
-  if (messageId) params.set('focusMessage', messageId);
-  window.location.href = `/sessions?${params.toString()}`;
-  return true;
+function openWorkflowExecutionFromTaskCenter(item) {
+  return openWorkflowExecution(workflowIdFromTaskCenterItem(item), executionIdFromTaskCenterItem(item));
+}
+
+function openWorkflowExecutionFromEvent(event) {
+  return openWorkflowExecution(workflowIdFromEvent(event), executionIdFromWorkflowEvent(event));
 }
 
 function TaskCenterSummary({ taskCenter }) {
@@ -2234,7 +2270,7 @@ function TaskCenterItem({ item, kind }) {
   const latestExecutionHash = taskCenterHashValue(item.latestExecutionHash);
   const itemName = kind === 'workflow' ? taskCenterWorkflowName(item) : item.name || item.id;
   const alertName = String(item.latestAlertName || '').trim();
-  const hasConversation = kind === 'workflow' && Boolean(String(item.sessionId || item.sessionID || '').trim());
+  const hasExecution = kind === 'workflow' && Boolean(workflowIdFromTaskCenterItem(item) && executionIdFromTaskCenterItem(item));
   const scheduledClosed = kind === 'scheduled' && ['disabled', 'stopped'].includes(schedulerStatus);
   const sub = kind === 'scheduled'
     ? scheduledClosed
@@ -2259,20 +2295,20 @@ function TaskCenterItem({ item, kind }) {
         h('span', { key: 'rate' }, ['成功率 ', h('b', { key: 'value' }, taskCenterPercent(successRate))]),
       ];
   const handleOpen = () => {
-    if (hasConversation) openTaskCenterConversation(item);
+    if (hasExecution) openWorkflowExecutionFromTaskCenter(item);
   };
   const handleKeyDown = (event) => {
-    if (!hasConversation) return;
+    if (!hasExecution) return;
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      openTaskCenterConversation(item);
+      openWorkflowExecutionFromTaskCenter(item);
     }
   };
   return h('article', {
-    className: cx('task-center-item', active && 'active', hasConversation && 'clickable'),
-    role: hasConversation ? 'button' : undefined,
-    tabIndex: hasConversation ? 0 : undefined,
-    title: hasConversation ? '打开对应对话' : undefined,
+    className: cx('task-center-item', active && 'active', hasExecution && 'clickable'),
+    role: hasExecution ? 'button' : undefined,
+    tabIndex: hasExecution ? 0 : undefined,
+    title: hasExecution ? '打开执行详情' : undefined,
     onClick: handleOpen,
     onKeyDown: handleKeyDown,
   }, [
@@ -2292,8 +2328,8 @@ function TaskCenterItem({ item, kind }) {
     kind === 'workflow' ? h('div', { className: 'task-center-hash', title: latestExecutionHash, key: 'hash' }, [
       h('span', { key: 'label' }, '执行ID'),
       h('code', { key: 'value' }, latestExecutionHash),
-      h('span', { key: 'link-label' }, '关联对话'),
-      h('code', { className: cx('task-center-jump', hasConversation && 'enabled'), key: 'link' }, hasConversation ? '查看对话' : '暂无关联对话'),
+      h('span', { key: 'link-label' }, '执行详情'),
+      h('code', { className: cx('task-center-jump', hasExecution && 'enabled'), key: 'link' }, hasExecution ? '查看执行' : '暂无执行记录'),
     ]) : null,
     h('div', { className: cx('task-center-stats', kind === 'workflow' && 'workflow-stats'), key: 'stats' }, stats),
     h('div', {
@@ -2414,23 +2450,23 @@ function CommandAiTaskPanel({ activity, timeFilter }) {
         : task.state === 'processing'
           ? task.stage === 'triage' ? '证据关联与结论生成中' : '特征提取与相似聚类中'
           : '等待 AI 处理';
-      const hasConversation = Boolean(String(event?.sessionId || event?.sessionID || '').trim());
+      const hasExecution = Boolean(workflowIdFromEvent(event) && executionIdFromWorkflowEvent(event));
       const handleOpen = () => {
-        if (hasConversation) openConversationFromEvent(event);
+        if (hasExecution) openWorkflowExecutionFromEvent(event);
       };
       const handleKeyDown = (keyboardEvent) => {
-        if (!hasConversation) return;
+        if (!hasExecution) return;
         if (keyboardEvent.key === 'Enter' || keyboardEvent.key === ' ') {
           keyboardEvent.preventDefault();
-          openConversationFromEvent(event);
+          openWorkflowExecutionFromEvent(event);
         }
       };
       return h('article', {
-        className: cx('event-rail-item', `state-${task.state}`, `kind-${task.stage}`, `motion-${task.motion || 'stable'}`, hasConversation && 'clickable'),
+        className: cx('event-rail-item', `state-${task.state}`, `kind-${task.stage}`, `motion-${task.motion || 'stable'}`, hasExecution && 'clickable'),
         key: task.key,
-        role: hasConversation ? 'button' : undefined,
-        tabIndex: hasConversation ? 0 : undefined,
-        title: hasConversation ? '打开对应对话' : undefined,
+        role: hasExecution ? 'button' : undefined,
+        tabIndex: hasExecution ? 0 : undefined,
+        title: hasExecution ? '打开执行详情' : undefined,
         onClick: handleOpen,
         onKeyDown: handleKeyDown,
       }, [
@@ -2441,7 +2477,7 @@ function CommandAiTaskPanel({ activity, timeFilter }) {
         ]),
         h('strong', { title, key: 'title' }, title),
         h('span', { title: eventEndpoint(event), key: 'endpoint' }, eventEndpoint(event)),
-        h('small', { key: 'result' }, hasConversation ? `${detail} · 查看对话` : detail),
+        h('small', { key: 'result' }, hasExecution ? `${detail} · 查看执行` : detail),
         task.state === 'processing' ? h(EventQueueProgress, { event, key: 'progress' }) : null,
       ]);
     }) : h('div', { className: 'event-rail-empty' }, '等待新的降噪或研判任务')),
@@ -2752,8 +2788,8 @@ export default function Page() {
           const incomingEvents = rawIncomingEvents.filter((event) => event?.stage !== 'denoise');
           const workflowEvents = Array.isArray(payload.workflowEvents) ? payload.workflowEvents : [];
           for (const workflowEvent of workflowEvents) {
-            const hasConversation = Boolean(String(workflowEvent?.sessionId || workflowEvent?.sessionID || '').trim());
-            if (hasConversation) {
+            const hasExecution = Boolean(workflowIdFromEvent(workflowEvent) && executionIdFromWorkflowEvent(workflowEvent));
+            if (hasExecution) {
               incomingEvents.push(workflowEvent);
             }
           }

--- a/webui/src/locales/en-US/workflow.json
+++ b/webui/src/locales/en-US/workflow.json
@@ -393,6 +393,7 @@
       "historySummary": "{{count}} records · Latest {{time}}",
       "historySummaryLoading": "Loading execution history",
       "noHistory": "No execution records",
+      "executionNotFound": "Specified execution record was not found",
       "noOutput": "No output data",
       "stepsCompleted": "steps completed",
       "stepInputs": "Inputs",

--- a/webui/src/locales/zh-CN/workflow.json
+++ b/webui/src/locales/zh-CN/workflow.json
@@ -393,6 +393,7 @@
       "historySummary": "{{count}} 条记录 · 最近 {{time}}",
       "historySummaryLoading": "正在加载执行历史",
       "noHistory": "暂无执行记录",
+      "executionNotFound": "未找到指定执行记录",
       "noOutput": "无输出数据",
       "stepsCompleted": "步已完成",
       "stepInputs": "输入",

--- a/webui/src/pages/WorkflowDetail/RightPanel.tsx
+++ b/webui/src/pages/WorkflowDetail/RightPanel.tsx
@@ -79,6 +79,7 @@ interface RightPanelProps {
   onFirstMessageSent?: () => void;
   onSessionChange?: (sessionId: string | null) => void;
   onGuidePrompt?: (prompt: string, displayLabel: string) => void;
+  focusExecutionId?: string;
   /** Currently selected node — passed to ChatTab to show reference chip in input */
   selectedNode?: WorkflowNode | null;
   onDeselectNode?: () => void;
@@ -97,6 +98,7 @@ export default function RightPanel({
   onFirstMessageSent,
   onSessionChange,
   onGuidePrompt,
+  focusExecutionId,
   selectedNode, onDeselectNode,
   onDelete,
 }: RightPanelProps) {
@@ -181,6 +183,7 @@ export default function RightPanel({
               latestExecution={latestExecution ?? null}
               onLatestExecutionChange={onLatestExecutionChange}
               onExecutionSettled={onExecutionSettled}
+              focusExecutionId={focusExecutionId}
             />
           </TabErrorBoundary>
         )}

--- a/webui/src/pages/WorkflowDetail/index.tsx
+++ b/webui/src/pages/WorkflowDetail/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { X, GitBranch, FileText, Code2, FileJson, Bot } from 'lucide-react';
 import { workflowAPI, Workflow, WorkflowExecution, WorkflowNode } from '@/api/workflow';
@@ -52,7 +52,10 @@ export default function WorkflowDetail() {
   const { t } = useTranslation('workflow');
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const confirm = useConfirm();
+  const queryTab = searchParams.get('tab');
+  const focusedExecutionId = searchParams.get('execId')?.trim() || '';
 
   const CANVAS_TABS: { id: CanvasTab; label: string; icon: React.ReactNode }[] = [
     { id: 'flow', label: t('detail.canvasTabs.flow'), icon: <GitBranch className="w-3.5 h-3.5" /> },
@@ -151,6 +154,12 @@ export default function WorkflowDetail() {
     if (!id) return;
     void loadWorkflow();
   }, [id, loadWorkflow]);
+
+  useEffect(() => {
+    if (queryTab !== 'run' && !focusedExecutionId) return;
+    setPanelOpen(true);
+    setRightPanelTab('overview');
+  }, [focusedExecutionId, queryTab]);
 
   useEffect(() => {
     const next = workflow?.markdownContent ?? workflow?.editMarkdownContent ?? '';
@@ -802,6 +811,7 @@ export default function WorkflowDetail() {
           onFirstMessageSent={handleFirstMessageSent}
           onSessionChange={handleWorkflowChatSessionChange}
           onGuidePrompt={launchWorkflowGuidePrompt}
+          focusExecutionId={focusedExecutionId}
           selectedNode={drawerNode}
           onDeselectNode={() => setDrawerNode(null)}
           onDelete={handleDelete}

--- a/webui/src/pages/WorkflowDetail/tabs/OverviewTab.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/OverviewTab.tsx
@@ -9,6 +9,7 @@ interface OverviewTabProps {
   latestExecution?: WorkflowExecution | null;
   onLatestExecutionChange?: (execution: WorkflowExecution | null) => void;
   onExecutionSettled?: () => void;
+  focusExecutionId?: string;
 }
 
 function MetaRow({ icon, label, value }: { icon: ReactNode; label: string; value: ReactNode }) {
@@ -99,6 +100,7 @@ export default function OverviewTab({
   latestExecution = null,
   onLatestExecutionChange,
   onExecutionSettled,
+  focusExecutionId,
 }: OverviewTabProps) {
   const { t, i18n } = useTranslation('workflow');
   const [configExpanded, setConfigExpanded] = useState(true);
@@ -222,6 +224,7 @@ export default function OverviewTab({
           latestExecution={latestExecution}
           onLatestExecutionChange={onLatestExecutionChange}
           onExecutionSettled={onExecutionSettled}
+          focusExecutionId={focusExecutionId}
           embedded
           embeddedTabs
           hideSectionHeaders

--- a/webui/src/pages/WorkflowDetail/tabs/RunTab.test.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/RunTab.test.tsx
@@ -88,6 +88,7 @@ vi.mock('react-i18next', () => ({
         'detail.run.syslogHint': 'syslog hint',
         'detail.run.historySection': '执行历史',
         'detail.run.noHistory': '暂无执行记录',
+        'detail.run.executionNotFound': '未找到指定执行记录',
         'detail.run.noOutput': '无输出数据',
         'detail.run.stepsCompleted': '步已完成',
         'detail.run.stepInputs': '输入',
@@ -120,9 +121,11 @@ const baseWorkflow = {
 function ControlledRunTab({
   initialExecution = null,
   workflow = baseWorkflow,
+  focusExecutionId,
 }: {
   initialExecution?: WorkflowExecution | null;
   workflow?: typeof baseWorkflow;
+  focusExecutionId?: string;
 }) {
   const [latestExecution, setLatestExecution] = React.useState<WorkflowExecution | null>(initialExecution);
 
@@ -131,6 +134,7 @@ function ControlledRunTab({
       workflow={workflow}
       latestExecution={latestExecution}
       onLatestExecutionChange={setLatestExecution}
+      focusExecutionId={focusExecutionId}
     />
   );
 }
@@ -138,12 +142,24 @@ function ControlledRunTab({
 describe('RunTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
+    window.history.replaceState(null, '', '/workflows/wf-1');
     workflowAPI.getSampleInputs.mockResolvedValue({ data: { sampleInputs: {} } });
     workflowAPI.saveSampleInputs.mockResolvedValue({ data: { ok: true } });
     workflowAPI.getService.mockResolvedValue({ data: null });
     workflowAPI.getKafkaConfig.mockResolvedValue({ data: null });
     workflowAPI.getSyslogConfig.mockResolvedValue({ data: null });
     workflowAPI.getHistory.mockResolvedValue({ data: [] });
+    workflowAPI.getExecution.mockResolvedValue({
+      data: {
+        id: 'exec-1',
+        workflowId: 'wf-1',
+        inputParams: {},
+        status: 'success',
+        startedAt: Date.now(),
+        executionLog: [],
+      },
+    });
     workflowAPI.run.mockResolvedValue({
       data: {
         id: 'exec-1',
@@ -174,6 +190,13 @@ describe('RunTab', () => {
       executionLog: [],
     };
     workflowAPI.getHistory.mockResolvedValue({ data: [runningExecution] });
+    workflowAPI.getExecution.mockResolvedValue({
+      data: {
+        ...runningExecution,
+        currentPhase: 'cancelling',
+        errorMessage: 'Cancellation requested',
+      },
+    });
 
     render(
       <ControlledRunTab
@@ -271,6 +294,9 @@ describe('RunTab', () => {
       },
     ];
     workflowAPI.getHistory.mockResolvedValue({ data: executions });
+    workflowAPI.getExecution.mockImplementation((workflowId: string, executionId: string) => (
+      Promise.resolve({ data: executions.find((execution) => execution.id === executionId) })
+    ));
 
     render(
       <RunTab
@@ -289,6 +315,84 @@ describe('RunTab', () => {
 
     const firstDetail = screen.getByText(/"marker": "first"/);
     expect(firstDetail.compareDocumentPosition(secondHistoryButton!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('loads and expands a focused execution even when it is outside recent history', async () => {
+    const focusedExecution = {
+      id: 'exec-focused',
+      workflowId: 'wf-1',
+      inputParams: { alert_id: 'alert-focused' },
+      outputResults: { marker: 'focused' },
+      status: 'success' as const,
+      startedAt: new Date('2026-01-03T00:00:00Z').getTime(),
+      duration: 3,
+      executionLog: [],
+    };
+    workflowAPI.getHistory.mockResolvedValue({ data: [] });
+    workflowAPI.getExecution.mockResolvedValue({ data: focusedExecution });
+
+    render(
+      <RunTab
+        workflow={baseWorkflow}
+        latestExecution={null}
+        sections={['history']}
+        focusExecutionId="exec-focused"
+      />,
+    );
+
+    expect(await screen.findByText('3.0s')).toBeInTheDocument();
+    expect(screen.getByText(/"marker": "focused"/)).toBeInTheDocument();
+    expect(workflowAPI.getExecution).toHaveBeenCalledWith('wf-1', 'exec-focused');
+  });
+
+  it('opens embedded history tab when an execution is focused', async () => {
+    const focusedExecution = {
+      id: 'exec-focused',
+      workflowId: 'wf-1',
+      inputParams: {},
+      outputResults: { marker: 'embedded-focused' },
+      status: 'success' as const,
+      startedAt: Date.now(),
+      duration: 1,
+      executionLog: [],
+    };
+    workflowAPI.getHistory.mockResolvedValue({ data: [focusedExecution] });
+
+    render(
+      <RunTab
+        workflow={baseWorkflow}
+        latestExecution={null}
+        sections={['test', 'history']}
+        embeddedTabs
+        focusExecutionId="exec-focused"
+      />,
+    );
+
+    expect(await screen.findByText(/"marker": "embedded-focused"/)).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: '执行历史' })[0]).toHaveClass('bg-white');
+  });
+
+  it('uses dashboard mock execution fallback with the same execution id as task-center data', async () => {
+    const user = userEvent.setup();
+    window.history.replaceState(null, '', '/workflows/stream_alert_triage?tab=run&execId=mock-triage-run-002&mockDashboard=1');
+    workflowAPI.getHistory.mockResolvedValue({ data: [] });
+    workflowAPI.getExecution.mockRejectedValue(new Error('not found'));
+
+    render(
+      <RunTab
+        workflow={{
+          ...baseWorkflow,
+          id: 'stream_alert_triage',
+        }}
+        latestExecution={null}
+        sections={['history']}
+        focusExecutionId="mock-triage-run-002"
+      />,
+    );
+
+    expect(await screen.findByText(/"verdict": "疑似攻击行为"/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: '执行日志 (2)' }));
+    expect(screen.getByText('concurrent_triage')).toBeInTheDocument();
   });
 
 });

--- a/webui/src/pages/WorkflowDetail/tabs/RunTab.tsx
+++ b/webui/src/pages/WorkflowDetail/tabs/RunTab.tsx
@@ -23,6 +23,7 @@ interface RunTabProps {
   embedded?: boolean;
   embeddedTabs?: boolean;
   hideSectionHeaders?: boolean;
+  focusExecutionId?: string;
 }
 
 export type RunTabSection = 'test' | 'history';
@@ -198,6 +199,224 @@ type SaveState = 'idle' | 'saving' | 'saved' | 'error';
 
 function isPlainObject(value: unknown): value is Record<string, any> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const MOCK_DASHBOARD_STORAGE_KEYS = [
+  'soc-dashboard-mock-v1',
+  'soc-dashboard-mock-activity-v1',
+  'soc-dashboard-mock-task-center-v1',
+];
+
+function isMockExecutionFallbackEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  const params = new URLSearchParams(window.location.search);
+  if (
+    params.get('mockDashboard') === '1'
+    || params.get('mockActivity') === '1'
+    || params.get('mockTaskCenter') === '1'
+    || params.get('mockExecution') === '1'
+  ) {
+    return true;
+  }
+  try {
+    return MOCK_DASHBOARD_STORAGE_KEYS.some((key) => window.localStorage?.getItem(key) === '1');
+  } catch {
+    return false;
+  }
+}
+
+function createMockWorkflowExecutions(workflowId: string): WorkflowExecution[] {
+  const now = Date.now();
+  if (workflowId === 'stream_alert_triage') {
+    return [
+      {
+        id: 'mock-triage-run-002',
+        workflowId: 'stream_alert_triage',
+        inputParams: {
+          alert_id: 'mock-alert-rce',
+          source_type: 'tdp',
+          threat_name: '远程命令执行攻击（Mock）',
+          src_ip: '203.0.113.41',
+          dst_ip: '10.12.4.18',
+          request_uri: '/cgi-bin/luci/;stok=/locale',
+        },
+        status: 'running',
+        startedAt: now - 4 * 60 * 1000,
+        duration: 240.2,
+        outputResults: {
+          alert_id: 'mock-alert-rce',
+          verdict: '疑似攻击行为',
+          confidence: 0.82,
+          next_action: '等待证据汇总节点完成后自动提交研判结论',
+        },
+        executionLog: [
+          {
+            node_id: 'load_dedup_file',
+            node_type: 'python',
+            inputs: {
+              alert_id: 'mock-alert-rce',
+              dedup_path: '~/.flocks/workspace/outputs/2026-08-13/artifacts/dedup.jsonl',
+            },
+            outputs: {
+              related_count: 3,
+              cluster_id: 'MOCK-RCE-12',
+              latest_seen: new Date(now - 6 * 60 * 1000).toISOString(),
+            },
+            stdout: 'Loaded 3 related alerts from dedup artifact.',
+            duration_ms: 892,
+          },
+          {
+            node_id: 'concurrent_triage',
+            node_type: 'python',
+            inputs: {
+              alert_id: 'mock-alert-rce',
+              evidence_count: 3,
+              model: 'security-triage-llm',
+            },
+            outputs: {
+              verdict: '疑似攻击行为',
+              confidence: 0.82,
+              evidence: [
+                '请求路径命中历史 RCE 利用模式',
+                '源 IP 在最近窗口内触发多类探测',
+                '目标资产暴露管理接口',
+              ],
+            },
+            stdout: 'LLM triage completed; waiting for downstream cursor commit.',
+            duration_ms: 31244,
+          },
+        ],
+        triggerSource: 'workflow_execution',
+        currentNodeId: 'concurrent_triage',
+        currentNodeType: 'python',
+        currentPhase: 'running',
+        currentStepIndex: 2,
+        stepCount: 4,
+        stepLogOffset: 0,
+        stepLogLimit: 500,
+        stepLogTotal: 2,
+      },
+      {
+        id: 'mock-triage-run-003',
+        workflowId: 'stream_alert_triage',
+        inputParams: {
+          alert_id: 'mock-alert-sql',
+          source_type: 'onesec',
+          threat_name: 'SQL 注入探测（Mock）',
+        },
+        status: 'running',
+        startedAt: now - 18 * 1000,
+        duration: 18,
+        outputResults: {},
+        executionLog: [
+          {
+            node_id: 'load_dedup_file',
+            node_type: 'python',
+            inputs: { alert_id: 'mock-alert-sql' },
+            outputs: { related_count: 1, cluster_id: 'MOCK-SQL-04' },
+            stdout: 'Loaded 1 related alert.',
+            duration_ms: 711,
+          },
+        ],
+        triggerSource: 'workflow_execution',
+        currentNodeId: 'concurrent_triage',
+        currentNodeType: 'python',
+        currentPhase: 'running',
+        currentStepIndex: 1,
+        stepCount: 4,
+        stepLogOffset: 0,
+        stepLogLimit: 500,
+        stepLogTotal: 1,
+      },
+    ];
+  }
+  if (workflowId === 'stream_alert_denoise') {
+    return [
+      {
+        id: 'mock-denoise-run-001',
+        workflowId: 'stream_alert_denoise',
+        inputParams: {
+          batch_id: 'mock-alert-login-burst',
+          source_type: 'skyeye',
+          sample_count: 6,
+        },
+        status: 'running',
+        startedAt: now - 7 * 60 * 1000,
+        duration: 421.6,
+        outputResults: {
+          cluster_id: 'MOCK-LOGIN-07',
+          raw_count: 18,
+          reduced_count: 11,
+          unique_count: 7,
+          reduction_rate: 0.6111,
+        },
+        executionLog: [
+          {
+            node_id: 'normalize_alerts',
+            node_type: 'python',
+            inputs: { batch_id: 'mock-alert-login-burst', raw_count: 18 },
+            outputs: { normalized_count: 18 },
+            stdout: 'Normalized 18 alerts from skyeye.',
+            duration_ms: 1024,
+          },
+          {
+            node_id: 'cluster_alerts',
+            node_type: 'python',
+            inputs: { normalized_count: 18 },
+            outputs: { cluster_id: 'MOCK-LOGIN-07', duplicate_count: 7, unique_count: 7 },
+            stdout: 'Clustered alerts by source, target and login pattern.',
+            duration_ms: 2380,
+          },
+        ],
+        triggerSource: 'workflow_execution',
+        currentNodeId: 'cluster_alerts',
+        currentNodeType: 'python',
+        currentPhase: 'running',
+        currentStepIndex: 2,
+        stepCount: 5,
+        stepLogOffset: 0,
+        stepLogLimit: 500,
+        stepLogTotal: 2,
+      },
+      {
+        id: 'mock-denoise-run-004',
+        workflowId: 'stream_alert_denoise',
+        inputParams: {
+          batch_id: 'mock-alert-scan',
+          source_type: 'qingteng',
+          sample_count: 4,
+        },
+        status: 'running',
+        startedAt: now - 26 * 1000,
+        duration: 26,
+        outputResults: {},
+        executionLog: [
+          {
+            node_id: 'normalize_alerts',
+            node_type: 'python',
+            inputs: { batch_id: 'mock-alert-scan', raw_count: 12 },
+            outputs: { normalized_count: 12 },
+            stdout: 'Normalized 12 scan alerts.',
+            duration_ms: 944,
+          },
+        ],
+        triggerSource: 'workflow_execution',
+        currentNodeId: 'cluster_alerts',
+        currentNodeType: 'python',
+        currentPhase: 'running',
+        currentStepIndex: 1,
+        stepCount: 5,
+        stepLogOffset: 0,
+        stepLogLimit: 500,
+        stepLogTotal: 1,
+      },
+    ];
+  }
+  return [];
+}
+
+function getMockWorkflowExecution(workflowId: string, executionId: string): WorkflowExecution | null {
+  return createMockWorkflowExecutions(workflowId).find((execution) => execution.id === executionId) ?? null;
 }
 
 // ─────────────────────────────────────────────
@@ -724,12 +943,14 @@ function HistoryExecDetail({ exec: ex }: { exec: WorkflowExecution }) {
 function HistorySection({
   workflowId,
   latestExecutionId,
+  focusExecutionId,
   onLatestExecutionChange,
   embedded = false,
   hideSectionHeader = false,
 }: {
   workflowId: string;
   latestExecutionId?: string;
+  focusExecutionId?: string;
   onLatestExecutionChange?: (execution: WorkflowExecution | null) => void;
   embedded?: boolean;
   hideSectionHeader?: boolean;
@@ -739,26 +960,58 @@ function HistorySection({
   const [history, setHistory] = useState<WorkflowExecution[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedExec, setSelectedExec] = useState<WorkflowExecution | null>(null);
+  const [focusedExecutionError, setFocusedExecutionError] = useState('');
+  const executionNotFoundText = t('detail.run.executionNotFound');
+
+  const loadFocusedExecution = useCallback(async (executionId: string): Promise<WorkflowExecution | null> => {
+    try {
+      const res = await workflowAPI.getExecution(workflowId, executionId);
+      return res.data;
+    } catch {
+      if (!isMockExecutionFallbackEnabled()) return null;
+      return getMockWorkflowExecution(workflowId, executionId);
+    }
+  }, [workflowId]);
 
   const fetchHistory = useCallback(async () => {
     try {
+      setFocusedExecutionError('');
       const res = await workflowAPI.getHistory(workflowId, { limit: 10 });
-      setHistory(res.data);
-      if (res.data.length > 0) {
+      let nextHistory = res.data;
+      if (nextHistory.length === 0 && isMockExecutionFallbackEnabled()) {
+        nextHistory = createMockWorkflowExecutions(workflowId);
+      }
+      if (focusExecutionId && !nextHistory.some((item: WorkflowExecution) => item.id === focusExecutionId)) {
+        const focusedExecution = await loadFocusedExecution(focusExecutionId);
+        if (focusedExecution) {
+          nextHistory = [focusedExecution, ...nextHistory];
+        } else {
+          setFocusedExecutionError(executionNotFoundText);
+        }
+      }
+      setHistory(nextHistory);
+      if (focusExecutionId) {
+        const focusedExecution = nextHistory.find((item: WorkflowExecution) => item.id === focusExecutionId) ?? null;
+        if (focusedExecution) {
+          onLatestExecutionChange?.(focusedExecution);
+          setSelectedExec(focusedExecution);
+          setExpanded(true);
+        }
+      } else if (nextHistory.length > 0) {
         const matchingExecution = latestExecutionId
-          ? res.data.find((item: WorkflowExecution) => item.id === latestExecutionId)
-          : res.data[0];
+          ? nextHistory.find((item: WorkflowExecution) => item.id === latestExecutionId)
+          : nextHistory[0];
         if (matchingExecution) {
           onLatestExecutionChange?.(matchingExecution);
         } else if (!latestExecutionId) {
-          onLatestExecutionChange?.(res.data[0]);
+          onLatestExecutionChange?.(nextHistory[0]);
         }
       } else if (!latestExecutionId) {
         onLatestExecutionChange?.(null);
       }
       setSelectedExec(prev => {
         if (!prev) return null;
-        const updated = res.data.find((e: WorkflowExecution) => e.id === prev.id);
+        const updated = nextHistory.find((e: WorkflowExecution) => e.id === prev.id);
         if (!updated) return prev;
         return {
           ...updated,
@@ -769,11 +1022,32 @@ function HistorySection({
         };
       });
     } catch {
-      setHistory([]);
+      const fallbackHistory = isMockExecutionFallbackEnabled()
+        ? createMockWorkflowExecutions(workflowId)
+        : [];
+      let nextHistory = fallbackHistory;
+      if (focusExecutionId && !nextHistory.some((item) => item.id === focusExecutionId)) {
+        const focusedExecution = getMockWorkflowExecution(workflowId, focusExecutionId);
+        if (focusedExecution) {
+          nextHistory = [focusedExecution, ...nextHistory];
+        } else if (isMockExecutionFallbackEnabled()) {
+          setFocusedExecutionError(executionNotFoundText);
+        }
+      }
+      setHistory(nextHistory);
+      if (focusExecutionId) {
+        const focusedExecution = nextHistory.find((item) => item.id === focusExecutionId) ?? null;
+        setSelectedExec(focusedExecution);
+        if (focusedExecution) onLatestExecutionChange?.(focusedExecution);
+      } else if (nextHistory.length > 0) {
+        onLatestExecutionChange?.(nextHistory[0]);
+      } else {
+        onLatestExecutionChange?.(null);
+      }
     } finally {
       setLoading(false);
     }
-  }, [latestExecutionId, onLatestExecutionChange, workflowId]);
+  }, [executionNotFoundText, focusExecutionId, latestExecutionId, loadFocusedExecution, onLatestExecutionChange, workflowId]);
 
   const hasRunning = history.some(e => e.status === 'running');
 
@@ -808,7 +1082,11 @@ function HistorySection({
       const res = await workflowAPI.getExecution(workflowId, exec.id);
       setSelectedExec(res.data);
     } catch {
-      setSelectedExec(exec);
+      setSelectedExec(
+        isMockExecutionFallbackEnabled()
+          ? getMockWorkflowExecution(workflowId, exec.id) ?? exec
+          : exec,
+      );
     }
   };
 
@@ -827,6 +1105,11 @@ function HistorySection({
           {loading ? (
             <div className="flex items-center justify-center py-6">
               <Loader2 className="w-4 h-4 animate-spin text-gray-400" />
+            </div>
+          ) : focusedExecutionError ? (
+            <div className="py-6 text-center">
+              <AlertCircle className="w-8 h-8 text-orange-300 mx-auto mb-2" />
+              <p className="text-xs text-gray-400">{focusedExecutionError}</p>
             </div>
           ) : history.length === 0 ? (
             <div className="py-6 text-center">
@@ -881,11 +1164,17 @@ export default function RunTab({
   embedded = false,
   embeddedTabs = false,
   hideSectionHeaders = false,
+  focusExecutionId,
 }: RunTabProps) {
   const { t } = useTranslation('workflow');
-  const [activeEmbeddedSection, setActiveEmbeddedSection] = useState<RunTabSection>('test');
+  const [activeEmbeddedSection, setActiveEmbeddedSection] = useState<RunTabSection>(focusExecutionId ? 'history' : 'test');
   const showTest = sections.includes('test');
   const showHistory = sections.includes('history');
+  useEffect(() => {
+    if (focusExecutionId && showHistory) {
+      setActiveEmbeddedSection('history');
+    }
+  }, [focusExecutionId, showHistory]);
   const activeSection =
     activeEmbeddedSection === 'test' && showTest
       ? 'test'
@@ -936,6 +1225,7 @@ export default function RunTab({
               <HistorySection
                 workflowId={workflow.id}
                 latestExecutionId={latestExecution?.id}
+                focusExecutionId={focusExecutionId}
                 onLatestExecutionChange={onLatestExecutionChange}
                 embedded={embedded}
                 hideSectionHeader={hideSectionHeaders}
@@ -963,6 +1253,7 @@ export default function RunTab({
         <HistorySection
           workflowId={workflow.id}
           latestExecutionId={latestExecution?.id}
+          focusExecutionId={focusExecutionId}
           onLatestExecutionChange={onLatestExecutionChange}
           embedded={embedded}
           hideSectionHeader={hideSectionHeaders}

--- a/webui/src/utils/socDashboardPageRuntime.test.tsx
+++ b/webui/src/utils/socDashboardPageRuntime.test.tsx
@@ -30,6 +30,8 @@ describe('SOC dashboard contract page runtime', () => {
   beforeEach(() => {
     installContractSdk();
     setDocumentHidden(false);
+    window.localStorage.clear();
+    window.history.replaceState(null, '', '/');
     window.sessionStorage.clear();
     pageGetMock.mockImplementation((path: string) => {
       if (path === '/stats') {
@@ -112,12 +114,14 @@ describe('SOC dashboard contract page runtime', () => {
             recentEvents: [],
             workflowEvents: [
               {
-                eventId: 'workflow-denoise-1',
+                eventId: 'workflow-execution:exec-denoise-1',
                 stage: 'denoise',
                 status: 'running',
                 occurredAt,
                 triggerSource: 'workflow_execution',
-                sessionId: 'session-1',
+                workflowId: 'stream_alert_denoise',
+                sessionId: '',
+                messageId: '',
                 alert: {
                   id: 'alert-1',
                   sourceType: 'workflow.db',
@@ -131,12 +135,14 @@ describe('SOC dashboard contract page runtime', () => {
                 },
               },
               {
-                eventId: 'workflow-triage-1',
+                eventId: 'workflow-execution:exec-triage-1',
                 stage: 'triage',
                 status: 'running',
                 occurredAt,
                 triggerSource: 'workflow_execution',
-                sessionId: 'session-1',
+                workflowId: 'stream_alert_triage',
+                sessionId: '',
+                messageId: '',
                 alert: {
                   id: 'alert-1',
                   sourceType: 'workflow.db',
@@ -223,8 +229,8 @@ describe('SOC dashboard contract page runtime', () => {
                 lastRunAt: Date.now(),
                 latestExecutionHash: 'workflow-run-1',
                 latestAlertName: '远程命令执行',
-                sessionId: 'session-1',
-                messageId: 'message-1',
+                sessionId: '',
+                messageId: '',
                 progressPercent: 0.5,
                 progressLabel: '运行中',
               },
@@ -253,8 +259,8 @@ describe('SOC dashboard contract page runtime', () => {
     expect(screen.getByText('远程命令执行')).toBeInTheDocument();
     expect(screen.getByText('执行ID')).toBeInTheDocument();
     expect(screen.getByText('workflow-run-1')).toBeInTheDocument();
-    expect(screen.getByText('关联对话')).toBeInTheDocument();
-    expect(screen.getByText('查看对话')).toBeInTheDocument();
+    expect(screen.getByText('执行详情')).toBeInTheDocument();
+    expect(screen.getByText('查看执行')).toBeInTheDocument();
     expect(screen.getByText(/最近调用/)).toBeInTheDocument();
 
     const summary = container.querySelector('.task-center-summary') as HTMLElement;
@@ -272,6 +278,21 @@ describe('SOC dashboard contract page runtime', () => {
     const workflowStats = container.querySelector('.task-center-stats.workflow-stats') as HTMLElement;
     expect(within(workflowStats).getByText('调用')).toBeInTheDocument();
     expect(within(workflowStats).getByText('今日调用')).toBeInTheDocument();
+  });
+
+  it('uses dashboard mock rows with the same workflow execution field shape as real task-center data', async () => {
+    window.localStorage.setItem('soc-dashboard-mock-v1', '1');
+
+    render(<Page />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('tab', { name: '任务中心' }));
+
+    expect(await screen.findByText('告警研判工作流（Mock）')).toBeInTheDocument();
+    expect(screen.getByText('mock-triage-run-002')).toBeInTheDocument();
+    expect(screen.getAllByText('执行详情').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('查看执行').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('查看对话')).not.toBeInTheDocument();
   });
 
   it('reacts to the shared SOC dashboard title change event', async () => {


### PR DESCRIPTION
## 变更内容

- 将 SOC 任务中心和处理队列中的“查看对话”替换为“查看执行”
- 工作流跳转改为进入 `/workflows/:workflowId?tab=run&execId=:executionId`
- 支持按 `execId` 自动展开工作流执行历史
- 调整 mock 数据结构，使其与真实 workflow execution 数据契约一致

## 验证

- npm test -- --run src/pages/WorkflowDetail/tabs/RunTab.test.tsx src/utils/socDashboardPageRuntime.test.tsx
- npm run lint
- npm run build