### PR TITLE
refactor(session): centralize prompt context assembly

### DIFF
--- a/flocks/agent/agents/hephaestus/prompt_builder.py
+++ b/flocks/agent/agents/hephaestus/prompt_builder.py
@@ -36,7 +36,10 @@ def build_hephaestus_prompt(
     available_agents: List["AvailableAgent"],
     available_tools: List["AvailableTool"],
     available_skills: List["AvailableSkill"],
+    use_task_system: bool = False,
 ) -> str:
+    del use_task_system
+
     from flocks.agent.prompt_utils import (
         build_agent_selection_table,
         build_key_triggers_section,

--- a/flocks/agent/agents/hephaestus/prompt_builder.py
+++ b/flocks/agent/agents/hephaestus/prompt_builder.py
@@ -29,7 +29,6 @@ def inject(
         available_agents=available_agents,
         available_tools=tools,
         available_skills=skills,
-        use_task_system=False,
     )
 
 
@@ -37,7 +36,6 @@ def build_hephaestus_prompt(
     available_agents: List["AvailableAgent"],
     available_tools: List["AvailableTool"],
     available_skills: List["AvailableSkill"],
-    use_task_system: bool = False,
 ) -> str:
     from flocks.agent.prompt_utils import (
         build_agent_selection_table,
@@ -62,7 +60,7 @@ def build_hephaestus_prompt(
     oracle_section = build_oracle_section(available_agents)
     hard_blocks = build_hard_blocks_section()
     anti_patterns = build_anti_patterns_section()
-    todo_discipline = _todo_discipline_section(use_task_system)
+    todo_discipline = _todo_discipline_section()
 
     template = """You are Hephaestus, an autonomous deep worker for software engineering.
 
@@ -245,44 +243,7 @@ Before final response:
     return prompt
 
 
-def _todo_discipline_section(use_task_system: bool) -> str:
-    if use_task_system:
-        return """## Task Discipline (NON-NEGOTIABLE)
-
-**Track ALL multi-step work with tasks. This is your execution backbone.**
-
-### When to Create Tasks (MANDATORY)
-
-| Trigger | Action |
-|---------|--------|
-| 2+ step task | `TaskCreate` FIRST, atomic breakdown |
-| Uncertain scope | `TaskCreate` to clarify thinking |
-| Complex single task | Break down into trackable steps |
-
-### Workflow (STRICT)
-
-1. **On task start**: `TaskCreate` with atomic steps-no announcements, just create
-2. **Before each step**: `TaskUpdate(status="in_progress")` (ONE at a time)
-3. **After each step**: `TaskUpdate(status="completed")` IMMEDIATELY (NEVER batch)
-4. **Scope changes**: Update tasks BEFORE proceeding
-
-### Why This Matters
-
-- **Execution anchor**: Tasks prevent drift from original request
-- **Recovery**: If interrupted, tasks enable seamless continuation
-- **Accountability**: Each task = explicit commitment to deliver
-
-### Anti-Patterns (BLOCKING)
-
-| Violation | Why It Fails |
-|-----------|--------------|
-| Skipping tasks on multi-step work | Steps get forgotten, user has no visibility |
-| Batch-completing multiple tasks | Defeats real-time tracking purpose |
-| Proceeding without `in_progress` | No indication of current work |
-| Finishing without completing tasks | Task appears incomplete |
-
-**NO TASKS ON MULTI-STEP WORK = INCOMPLETE WORK.**"""
-
+def _todo_discipline_section() -> str:
     return """## Todo Discipline (NON-NEGOTIABLE)
 
 **Track ALL multi-step work with todos. This is your execution backbone.**

--- a/flocks/agent/agents/rex/prompt_builder.py
+++ b/flocks/agent/agents/rex/prompt_builder.py
@@ -30,7 +30,6 @@ def inject(
         available_tools=tools,
         available_skills=skills,
         available_workflows=workflows or [],
-        use_task_system=False,
     )
 
 
@@ -39,7 +38,6 @@ def build_dynamic_rex_prompt(
     available_tools: List["AvailableTool"],
     available_skills: List["AvailableSkill"],
     available_workflows: Optional[List["AvailableWorkflow"]] = None,
-    use_task_system: bool = False,
 ) -> str:
     from flocks.agent.prompt_utils import (
         build_agent_selection_table,
@@ -58,12 +56,8 @@ def build_dynamic_rex_prompt(
     im_send_section = _build_im_send_pointer_section()
     anti_patterns = _build_rex_anti_patterns_section()
     command_guidance_section = _build_command_guidance_section()
-    task_management_section = _task_management_section(use_task_system)
-    todo_hook_note = (
-        "YOUR TASK CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TASK CONTINUATION])"
-        if use_task_system
-        else "YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION])"
-    )
+    task_management_section = _task_management_section()
+    todo_hook_note = "YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION])"
 
     template = """<Role>
 You are "Rex" - Powerful AI orchestrator for security operations.
@@ -143,13 +137,12 @@ Reuse `session_id` when follow-up work belongs to the same delegated thread. Do 
 - Match existing codebase patterns when editing.
 - Fix bugs minimally; do not refactor during a bugfix unless required.
 - Keep search bounded: stop when you have enough context, when results repeat, or when direct evidence already answers the question.
-- For independent parallel branches whose results are needed this turn, emit multiple foreground `delegate_task` / `task` tool calls in the same assistant turn. The runtime executes those sibling tool calls concurrently and returns all tool results before you continue.
+- For independent parallel branches whose results are needed this turn, emit multiple foreground `delegate_task` tool calls in the same assistant turn. The runtime executes those sibling tool calls concurrently and returns all tool results before you continue.
 - Do not use `run_in_background=true`; background subagent execution is disabled.
 
 ## 5. Verify
 
- - Use `lsp` for symbol-aware checks when useful, and run relevant tests on changed files before considering the work complete.
-- Run relevant build or test commands before finalizing when the affected area has them.
+- After code changes, run the lint/typecheck/tests. If tests fail, iterate until they pass before finalizing.
 - Verification evidence is mandatory: clean diagnostics, successful commands, or an explicit note about pre-existing failures.
 - Verify delegated work against expected behavior, codebase patterns, and any `must-do` / `must-not-do` requirements.
 
@@ -278,55 +271,42 @@ Should I proceed with [recommendation], or would you prefer differently?
 ```"""
 
 
-def _task_management_section(use_task_system: bool) -> str:
-    title = "Task Management" if use_task_system else "Todo Management"
-    unit = "tasks" if use_task_system else "todos"
-    create_action = "`TaskCreate`" if use_task_system else '`todo(action="write")`'
-    progress_action = (
-        '`TaskUpdate(status="in_progress")`'
-        if use_task_system
-        else "mark `in_progress`"
-    )
-    complete_action = (
-        '`TaskUpdate(status="completed")`'
-        if use_task_system
-        else "mark `completed`"
-    )
+def _task_management_section() -> str:
     clarification_protocol = _build_clarification_protocol()
 
-    return f"""<Task_Management>
-## {title}
+    return f"""<Todo_Management>
+## Todo Management
 
-Use {unit} as the primary coordination mechanism for non-trivial execution work.
+Use todos as the primary coordination mechanism for non-trivial execution work.
 
 ### When They Are Mandatory
 
 | Trigger | Action |
 |---------|--------|
-| Multi-step work (2+ steps) | Create {unit} first |
-| Uncertain scope | Create {unit} to structure the work |
-| User request with multiple items | Create {unit} first |
-| Complex single task | Break it into {unit} |
+| Multi-step work (2+ steps) | Create todos first |
+| Uncertain scope | Create todos to structure the work |
+| User request with multiple items | Create todos first |
+| Complex single task | Break it into todos |
 
 ### Operating Rules
 
-1. Start with {create_action} before implementation work begins.
-2. ONLY add {unit} when the user wants execution, not when they only want analysis or planning.
-3. Before each step, {progress_action}. Keep only one item in progress.
-4. After each step, {complete_action} immediately. Never batch updates.
-5. If scope changes, update the {unit} before continuing.
+1. Start with `todo(action="write")` before implementation work begins.
+2. ONLY add todos when the user wants execution, not when they only want analysis or planning.
+3. Before each step, mark it `in_progress`. Keep only one item in progress.
+4. After each step, mark it `completed` immediately. Never batch updates.
+5. If scope changes, update the todos before continuing.
 
 ### Failure Modes
 
 | Violation | Why It Breaks the Workflow |
 |-----------|----------------------------|
-| Skipping {unit} on non-trivial work | The user loses progress visibility and steps get dropped |
-| Batch-completing multiple {unit} | Real-time tracking becomes meaningless |
+| Skipping todos on non-trivial work | The user loses progress visibility and steps get dropped |
+| Batch-completing multiple todos | Real-time tracking becomes meaningless |
 | Proceeding without an in-progress item | It is unclear what is being worked on |
 | Finishing without closing items | The work appears incomplete |
 
 {clarification_protocol}
-</Task_Management>"""
+</Todo_Management>"""
 
 
 def _build_security_priority_section(available_agents: List["AvailableAgent"]) -> str:

--- a/flocks/agent/agents/rex/prompt_builder.py
+++ b/flocks/agent/agents/rex/prompt_builder.py
@@ -38,6 +38,7 @@ def build_dynamic_rex_prompt(
     available_tools: List["AvailableTool"],
     available_skills: List["AvailableSkill"],
     available_workflows: Optional[List["AvailableWorkflow"]] = None,
+    use_task_system: bool = False,
 ) -> str:
     from flocks.agent.prompt_utils import (
         build_agent_selection_table,
@@ -47,6 +48,7 @@ def build_dynamic_rex_prompt(
     )
 
     _ = available_tools
+    del use_task_system
 
     key_triggers = build_key_triggers_section(available_agents, available_skills)
     agent_selection = build_agent_selection_table(available_agents)

--- a/flocks/session/context_usage.py
+++ b/flocks/session/context_usage.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from flocks.provider.provider import Provider
 from flocks.session.message import Message
-from flocks.session.prompt import SessionPrompt
+from flocks.session.prompt import SessionPrompt, TurnPromptContext
 from flocks.session.session import SessionInfo
 from flocks.utils.log import Log
 
@@ -309,7 +309,16 @@ async def _estimate_system_prompt_tokens(
         if agent is None:
             agent = await Agent.get("rex")
 
-        prompts = await SessionPrompt.build_system_prompts(
+        from flocks.config import Config
+        from flocks.project.instance import Instance
+
+        try:
+            config = await Config.get()
+            config_instructions = tuple(config.instructions or ())
+        except Exception:
+            config_instructions = ()
+
+        prompt_blocks = await SessionPrompt.build_system_prompt_blocks(
             session_id=session_id,
             session_directory=getattr(session, "directory", None) if session is not None else None,
             agent_name=getattr(agent, "name", agent_name) if agent is not None else agent_name,
@@ -317,9 +326,16 @@ async def _estimate_system_prompt_tokens(
             provider_id=provider_id,
             model_id=model_id,
             prompt_tool_names=prompt_tool_names,
-            tool_revision=ToolRegistry.revision(),
+            turn_context=TurnPromptContext(
+                worktree=Instance.get_worktree(),
+                config_instructions=config_instructions,
+                tool_revision=ToolRegistry.revision(),
+            ),
         )
-        return sum(SessionPrompt.count_tokens(prompt) for prompt in prompts)
+        return sum(
+            SessionPrompt.count_tokens(block.content)
+            for block in prompt_blocks
+        )
     except Exception as exc:
         log.debug("context_usage.system_prompt_estimate_failed", {
             "session_id": session_id,

--- a/flocks/session/context_usage.py
+++ b/flocks/session/context_usage.py
@@ -310,7 +310,7 @@ async def _estimate_system_prompt_tokens(
             agent = await Agent.get("rex")
 
         from flocks.config import Config
-        from flocks.project.instance import Instance
+        from flocks.project.project import Project
 
         try:
             config = await Config.get()
@@ -318,16 +318,24 @@ async def _estimate_system_prompt_tokens(
         except Exception:
             config_instructions = ()
 
+        session_directory = (
+            getattr(session, "directory", None) if session is not None else None
+        )
+        worktree = (
+            Project.worktree_for_directory(session_directory)
+            if session_directory
+            else None
+        )
         prompt_blocks = await SessionPrompt.build_system_prompt_blocks(
             session_id=session_id,
-            session_directory=getattr(session, "directory", None) if session is not None else None,
+            session_directory=session_directory,
             agent_name=getattr(agent, "name", agent_name) if agent is not None else agent_name,
             agent_prompt=getattr(agent, "prompt", None) if agent is not None else None,
             provider_id=provider_id,
             model_id=model_id,
             prompt_tool_names=prompt_tool_names,
             turn_context=TurnPromptContext(
-                worktree=Instance.get_worktree(),
+                worktree=worktree,
                 config_instructions=config_instructions,
                 tool_revision=ToolRegistry.revision(),
             ),

--- a/flocks/session/prompt.py
+++ b/flocks/session/prompt.py
@@ -35,8 +35,7 @@ if TYPE_CHECKING:
 # Output token maximum
 OUTPUT_TOKEN_MAX = int(os.getenv("FLOCKS_OUTPUT_TOKEN_MAX", "32000"))
 SystemPromptCache = Dict[str, Any]
-AsyncPromptFactory = Callable[[], Awaitable[Optional[str]]]
-StringPromptFactory = Callable[[], Optional[str]]
+AsyncPromptLoader = Callable[[], Awaitable[Optional[str]]]
 
 
 # Prompt template directory (same structure as Flocks)
@@ -139,13 +138,30 @@ class ContextInfo(BaseModel):
 
 @dataclass(frozen=True)
 class SystemPromptBlock:
-    """Internal system prompt layer with cache metadata."""
+    """Assembled system prompt layer."""
 
     name: str
     content: str
     cache_scope: str
-    digest_inputs: Dict[str, Any]
-    cache_key: str
+
+
+@dataclass(frozen=True)
+class TurnPromptContext:
+    """Runtime prompt values collected once before deterministic assembly."""
+
+    tool_catalog: Optional[str] = None
+    device_asset_hint: Optional[str] = None
+    sandbox_context: Optional[str] = None
+    channel_context: Optional[str] = None
+    additional_context: Optional[str] = None
+    text_tool_catalog: Optional[str] = None
+    tool_results_reminder: Optional[str] = None
+    repeated_tool_calls_reminder: Optional[str] = None
+    worktree: Optional[str] = None
+    config_instructions: tuple[str, ...] = ()
+    tool_revision: Optional[int] = None
+    device_revision: Optional[int] = None
+    minimal_prompt: Optional[bool] = None
 
 
 class SystemPrompt:
@@ -805,49 +821,6 @@ class SessionPrompt:
         return f"system_prompt_block:{name}:{cls._system_prompt_cache_digest(digest_inputs)}"
 
     @classmethod
-    def _system_prompt_cache_key(
-        cls,
-        *,
-        session_id: str,
-        agent_name: str,
-        provider_id: str,
-        model_id: str,
-        block_keys: Iterable[str],
-    ) -> str:
-        """Build the cache key for the composed system prompt snapshot."""
-        cache_digest = cls._system_prompt_cache_digest({
-            "block_keys": tuple(block_keys),
-        })
-        return f"system_prompts:{session_id}:{agent_name}:{provider_id}:{model_id}:{cache_digest}"
-
-    @classmethod
-    def _read_system_prompt_cache(
-        cls,
-        static_cache: Optional[SystemPromptCache],
-        cache_key: Optional[str],
-    ) -> Optional[List[str]]:
-        """Return a defensive copy of cached prompt blocks when available."""
-        if static_cache is None or cache_key is None:
-            return None
-
-        cached = static_cache.get(cache_key)
-        if cached is None:
-            return None
-        return list(cached)
-
-    @classmethod
-    def _write_system_prompt_cache(
-        cls,
-        static_cache: Optional[SystemPromptCache],
-        cache_key: Optional[str],
-        prompts: List[str],
-    ) -> None:
-        """Store a defensive copy of prompt blocks in the session cache."""
-        if static_cache is None or cache_key is None:
-            return
-        static_cache[cache_key] = list(prompts)
-
-    @classmethod
     def _read_cached_prompt_block(
         cls,
         static_cache: Optional[SystemPromptCache],
@@ -909,8 +882,6 @@ class SessionPrompt:
             name=name,
             content=content,
             cache_scope=cache_scope,
-            digest_inputs=digest_inputs,
-            cache_key=cache_key,
         )
 
     @classmethod
@@ -921,22 +892,21 @@ class SessionPrompt:
         name: str,
         cache_scope: str,
         digest_inputs: Dict[str, Any],
-        builder: AsyncPromptFactory,
+        loader: AsyncPromptLoader,
     ) -> Optional[SystemPromptBlock]:
         """Build or reuse a cached async prompt block."""
         cache_key = cls._layer_cache_key(name=name, digest_inputs=digest_inputs)
         content = cls._read_cached_prompt_block(static_cache, cache_key)
         if content is None:
-            content = cls._normalize_prompt_text(await builder())
-            cls._write_cached_prompt_block(static_cache, cache_key, content)
+            content = cls._normalize_prompt_text(await loader())
+            if content:
+                cls._write_cached_prompt_block(static_cache, cache_key, content)
         if not content:
             return None
         return SystemPromptBlock(
             name=name,
             content=content,
             cache_scope=cache_scope,
-            digest_inputs=digest_inputs,
-            cache_key=cache_key,
         )
 
     @classmethod
@@ -1045,26 +1015,6 @@ class SessionPrompt:
         ]
 
     @classmethod
-    async def _build_optional_async_prompt(
-        cls,
-        prompt_factory: Optional[AsyncPromptFactory],
-    ) -> Optional[str]:
-        """Run an optional async prompt factory."""
-        if not prompt_factory:
-            return None
-        return await prompt_factory()
-
-    @classmethod
-    def _build_optional_prompt(
-        cls,
-        prompt_factory: Optional[StringPromptFactory],
-    ) -> Optional[str]:
-        """Run an optional synchronous prompt factory."""
-        if not prompt_factory:
-            return None
-        return prompt_factory()
-
-    @classmethod
     def _print_system_prompts_for_debug(
         cls,
         *,
@@ -1072,7 +1022,7 @@ class SessionPrompt:
         agent_name: str,
         provider_id: str,
         model_id: str,
-        prompts: List[str],
+        blocks: Iterable[SystemPromptBlock],
     ) -> None:
         """Print prompt blocks when FLOCKS_PRINT_SYSTEM_PROMPT is enabled."""
         if os.getenv("FLOCKS_PRINT_SYSTEM_PROMPT", "").lower() not in ("1", "true", "yes"):
@@ -1083,8 +1033,12 @@ class SessionPrompt:
             f"agent={agent_name} model={provider_id}/{model_id} ==="
         )
         print(header, file=sys.stderr)
-        for idx, prompt in enumerate(prompts):
-            print(f"\n--- prompt[{idx}] ---\n{prompt}\n", file=sys.stderr)
+        for idx, block in enumerate(blocks):
+            print(
+                f"\n--- prompt[{idx}] {block.name} scope={block.cache_scope} "
+                f"---\n{block.content}\n",
+                file=sys.stderr,
+            )
         print("=== end system_prompt ===\n", file=sys.stderr)
 
     @classmethod
@@ -1141,22 +1095,92 @@ class SessionPrompt:
             return False
 
     @classmethod
-    async def _build_subagent_minimal_prompts(
+    def _append_turn_tail_blocks(
         cls,
         *,
-        session_directory: Optional[str],
-        agent_prompt: Optional[str],
-    ) -> List[str]:
-        """Build minimal system prompts for built-in system subagents."""
-        prompts = [
-            get_prompt_flocks_config_guard().strip(),
-            cls._normalize_prompt_text(agent_prompt),
-            cls._build_minimal_environment(session_directory),
+        blocks: List[SystemPromptBlock],
+        turn_context: TurnPromptContext,
+        static_cache: Optional[SystemPromptCache],
+        session_id: str,
+    ) -> None:
+        """Append per-turn values in the exact order sent to the model."""
+        tail_values = [
+            ("turn_additional_context", turn_context.additional_context),
+            ("text_tool_catalog", turn_context.text_tool_catalog),
+            ("tool_results_reminder", turn_context.tool_results_reminder),
+            (
+                "repeated_tool_calls_reminder",
+                turn_context.repeated_tool_calls_reminder,
+            ),
         ]
-        return [prompt for prompt in prompts if prompt]
+        for name, content in tail_values:
+            normalized_content = cls._normalize_prompt_text(content)
+            block = cls._build_cached_prompt_block(
+                static_cache=static_cache,
+                name=name,
+                cache_scope="runtime_tail",
+                digest_inputs={"session_id": session_id, "content": content or ""},
+                builder=lambda: normalized_content,
+            )
+            if block is not None:
+                blocks.append(block)
 
     @classmethod
-    async def build_system_prompts(
+    def _build_subagent_minimal_blocks(
+        cls,
+        *,
+        session_id: str,
+        session_directory: Optional[str],
+        agent_prompt: Optional[str],
+        turn_context: TurnPromptContext,
+        static_cache: Optional[SystemPromptCache],
+    ) -> List[SystemPromptBlock]:
+        """Build minimal prompt blocks for built-in system subagents."""
+        blocks: List[SystemPromptBlock] = []
+        guard_block = cls._build_cached_prompt_block(
+            static_cache=static_cache,
+            name="flocks_config_guard",
+            cache_scope="global",
+            digest_inputs={"prompt": get_prompt_flocks_config_guard()},
+            builder=lambda: get_prompt_flocks_config_guard().strip(),
+        )
+        if guard_block is not None:
+            blocks.append(guard_block)
+
+        agent_block = cls._build_cached_prompt_block(
+            static_cache=static_cache,
+            name="agent_identity",
+            cache_scope="agent",
+            digest_inputs={"agent_prompt": agent_prompt or ""},
+            builder=lambda: cls._normalize_prompt_text(agent_prompt),
+        )
+        if agent_block is not None:
+            blocks.append(agent_block)
+
+        environment_block = cls._build_cached_prompt_block(
+            static_cache=static_cache,
+            name="minimal_environment",
+            cache_scope="runtime_tail",
+            digest_inputs={
+                "directory": session_directory,
+                "runtime_day": datetime.now().strftime("%Y-%m-%d"),
+                "platform": platform.system().lower(),
+            },
+            builder=lambda: cls._build_minimal_environment(session_directory),
+        )
+        if environment_block is not None:
+            blocks.append(environment_block)
+
+        cls._append_turn_tail_blocks(
+            blocks=blocks,
+            turn_context=turn_context,
+            static_cache=static_cache,
+            session_id=session_id,
+        )
+        return blocks
+
+    @classmethod
+    async def build_system_prompt_blocks(
         cls,
         *,
         session_id: str,
@@ -1167,45 +1191,51 @@ class SessionPrompt:
         model_id: str,
         execution_mode_prompt: Optional[str] = None,
         prompt_tool_names: Iterable[str] = (),
-        tool_revision: Optional[int] = None,
         memory_bootstrap_data: Optional[Dict[str, Any]] = None,
         static_cache: Optional[SystemPromptCache] = None,
-        sandbox_prompt_factory: Optional[AsyncPromptFactory] = None,
-        channel_context_prompt_factory: Optional[AsyncPromptFactory] = None,
-        tool_catalog_prompt_factory: Optional[StringPromptFactory] = None,
-        device_asset_prompt_factory: Optional[AsyncPromptFactory] = None,
-        device_revision: Optional[int] = None,
+        turn_context: Optional[TurnPromptContext] = None,
         use_text_tool_call_mode: bool = False,
-    ) -> List[str]:
-        """Build the runtime system prompt blocks for a session turn.
+    ) -> List[SystemPromptBlock]:
+        """Build the ordered system prompt blocks for a session turn.
 
         Stable identity and execution guidance come first, followed by
         session/workspace context, with runtime-only metadata kept at the
-        prompt tail. Cache mechanics are intentionally kept out of the block
-        construction below so this method reads as an ordered list of prompt
-        layers.
+        prompt tail. Runtime I/O is collected before this method so assembly is
+        deterministic and every downstream consumer sees the same blocks.
         """
+        turn_context = turn_context or TurnPromptContext()
         vcs = "git" if session_directory else None
-        if await cls._is_builtin_system_subagent_session(
-            session_id=session_id,
-            agent_name=agent_name,
-        ):
-            prompts = await cls._build_subagent_minimal_prompts(
+        minimal_prompt = turn_context.minimal_prompt
+        if minimal_prompt is None:
+            minimal_prompt = await cls._is_builtin_system_subagent_session(
+                session_id=session_id,
+                agent_name=agent_name,
+            )
+        if minimal_prompt:
+            minimal_blocks = cls._build_subagent_minimal_blocks(
+                session_id=session_id,
                 session_directory=session_directory,
                 agent_prompt=agent_prompt,
+                turn_context=turn_context,
+                static_cache=static_cache,
             )
             cls._print_system_prompts_for_debug(
                 session_id=session_id,
                 agent_name=agent_name,
                 provider_id=provider_id,
                 model_id=model_id,
-                prompts=prompts,
+                blocks=minimal_blocks,
             )
-            return prompts
+            return minimal_blocks
 
         normalized_tool_names = tuple(sorted(prompt_tool_names))
         runtime_day = datetime.now().strftime("%Y-%m-%d")
-        custom_signature = SystemPrompt.custom_signature(directory=session_directory)
+        config_instructions = list(turn_context.config_instructions)
+        custom_signature = SystemPrompt.custom_signature(
+            directory=session_directory,
+            worktree=turn_context.worktree,
+            config_instructions=config_instructions,
+        )
         memory_guidance = cls._build_memory_guidance_prompt(
             normalized_tool_names,
             memory_bootstrap_data,
@@ -1217,7 +1247,11 @@ class SessionPrompt:
 
         async def build_custom_context() -> Optional[str]:
             return cls._join_prompt_parts(
-                await SystemPrompt.custom(directory=session_directory),
+                await SystemPrompt.custom(
+                    directory=session_directory,
+                    worktree=turn_context.worktree,
+                    config_instructions=config_instructions,
+                ),
             )
 
         blocks: List[Optional[SystemPromptBlock]] = [
@@ -1281,23 +1315,32 @@ class SessionPrompt:
                 cache_scope="catalog",
                 digest_inputs={
                     "agent_name": agent_name,
-                    "tool_revision": tool_revision,
+                    "tool_revision": turn_context.tool_revision,
+                    "content": turn_context.tool_catalog or "",
                 },
-                builder=lambda: cls._build_optional_prompt(tool_catalog_prompt_factory) or "",
+                builder=lambda: cls._normalize_prompt_text(
+                    turn_context.tool_catalog,
+                ),
             ),
         ]
 
-        if device_asset_prompt_factory:
-            blocks.append(await cls._build_cached_async_prompt_block(
-                static_cache=static_cache,
-                name="device_asset_hint",
-                cache_scope="runtime",
-                digest_inputs={
-                    "session_id": session_id,
-                    "device_revision": device_revision,
-                },
-                builder=device_asset_prompt_factory,
-            ))
+        if turn_context.device_asset_hint:
+            blocks.append(
+                cls._build_cached_prompt_block(
+                    static_cache=static_cache,
+                    name="device_asset_hint",
+                    cache_scope="runtime",
+                    digest_inputs={
+                        "session_id": session_id,
+                        "device_revision": turn_context.device_revision,
+                        "tool_revision": turn_context.tool_revision,
+                        "content": turn_context.device_asset_hint,
+                    },
+                    builder=lambda: cls._normalize_prompt_text(
+                        turn_context.device_asset_hint,
+                    ),
+                )
+            )
 
         blocks.append(
             cls._build_cached_prompt_block(
@@ -1319,33 +1362,52 @@ class SessionPrompt:
             static_cache=static_cache,
             name="context_files",
             cache_scope="workspace",
-            digest_inputs={"directory": session_directory, "signature": custom_signature},
-            builder=build_custom_context,
+            digest_inputs={
+                "directory": session_directory,
+                "worktree": turn_context.worktree,
+                "signature": custom_signature,
+            },
+            loader=build_custom_context,
         )
         blocks.append(custom_block)
 
-        if sandbox_prompt_factory:
-            blocks.append(await cls._build_cached_async_prompt_block(
-                static_cache=static_cache,
-                name="sandbox_context",
-                cache_scope="runtime",
-                digest_inputs={"session_id": session_id, "agent_name": agent_name},
-                builder=sandbox_prompt_factory,
-            ))
+        if turn_context.sandbox_context:
+            blocks.append(
+                cls._build_cached_prompt_block(
+                    static_cache=static_cache,
+                    name="sandbox_context",
+                    cache_scope="runtime_tail",
+                    digest_inputs={
+                        "session_id": session_id,
+                        "agent_name": agent_name,
+                        "content": turn_context.sandbox_context,
+                    },
+                    builder=lambda: cls._normalize_prompt_text(
+                        turn_context.sandbox_context,
+                    ),
+                )
+            )
 
-        if channel_context_prompt_factory:
-            blocks.append(await cls._build_cached_async_prompt_block(
-                static_cache=static_cache,
-                name="channel_context",
-                cache_scope="runtime",
-                digest_inputs={"session_id": session_id},
-                builder=channel_context_prompt_factory,
-            ))
+        if turn_context.channel_context:
+            blocks.append(
+                cls._build_cached_prompt_block(
+                    static_cache=static_cache,
+                    name="channel_context",
+                    cache_scope="runtime_tail",
+                    digest_inputs={
+                        "session_id": session_id,
+                        "content": turn_context.channel_context,
+                    },
+                    builder=lambda: cls._normalize_prompt_text(
+                        turn_context.channel_context,
+                    ),
+                )
+            )
 
         blocks.append(cls._build_cached_prompt_block(
             static_cache=static_cache,
             name="runtime_metadata",
-            cache_scope="runtime",
+            cache_scope="runtime_tail",
             digest_inputs={
                 "session_id": session_id,
                 "directory": session_directory,
@@ -1364,28 +1426,55 @@ class SessionPrompt:
             ),
         ))
 
-        cache_key = cls._system_prompt_cache_key(
+        resolved_blocks = [block for block in blocks if block is not None]
+        cls._append_turn_tail_blocks(
+            blocks=resolved_blocks,
+            turn_context=turn_context,
+            static_cache=static_cache,
             session_id=session_id,
-            agent_name=agent_name,
-            provider_id=provider_id,
-            model_id=model_id,
-            block_keys=[block.cache_key for block in blocks if block is not None],
         )
-        cached_prompts = cls._read_system_prompt_cache(static_cache, cache_key)
-        if cached_prompts is not None:
-            return cached_prompts
-
-        prompts = cls._prompt_blocks_to_list(blocks)
         cls._print_system_prompts_for_debug(
             session_id=session_id,
             agent_name=agent_name,
             provider_id=provider_id,
             model_id=model_id,
-            prompts=prompts,
+            blocks=resolved_blocks,
         )
+        return resolved_blocks
 
-        cls._write_system_prompt_cache(static_cache, cache_key, prompts)
-        return list(prompts)
+    @classmethod
+    async def build_system_prompts(
+        cls,
+        *,
+        session_id: str,
+        session_directory: Optional[str],
+        agent_name: str,
+        agent_prompt: Optional[str],
+        provider_id: str,
+        model_id: str,
+        execution_mode_prompt: Optional[str] = None,
+        prompt_tool_names: Iterable[str] = (),
+        memory_bootstrap_data: Optional[Dict[str, Any]] = None,
+        static_cache: Optional[SystemPromptCache] = None,
+        turn_context: Optional[TurnPromptContext] = None,
+        use_text_tool_call_mode: bool = False,
+    ) -> List[str]:
+        """Compatibility API returning only the assembled prompt text."""
+        blocks = await cls.build_system_prompt_blocks(
+            session_id=session_id,
+            session_directory=session_directory,
+            agent_name=agent_name,
+            agent_prompt=agent_prompt,
+            provider_id=provider_id,
+            model_id=model_id,
+            execution_mode_prompt=execution_mode_prompt,
+            prompt_tool_names=prompt_tool_names,
+            memory_bootstrap_data=memory_bootstrap_data,
+            static_cache=static_cache,
+            turn_context=turn_context,
+            use_text_tool_call_mode=use_text_tool_call_mode,
+        )
+        return cls._prompt_blocks_to_list(blocks)
 
     @classmethod
     def _build_context_section(cls, context: ContextInfo) -> str:

--- a/flocks/session/prompt.py
+++ b/flocks/session/prompt.py
@@ -6,7 +6,7 @@ Based on Flocks' ported src/session/prompt.ts and src/session/system.ts
 """
 
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Awaitable, Callable, Dict, Any, Iterable, List, Optional, TYPE_CHECKING, Union
 from pydantic import BaseModel, Field
 import hashlib
@@ -35,7 +35,9 @@ if TYPE_CHECKING:
 # Output token maximum
 OUTPUT_TOKEN_MAX = int(os.getenv("FLOCKS_OUTPUT_TOKEN_MAX", "32000"))
 SystemPromptCache = Dict[str, Any]
-AsyncPromptLoader = Callable[[], Awaitable[Optional[str]]]
+AsyncPromptFactory = Callable[[], Awaitable[Optional[str]]]
+StringPromptFactory = Callable[[], Optional[str]]
+AsyncPromptLoader = AsyncPromptFactory
 
 
 # Prompt template directory (same structure as Flocks)
@@ -1454,12 +1456,73 @@ class SessionPrompt:
         model_id: str,
         execution_mode_prompt: Optional[str] = None,
         prompt_tool_names: Iterable[str] = (),
+        tool_revision: Optional[int] = None,
         memory_bootstrap_data: Optional[Dict[str, Any]] = None,
         static_cache: Optional[SystemPromptCache] = None,
+        sandbox_prompt_factory: Optional[AsyncPromptFactory] = None,
+        channel_context_prompt_factory: Optional[AsyncPromptFactory] = None,
+        tool_catalog_prompt_factory: Optional[StringPromptFactory] = None,
+        device_asset_prompt_factory: Optional[AsyncPromptFactory] = None,
+        device_revision: Optional[int] = None,
         turn_context: Optional[TurnPromptContext] = None,
         use_text_tool_call_mode: bool = False,
     ) -> List[str]:
-        """Compatibility API returning only the assembled prompt text."""
+        """Compatibility API returning only the assembled prompt text.
+
+        Legacy prompt factories populate missing values in ``turn_context``.
+        Explicit context values take precedence when both APIs are used.
+        """
+        legacy_context_requested = any((
+            tool_revision is not None,
+            sandbox_prompt_factory is not None,
+            channel_context_prompt_factory is not None,
+            tool_catalog_prompt_factory is not None,
+            device_asset_prompt_factory is not None,
+            device_revision is not None,
+        ))
+        if legacy_context_requested:
+            resolved_context = turn_context or TurnPromptContext()
+            minimal_prompt = resolved_context.minimal_prompt
+            if minimal_prompt is None:
+                minimal_prompt = await cls._is_builtin_system_subagent_session(
+                    session_id=session_id,
+                    agent_name=agent_name,
+                )
+
+            context_updates: Dict[str, Any] = {"minimal_prompt": minimal_prompt}
+            if resolved_context.tool_revision is None and tool_revision is not None:
+                context_updates["tool_revision"] = tool_revision
+            if resolved_context.device_revision is None and device_revision is not None:
+                context_updates["device_revision"] = device_revision
+
+            if not minimal_prompt:
+                if (
+                    resolved_context.tool_catalog is None
+                    and tool_catalog_prompt_factory is not None
+                ):
+                    context_updates["tool_catalog"] = tool_catalog_prompt_factory()
+                if (
+                    resolved_context.device_asset_hint is None
+                    and device_asset_prompt_factory is not None
+                ):
+                    context_updates["device_asset_hint"] = (
+                        await device_asset_prompt_factory()
+                    )
+                if (
+                    resolved_context.sandbox_context is None
+                    and sandbox_prompt_factory is not None
+                ):
+                    context_updates["sandbox_context"] = await sandbox_prompt_factory()
+                if (
+                    resolved_context.channel_context is None
+                    and channel_context_prompt_factory is not None
+                ):
+                    context_updates["channel_context"] = (
+                        await channel_context_prompt_factory()
+                    )
+
+            turn_context = replace(resolved_context, **context_updates)
+
         blocks = await cls.build_system_prompt_blocks(
             session_id=session_id,
             session_directory=session_directory,

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -19,7 +19,7 @@ import time
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Optional, Dict, Any, List, Callable, Awaitable, Tuple
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import httpcore
 import httpx
@@ -28,7 +28,7 @@ from flocks.utils.log import Log
 from flocks.utils.id import Identifier
 from flocks.session.session import Session, SessionInfo
 from flocks.session.message import Message, MessageInfo, MessageRole, TextPart
-from flocks.session.prompt import SessionPrompt
+from flocks.session.prompt import SessionPrompt, SystemPromptBlock, TurnPromptContext
 from flocks.session.core.status import SessionStatus, SessionStatusRetry, SessionStatusBusy
 from flocks.session.core.defaults import (
     DEFAULT_MAX_TOOL_STEPS,
@@ -1509,24 +1509,19 @@ class SessionRunner:
         self._log_perf("runner.process_step.tools_ready", tools_started_at, tool_count=len(tools))
         prompt_tool_names = self._get_prompt_tool_names_from_schema(tools)
 
-        async def sandbox_prompt_factory() -> Optional[str]:
-            return await self._build_sandbox_prompt(agent)
-
-        async def channel_context_prompt_factory() -> Optional[str]:
-            return await self._build_channel_context_prompt()
-
-        async def device_asset_prompt_factory() -> Optional[str]:
-            return await self._build_device_asset_hint()
-
-        try:
-            from flocks.tool.device.store import device_revision as get_device_revision
-
-            current_device_revision = get_device_revision()
-        except Exception:
-            current_device_revision = None
-
         prompts_started_at = time.perf_counter()
-        system_prompts = await SessionPrompt.build_system_prompts(
+        minimal_prompt = await SessionPrompt._is_builtin_system_subagent_session(
+            session_id=self.session.id,
+            agent_name=agent.name,
+        )
+        turn_prompt_context = await self._build_turn_prompt_context(
+            agent=agent,
+            messages=messages,
+            last_user=last_user,
+            tools=tools,
+            minimal_prompt=minimal_prompt,
+        )
+        system_prompts = await SessionPrompt.build_system_prompt_blocks(
             session_id=self.session.id,
             session_directory=self.session.directory,
             agent_name=agent.name,
@@ -1539,56 +1534,14 @@ class SessionRunner:
                 plan_file=self._turn_plan_file,
             ),
             prompt_tool_names=prompt_tool_names,
-            tool_revision=ToolRegistry.revision(),
             memory_bootstrap_data=self._memory_bootstrap_data,
             static_cache=self._static_cache,
-            sandbox_prompt_factory=sandbox_prompt_factory,
-            channel_context_prompt_factory=channel_context_prompt_factory,
-            tool_catalog_prompt_factory=lambda: self._build_tool_catalog_prompt(agent),
-            device_asset_prompt_factory=device_asset_prompt_factory,
-            device_revision=current_device_revision,
+            turn_context=turn_prompt_context,
             use_text_tool_call_mode=self._should_use_text_tool_call_mode(),
         )
         self._log_perf("runner.process_step.system_prompts_ready", prompts_started_at, prompt_count=len(system_prompts))
 
         await self._run_session_start_hook(agent)
-
-        if self._turn_additional_context:
-            system_prompts.append(self._turn_additional_context)
-
-        if self._should_use_text_tool_call_mode() and tools:
-            text_tool_catalog = self._build_text_tool_call_catalog_prompt(tools)
-            if text_tool_catalog:
-                system_prompts.append(text_tool_catalog)
-
-        # If the last assistant message only contains tool results and no text,
-        # force a direct answer to avoid repeated tool calls.
-        last_assistant_msg = None
-        for msg in reversed(messages):
-            if msg.role == MessageRole.ASSISTANT:
-                last_assistant_msg = msg
-                break
-        if last_assistant_msg:
-            parts = await Message.parts(last_assistant_msg.id, self.session.id)
-            has_text = any(getattr(p, "type", None) == "text" and getattr(p, "text", "").strip() for p in parts)
-            has_tool_result = any(
-                getattr(p, "type", None) == "tool" and
-                getattr(getattr(p, "state", None), "status", None) in ("completed", "error", "running")
-                for p in parts
-            )
-            if has_tool_result and not has_text:
-                from flocks.session.prompt_strings import PROMPT_TOOL_RESULTS_AVAILABLE
-                system_prompts.append(PROMPT_TOOL_RESULTS_AVAILABLE)
-            
-            if has_tool_result and self._should_warn_about_tool_loop(last_user_id=last_user.id):
-                state = self._get_tool_loop_guard_state(last_user_id=last_user.id)
-                log.warn("runner.repeated_tool_calls_detected", {
-                    "tool_name": state.get("last_signature", "").split(":", 1)[0],
-                    "exact_count": state.get("exact_count", 0),
-                    "step": self._step,
-                })
-                from flocks.session.prompt_strings import PROMPT_REPEATED_TOOL_CALLS
-                system_prompts.append(PROMPT_REPEATED_TOOL_CALLS)
 
         # Convert messages to chat format with error handling
         try:
@@ -2100,6 +2053,133 @@ class SessionRunner:
                 "error": str(exc),
             })
     
+    async def _build_turn_prompt_context(
+        self,
+        *,
+        agent: AgentInfo,
+        messages: List[MessageInfo],
+        last_user: MessageInfo,
+        tools: List[Dict[str, Any]],
+        minimal_prompt: bool = False,
+    ) -> TurnPromptContext:
+        """Collect cached runtime values before deterministic prompt assembly."""
+        if minimal_prompt:
+            return await self._add_turn_prompt_tail(
+                TurnPromptContext(minimal_prompt=True),
+                messages=messages,
+                last_user=last_user,
+                tools=tools,
+            )
+
+        from flocks.config import Config
+        from flocks.project.instance import Instance
+
+        try:
+            from flocks.tool.device.store import device_revision
+
+            current_device_revision = device_revision()
+        except Exception:
+            current_device_revision = None
+
+        current_tool_revision = ToolRegistry.revision()
+        try:
+            config = await Config.get()
+            config_data = config.model_dump(by_alias=True, exclude_none=True)
+            config_instructions = tuple(config.instructions or ())
+        except Exception as exc:
+            log.debug("runner.prompt_context.config_error", {"error": str(exc)})
+            config_data = None
+            config_instructions = ()
+
+        worktree = Instance.get_worktree()
+        sandbox_context, channel_context, device_asset_hint = await asyncio.gather(
+            self._build_sandbox_prompt(agent, config_data=config_data),
+            self._build_channel_context_prompt(),
+            self._build_device_asset_hint(),
+        )
+        source_context = TurnPromptContext(
+            tool_catalog=self._build_tool_catalog_prompt(agent),
+            device_asset_hint=device_asset_hint,
+            sandbox_context=sandbox_context,
+            channel_context=channel_context,
+            worktree=worktree,
+            config_instructions=config_instructions,
+            tool_revision=current_tool_revision,
+            device_revision=current_device_revision,
+            minimal_prompt=False,
+        )
+
+        return await self._add_turn_prompt_tail(
+            source_context,
+            messages=messages,
+            last_user=last_user,
+            tools=tools,
+        )
+
+    async def _add_turn_prompt_tail(
+        self,
+        source_context: TurnPromptContext,
+        *,
+        messages: List[MessageInfo],
+        last_user: MessageInfo,
+        tools: List[Dict[str, Any]],
+    ) -> TurnPromptContext:
+        """Add uncached per-step context and reminders to a source snapshot."""
+        text_tool_catalog = None
+        if self._should_use_text_tool_call_mode() and tools:
+            text_tool_catalog = self._build_text_tool_call_catalog_prompt(tools)
+
+        tool_results_reminder = None
+        repeated_tool_calls_reminder = None
+        last_assistant_msg = next(
+            (
+                message
+                for message in reversed(messages)
+                if message.role == MessageRole.ASSISTANT
+            ),
+            None,
+        )
+        if last_assistant_msg is not None:
+            parts = await Message.parts(last_assistant_msg.id, self.session.id)
+            has_text = any(
+                getattr(part, "type", None) == "text"
+                and getattr(part, "text", "").strip()
+                for part in parts
+            )
+            has_tool_result = any(
+                getattr(part, "type", None) == "tool"
+                and getattr(getattr(part, "state", None), "status", None)
+                in ("completed", "error", "running")
+                for part in parts
+            )
+            if has_tool_result and not has_text:
+                from flocks.session.prompt_strings import (
+                    PROMPT_TOOL_RESULTS_AVAILABLE,
+                )
+
+                tool_results_reminder = PROMPT_TOOL_RESULTS_AVAILABLE
+
+            if has_tool_result and self._should_warn_about_tool_loop(
+                last_user_id=last_user.id,
+            ):
+                state = self._get_tool_loop_guard_state(last_user_id=last_user.id)
+                log.warn("runner.repeated_tool_calls_detected", {
+                    "tool_name": state.get("last_signature", "").split(":", 1)[0],
+                    "exact_count": state.get("exact_count", 0),
+                    "step": self._step,
+                })
+                from flocks.session.prompt_strings import PROMPT_REPEATED_TOOL_CALLS
+
+                repeated_tool_calls_reminder = PROMPT_REPEATED_TOOL_CALLS
+
+        return replace(
+            source_context,
+            additional_context=self._turn_additional_context,
+            text_tool_catalog=text_tool_catalog,
+            tool_results_reminder=tool_results_reminder,
+            repeated_tool_calls_reminder=repeated_tool_calls_reminder,
+        )
+
     async def _build_device_asset_hint(self) -> Optional[str]:
         """Return concise device-aware tool guidance plus enabled device summary."""
         try:
@@ -2142,15 +2222,22 @@ class SessionRunner:
             "如果同类设备有多个候选，不要猜测，先询问用户选择。"
         )
 
-    async def _build_sandbox_prompt(self, agent: AgentInfo) -> Optional[str]:
+    async def _build_sandbox_prompt(
+        self,
+        agent: AgentInfo,
+        *,
+        config_data: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
         """Build sandbox context prompt when sandboxing is active."""
         try:
-            from flocks.config import Config
             from flocks.session.core.session_state import get_main_session_id
             from flocks.sandbox.system_prompt import build_sandbox_system_prompt
 
-            cfg = await Config.get()
-            config_data = cfg.model_dump(by_alias=True, exclude_none=True)
+            if config_data is None:
+                from flocks.config import Config
+
+                config = await Config.get()
+                config_data = config.model_dump(by_alias=True, exclude_none=True)
             session_key = self.session.id
             main_session_key = get_main_session_id() or self.session.id
             return await build_sandbox_system_prompt(
@@ -2662,14 +2749,26 @@ class SessionRunner:
 
     def _build_system_message_content(
         self,
-        system_prompts: List[str],
+        system_prompts: List[SystemPromptBlock] | List[str],
     ) -> str | list[dict[str, Any]]:
         """Format system prompts for the active provider.
 
         Anthropic supports structured system blocks, which lets us place a
         conservative cache breakpoint before the dynamic runtime tail.
         """
-        prompt_parts = [prompt for prompt in system_prompts if prompt and prompt.strip()]
+        typed_blocks = [
+            block
+            for block in system_prompts
+            if isinstance(block, SystemPromptBlock) and block.content.strip()
+        ]
+        if typed_blocks:
+            prompt_parts = [block.content for block in typed_blocks]
+        else:
+            prompt_parts = [
+                prompt
+                for prompt in system_prompts
+                if isinstance(prompt, str) and prompt.strip()
+            ]
         if not prompt_parts:
             return ""
 
@@ -2677,7 +2776,19 @@ class SessionRunner:
         if "anthropic" not in provider_lower:
             return "\n\n".join(prompt_parts)
 
-        cache_break_index = max(0, len(prompt_parts) - 3)
+        if typed_blocks:
+            first_runtime_tail = next(
+                (
+                    index
+                    for index, block in enumerate(typed_blocks)
+                    if block.cache_scope == "runtime_tail"
+                ),
+                len(typed_blocks),
+            )
+            cache_break_index = max(0, first_runtime_tail - 1)
+        else:
+            # Compatibility for callers still passing plain strings.
+            cache_break_index = max(0, len(prompt_parts) - 3)
         blocks: list[dict[str, Any]] = []
         for index, prompt in enumerate(prompt_parts):
             block: dict[str, Any] = {
@@ -2692,7 +2803,7 @@ class SessionRunner:
     async def _to_chat_messages(
         self,
         messages: List[MessageInfo],
-        system_prompts: List[str],
+        system_prompts: List[SystemPromptBlock] | List[str],
     ) -> List[ChatMessage]:
         """
         Convert messages to chat format with tool calls.

--- a/tests/agent/test_prompt_builders.py
+++ b/tests/agent/test_prompt_builders.py
@@ -1,0 +1,36 @@
+"""Direct tests for Rex and Hephaestus prompt builders."""
+
+import inspect
+
+from flocks.agent.agents.hephaestus.prompt_builder import build_hephaestus_prompt
+from flocks.agent.agents.rex.prompt_builder import build_dynamic_rex_prompt
+
+
+def test_rex_prompt_uses_todos_and_delegate_task_only():
+    prompt = build_dynamic_rex_prompt([], [], [], [])
+
+    assert "## Todo Management" in prompt
+    assert "YOUR TODO CREATION WOULD BE TRACKED BY HOOK" in prompt
+    assert "multiple foreground `delegate_task` tool calls" in prompt
+    assert "`delegate_task` / `task`" not in prompt
+    assert "After code changes, run the lint/typecheck/tests." in prompt
+    assert "If tests fail, iterate until they pass before finalizing." in prompt
+    assert "explicit note about pre-existing failures" in prompt
+    assert "Verify delegated work against expected behavior" in prompt
+    assert "TaskCreate" not in prompt
+    assert "TaskUpdate" not in prompt
+
+
+def test_hephaestus_prompt_uses_existing_todo_discipline():
+    prompt = build_hephaestus_prompt([], [], [])
+
+    assert "## Todo Discipline (NON-NEGOTIABLE)" in prompt
+    assert "Track ALL multi-step work with todos." in prompt
+    assert '`todo(action="write")`' in prompt
+    assert "TaskCreate" not in prompt
+    assert "TaskUpdate" not in prompt
+
+
+def test_prompt_builder_signatures_exclude_task_system_flag():
+    assert "use_task_system" not in inspect.signature(build_dynamic_rex_prompt).parameters
+    assert "use_task_system" not in inspect.signature(build_hephaestus_prompt).parameters

--- a/tests/agent/test_prompt_builders.py
+++ b/tests/agent/test_prompt_builders.py
@@ -1,6 +1,6 @@
 """Direct tests for Rex and Hephaestus prompt builders."""
 
-import inspect
+import pytest
 
 from flocks.agent.agents.hephaestus.prompt_builder import build_hephaestus_prompt
 from flocks.agent.agents.rex.prompt_builder import build_dynamic_rex_prompt
@@ -31,6 +31,23 @@ def test_hephaestus_prompt_uses_existing_todo_discipline():
     assert "TaskUpdate" not in prompt
 
 
-def test_prompt_builder_signatures_exclude_task_system_flag():
-    assert "use_task_system" not in inspect.signature(build_dynamic_rex_prompt).parameters
-    assert "use_task_system" not in inspect.signature(build_hephaestus_prompt).parameters
+@pytest.mark.parametrize("use_task_system", [False, True])
+def test_prompt_builders_ignore_task_system_flag(use_task_system):
+    rex_prompt = build_dynamic_rex_prompt(
+        [],
+        [],
+        [],
+        [],
+        use_task_system=use_task_system,
+    )
+    hephaestus_prompt = build_hephaestus_prompt(
+        [],
+        [],
+        [],
+        use_task_system=use_task_system,
+    )
+
+    assert "## Todo Management" in rex_prompt
+    assert "## Todo Discipline (NON-NEGOTIABLE)" in hephaestus_prompt
+    assert "TaskCreate" not in rex_prompt
+    assert "TaskCreate" not in hephaestus_prompt

--- a/tests/session/test_context_usage.py
+++ b/tests/session/test_context_usage.py
@@ -1,8 +1,10 @@
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 from flocks.session import context_usage
+from flocks.session.prompt import SystemPromptBlock, TurnPromptContext
 
 
 def _message(
@@ -305,3 +307,58 @@ async def test_context_usage_splits_skill_and_delegation_tools(context_usage_moc
     ]
     tools_segment = next(segment for segment in snapshot.segments if segment.key == "tools")
     assert tools_segment.tokens == 30
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_estimate_uses_resolved_turn_context(monkeypatch):
+    captured = {}
+
+    async def fake_build_system_prompt_blocks(**kwargs):
+        captured.update(kwargs)
+        return [
+            SystemPromptBlock("stable", "a" * 40, "global"),
+            SystemPromptBlock("tail", "b" * 20, "runtime_tail"),
+        ]
+
+    agent = SimpleNamespace(name="rex", prompt="agent prompt")
+    config = SimpleNamespace(instructions=["rules.md"])
+    monkeypatch.setattr(
+        context_usage.SessionPrompt,
+        "build_system_prompt_blocks",
+        fake_build_system_prompt_blocks,
+    )
+    monkeypatch.setattr(
+        "flocks.agent.registry.Agent.default_agent",
+        AsyncMock(return_value="rex"),
+    )
+    monkeypatch.setattr(
+        "flocks.agent.registry.Agent.get",
+        AsyncMock(return_value=agent),
+    )
+    monkeypatch.setattr(
+        "flocks.config.Config.get",
+        AsyncMock(return_value=config),
+    )
+    monkeypatch.setattr(
+        "flocks.project.instance.Instance.get_worktree",
+        lambda: "/workspace",
+    )
+    monkeypatch.setattr(
+        "flocks.tool.registry.ToolRegistry.revision",
+        lambda: 7,
+    )
+
+    tokens = await context_usage._estimate_system_prompt_tokens(
+        "sess-1",
+        session=SimpleNamespace(directory="/workspace/project"),
+        messages=[],
+        provider_id="openai",
+        model_id="gpt-5",
+    )
+
+    assert tokens == 15
+    assert captured["turn_context"] == TurnPromptContext(
+        worktree="/workspace",
+        config_instructions=("rules.md",),
+        tool_revision=7,
+    )

--- a/tests/session/test_context_usage.py
+++ b/tests/session/test_context_usage.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -339,9 +339,14 @@ async def test_system_prompt_estimate_uses_resolved_turn_context(monkeypatch):
         "flocks.config.Config.get",
         AsyncMock(return_value=config),
     )
+    worktree_for_directory = MagicMock(return_value="/workspace")
+    monkeypatch.setattr(
+        "flocks.project.project.Project.worktree_for_directory",
+        worktree_for_directory,
+    )
     monkeypatch.setattr(
         "flocks.project.instance.Instance.get_worktree",
-        lambda: "/workspace",
+        lambda: "/ambient-worktree",
     )
     monkeypatch.setattr(
         "flocks.tool.registry.ToolRegistry.revision",
@@ -362,3 +367,4 @@ async def test_system_prompt_estimate_uses_resolved_turn_context(monkeypatch):
         config_instructions=("rules.md",),
         tool_revision=7,
     )
+    worktree_for_directory.assert_called_once_with("/workspace/project")

--- a/tests/session/test_prompt_tokens.py
+++ b/tests/session/test_prompt_tokens.py
@@ -26,6 +26,7 @@ from flocks.session.prompt import (
     PromptTemplate,
     SessionPrompt,
     SystemPrompt,
+    TurnPromptContext,
 )
 from flocks.session import prompt_strings
 
@@ -265,7 +266,9 @@ class TestBuildSystemPrompts:
                 agent_prompt="You are Rex Junior.",
                 provider_id="anthropic",
                 model_id="claude-sonnet",
-                tool_catalog_prompt_factory=lambda: "SHOULD_NOT_APPEAR",
+                turn_context=TurnPromptContext(
+                    tool_catalog="SHOULD_NOT_APPEAR",
+                ),
             )
 
         assert len(prompts) == 3
@@ -304,6 +307,38 @@ class TestBuildSystemPrompts:
 
         assert len(prompts) > 2
         assert any(PROMPT_DEFAULT.strip() in prompt for prompt in prompts)
+
+    @pytest.mark.asyncio
+    async def test_full_prompt_loads_worktree_and_config_instructions(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        nested = tmp_path / "src" / "package"
+        nested.mkdir(parents=True)
+        (tmp_path / "AGENTS.md").write_text("project rules", encoding="utf-8")
+        (nested / "extra-rules.md").write_text("extra rules", encoding="utf-8")
+
+        with patch.object(
+            SessionPrompt,
+            "_is_builtin_system_subagent_session",
+            AsyncMock(return_value=False),
+        ):
+            prompts = await SessionPrompt.build_system_prompts(
+                session_id="ses-instructions",
+                session_directory=str(nested),
+                agent_name="rex",
+                agent_prompt="agent prompt",
+                provider_id="openai",
+                model_id="gpt-5",
+                turn_context=TurnPromptContext(
+                    worktree=str(tmp_path),
+                    config_instructions=("extra-rules.md",),
+                ),
+            )
+
+        combined = "\n\n".join(prompts)
+        assert "project rules" in combined
+        assert "extra rules" in combined
 
     @pytest.mark.asyncio
     async def test_evolution_subagent_child_uses_full_prompt(self):

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -635,6 +635,47 @@ class TestBuildTools:
 
 class TestBuildSystemPrompts:
     @pytest.mark.asyncio
+    async def test_build_system_prompts_accepts_legacy_context_factories(self):
+        sandbox_mock = AsyncMock(return_value="legacy sandbox prompt")
+        channel_mock = AsyncMock(return_value="legacy channel prompt")
+        device_mock = AsyncMock(return_value="legacy device prompt")
+
+        with (
+            patch.object(
+                SessionPrompt,
+                "_is_builtin_system_subagent_session",
+                AsyncMock(return_value=False),
+            ),
+            patch(
+                "flocks.session.prompt.SystemPrompt.custom",
+                AsyncMock(return_value=[]),
+            ),
+        ):
+            prompts = await SessionPrompt.build_system_prompts(
+                session_id="ses_legacy_prompt_context",
+                session_directory="/tmp",
+                agent_name="rex",
+                agent_prompt="agent prompt",
+                provider_id="openai",
+                model_id="gpt-5",
+                tool_revision=3,
+                sandbox_prompt_factory=sandbox_mock,
+                channel_context_prompt_factory=channel_mock,
+                tool_catalog_prompt_factory=lambda: "legacy tool catalog",
+                device_asset_prompt_factory=device_mock,
+                device_revision=5,
+            )
+
+        combined = "\n\n".join(prompts)
+        assert "legacy tool catalog" in combined
+        assert "legacy device prompt" in combined
+        assert "legacy sandbox prompt" in combined
+        assert "legacy channel prompt" in combined
+        sandbox_mock.assert_awaited_once()
+        channel_mock.assert_awaited_once()
+        device_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_build_system_prompts_reuses_loop_static_cache(self):
         shared_cache = {}
         session = _make_session("ses_prompts_cache")

--- a/tests/session/test_runner_step.py
+++ b/tests/session/test_runner_step.py
@@ -33,7 +33,12 @@ from flocks.session.runner import (
     StepResult,
     ToolCall,
 )
-from flocks.session.prompt import SessionPrompt, get_prompt_flocks_config_guard
+from flocks.session.prompt import (
+    SessionPrompt,
+    SystemPromptBlock,
+    TurnPromptContext,
+    get_prompt_flocks_config_guard,
+)
 from flocks.session.core.defaults import DEFAULT_MAX_TOOL_STEPS
 from flocks.session.session import Session, SessionInfo
 from flocks.tool.registry import ToolCategory, ToolInfo
@@ -641,14 +646,21 @@ class TestBuildSystemPrompts:
         env_mock = MagicMock(return_value=["env prompt"])
         runtime_mock = MagicMock(return_value=["runtime prompt"])
         custom_mock = AsyncMock(return_value=["custom prompt"])
-        sandbox_mock = AsyncMock(return_value="sandbox prompt")
-        channel_mock = AsyncMock(return_value="channel prompt")
-        device_mock = AsyncMock(return_value="device prompt")
+        turn_context = TurnPromptContext(
+            sandbox_context="sandbox prompt",
+            channel_context="channel prompt",
+            tool_catalog="tool catalog",
+            device_asset_hint="device prompt",
+            tool_revision=1,
+            device_revision=7,
+        )
 
-        with patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]), \
-             patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock), \
-             patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock), \
-             patch("flocks.session.prompt.SystemPrompt.custom", custom_mock):
+        with (
+            patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]),
+            patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock),
+            patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock),
+            patch("flocks.session.prompt.SystemPrompt.custom", custom_mock),
+        ):
             prompts1 = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
                 session_directory=session.directory,
@@ -657,13 +669,8 @@ class TestBuildSystemPrompts:
                 provider_id=runner1.provider_id,
                 model_id=runner1.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
-                tool_catalog_prompt_factory=lambda: "tool catalog",
-                device_asset_prompt_factory=device_mock,
-                device_revision=7,
+                turn_context=turn_context,
             )
             prompts2 = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
@@ -673,22 +680,14 @@ class TestBuildSystemPrompts:
                 provider_id=runner2.provider_id,
                 model_id=runner2.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
-                tool_catalog_prompt_factory=lambda: "tool catalog",
-                device_asset_prompt_factory=device_mock,
-                device_revision=7,
+                turn_context=turn_context,
             )
 
         assert prompts1 == prompts2
         env_mock.assert_called_once()
         runtime_mock.assert_called_once()
         custom_mock.assert_awaited_once()
-        sandbox_mock.assert_awaited_once()
-        channel_mock.assert_awaited_once()
-        device_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_build_system_prompts_orders_stable_prefix_before_runtime_tail(self):
@@ -704,15 +703,13 @@ class TestBuildSystemPrompts:
                 "inject": True,
             },
         }
-        sandbox_mock = AsyncMock(return_value="sandbox prompt")
-        channel_mock = AsyncMock(return_value="channel prompt")
-        device_mock = AsyncMock(return_value="device prompt")
-
-        with patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]), \
-             patch.object(SessionPrompt, "_build_tool_guidance_prompt", return_value="tool protocol"), \
-             patch("flocks.session.prompt.SystemPrompt.environment_stable", return_value=["env prompt"]), \
-             patch("flocks.session.prompt.SystemPrompt.runtime_metadata", return_value=["runtime prompt"]), \
-             patch("flocks.session.prompt.SystemPrompt.custom", AsyncMock(return_value=["custom prompt"])):
+        with (
+            patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]),
+            patch.object(SessionPrompt, "_build_tool_guidance_prompt", return_value="tool protocol"),
+            patch("flocks.session.prompt.SystemPrompt.environment_stable", return_value=["env prompt"]),
+            patch("flocks.session.prompt.SystemPrompt.runtime_metadata", return_value=["runtime prompt"]),
+            patch("flocks.session.prompt.SystemPrompt.custom", AsyncMock(return_value=["custom prompt"])),
+        ):
             prompts = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
                 session_directory=session.directory,
@@ -730,11 +727,17 @@ class TestBuildSystemPrompts:
                     "write",
                 ),
                 memory_bootstrap_data=memory_bootstrap_data,
-                tool_catalog_prompt_factory=lambda: "tool catalog",
-                device_asset_prompt_factory=device_mock,
-                device_revision=3,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
+                turn_context=TurnPromptContext(
+                    tool_catalog="tool catalog",
+                    device_asset_hint="device prompt",
+                    sandbox_context="sandbox prompt",
+                    channel_context="channel prompt",
+                    additional_context="additional prompt",
+                    text_tool_catalog="text tool catalog",
+                    tool_results_reminder="tool results reminder",
+                    repeated_tool_calls_reminder="tool loop reminder",
+                    device_revision=3,
+                ),
             )
 
         assert prompts == [
@@ -751,6 +754,10 @@ class TestBuildSystemPrompts:
             "sandbox prompt",
             "channel prompt",
             "runtime prompt",
+            "additional prompt",
+            "text tool catalog",
+            "tool results reminder",
+            "tool loop reminder",
         ]
 
     @pytest.mark.asyncio
@@ -764,16 +771,12 @@ class TestBuildSystemPrompts:
         env_mock = MagicMock(return_value=["env prompt"])
         runtime_mock = MagicMock(return_value=["runtime prompt"])
         custom_mock = AsyncMock(return_value=["custom prompt"])
-        sandbox_mock = AsyncMock(return_value="sandbox prompt")
-        channel_mock = AsyncMock(return_value="channel prompt")
-        device_mock = AsyncMock(return_value="device prompt")
-
-        catalog_prompts = iter(["tool catalog v1", "tool catalog v2"])
-
-        with patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]), \
-             patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock), \
-             patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock), \
-             patch("flocks.session.prompt.SystemPrompt.custom", custom_mock):
+        with (
+            patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]),
+            patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock),
+            patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock),
+            patch("flocks.session.prompt.SystemPrompt.custom", custom_mock),
+        ):
             prompts1 = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
                 session_directory=session.directory,
@@ -782,13 +785,15 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
-                tool_catalog_prompt_factory=lambda: next(catalog_prompts),
-                device_asset_prompt_factory=device_mock,
-                device_revision=1,
+                turn_context=TurnPromptContext(
+                    sandbox_context="sandbox prompt",
+                    channel_context="channel prompt",
+                    tool_catalog="tool catalog v1",
+                    device_asset_hint="device prompt",
+                    tool_revision=1,
+                    device_revision=1,
+                ),
             )
             agent.prompt = "agent prompt v2"
             prompts2 = await SessionPrompt.build_system_prompts(
@@ -799,13 +804,15 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=2,
                 static_cache=shared_cache,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
-                tool_catalog_prompt_factory=lambda: next(catalog_prompts),
-                device_asset_prompt_factory=device_mock,
-                device_revision=1,
+                turn_context=TurnPromptContext(
+                    sandbox_context="sandbox prompt",
+                    channel_context="channel prompt",
+                    tool_catalog="tool catalog v2",
+                    device_asset_hint="device prompt",
+                    tool_revision=2,
+                    device_revision=1,
+                ),
             )
 
         assert prompts1 != prompts2
@@ -816,8 +823,6 @@ class TestBuildSystemPrompts:
         env_mock.assert_called_once()
         runtime_mock.assert_called_once()
         custom_mock.assert_awaited_once()
-        sandbox_mock.assert_awaited_once()
-        channel_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_build_system_prompts_reuses_static_device_hint_cache(self):
@@ -830,14 +835,20 @@ class TestBuildSystemPrompts:
         env_mock = MagicMock(return_value=["env prompt"])
         runtime_mock = MagicMock(return_value=["runtime prompt"])
         custom_mock = AsyncMock(return_value=["custom prompt"])
-        sandbox_mock = AsyncMock(return_value="sandbox prompt")
-        channel_mock = AsyncMock(return_value="channel prompt")
-        device_mock = AsyncMock(return_value="device prompt")
+        turn_context = TurnPromptContext(
+            sandbox_context="sandbox prompt",
+            channel_context="channel prompt",
+            tool_catalog="tool catalog",
+            device_asset_hint="device prompt",
+            tool_revision=1,
+        )
 
-        with patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]), \
-             patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock), \
-             patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock), \
-             patch("flocks.session.prompt.SystemPrompt.custom", custom_mock):
+        with (
+            patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]),
+            patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock),
+            patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock),
+            patch("flocks.session.prompt.SystemPrompt.custom", custom_mock),
+        ):
             prompts1 = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
                 session_directory=session.directory,
@@ -846,12 +857,8 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
-                tool_catalog_prompt_factory=lambda: "tool catalog",
-                device_asset_prompt_factory=device_mock,
+                turn_context=turn_context,
             )
             prompts2 = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
@@ -861,12 +868,8 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
-                tool_catalog_prompt_factory=lambda: "tool catalog",
-                device_asset_prompt_factory=device_mock,
+                turn_context=turn_context,
             )
 
         assert prompts1 == prompts2
@@ -874,9 +877,6 @@ class TestBuildSystemPrompts:
         env_mock.assert_called_once()
         runtime_mock.assert_called_once()
         custom_mock.assert_awaited_once()
-        sandbox_mock.assert_awaited_once()
-        channel_mock.assert_awaited_once()
-        device_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_build_system_prompts_rebuilds_when_device_revision_changes(self):
@@ -889,14 +889,12 @@ class TestBuildSystemPrompts:
         env_mock = MagicMock(return_value=["env prompt"])
         runtime_mock = MagicMock(return_value=["runtime prompt"])
         custom_mock = AsyncMock(return_value=["custom prompt"])
-        sandbox_mock = AsyncMock(return_value="sandbox prompt")
-        channel_mock = AsyncMock(return_value="channel prompt")
-        device_prompts = iter(["device prompt v1", "device prompt v2"])
-
-        with patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]), \
-             patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock), \
-             patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock), \
-             patch("flocks.session.prompt.SystemPrompt.custom", custom_mock):
+        with (
+            patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]),
+            patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock),
+            patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock),
+            patch("flocks.session.prompt.SystemPrompt.custom", custom_mock),
+        ):
             prompts1 = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
                 session_directory=session.directory,
@@ -905,13 +903,15 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
-                tool_catalog_prompt_factory=lambda: "tool catalog",
-                device_asset_prompt_factory=AsyncMock(side_effect=lambda: next(device_prompts)),
-                device_revision=1,
+                turn_context=TurnPromptContext(
+                    sandbox_context="sandbox prompt",
+                    channel_context="channel prompt",
+                    tool_catalog="tool catalog",
+                    device_asset_hint="device prompt v1",
+                    tool_revision=1,
+                    device_revision=1,
+                ),
             )
             prompts2 = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
@@ -921,13 +921,15 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
-                sandbox_prompt_factory=sandbox_mock,
-                channel_context_prompt_factory=channel_mock,
-                tool_catalog_prompt_factory=lambda: "tool catalog",
-                device_asset_prompt_factory=AsyncMock(side_effect=lambda: next(device_prompts)),
-                device_revision=2,
+                turn_context=TurnPromptContext(
+                    sandbox_context="sandbox prompt",
+                    channel_context="channel prompt",
+                    tool_catalog="tool catalog",
+                    device_asset_hint="device prompt v2",
+                    tool_revision=1,
+                    device_revision=2,
+                ),
             )
 
         assert prompts1 != prompts2
@@ -936,8 +938,6 @@ class TestBuildSystemPrompts:
         env_mock.assert_called_once()
         runtime_mock.assert_called_once()
         custom_mock.assert_awaited_once()
-        sandbox_mock.assert_awaited_once()
-        channel_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_build_system_prompts_rebuilds_when_agent_prompt_changes(self):
@@ -951,10 +951,12 @@ class TestBuildSystemPrompts:
         runtime_mock = MagicMock(return_value=["runtime prompt"])
         custom_mock = AsyncMock(return_value=["custom prompt"])
 
-        with patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]), \
-             patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock), \
-             patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock), \
-             patch("flocks.session.prompt.SystemPrompt.custom", custom_mock):
+        with (
+            patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]),
+            patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock),
+            patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock),
+            patch("flocks.session.prompt.SystemPrompt.custom", custom_mock),
+        ):
             prompts1 = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
                 session_directory=session.directory,
@@ -963,8 +965,8 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
+                turn_context=TurnPromptContext(tool_revision=1),
             )
             agent.prompt = "agent prompt v2"
             prompts2 = await SessionPrompt.build_system_prompts(
@@ -975,8 +977,8 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 static_cache=shared_cache,
+                turn_context=TurnPromptContext(tool_revision=1),
             )
 
         assert prompts1 != prompts2
@@ -1109,10 +1111,12 @@ class TestBuildSystemPrompts:
         runtime_mock = MagicMock(return_value=["runtime prompt"])
         custom_mock = AsyncMock(return_value=["custom prompt"])
 
-        with patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]), \
-             patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock), \
-             patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock), \
-             patch("flocks.session.prompt.SystemPrompt.custom", custom_mock):
+        with (
+            patch("flocks.session.prompt.SystemPrompt.provider", return_value=["provider prompt"]),
+            patch("flocks.session.prompt.SystemPrompt.environment_stable", env_mock),
+            patch("flocks.session.prompt.SystemPrompt.runtime_metadata", runtime_mock),
+            patch("flocks.session.prompt.SystemPrompt.custom", custom_mock),
+        ):
             prompts_with_memory = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
                 session_directory=session.directory,
@@ -1128,9 +1132,9 @@ class TestBuildSystemPrompts:
                     "read",
                     "write",
                 ),
-                tool_revision=1,
                 memory_bootstrap_data=runner._memory_bootstrap_data,
                 static_cache=shared_cache,
+                turn_context=TurnPromptContext(tool_revision=1),
             )
             prompts_without_memory = await SessionPrompt.build_system_prompts(
                 session_id=session.id,
@@ -1140,9 +1144,9 @@ class TestBuildSystemPrompts:
                 provider_id=runner.provider_id,
                 model_id=runner.model_id,
                 prompt_tool_names=("read",),
-                tool_revision=1,
                 memory_bootstrap_data=runner._memory_bootstrap_data,
                 static_cache=shared_cache,
+                turn_context=TurnPromptContext(tool_revision=1),
             )
 
         assert prompts_with_memory != prompts_without_memory
@@ -1476,15 +1480,25 @@ async def test_to_chat_messages_uses_structured_anthropic_system_blocks(monkeypa
     monkeypatch.setattr(runner_mod.Message, "parts", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="hello"))
 
-    chat_messages = await runner._to_chat_messages(
-        [message],
-        ["provider prompt", "agent prompt", "context prompt", "runtime prompt"],
-    )
+    prompt_blocks = [
+        SystemPromptBlock(name, content, cache_scope)
+        for name, content, cache_scope in (
+            ("provider", "provider prompt", "global"),
+            ("agent", "agent prompt", "agent"),
+            ("context", "context prompt", "workspace"),
+            ("sandbox", "sandbox prompt", "runtime_tail"),
+            ("runtime", "runtime prompt", "runtime_tail"),
+            ("reminder", "reminder prompt", "runtime_tail"),
+        )
+    ]
+
+    chat_messages = await runner._to_chat_messages([message], prompt_blocks)
 
     assert chat_messages[0].role == "system"
     assert isinstance(chat_messages[0].content, list)
-    assert chat_messages[0].content[1]["cache_control"] == {"type": "ephemeral"}
-    assert chat_messages[0].content[-1]["text"] == "runtime prompt"
+    assert chat_messages[0].content[2]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in chat_messages[0].content[3]
+    assert chat_messages[0].content[-1]["text"] == "reminder prompt"
 
 
 @pytest.mark.asyncio
@@ -2246,7 +2260,7 @@ async def test_process_step_creates_assistant_message_with_provider_and_model(mo
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         runner,
@@ -2304,7 +2318,7 @@ async def test_process_step_invalidates_chat_cache_for_queued_messages(monkeypat
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_to_chat_messages", fake_to_chat_messages)
     monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="queued"))
@@ -2352,7 +2366,7 @@ async def test_process_step_limits_connection_error_retries(monkeypatch):
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         runner,
@@ -2428,7 +2442,7 @@ async def test_process_step_marks_aborted_llm_message_as_error(monkeypatch):
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         runner,
@@ -2661,7 +2675,7 @@ async def test_process_step_persists_visible_error_when_model_returns_empty_stre
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", staticmethod(lambda _provider_id: EmptyProvider()))
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(SessionRunner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner_mod.SessionRetry, "sleep", AsyncMock(return_value=None))
 
@@ -2708,7 +2722,7 @@ async def test_process_step_uses_loaded_tool_schema_names_for_prompt_guidance(mo
     provider = MagicMock()
     provider.is_configured.return_value = True
     assistant_msg = SimpleNamespace(id="msg_assistant_prompt_guidance")
-    build_system_prompts = AsyncMock(return_value=[])
+    build_system_prompt_blocks = AsyncMock(return_value=[])
     tool_schema = [
         {"type": "function", "function": {"name": "memory_search", "description": "", "parameters": {}}},
         {"type": "function", "function": {"name": "bash", "description": "", "parameters": {}}},
@@ -2717,7 +2731,7 @@ async def test_process_step_uses_loaded_tool_schema_names_for_prompt_guidance(mo
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", build_system_prompts)
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", build_system_prompt_blocks)
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=tool_schema))
     monkeypatch.setattr(
         runner,
@@ -2737,8 +2751,12 @@ async def test_process_step_uses_loaded_tool_schema_names_for_prompt_guidance(mo
     result = await runner._process_step([last_user], last_user)
 
     assert result.content == "done"
-    build_system_prompts.assert_awaited_once()
-    assert build_system_prompts.await_args.kwargs["prompt_tool_names"] == ("bash", "memory_search")
+    build_system_prompt_blocks.assert_awaited_once()
+    assert build_system_prompt_blocks.await_args.kwargs["prompt_tool_names"] == ("bash", "memory_search")
+    assert isinstance(
+        build_system_prompt_blocks.await_args.kwargs["turn_context"],
+        TurnPromptContext,
+    )
 
 
 @pytest.mark.asyncio
@@ -2766,7 +2784,7 @@ async def test_process_step_records_usage_after_success(monkeypatch):
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         runner,
@@ -2791,7 +2809,7 @@ async def test_process_step_records_usage_after_success(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_process_step_passes_device_hint_factory_into_build_system_prompts(monkeypatch):
+async def test_process_step_passes_resolved_device_hint_into_turn_context(monkeypatch):
     runner = _make_runner("ses_runner_device_hint_order")
     runner.callbacks = RunnerCallbacks(on_error=AsyncMock())
 
@@ -2808,12 +2826,12 @@ async def test_process_step_passes_device_hint_factory_into_build_system_prompts
     provider = MagicMock()
     provider.is_configured.return_value = True
     assistant_msg = SimpleNamespace(id="msg_assistant_device_hint_order")
-    build_system_prompts = AsyncMock(return_value=["provider", "tool catalog awareness", "device hint"])
+    build_system_prompt_blocks = AsyncMock(return_value=["provider", "tool catalog awareness", "device hint"])
 
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", build_system_prompts)
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", build_system_prompt_blocks)
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     device_hint_mock = AsyncMock(return_value="device hint")
     monkeypatch.setattr(runner, "_build_device_asset_hint", device_hint_mock)
@@ -2836,11 +2854,11 @@ async def test_process_step_passes_device_hint_factory_into_build_system_prompts
     result = await runner._process_step([last_user], last_user)
 
     assert result.content == "done"
-    build_system_prompts.assert_awaited_once()
-    kwargs = build_system_prompts.await_args.kwargs
-    assert kwargs["device_revision"] == 9
-    assert kwargs["device_asset_prompt_factory"] is not None
-    assert await kwargs["device_asset_prompt_factory"]() == "device hint"
+    build_system_prompt_blocks.assert_awaited_once()
+    turn_context = build_system_prompt_blocks.await_args.kwargs["turn_context"]
+    assert turn_context.device_revision == 9
+    assert turn_context.device_asset_hint == "device hint"
+    device_hint_mock.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -2871,7 +2889,7 @@ async def test_process_step_empty_retry_records_usage_per_attempt(monkeypatch):
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         runner,
@@ -2933,7 +2951,7 @@ async def test_process_step_retries_empty_transport_exception(monkeypatch):
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         runner,
@@ -2985,7 +3003,7 @@ async def test_process_step_does_not_retry_after_tool_execution_started(monkeypa
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
     monkeypatch.setattr(
         runner_mod.SessionPrompt,
-        "build_system_prompts",
+        "build_system_prompt_blocks",
         AsyncMock(return_value=[]),
     )
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=[]))
@@ -3033,7 +3051,7 @@ async def test_process_step_uses_default_max_steps_when_agent_steps_missing(monk
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=sentinel_tools))
     monkeypatch.setattr(
         runner,
@@ -3082,7 +3100,7 @@ async def test_process_step_respects_explicit_agent_steps_over_default(monkeypat
     monkeypatch.setattr(runner_mod.Agent, "get", AsyncMock(return_value=agent))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_build_callable_tool_schema", AsyncMock(return_value=sentinel_tools))
     monkeypatch.setattr(
         runner,
@@ -3136,7 +3154,7 @@ async def test_process_step_halts_after_third_exact_tool_only_turn(monkeypatch):
     )))
     monkeypatch.setattr(runner_mod.Provider, "get", lambda provider_id: provider)
     monkeypatch.setattr(runner_mod.Provider, "apply_config", AsyncMock(return_value=None))
-    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(runner_mod.SessionPrompt, "build_system_prompt_blocks", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner_mod.Message, "get_text_content", AsyncMock(return_value="hi"))
     monkeypatch.setattr(runner_mod.Message, "parts", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner_mod.Message, "create", create_mock)

--- a/tests/session/test_session_runner_tool_only_message.py
+++ b/tests/session/test_session_runner_tool_only_message.py
@@ -81,7 +81,7 @@ async def test_runner_does_not_disable_tools_after_tool_only_assistant_message(m
         del self, agent
         return ()
 
-    async def fake_build_system_prompts(*args, **kwargs):  # noqa: ANN002, ANN003
+    async def fake_build_system_prompt_blocks(*args, **kwargs):  # noqa: ANN002, ANN003
         del args, kwargs
         return []
 
@@ -100,7 +100,11 @@ async def test_runner_does_not_disable_tools_after_tool_only_assistant_message(m
     monkeypatch.setattr(Provider, "apply_config", fake_apply_config)
     monkeypatch.setattr(Agent, "get", fake_agent_get)
     monkeypatch.setattr(SessionRunner, "_get_prompt_tool_names", fake_get_prompt_tool_names)
-    monkeypatch.setattr(SessionPrompt, "build_system_prompts", fake_build_system_prompts)
+    monkeypatch.setattr(
+        SessionPrompt,
+        "build_system_prompt_blocks",
+        fake_build_system_prompt_blocks,
+    )
     monkeypatch.setattr(SessionRunner, "_build_callable_tool_schema", fake_build_callable_tool_schema)
     monkeypatch.setattr(SessionRunner, "_to_chat_messages", fake_to_chat_messages)
     monkeypatch.setattr(SessionRunner, "_call_llm", fake_call_llm)


### PR DESCRIPTION
## Summary
- collect turn-scoped runtime inputs once and assemble typed prompt blocks with explicit stable-prefix and runtime-tail boundaries
- use the same prompt assembly contract for provider messages and context-usage estimation while preserving the existing `SessionRunner` and task/subtask compatibility
- make Rex and Hephaestus todo guidance unconditional and tighten Rex verification requirements
- exclude the session runtime rewrite and unrelated task, TUI, WebUI, SDK, and lockfile changes

## Test plan
- [x] `uv run --frozen pytest tests/session/test_prompt_tokens.py tests/session/test_runner_step.py tests/session/test_session_runner_tool_only_message.py tests/session/test_context_usage.py tests/agent/test_prompt_builders.py` (167 passed)
- [x] `uv run --frozen ruff check` on all touched Python files
- [x] focused mypy on touched production files matches `origin/dev` exactly (108 pre-existing errors; no new errors)
- [x] `uv run --frozen pytest tests/session` (961 passed; 5 failures and 2 teardown errors reproduced on `origin/dev`)
- [x] agent prompt integration (71 passed; the remaining `plan` agent lookup failure is reproduced on `origin/dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)