### PR TITLE
Fix process duration elapsed display

### DIFF
--- a/webui/src/components/common/SessionChat.test.ts
+++ b/webui/src/components/common/SessionChat.test.ts
@@ -1771,18 +1771,62 @@ describe('getThinkingFirstSentence', () => {
 });
 
 describe('process group duration', () => {
-  it('uses the full wall-clock range and the current time for an active step', () => {
+  it('sums actual process intervals without counting gaps', () => {
     const parts = [
-      { id: 'reason', type: 'reasoning', time: { start: 1_000, end: 2_000 } },
-      { id: 'tool', type: 'tool', state: { status: 'running', time: { start: 2_500 } } },
+      { id: 'reason', type: 'reasoning', time: { start: 0, end: 5_000 } },
+      { id: 'summary', type: 'text', text: '继续检查', time: { start: 8_000, end: 9_000 } },
+      { id: 'tool', type: 'tool', state: { status: 'completed', time: { start: 20_000, end: 28_000 } } },
     ] as Message['parts'];
 
-    expect(getProcessGroupDurationMs(parts, 5_000)).toBe(4_000);
+    expect(getProcessGroupDurationMs(parts)).toBe(14_000);
     expect(formatProcessDuration(500)).toBe('1s');
     expect(formatProcessDuration(7_600)).toBe('7s');
     expect(formatProcessDuration(260_900)).toBe('4m20s');
     expect(getProcessGroupDurationMs([{ id: 'legacy', type: 'reasoning' }] as Message['parts']))
       .toBeNull();
+  });
+
+  it('uses current time only for unfinished active intervals', () => {
+    const parts = [
+      { id: 'done', type: 'tool', state: { status: 'completed', time: { start: 0, end: 5_000 } } },
+      { id: 'stale-text', type: 'text', text: 'missed final update', time: { start: 8_000 } },
+      { id: 'running', type: 'tool', state: { status: 'running', time: { start: 20_000 } } },
+      { id: 'future-text', type: 'text', text: '等待下一步', time: { start: 40_000 } },
+    ] as Message['parts'];
+
+    expect(getProcessGroupDurationMs(parts, 22_000)).toBe(7_000);
+    expect(getProcessGroupDurationMs(parts, 23_000)).toBe(8_000);
+    expect(getProcessGroupDurationMs(parts, 23_000, 'running')).toBe(8_000);
+  });
+
+  it('merges overlapping intervals so parallel process steps are not double counted', () => {
+    const parts = [
+      { id: 'tool-a', type: 'tool', state: { status: 'completed', time: { start: 0, end: 10_000 } } },
+      { id: 'tool-b', type: 'tool', state: { status: 'completed', time: { start: 5_000, end: 15_000 } } },
+      { id: 'reason', type: 'reasoning', time: { start: 20_000, end: 22_000 } },
+    ] as Message['parts'];
+
+    expect(getProcessGroupDurationMs(parts)).toBe(17_000);
+  });
+
+  it('ignores invalid or incomplete historical intervals', () => {
+    const parts = [
+      { id: 'missing-start', type: 'reasoning', time: { end: 5_000 } },
+      { id: 'missing-end', type: 'tool', state: { status: 'completed', time: { start: 10_000 } } },
+      { id: 'negative', type: 'text', text: 'bad clock', time: { start: 20_000, end: 19_000 } },
+      { id: 'zero', type: 'tool', state: { status: 'completed', time: { start: 25_000, end: 25_000 } } },
+      { id: 'valid', type: 'reasoning', time: { start: 30_000, end: 32_000 } },
+    ] as unknown as Message['parts'];
+
+    expect(getProcessGroupDurationMs(parts)).toBe(2_000);
+  });
+
+  it('keeps zero-duration completed intervals displayable', () => {
+    const parts = [
+      { id: 'instant', type: 'tool', state: { status: 'completed', time: { start: 1_000, end: 1_000 } } },
+    ] as Message['parts'];
+
+    expect(getProcessGroupDurationMs(parts)).toBe(0);
   });
 
   it('updates the displayed duration while the last process step is active', () => {
@@ -5664,6 +5708,27 @@ describe('areChatMessagePartsRenderEqual', () => {
       [
         { id: 'text-1', type: 'text', text: '现在生成简化版 workflow.json' } as Message['parts'][number],
         sharedToolPart,
+      ],
+    )).toBe(false);
+  });
+
+  it('detects top-level part time updates used by reasoning and text parts', () => {
+    expect(areChatMessagePartsRenderEqual(
+      [
+        {
+          id: 'reason-1',
+          type: 'reasoning',
+          text: '检查上下文',
+          time: { start: 1_000 },
+        } as Message['parts'][number],
+      ],
+      [
+        {
+          id: 'reason-1',
+          type: 'reasoning',
+          text: '检查上下文',
+          time: { start: 1_000, end: 2_500 },
+        } as Message['parts'][number],
       ],
     )).toBe(false);
   });

--- a/webui/src/components/common/SessionChat.tsx
+++ b/webui/src/components/common/SessionChat.tsx
@@ -311,24 +311,81 @@ function getProcessPartTime(part: MessagePart): { start: number; end?: number } 
   return part.type === 'tool' ? part.state?.time : part.time;
 }
 
+type ProcessTimeInterval = {
+  start: number;
+  end: number;
+};
+
+function getProcessPartInterval(part: MessagePart, activeNowMs?: number): ProcessTimeInterval | null {
+  const time = getProcessPartTime(part);
+  if (!time || !Number.isFinite(time.start)) return null;
+
+  const end = Number.isFinite(time.end) ? time.end : activeNowMs;
+  if (end === undefined || !Number.isFinite(end) || end < time.start) return null;
+
+  return { start: time.start, end };
+}
+
+function sumMergedProcessIntervals(intervals: ProcessTimeInterval[]): number {
+  if (intervals.length === 0) return 0;
+
+  const sorted = [...intervals].sort((a, b) => a.start - b.start);
+  let total = 0;
+  let currentStart = sorted[0].start;
+  let currentEnd = sorted[0].end;
+
+  for (let index = 1; index < sorted.length; index += 1) {
+    const interval = sorted[index];
+    if (interval.start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, interval.end);
+      continue;
+    }
+
+    total += currentEnd - currentStart;
+    currentStart = interval.start;
+    currentEnd = interval.end;
+  }
+
+  return total + currentEnd - currentStart;
+}
+
 export function getProcessGroupDurationMs(
   parts: readonly MessagePart[],
   activeNowMs?: number,
+  activePartId?: string,
 ): number | null {
-  let firstStart = Number.POSITIVE_INFINITY;
-  let lastEnd = Number.NEGATIVE_INFINITY;
-
-  for (const part of parts) {
-    const time = getProcessPartTime(part);
-    if (!time || !Number.isFinite(time.start)) continue;
-    const end = Number.isFinite(time.end) ? time.end : activeNowMs;
-    if (end === undefined || !Number.isFinite(end)) continue;
-    firstStart = Math.min(firstStart, time.start);
-    lastEnd = Math.max(lastEnd, end);
+  let activeIntervalIndex = -1;
+  if (activeNowMs !== undefined) {
+    const startIndex = activePartId
+      ? parts.findIndex((part) => part.id === activePartId)
+      : parts.length - 1;
+    const endIndex = activePartId ? startIndex : 0;
+    for (let index = startIndex; index >= endIndex; index -= 1) {
+      const part = parts[index];
+      if (!part) continue;
+      const time = getProcessPartTime(part);
+      if (
+        !!time
+        && Number.isFinite(time.start)
+        && !Number.isFinite(time.end)
+        && time.start <= activeNowMs
+        && (part.type !== 'tool' || isActiveToolPart(part))
+      ) {
+        activeIntervalIndex = index;
+        break;
+      }
+    }
   }
 
-  if (!Number.isFinite(firstStart) || !Number.isFinite(lastEnd)) return null;
-  return Math.max(0, lastEnd - firstStart);
+  const intervals = parts
+    .map((part, index) => getProcessPartInterval(
+      part,
+      index === activeIntervalIndex ? activeNowMs : undefined,
+    ))
+    .filter((interval): interval is ProcessTimeInterval => interval !== null);
+
+  if (intervals.length === 0) return null;
+  return sumMergedProcessIntervals(intervals);
 }
 
 export function formatProcessDuration(durationMs: number): string {
@@ -5343,6 +5400,7 @@ function ChatMessageBubbleInner({
             const processDurationMs = getProcessGroupDurationMs(
               group.map(({ part }) => part),
               processGroupActive ? processElapsedClock : undefined,
+              processGroupActive ? activeTailPart?.id : undefined,
             );
             const hasStoredOpenState = !!processGroupOpenState
               && Object.prototype.hasOwnProperty.call(processGroupOpenState, processGroupKey);

--- a/webui/src/components/common/sessionChatRenderEquality.ts
+++ b/webui/src/components/common/sessionChatRenderEquality.ts
@@ -57,6 +57,9 @@ export function areChatMessagePartsRenderEqual(
       || prevPart.mime !== nextPart.mime
       || prevPart.filename !== nextPart.filename
       || prevPart.url !== nextPart.url
+      || prevPart.time?.start !== nextPart.time?.start
+      || prevPart.time?.end !== nextPart.time?.end
+      || prevPart.time?.compacted !== nextPart.time?.compacted
       || prevPart.image?.url !== nextPart.image?.url
       || prevPart.image?.alt !== nextPart.image?.alt
     ) {


### PR DESCRIPTION
## 变更说明

修复页面“过程执行时间”展示跳变问题。

原逻辑使用过程组内 `max(end) - min(start)` 计算耗时，会把不同步骤之间的空档也计入，导致新一轮 tool/reasoning/text part 到来时，时间从例如 `5s` 突然跳到 `20s`。

本次改为按实际处理时间计算：

- 提取每个过程 part 的有效时间区间
- 合并重叠区间，避免并发步骤重复计时
- 累加有效区间时长，不再统计不连续步骤之间的空档
- 运行中时间只补给当前活跃 part
- 补充顶层 `part.time` 渲染比较，确保 reasoning/text 时间更新能触发重渲染

## 验证

- `npm run test:run -- SessionChat.test.ts`
- `npm run build`
- `npm run lint`

说明：全量 `npm run test:run` 仍有一个既有失败，位于 `SecurityConfig/index.test.tsx`，与本次过程耗时改动无关。