### PR TITLE
fix provider cache usage accounting

### DIFF
--- a/tui/flocks/provider/openai-compatible-usage.test.ts
+++ b/tui/flocks/provider/openai-compatible-usage.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "bun:test"
+import type { FetchFunction } from "@ai-sdk/provider-utils"
+import { createFlocksOpenAICompatible, createOpenAICompatibleUsageMetadataExtractor } from "./openai-compatible-usage"
+
+describe("createOpenAICompatibleUsageMetadataExtractor", () => {
+  test("extracts sanitized usage metadata from a response body", async () => {
+    const extractor = createOpenAICompatibleUsageMetadataExtractor("deepseek")
+
+    await expect(
+      extractor.extractMetadata({
+        parsedBody: {
+          id: "chatcmpl-test",
+          choices: [{ message: { content: "hidden" } }],
+          usage: {
+            prompt_tokens: 640,
+            completion_tokens: 20,
+            total_tokens: 660,
+            prompt_cache_hit_tokens: 512,
+            prompt_cache_miss_tokens: 128,
+            prompt_tokens_details: {
+              cached_tokens: 0,
+              cache_creation_tokens: 42,
+              ignored: "value",
+            },
+            ignored: "value",
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      deepseek: {
+        usage: {
+          prompt_tokens: 640,
+          completion_tokens: 20,
+          total_tokens: 660,
+          prompt_cache_hit_tokens: 512,
+          prompt_cache_miss_tokens: 128,
+          prompt_tokens_details: {
+            cached_tokens: 0,
+            cache_creation_tokens: 42,
+          },
+        },
+      },
+    })
+  })
+
+  test("uses the latest streaming usage chunk", () => {
+    const extractor = createOpenAICompatibleUsageMetadataExtractor("deepseek").createStreamExtractor()
+
+    extractor.processChunk({
+      choices: [{ delta: { content: "hello" } }],
+    })
+    extractor.processChunk({
+      choices: [],
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 10,
+        total_tokens: 110,
+        prompt_cache_hit_tokens: 64,
+        prompt_cache_miss_tokens: 36,
+      },
+    })
+
+    expect(extractor.buildMetadata()).toEqual({
+      deepseek: {
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 10,
+          total_tokens: 110,
+          prompt_cache_hit_tokens: 64,
+          prompt_cache_miss_tokens: 36,
+        },
+      },
+    })
+  })
+
+  test("returns undefined when no numeric usage metadata is available", async () => {
+    const extractor = createOpenAICompatibleUsageMetadataExtractor("custom")
+
+    await expect(extractor.extractMetadata({ parsedBody: { usage: { ignored: "value" } } })).resolves.toBeUndefined()
+    expect(extractor.createStreamExtractor().buildMetadata()).toBeUndefined()
+  })
+
+  test("preserves DeepSeek raw usage metadata through the OpenAI-compatible chat model", async () => {
+    const fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl-test",
+          created: 1,
+          model: "deepseek-chat",
+          choices: [
+            {
+              index: 0,
+              finish_reason: "stop",
+              message: { role: "assistant", content: "ok" },
+            },
+          ],
+          usage: {
+            prompt_tokens: 640,
+            completion_tokens: 20,
+            total_tokens: 660,
+            prompt_cache_hit_tokens: 512,
+            prompt_cache_miss_tokens: 128,
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      )) as unknown as FetchFunction
+
+    const provider = createFlocksOpenAICompatible({
+      name: "deepseek",
+      baseURL: "https://api.deepseek.com",
+      includeUsage: true,
+      fetch,
+    })
+
+    const result = await (provider.languageModel("deepseek-chat") as any).doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      headers: {},
+    })
+
+    expect(result.usage).toEqual({
+      inputTokens: 640,
+      outputTokens: 20,
+      totalTokens: 660,
+      reasoningTokens: undefined,
+      cachedInputTokens: undefined,
+    })
+    expect(result.providerMetadata).toEqual({
+      deepseek: {
+        usage: {
+          prompt_tokens: 640,
+          completion_tokens: 20,
+          total_tokens: 660,
+          prompt_cache_hit_tokens: 512,
+          prompt_cache_miss_tokens: 128,
+        },
+      },
+    })
+  })
+
+  test("preserves DeepSeek raw usage metadata through OpenAI-compatible streaming", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder()
+        controller.enqueue(
+          encoder.encode(
+            [
+              "data: " +
+                JSON.stringify({
+                  id: "chatcmpl-test",
+                  created: 1,
+                  model: "deepseek-chat",
+                  choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }],
+                }),
+              "",
+              "data: " +
+                JSON.stringify({
+                  id: "chatcmpl-test",
+                  created: 1,
+                  model: "deepseek-chat",
+                  choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+                  usage: {
+                    prompt_tokens: 640,
+                    completion_tokens: 20,
+                    total_tokens: 660,
+                    prompt_cache_hit_tokens: 512,
+                    prompt_cache_miss_tokens: 128,
+                  },
+                }),
+              "",
+              "data: [DONE]",
+              "",
+            ].join("\n"),
+          ),
+        )
+        controller.close()
+      },
+    })
+    const fetch = (async () => new Response(stream, { headers: { "content-type": "text/event-stream" } })) as unknown as FetchFunction
+    const provider = createFlocksOpenAICompatible({
+      name: "deepseek",
+      baseURL: "https://api.deepseek.com",
+      includeUsage: true,
+      fetch,
+    })
+
+    const result = await (provider.languageModel("deepseek-chat") as any).doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      headers: {},
+    })
+    const events = []
+    for await (const event of result.stream) {
+      events.push(event)
+    }
+
+    expect(events[events.length - 1]).toEqual({
+      type: "finish",
+      finishReason: "stop",
+      usage: {
+        inputTokens: 640,
+        outputTokens: 20,
+        totalTokens: 660,
+        reasoningTokens: undefined,
+        cachedInputTokens: undefined,
+      },
+      providerMetadata: {
+        deepseek: {
+          usage: {
+            prompt_tokens: 640,
+            completion_tokens: 20,
+            total_tokens: 660,
+            prompt_cache_hit_tokens: 512,
+            prompt_cache_miss_tokens: 128,
+          },
+        },
+      },
+    })
+  })
+})

