### PR TITLE
fix(webui): show extra memory root files

### DIFF
--- a/flocks/server/routes/workspace.py
+++ b/flocks/server/routes/workspace.py
@@ -1,7 +1,7 @@
 """
 Workspace routes
 
-Generic file-manager API for ~/.flocks/workspace/ plus a read-only view
+Generic file-manager API for ~/.flocks/workspace/ plus a managed view
 of the agent memory directory (~/.flocks/data/memory/).
 
 All `path` query/body parameters are **relative** to the respective root.
@@ -26,9 +26,10 @@ File operations (workspace only)
   POST   /api/workspace/move          move / rename
   POST   /api/workspace/reveal        open containing folder in system file manager
 
-Memory view (read-only, points to data/memory/)
+Memory view (points to data/memory/)
   GET /api/workspace/memory/list      list memory files
   GET /api/workspace/memory/file      read memory file content
+  PUT /api/workspace/memory/file      update editable memory files
   GET /api/workspace/memory/preview   preview single memory file inline
   GET /api/workspace/memory/download  download single memory file
 
@@ -50,10 +51,12 @@ import zipfile
 from pathlib import Path
 from typing import List, Optional, Literal
 
-from fastapi import APIRouter, HTTPException, Query, UploadFile, File
+from fastapi import APIRouter, HTTPException, Query, UploadFile, File, Request, status
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 
+from flocks.project.project import Project
+from flocks.server.auth import get_optional_user, require_user
 from flocks.workspace.manager import WorkspaceManager
 from flocks.workspace.models import WorkspaceNode, WorkspaceStats
 from flocks.utils.log import Log
@@ -585,9 +588,39 @@ def _memory_child_sort_key(path: Path) -> tuple[int, str]:
     return (0 if path.is_dir() else 1, path.name.casefold())
 
 
-def _build_memory_node_sync(path: Path, memory_dir: Path) -> WorkspaceNode:
+def _memory_path_parts(rel_path: str) -> list[str]:
+    return [part for part in rel_path.replace("\\", "/").split("/") if part]
+
+
+def _is_editable_memory_path(
+    rel_path: str,
+    writable_project_ids: Optional[set[str]] = None,
+) -> bool:
+    """Return whether the current user may edit a memory file path."""
+    path_parts = _memory_path_parts(rel_path)
+    if len(path_parts) == 1:
+        return path_parts[0] in {"USER.md", "MEMORY.md"}
+    if len(path_parts) == 2:
+        return path_parts[0] == "daily" and path_parts[1].endswith(".md")
+    if len(path_parts) == 3:
+        return (
+            path_parts[0] == "projects"
+            and path_parts[2] == "MEMORY.md"
+            and writable_project_ids is not None
+            and path_parts[1] in writable_project_ids
+        )
+    return False
+
+
+def _build_memory_node_sync(
+    path: Path,
+    memory_dir: Path,
+    writable_project_ids: Optional[set[str]],
+) -> WorkspaceNode:
     """Build one recursive node for the Memory tree."""
     node = _node_from_path(path, memory_dir)
+    if node.type == "file":
+        node.editable = _is_editable_memory_path(node.path, writable_project_ids)
     if node.type == "directory":
         children = (
             child
@@ -595,13 +628,16 @@ def _build_memory_node_sync(path: Path, memory_dir: Path) -> WorkspaceNode:
             if not child.is_symlink()
         )
         node.children = [
-            _build_memory_node_sync(child, memory_dir)
+            _build_memory_node_sync(child, memory_dir, writable_project_ids)
             for child in sorted(children, key=_memory_child_sort_key)
         ]
     return node
 
 
-def _list_memory_sync(memory_dir: Path) -> List[WorkspaceNode]:
+def _list_memory_sync(
+    memory_dir: Path,
+    writable_project_ids: Optional[set[str]],
+) -> List[WorkspaceNode]:
     """Build the USER/global/daily/project Memory hierarchy."""
     children = (
         child
@@ -615,16 +651,21 @@ def _list_memory_sync(memory_dir: Path) -> List[WorkspaceNode]:
             child.name.casefold(),
         ),
     )
-    return [_build_memory_node_sync(child, memory_dir) for child in ordered]
+    return [
+        _build_memory_node_sync(child, memory_dir, writable_project_ids)
+        for child in ordered
+    ]
 
 
 @router.get("/memory/list", response_model=List[WorkspaceNode], summary="List memory files")
-async def list_memory():
+async def list_memory(request: Request):
     mgr = _get_manager()
     memory_dir = mgr.get_memory_dir()
     if not memory_dir.exists():
         return []
-    return await asyncio.to_thread(_list_memory_sync, memory_dir)
+    user = get_optional_user(request)
+    writable_project_ids = Project.registered_project_ids(user.id) if user else set()
+    return await asyncio.to_thread(_list_memory_sync, memory_dir, writable_project_ids)
 
 
 @router.get("/memory/file", summary="Read memory file content")
@@ -664,12 +705,19 @@ async def read_memory_file(
 
 
 @router.put("/memory/file", summary="Write memory file content")
-async def write_memory_file(body: FileWriteRequest):
+async def write_memory_file(request: Request, body: FileWriteRequest):
+    user = require_user(request)
     mgr = _get_manager()
     try:
         target = mgr.resolve_memory_path(body.path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    writable_project_ids = Project.registered_project_ids(user.id)
+    if not _is_editable_memory_path(body.path, writable_project_ids):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Memory file is read-only",
+        )
     target.parent.mkdir(parents=True, exist_ok=True)
     try:
         target.write_text(body.content, encoding="utf-8")

--- a/flocks/workspace/models.py
+++ b/flocks/workspace/models.py
@@ -14,6 +14,7 @@ class WorkspaceNode(BaseModel):
     size: Optional[int] = None
     modified_at: Optional[float] = None
     is_text_file: bool = False
+    editable: bool = False
     children: Optional[list["WorkspaceNode"]] = None
 
 

--- a/tests/workspace/test_workspace_models.py
+++ b/tests/workspace/test_workspace_models.py
@@ -15,6 +15,7 @@ class TestWorkspaceNode:
         assert node.size is None
         assert node.modified_at is None
         assert node.is_text_file is False
+        assert node.editable is False
         assert node.children is None
 
     def test_directory_node_with_children(self):
@@ -37,10 +38,12 @@ class TestWorkspaceNode:
             size=204800,
             modified_at=1741900000.0,
             is_text_file=False,
+            editable=True,
         )
         assert node.size == 204800
         assert node.modified_at == pytest.approx(1741900000.0)
         assert node.is_text_file is False
+        assert node.editable is True
 
     def test_invalid_type_raises(self):
         with pytest.raises(Exception):

--- a/tests/workspace/test_workspace_routes.py
+++ b/tests/workspace/test_workspace_routes.py
@@ -49,6 +49,7 @@ def workspace_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setenv("FLOCKS_WORKSPACE_DIR", str(ws))
     monkeypatch.setenv("FLOCKS_DATA_DIR", str(data))
+    monkeypatch.setenv("FLOCKS_ROOT", str(tmp_path / ".flocks"))
 
     # Reset both singletons so they re-read env vars
     from flocks.workspace.manager import WorkspaceManager
@@ -58,9 +59,21 @@ def workspace_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     # Build a minimal FastAPI app with only the workspace router
     from fastapi import FastAPI
+    from flocks.auth.context import AuthUser
     from flocks.server.routes.workspace import router
 
     app = FastAPI()
+
+    @app.middleware("http")
+    async def inject_auth_user(request, call_next):
+        request.state.auth_user = AuthUser(
+            id="usr_workspace",
+            username="workspace",
+            role="member",
+            status="active",
+        )
+        return await call_next(request)
+
     app.include_router(router, prefix="/api/workspace")
 
     client = TestClient(app, raise_server_exceptions=True)
@@ -697,10 +710,21 @@ class TestMemoryView:
         assert daily["type"] == "directory"
         assert daily["children"] == []
 
-    def test_list_memory_with_files(self, workspace_client):
+    def test_list_memory_with_files(self, workspace_client, monkeypatch):
+        from flocks.project.project import Project
+
+        monkeypatch.setattr(
+            Project,
+            "registered_project_ids",
+            classmethod(lambda cls, owner_id: {"prj_example"}),
+        )
         mem = _mem(workspace_client)
         (mem / "USER.md").write_text("# User")
         (mem / "MEMORY.md").write_text("# Memory")
+        (mem / "SHORT_MEMORY.md").write_text("# Short")
+        (mem / "bak.txt").write_text("backup")
+        (mem / "archive").mkdir()
+        (mem / "archive" / "2026-08-18.md").write_text("# Archived")
         (mem / "daily").mkdir()
         (mem / "daily" / "2026-03-14.md").write_text("## Daily")
         (mem / "projects" / "prj_example").mkdir(parents=True)
@@ -716,17 +740,29 @@ class TestMemoryView:
             "MEMORY.md",
             "projects",
             "daily",
+            "archive",
+            "bak.txt",
+            "SHORT_MEMORY.md",
         ]
         nodes = {node["name"]: node for node in r.json()}
-        assert set(nodes) == {"USER.md", "MEMORY.md", "daily", "projects"}
+        assert set(nodes) == {"USER.md", "MEMORY.md", "SHORT_MEMORY.md", "archive", "bak.txt", "daily", "projects"}
         assert nodes["USER.md"]["type"] == "file"
+        assert nodes["USER.md"]["editable"] is True
         assert nodes["MEMORY.md"]["type"] == "file"
+        assert nodes["MEMORY.md"]["editable"] is True
+        assert nodes["SHORT_MEMORY.md"]["editable"] is False
+        assert nodes["bak.txt"]["editable"] is False
+        assert nodes["archive"]["editable"] is False
+        assert nodes["archive"]["children"][0]["path"] == "archive/2026-08-18.md"
+        assert nodes["archive"]["children"][0]["editable"] is False
         assert nodes["daily"]["type"] == "directory"
         assert nodes["daily"]["children"][0]["path"] == "daily/2026-03-14.md"
+        assert nodes["daily"]["children"][0]["editable"] is True
         assert nodes["projects"]["type"] == "directory"
         project = nodes["projects"]["children"][0]
         assert project["path"] == "projects/prj_example"
         assert project["children"][0]["path"] == "projects/prj_example/MEMORY.md"
+        assert project["children"][0]["editable"] is True
 
     def test_read_memory_file(self, workspace_client):
         mem = _mem(workspace_client)
@@ -833,6 +869,40 @@ class TestMemoryView:
             "written": True,
         }
         assert target.read_text() == "new content"
+
+    def test_write_non_editable_memory_file_returns_403(self, workspace_client):
+        mem = _mem(workspace_client)
+        target = mem / "SHORT_MEMORY.md"
+        target.write_text("old content")
+
+        r = _client(workspace_client).put(
+            "/api/workspace/memory/file",
+            json={"path": "SHORT_MEMORY.md", "content": "tampered"},
+        )
+
+        assert r.status_code == 403
+        assert target.read_text() == "old content"
+
+    def test_write_unreadable_project_memory_returns_403(self, workspace_client, monkeypatch):
+        from flocks.project.project import Project
+
+        monkeypatch.setattr(
+            Project,
+            "registered_project_ids",
+            classmethod(lambda cls, owner_id: {"prj_allowed"}),
+        )
+        mem = _mem(workspace_client)
+        target = mem / "projects" / "prj_stale" / "MEMORY.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("old content")
+
+        r = _client(workspace_client).put(
+            "/api/workspace/memory/file",
+            json={"path": "projects/prj_stale/MEMORY.md", "content": "tampered"},
+        )
+
+        assert r.status_code == 403
+        assert target.read_text() == "old content"
 
     def test_write_memory_traversal_rejected(self, workspace_client):
         r = _client(workspace_client).put(

--- a/webui/src/api/workspace.ts
+++ b/webui/src/api/workspace.ts
@@ -9,6 +9,7 @@ export interface WorkspaceNode {
   size?: number;
   modified_at?: number;
   is_text_file?: boolean;
+  editable?: boolean;
   children?: WorkspaceNode[];
   project_name?: string;
   project_worktree?: string;

--- a/webui/src/pages/Workspace/index.test.tsx
+++ b/webui/src/pages/Workspace/index.test.tsx
@@ -196,7 +196,7 @@ function directory(name: string, path: string) {
   };
 }
 
-function file(name: string, path: string, isTextFile = true) {
+function file(name: string, path: string, isTextFile = true, editable = isTextFile) {
   return {
     name,
     path,
@@ -204,6 +204,7 @@ function file(name: string, path: string, isTextFile = true) {
     size: 24,
     modified_at: 1710000000,
     is_text_file: isTextFile,
+    editable,
   };
 }
 
@@ -513,11 +514,11 @@ describe('WorkspacePage', () => {
   it('Memory 根目录的其他文件和目录会显示但默认只读', async () => {
     mocks.listMemory.mockResolvedValue({
       data: [
-        file('SHORT_MEMORY.md', 'SHORT_MEMORY.md'),
-        file('bak.txt', 'bak.txt'),
+        file('SHORT_MEMORY.md', 'SHORT_MEMORY.md', true, false),
+        file('bak.txt', 'bak.txt', true, false),
         {
           ...directory('archive', 'archive'),
-          children: [file('2026-08-18.md', 'archive/2026-08-18.md')],
+          children: [file('2026-08-18.md', 'archive/2026-08-18.md', true, false)],
         },
       ],
     });

--- a/webui/src/pages/Workspace/index.test.tsx
+++ b/webui/src/pages/Workspace/index.test.tsx
@@ -452,7 +452,7 @@ describe('WorkspacePage', () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith('Saved successfully');
   });
 
-  it('Memory 文件按 USER、Global、Project 和 Daily 层级展示', async () => {
+  it('Memory 文件按核心记忆、Project、Daily、其他根文件层级展示', async () => {
     mocks.listVisibleProjects.mockResolvedValue({
       data: [{
         id: 'prj_example',
@@ -496,27 +496,37 @@ describe('WorkspacePage', () => {
     expect(daily).toBeInTheDocument();
     expect(screen.queryByText('projects')).not.toBeInTheDocument();
     expect(screen.queryByText('prj_stale/MEMORY.md')).not.toBeInTheDocument();
-    expect(screen.queryByText('2026-04-07.md')).not.toBeInTheDocument();
-    expect(screen.queryByText('test.md')).not.toBeInTheDocument();
+    expect(screen.getByText('2026-04-07.md')).toBeInTheDocument();
+    expect(screen.getByText('test.md')).toBeInTheDocument();
     expect(
       projectMemory.compareDocumentPosition(daily) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      daily.compareDocumentPosition(screen.getByText('2026-04-07.md')) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(screen.queryByText('2026-08-03.md')).not.toBeInTheDocument();
 
     await user.click(projectMemory);
     expect(await screen.findByText('/Users/test/workspace/flocks-raven')).toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: /daily/ }));
-    expect(await screen.findByText('2026-08-03.md')).toBeInTheDocument();
   });
 
-  it('Memory 根目录的非规范文件不显示', async () => {
+  it('Memory 根目录的其他文件和目录会显示但默认只读', async () => {
     mocks.listMemory.mockResolvedValue({
       data: [
-        file('profile.pdf', 'profile.pdf', false),
-        file('logo.svg', 'logo.svg', false),
-        file('legacy.md', 'legacy.md'),
+        file('SHORT_MEMORY.md', 'SHORT_MEMORY.md'),
+        file('bak.txt', 'bak.txt'),
+        {
+          ...directory('archive', 'archive'),
+          children: [file('2026-08-18.md', 'archive/2026-08-18.md')],
+        },
       ],
+    });
+    mocks.readMemoryFile.mockResolvedValue({
+      data: {
+        path: 'bak.txt',
+        content: 'backup memory',
+        truncated: false,
+      },
     });
 
     const user = userEvent.setup();
@@ -526,11 +536,20 @@ describe('WorkspacePage', () => {
     await waitFor(() => {
       expect(mocks.listMemory).toHaveBeenCalled();
     });
-    expect(screen.queryByText('profile.pdf')).not.toBeInTheDocument();
-    expect(screen.queryByText('logo.svg')).not.toBeInTheDocument();
-    expect(screen.queryByText('legacy.md')).not.toBeInTheDocument();
+    expect(screen.getByText('SHORT_MEMORY.md')).toBeInTheDocument();
+    expect(screen.getByText('archive')).toBeInTheDocument();
+    expect(screen.getByText('bak.txt')).toBeInTheDocument();
+
+    const archiveButton = screen.getByText('archive').closest('button');
+    if (!archiveButton) throw new Error('Archive memory row button not found');
+    await user.click(archiveButton);
+    expect(await screen.findByText('2026-08-18.md')).toBeInTheDocument();
+
+    await user.click(screen.getByText('bak.txt'));
+    expect(await screen.findByText('backup memory')).toBeInTheDocument();
+    expect(mocks.readMemoryFile).toHaveBeenCalledWith('bak.txt');
+    expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
     expect(pdfMocks.getDocument).not.toHaveBeenCalled();
-    expect(mocks.readMemoryFile).not.toHaveBeenCalled();
   });
 
   it('Memory 文本文件快速切换时忽略过期读取结果', async () => {

--- a/webui/src/pages/Workspace/index.tsx
+++ b/webui/src/pages/Workspace/index.tsx
@@ -1585,6 +1585,20 @@ function memoryPathParts(path: string): string[] {
   return path.replace(/\\/g, '/').split('/');
 }
 
+function isEditableMemoryNode(node: WorkspaceNode): boolean {
+  const pathParts = memoryPathParts(node.path);
+  if (pathParts.length === 1) {
+    return node.path === 'USER.md' || node.path === 'MEMORY.md';
+  }
+  if (pathParts.length === 2) {
+    return pathParts[0] === 'daily' && node.name.endsWith('.md');
+  }
+  if (pathParts.length === 3) {
+    return pathParts[0] === 'projects' && pathParts[2] === 'MEMORY.md';
+  }
+  return false;
+}
+
 function buildMemoryView(
   nodes: WorkspaceNode[],
   visibleProjects: WorkspaceProject[],
@@ -1594,11 +1608,19 @@ function buildMemoryView(
   const projects = nodes.find((node) => node.path === 'projects');
   const daily = nodes.find((node) => node.path === 'daily');
   const projectById = new Map(visibleProjects.map((project) => [project.id, project]));
+  const consumedRootPaths = new Set<string>();
   const view: WorkspaceNode[] = [];
 
-  if (userMemory) view.push(userMemory);
-  if (globalMemory) view.push(globalMemory);
+  if (userMemory) {
+    view.push(userMemory);
+    consumedRootPaths.add(userMemory.path);
+  }
+  if (globalMemory) {
+    view.push(globalMemory);
+    consumedRootPaths.add(globalMemory.path);
+  }
   if (projects) {
+    consumedRootPaths.add(projects.path);
     const projectMemories = collectMemoryFiles(projects.children ?? []).flatMap((node) => {
       const pathParts = memoryPathParts(node.path);
       const project = pathParts.length === 3 ? projectById.get(pathParts[1]) : undefined;
@@ -1613,7 +1635,11 @@ function buildMemoryView(
     });
     view.push(...projectMemories);
   }
-  if (daily) view.push(daily);
+  if (daily) {
+    view.push(daily);
+    consumedRootPaths.add(daily.path);
+  }
+  view.push(...nodes.filter((node) => !consumedRootPaths.has(node.path)));
   return view;
 }
 
@@ -1903,7 +1929,7 @@ function MemoryTab() {
               </div>
               <span className="text-xs text-gray-400">{formatBytes(selected.size ?? 0)}</span>
               <span className="text-xs text-gray-400">{formatDate(selected.modified_at)}</span>
-              {selected.is_text_file && !editing && !truncated && contentState === 'ready' && (
+              {selected.is_text_file && isEditableMemoryNode(selected) && !editing && !truncated && contentState === 'ready' && (
                 <button
                   onClick={() => {
                     setEditContent(content ?? '');

--- a/webui/src/pages/Workspace/index.tsx
+++ b/webui/src/pages/Workspace/index.tsx
@@ -1585,20 +1585,6 @@ function memoryPathParts(path: string): string[] {
   return path.replace(/\\/g, '/').split('/');
 }
 
-function isEditableMemoryNode(node: WorkspaceNode): boolean {
-  const pathParts = memoryPathParts(node.path);
-  if (pathParts.length === 1) {
-    return node.path === 'USER.md' || node.path === 'MEMORY.md';
-  }
-  if (pathParts.length === 2) {
-    return pathParts[0] === 'daily' && node.name.endsWith('.md');
-  }
-  if (pathParts.length === 3) {
-    return pathParts[0] === 'projects' && pathParts[2] === 'MEMORY.md';
-  }
-  return false;
-}
-
 function buildMemoryView(
   nodes: WorkspaceNode[],
   visibleProjects: WorkspaceProject[],
@@ -1929,7 +1915,7 @@ function MemoryTab() {
               </div>
               <span className="text-xs text-gray-400">{formatBytes(selected.size ?? 0)}</span>
               <span className="text-xs text-gray-400">{formatDate(selected.modified_at)}</span>
-              {selected.is_text_file && isEditableMemoryNode(selected) && !editing && !truncated && contentState === 'ready' && (
+              {selected.is_text_file && selected.editable === true && !editing && !truncated && contentState === 'ready' && (
                 <button
                   onClick={() => {
                     setEditContent(content ?? '');


### PR DESCRIPTION
## 变更说明

修复 WebUI 记忆文件列表未展示根目录额外文件的问题。现在除 `USER.md`、`MEMORY.md`、项目记忆和 `daily/` 外，也会显示后端返回的其他根目录文件/目录，例如 `SHORT_MEMORY.md`、`archive/`、`bak.txt`。

同时保留项目记忆的可见性过滤，避免展示无权限项目的 `MEMORY.md`；新增展示的非核心记忆文件默认只读，仅支持预览和下载，降低误编辑风险。

## 验证

- `npm --prefix webui run test:run -- src/pages/Workspace/index.test.tsx`
- `npm --prefix webui run lint`
- `npm --prefix webui run build`
- `uv run pytest tests/workspace/test_workspace_routes.py -k memory`