### PR TITLE
fix(kafka): align concurrency limits with syslog

### DIFF
--- a/flocks/ingest/kafka/manager.py
+++ b/flocks/ingest/kafka/manager.py
@@ -62,12 +62,11 @@ log = Log.create(service="kafka.manager")
 
 # Maximum concurrent workflow executions per workflow to avoid FD exhaustion and
 # SQLite write contention. Kafka messages can carry large JSON payloads, so keep
-# this lower than syslog to avoid several full workflow histories being resident
-# at the same time.
-_MAX_CONCURRENT_EXECUTIONS = 2
+# this bounded even when a trigger requests a larger worker pool.
+_MAX_CONCURRENT_EXECUTIONS = 8
 # Maximum number of buffered Kafka messages per workflow.  Unlike syslog we do
 # not drop on overflow; a full queue applies backpressure to the consumer loop.
-_MAX_QUEUE_SIZE = 100
+_MAX_QUEUE_SIZE = 1000
 # Maximum time we wait for the consumer to either connect successfully or fail
 # during ``restart_workflow`` so the HTTP save endpoint can surface connection
 # errors instead of pretending the consumer is running.


### PR DESCRIPTION
## Summary
- raise the Kafka workflow worker cap from 2 to 8
- raise the Kafka queue cap from 100 to 1000
- align Kafka concurrency limits with the Syslog manager while preserving Kafka backpressure behavior

## Root cause
Kafka trigger settings were silently capped below the requested values by lower manager-level safety limits.

## Validation
- uv run ruff check flocks/ingest/kafka/manager.py
- uv run pytest -q tests/ingest/test_kafka_manager.py (16 passed)