--- a/tui/flocks/provider/openai-compatible-usage.ts
+++ b/tui/flocks/provider/openai-compatible-usage.ts
@@ -1,0 +1,154 @@
+import type { JSONValue, SharedV2ProviderMetadata } from "@ai-sdk/provider"
+import {
+  OpenAICompatibleChatLanguageModel,
+  OpenAICompatibleCompletionLanguageModel,
+  OpenAICompatibleEmbeddingModel,
+  OpenAICompatibleImageModel,
+  VERSION as OPENAI_COMPATIBLE_VERSION,
+  type OpenAICompatibleProviderSettings,
+} from "@ai-sdk/openai-compatible"
+import { withUserAgentSuffix, withoutTrailingSlash } from "@ai-sdk/provider-utils"
+
+const USAGE_KEYS = [
+  "prompt_tokens",
+  "completion_tokens",
+  "total_tokens",
+  "prompt_cache_hit_tokens",
+  "prompt_cache_miss_tokens",
+] as const
+
+const PROMPT_TOKEN_DETAIL_KEYS = [
+  "cached_tokens",
+  "cache_write_tokens",
+  "cache_creation_tokens",
+] as const
+
+const INPUT_TOKEN_DETAIL_KEYS = [
+  "cached_tokens",
+  "cache_write_tokens",
+  "cache_creation_tokens",
+] as const
+
+type OpenAICompatibleUsageMetadata = Record<string, JSONValue>
+
+export function createOpenAICompatibleUsageMetadataExtractor(providerID: string) {
+  return {
+    async extractMetadata({ parsedBody }: { parsedBody: unknown }) {
+      return metadataFromUsage(providerID, usageFromObject(parsedBody))
+    },
+    createStreamExtractor() {
+      let usage: Record<string, unknown> | undefined
+      return {
+        processChunk(parsedChunk: unknown) {
+          const next = usageFromObject(parsedChunk)
+          if (next) usage = next
+        },
+        buildMetadata() {
+          return metadataFromUsage(providerID, usage)
+        },
+      }
+    },
+  }
+}
+
+export function createFlocksOpenAICompatible(options: OpenAICompatibleProviderSettings) {
+  const baseURL = withoutTrailingSlash(options.baseURL)
+  const providerName = options.name
+  const headers = {
+    ...(options.apiKey && { Authorization: `Bearer ${options.apiKey}` }),
+    ...options.headers,
+  }
+  const getHeaders = () => withUserAgentSuffix(headers, `ai-sdk/openai-compatible/${OPENAI_COMPATIBLE_VERSION}`)
+  const getCommonModelConfig = (modelType: string) => ({
+    provider: `${providerName}.${modelType}`,
+    url: ({ path }: { modelId: string; path: string }) => {
+      const url = new URL(`${baseURL}${path}`)
+      if (options.queryParams) {
+        url.search = new URLSearchParams(options.queryParams).toString()
+      }
+      return url.toString()
+    },
+    headers: getHeaders,
+    fetch: options.fetch,
+  })
+
+  const createChatModel = (modelId: string) =>
+    new OpenAICompatibleChatLanguageModel(modelId, {
+      ...getCommonModelConfig("chat"),
+      includeUsage: options.includeUsage,
+      supportsStructuredOutputs: options.supportsStructuredOutputs,
+      metadataExtractor: createOpenAICompatibleUsageMetadataExtractor(providerName),
+    })
+  const createCompletionModel = (modelId: string) =>
+    new OpenAICompatibleCompletionLanguageModel(modelId, {
+      ...getCommonModelConfig("completion"),
+      includeUsage: options.includeUsage,
+    })
+  const createEmbeddingModel = (modelId: string) =>
+    new OpenAICompatibleEmbeddingModel(modelId, {
+      ...getCommonModelConfig("embedding"),
+    })
+  const createImageModel = (modelId: string) => new OpenAICompatibleImageModel(modelId, getCommonModelConfig("image"))
+
+  const provider = (modelId: string) => createChatModel(modelId)
+  provider.languageModel = provider
+  provider.chat = createChatModel
+  provider.chatModel = createChatModel
+  provider.completion = createCompletionModel
+  provider.completionModel = createCompletionModel
+  provider.textEmbedding = createEmbeddingModel
+  provider.textEmbeddingModel = createEmbeddingModel
+  provider.imageModel = createImageModel
+  return provider
+}
+
+function metadataFromUsage(providerID: string, usage: Record<string, unknown> | undefined): SharedV2ProviderMetadata | undefined {
+  const sanitized = sanitizeUsage(usage)
+  if (!sanitized) return undefined
+  return {
+    [providerID]: {
+      usage: sanitized,
+    },
+  }
+}
+
+function usageFromObject(value: unknown) {
+  if (!isRecord(value)) return undefined
+  const usage = value["usage"]
+  if (!isRecord(usage)) return undefined
+  return usage
+}
+
+function sanitizeUsage(usage: Record<string, unknown> | undefined): OpenAICompatibleUsageMetadata | undefined {
+  if (!usage) return undefined
+
+  const result: OpenAICompatibleUsageMetadata = {}
+  copyNumberFields(result, usage, USAGE_KEYS)
+
+  const promptTokensDetails = sanitizeNestedUsage(usage["prompt_tokens_details"], PROMPT_TOKEN_DETAIL_KEYS)
+  if (promptTokensDetails) result["prompt_tokens_details"] = promptTokensDetails
+
+  const inputTokensDetails = sanitizeNestedUsage(usage["input_tokens_details"], INPUT_TOKEN_DETAIL_KEYS)
+  if (inputTokensDetails) result["input_tokens_details"] = inputTokensDetails
+
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+function sanitizeNestedUsage(value: unknown, keys: readonly string[]) {
+  if (!isRecord(value)) return undefined
+  const result: OpenAICompatibleUsageMetadata = {}
+  copyNumberFields(result, value, keys)
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+function copyNumberFields(target: OpenAICompatibleUsageMetadata, source: Record<string, unknown>, keys: readonly string[]) {
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value !== "number" || !Number.isFinite(value)) continue
+    target[key] = Math.max(value, 0)
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}

--- a/tui/flocks/provider/provider.ts
+++ b/tui/flocks/provider/provider.ts
@@ -22,7 +22,6 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google"
 import { createVertex } from "@ai-sdk/google-vertex"
 import { createVertexAnthropic } from "@ai-sdk/google-vertex/anthropic"
 import { createOpenAI } from "@ai-sdk/openai"
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import { createOpenRouter, type LanguageModelV2 } from "@openrouter/ai-sdk-provider"
 import { createOpenaiCompatible as createGitHubCopilotOpenAICompatible } from "./sdk/openai-compatible/src"
 import { createXai } from "@ai-sdk/xai"
@@ -37,6 +36,7 @@ import { createPerplexity } from "@ai-sdk/perplexity"
 import { createVercel } from "@ai-sdk/vercel"
 import { createGitLab } from "@gitlab/gitlab-ai-provider"
 import { ProviderTransform } from "./transform"
+import { createFlocksOpenAICompatible } from "./openai-compatible-usage"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -61,7 +61,7 @@ export namespace Provider {
     "@ai-sdk/google-vertex": createVertex,
     "@ai-sdk/google-vertex/anthropic": createVertexAnthropic,
     "@ai-sdk/openai": createOpenAI,
-    "@ai-sdk/openai-compatible": createOpenAICompatible,
+    "@ai-sdk/openai-compatible": createFlocksOpenAICompatible,
     "@openrouter/ai-sdk-provider": createOpenRouter,
     "@ai-sdk/xai": createXai,
     "@ai-sdk/mistral": createMistral,

--- a/tui/flocks/session/index.ts
+++ b/tui/flocks/session/index.ts
@@ -22,6 +22,7 @@ import { Snapshot } from "@/snapshot"
 import type { Provider } from "@/provider/provider"
 import { PermissionNext } from "@/permission/next"
 import { Global } from "@/global"
+import { normalizeCacheUsage, normalizeUsageToken } from "./usage"
 
 export namespace Session {
   const log = Log.create({ service: "session" })
@@ -416,29 +417,18 @@ export namespace Session {
       metadata: z.custom<ProviderMetadata>().optional(),
     }),
     (input) => {
-      const cachedInputTokens = input.usage.cachedInputTokens ?? 0
+      const cache = normalizeCacheUsage(input)
       const excludesCachedTokens = !!(input.metadata?.["anthropic"] || input.metadata?.["bedrock"])
       const adjustedInputTokens = excludesCachedTokens
         ? (input.usage.inputTokens ?? 0)
-        : (input.usage.inputTokens ?? 0) - cachedInputTokens
-      const safe = (value: number) => {
-        if (!Number.isFinite(value)) return 0
-        return value
-      }
+        : (input.usage.inputTokens ?? 0) - cache.read
+      const safe = normalizeUsageToken
 
       const tokens = {
         input: safe(adjustedInputTokens),
         output: safe(input.usage.outputTokens ?? 0),
         reasoning: safe(input.usage?.reasoningTokens ?? 0),
-        cache: {
-          write: safe(
-            (input.metadata?.["anthropic"]?.["cacheCreationInputTokens"] ??
-              // @ts-expect-error
-              input.metadata?.["bedrock"]?.["usage"]?.["cacheWriteInputTokens"] ??
-              0) as number,
-          ),
-          read: safe(cachedInputTokens),
-        },
+        cache,
       }
 
       const costInfo =

--- a/tui/flocks/session/usage.test.ts
+++ b/tui/flocks/session/usage.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test"
+import type { LanguageModelUsage, ProviderMetadata } from "ai"
+import { normalizeCacheUsage, normalizeUsageToken } from "./usage"
+
+function usage(input: Record<string, unknown>): LanguageModelUsage {
+  return input as LanguageModelUsage
+}
+
+function metadata(input: Record<string, unknown>): ProviderMetadata {
+  return input as ProviderMetadata
+}
+
+describe("normalizeCacheUsage", () => {
+  const cases: Array<{
+    name: string
+    usage: LanguageModelUsage
+    metadata?: ProviderMetadata
+    expected: { read: number; write: number }
+  }> = [
+    {
+      name: "AI SDK cached input tokens",
+      usage: usage({ cachedInputTokens: 12 }),
+      expected: { read: 12, write: 0 },
+    },
+    {
+      name: "OpenAI chat cached tokens",
+      usage: usage({ prompt_tokens_details: { cached_tokens: 128 } }),
+      expected: { read: 128, write: 0 },
+    },
+    {
+      name: "OpenAI responses cached tokens",
+      usage: usage({ input_tokens_details: { cached_tokens: 256 } }),
+      expected: { read: 256, write: 0 },
+    },
+    {
+      name: "DeepSeek prompt cache hit tokens",
+      usage: usage({ prompt_cache_hit_tokens: 512, prompt_cache_miss_tokens: 64 }),
+      expected: { read: 512, write: 0 },
+    },
+    {
+      name: "Anthropic raw usage tokens",
+      usage: usage({ cache_read_input_tokens: 32, cache_creation_input_tokens: 16 }),
+      expected: { read: 32, write: 16 },
+    },
+    {
+      name: "Anthropic provider metadata tokens",
+      usage: usage({}),
+      metadata: metadata({ anthropic: { cacheReadInputTokens: 24, cacheCreationInputTokens: 8 } }),
+      expected: { read: 24, write: 8 },
+    },
+    {
+      name: "Bedrock provider metadata tokens",
+      usage: usage({}),
+      metadata: metadata({ bedrock: { usage: { cacheReadInputTokens: 48, cacheWriteInputTokens: 12 } } }),
+      expected: { read: 48, write: 12 },
+    },
+    {
+      name: "Google cached content tokens",
+      usage: usage({ usageMetadata: { cachedContentTokenCount: 96 } }),
+      expected: { read: 96, write: 0 },
+    },
+    {
+      name: "Gateway cache tokens",
+      usage: usage({ input_cache_read: 144, input_cache_write: 36 }),
+      expected: { read: 144, write: 36 },
+    },
+    {
+      name: "OpenAI-compatible cache write tokens",
+      usage: usage({ prompt_tokens_details: { cache_write_tokens: 72 } }),
+      expected: { read: 0, write: 72 },
+    },
+    {
+      name: "positive raw fallback when SDK standard field is zero",
+      usage: usage({ cachedInputTokens: 0, prompt_cache_hit_tokens: 80 }),
+      expected: { read: 80, write: 0 },
+    },
+    {
+      name: "OpenAI-compatible provider metadata raw DeepSeek tokens",
+      usage: usage({ inputTokens: 640 }),
+      metadata: metadata({ deepseek: { usage: { prompt_cache_hit_tokens: 512, prompt_cache_miss_tokens: 128 } } }),
+      expected: { read: 512, write: 0 },
+    },
+    {
+      name: "OpenAI-compatible provider metadata raw cache write tokens",
+      usage: usage({}),
+      metadata: metadata({ custom: { usage: { prompt_tokens_details: { cache_creation_tokens: 44 } } } }),
+      expected: { read: 0, write: 44 },
+    },
+  ]
+
+  for (const item of cases) {
+    test(item.name, () => {
+      expect(normalizeCacheUsage({ usage: item.usage, metadata: item.metadata })).toEqual(item.expected)
+    })
+  }
+
+  test("ignores cache miss tokens for cache write", () => {
+    expect(normalizeCacheUsage({ usage: usage({ prompt_cache_miss_tokens: 100 }) })).toEqual({
+      read: 0,
+      write: 0,
+    })
+  })
+
+  test("normalizes invalid and negative values to zero", () => {
+    expect(
+      normalizeCacheUsage({
+        usage: usage({
+          cachedInputTokens: Number.NaN,
+          cacheCreationInputTokens: -10,
+        }),
+      }),
+    ).toEqual({ read: 0, write: 0 })
+    expect(normalizeUsageToken(Number.POSITIVE_INFINITY)).toBe(0)
+    expect(normalizeUsageToken(-1)).toBe(0)
+  })
+})

--- a/tui/flocks/session/usage.ts
+++ b/tui/flocks/session/usage.ts
@@ -1,0 +1,135 @@
+import type { LanguageModelUsage, ProviderMetadata } from "ai"
+
+type CacheUsageInput = {
+  usage: LanguageModelUsage
+  metadata?: ProviderMetadata
+}
+
+type CacheUsage = {
+  read: number
+  write: number
+}
+
+const CACHE_READ_USAGE_PATHS = [
+  ["cachedInputTokens"],
+  ["prompt_tokens_details", "cached_tokens"],
+  ["input_tokens_details", "cached_tokens"],
+  ["prompt_cache_hit_tokens"],
+  ["usageMetadata", "cachedContentTokenCount"],
+  ["cache_read_input_tokens"],
+  ["cacheReadInputTokens"],
+  ["input_cache_read"],
+] as const
+
+const CACHE_READ_METADATA_PATHS = [
+  ["anthropic", "cacheReadInputTokens"],
+  ["anthropic", "usage", "cache_read_input_tokens"],
+  ["bedrock", "usage", "cacheReadInputTokens"],
+  ["google", "usageMetadata", "cachedContentTokenCount"],
+  ["gateway", "input_cache_read"],
+  ["gateway", "usage", "input_cache_read"],
+] as const
+
+const CACHE_WRITE_USAGE_PATHS = [
+  ["cacheCreationInputTokens"],
+  ["cache_creation_input_tokens"],
+  ["cacheWriteInputTokens"],
+  ["prompt_tokens_details", "cache_write_tokens"],
+  ["prompt_tokens_details", "cache_creation_tokens"],
+  ["input_tokens_details", "cache_write_tokens"],
+  ["input_tokens_details", "cache_creation_tokens"],
+  ["input_cache_write"],
+] as const
+
+const CACHE_WRITE_METADATA_PATHS = [
+  ["anthropic", "cacheCreationInputTokens"],
+  ["anthropic", "usage", "cache_creation_input_tokens"],
+  ["bedrock", "usage", "cacheWriteInputTokens"],
+  ["gateway", "input_cache_write"],
+  ["gateway", "usage", "input_cache_write"],
+] as const
+
+const PROVIDER_USAGE_CACHE_READ_PATHS = [
+  ["usage", "prompt_tokens_details", "cached_tokens"],
+  ["usage", "input_tokens_details", "cached_tokens"],
+  ["usage", "prompt_cache_hit_tokens"],
+] as const
+
+const PROVIDER_USAGE_CACHE_WRITE_PATHS = [
+  ["usage", "cacheCreationInputTokens"],
+  ["usage", "cache_creation_input_tokens"],
+  ["usage", "cacheWriteInputTokens"],
+  ["usage", "prompt_tokens_details", "cache_write_tokens"],
+  ["usage", "prompt_tokens_details", "cache_creation_tokens"],
+  ["usage", "input_tokens_details", "cache_write_tokens"],
+  ["usage", "input_tokens_details", "cache_creation_tokens"],
+  ["usage", "input_cache_write"],
+] as const
+
+export function normalizeUsageToken(value: number | undefined | null) {
+  if (typeof value !== "number") return 0
+  if (!Number.isFinite(value)) return 0
+  return Math.max(value, 0)
+}
+
+export function normalizeCacheUsage(input: CacheUsageInput): CacheUsage {
+  const usage = input.usage as unknown
+  const metadata = input.metadata as unknown
+
+  return {
+    read:
+      firstPositiveNumber(usage, CACHE_READ_USAGE_PATHS) ??
+      firstPositiveNumber(metadata, CACHE_READ_METADATA_PATHS) ??
+      firstProviderUsageNumber(metadata, PROVIDER_USAGE_CACHE_READ_PATHS) ??
+      0,
+    write:
+      firstPositiveNumber(usage, CACHE_WRITE_USAGE_PATHS) ??
+      firstPositiveNumber(metadata, CACHE_WRITE_METADATA_PATHS) ??
+      firstProviderUsageNumber(metadata, PROVIDER_USAGE_CACHE_WRITE_PATHS) ??
+      0,
+  }
+}
+
+function firstPositiveNumber(source: unknown, paths: readonly (readonly string[])[]) {
+  let fallbackZero = false
+  for (const path of paths) {
+    const value = numberAt(source, path)
+    if (value === undefined) continue
+    if (value > 0) return value
+    fallbackZero = true
+  }
+  return fallbackZero ? 0 : undefined
+}
+
+function numberAt(source: unknown, path: readonly string[]) {
+  let current = source
+  for (const key of path) {
+    if (!isRecord(current)) return undefined
+    current = current[key]
+  }
+  return normalizeNumber(current)
+}
+
+function firstProviderUsageNumber(metadata: unknown, paths: readonly (readonly string[])[]) {
+  if (!isRecord(metadata)) return undefined
+  let fallbackZero = false
+  for (const providerMetadata of Object.values(metadata)) {
+    for (const path of paths) {
+      const value = numberAt(providerMetadata, path)
+      if (value === undefined) continue
+      if (value > 0) return value
+      fallbackZero = true
+    }
+  }
+  return fallbackZero ? 0 : undefined
+}
+
+function normalizeNumber(value: unknown) {
+  if (typeof value !== "number") return undefined
+  if (!Number.isFinite(value)) return 0
+  return Math.max(value, 0)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}


### PR DESCRIPTION
本 PR 修复 DeepSeek 等 OpenAI Compatible provider 在 session messages 中 tokens.cache.read 统计为 0 的问题。
主要改动：
为 Flocks 内置 @ai-sdk/openai-compatible 增加 wrapper，保留 sanitized raw usage metadata。
支持 DeepSeek prompt_cache_hit_tokens 在流式和非流式响应中被正确统计。
新增统一的 cache usage 归一化逻辑，兼容 OpenAI、DeepSeek、Anthropic、Bedrock、Google、Gateway 等常见字段。
明确不将 prompt_cache_miss_tokens 计入 cache.write。
增加相关单测和回归测试。