### PR TITLE
fix: restore default WeCom WebSocket URL after clearing custom value

### DIFF
--- a/webui/src/pages/Channel/index.test.tsx
+++ b/webui/src/pages/Channel/index.test.tsx
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import ChannelPage from './index';
+
+const { client, toast, useAgents, flocksproUsersApi } = vi.hoisted(() => ({
+  client: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    post: vi.fn(),
+  },
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  useAgents: vi.fn(),
+  flocksproUsersApi: {
+    hasCapability: vi.fn(),
+  },
+}));
+
+vi.mock('@/api/client', () => ({ default: client }));
+
+vi.mock('@/components/common/Toast', () => ({
+  useToast: () => toast,
+}));
+
+vi.mock('@/hooks/useAgents', () => ({
+  useAgents: () => useAgents(),
+}));
+
+vi.mock('@/api/flocksproUsers', () => ({
+  flocksproUsersApi,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'zh-CN' },
+  }),
+}));
+
+describe('ChannelPage WeCom configuration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAgents.mockReturnValue({ agents: [] });
+    flocksproUsersApi.hasCapability.mockResolvedValue(false);
+    client.patch.mockResolvedValue({ data: {} });
+    client.post.mockResolvedValue({ data: {} });
+    client.get.mockImplementation((url: string) => {
+      if (url === '/api/channel/list') {
+        return Promise.resolve({
+          data: [{
+            id: 'wecom',
+            label: 'WeCom',
+            aliases: [],
+            capabilities: {
+              chat_types: ['direct', 'group'],
+              media: true,
+              threads: false,
+              reactions: false,
+              edit: false,
+              rich_text: false,
+            },
+            running: false,
+          }],
+        });
+      }
+      if (url === '/api/config') {
+        return Promise.resolve({
+          data: {
+            channels: {
+              wecom: {
+                enabled: false,
+                botId: 'bot-id',
+                secret: 'secret',
+                websocketUrl: 'fafafafaf',
+              },
+            },
+          },
+        });
+      }
+      if (url === '/api/channel/status') {
+        return Promise.resolve({ data: {} });
+      }
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+  });
+
+  it('sends an explicit empty websocket URL after the field is cleared', async () => {
+    const user = userEvent.setup();
+    render(<ChannelPage />);
+
+    const websocketUrlInput = await screen.findByDisplayValue('fafafafaf');
+    await user.clear(websocketUrlInput);
+    await user.click(screen.getByRole('button', { name: 'save' }));
+
+    await waitFor(() => {
+      expect(client.patch).toHaveBeenCalledWith('/api/config/', expect.any(Object));
+    });
+
+    const payload = client.patch.mock.calls[0][1];
+    expect(
+      Object.prototype.hasOwnProperty.call(payload.channels.wecom, 'websocketUrl'),
+    ).toBe(true);
+    expect(payload.channels.wecom.websocketUrl).toBe('');
+  });
+});

--- a/webui/src/pages/Channel/index.tsx
+++ b/webui/src/pages/Channel/index.tsx
@@ -1638,7 +1638,7 @@ function WeComPanel({ config, agentOptions, onChange }: WeComPanelProps) {
         <FieldRow label={t('wecom.websocketUrl')} hint={t('wecom.websocketUrlHint')}>
           <TextInput
             value={config.websocketUrl ?? ''}
-            onChange={(v) => set('websocketUrl', v || undefined)}
+            onChange={(v) => set('websocketUrl', v)}
             placeholder={t('wecom.websocketUrlPlaceholder')}
           />
         </FieldRow>
@@ -3841,6 +3841,15 @@ function stripEmpty(obj: Record<string, any>): Record<string, any> {
 
 function stripChannelConfigForSave(channelId: string, cfg: Record<string, any>): Record<string, any> {
   const result = stripEmpty(cfg);
+
+  if (
+    channelId === 'wecom'
+    && Object.prototype.hasOwnProperty.call(cfg, 'websocketUrl')
+  ) {
+    // Config updates are deep-merged by the backend, so omitting a cleared URL
+    // would retain the previous custom endpoint instead of restoring the SDK default.
+    result.websocketUrl = cfg.websocketUrl ?? '';
+  }
 
   if (channelId === 'email') {
     if (result.authMode === 'xoauth2') {


### PR DESCRIPTION
## Summary

- preserve an explicitly cleared WeCom `websocketUrl` in the channel editor
- serialize the cleared value as `""` so the backend deep merge overwrites the stale custom endpoint
- keep never-configured channels unchanged and add a page-level regression test

## Root cause

The editor converted an empty WebSocket URL to `undefined`, and `stripEmpty` omitted it from the PATCH payload. Because configuration updates are deep-merged, the previously saved custom URL remained active even though the UI reported a successful save.

## Impact

Clearing a custom WeCom WebSocket endpoint now restores the SDK default endpoint after save and channel restart, so an invalid custom URI no longer remains silently active.

## Validation

- `npm run test:run -- src/pages/Channel/index.test.tsx`
- `npx eslint src/pages/Channel/index.tsx src/pages/Channel/index.test.tsx --max-warnings 0`
- `npm run build`
- `git diff --check`
- local WebUI flow: clear URL, save, observe explicit empty-string PATCH, restart, reload, and verify WeCom reconnects with `connected=true` and no connection error
