### PR TITLE
Fix question tool deny handling for agents

### DIFF
--- a/flocks/agent/registry.py
+++ b/flocks/agent/registry.py
@@ -40,6 +40,7 @@ from flocks.agent.agent import (
 )
 import flocks.agent.delegatable_settings as delegatable_settings
 from flocks.agent.toolset import agent_declares_tool
+from flocks.agent.tool_permissions import permission_items_to_ruleset
 from flocks.agent.prompt_utils import categorize_tools
 from flocks.agent.agent_factory import (
     scan_and_load,
@@ -172,6 +173,7 @@ def _storage_custom_agent_to_info(agent_data: Dict[str, Any]) -> Optional[AgentI
         native=False,
         hidden=agent_data.get("hidden", False),
         delegatable=agent_data.get("delegatable"),
+        permission=permission_items_to_ruleset(agent_data.get("permission")),
         tools=agent_data.get("tools", []),
         tags=agent_data.get("tags", []),
     )

--- a/flocks/agent/tool_permissions.py
+++ b/flocks/agent/tool_permissions.py
@@ -1,0 +1,86 @@
+"""Helpers for keeping agent tool selections and permission rules aligned."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from flocks.permission.rule import PermissionLevel, PermissionRule, PermissionScope
+
+QUESTION_TOOL_NAME = "question"
+TOOLS_MANAGED_PERMISSION_SOURCE = "agent_tools"
+
+
+def normalize_permission_items(value: Any) -> List[Dict[str, Any]]:
+    """Return stored permission rules in API/storage dict form."""
+    if not isinstance(value, list):
+        return []
+
+    normalized: List[Dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+
+        permission = item.get("permission")
+        action = item.get("action") or item.get("level")
+        action = getattr(action, "value", action)
+        pattern = item.get("pattern") or "*"
+        if not permission or action not in {"allow", "ask", "deny"}:
+            continue
+
+        rule = dict(item)
+        rule["permission"] = str(permission)
+        rule["action"] = str(action)
+        rule["pattern"] = str(pattern)
+        normalized.append(rule)
+
+    return normalized
+
+
+def sync_question_permission_with_tools(
+    permissions: Any,
+    tools: List[str],
+) -> List[Dict[str, Any]]:
+    """Make the Agent tools checkbox an effective question allow/deny toggle."""
+    normalized = normalize_permission_items(permissions)
+    without_managed_question = [
+        rule
+        for rule in normalized
+        if not (
+            rule.get("permission") == QUESTION_TOOL_NAME
+            and rule.get("pattern", "*") == "*"
+            and rule.get("source") == TOOLS_MANAGED_PERMISSION_SOURCE
+        )
+    ]
+
+    if QUESTION_TOOL_NAME in set(tools):
+        return without_managed_question
+
+    if any(
+        rule.get("permission") == QUESTION_TOOL_NAME
+        and rule.get("action") == "deny"
+        and rule.get("pattern", "*") == "*"
+        for rule in without_managed_question
+    ):
+        return without_managed_question
+
+    return without_managed_question + [
+        {
+            "permission": QUESTION_TOOL_NAME,
+            "action": "deny",
+            "pattern": "*",
+            "source": TOOLS_MANAGED_PERMISSION_SOURCE,
+        }
+    ]
+
+
+def permission_items_to_ruleset(value: Any) -> List[PermissionRule]:
+    """Convert stored permission dicts to the internal PermissionRule shape."""
+    return [
+        PermissionRule(
+            permission=item["permission"],
+            level=PermissionLevel(item["action"]),
+            scope=PermissionScope.PATTERN,
+            pattern=item.get("pattern") or "*",
+        )
+        for item in normalize_permission_items(value)
+    ]

--- a/flocks/server/routes/agent.py
+++ b/flocks/server/routes/agent.py
@@ -29,6 +29,11 @@ from pydantic import BaseModel, Field
 
 import flocks.agent.delegatable_settings as delegatable_settings
 from flocks.agent.registry import Agent
+from flocks.agent.tool_permissions import (
+    normalize_permission_items,
+    permission_items_to_ruleset,
+    sync_question_permission_with_tools,
+)
 from flocks.agent.agent import AgentInfo as AgentInfoModel, AgentModel as AgentModelConfig
 from flocks.agent.agent_factory import find_yaml_agent, read_yaml_agent, update_yaml_agent, delete_yaml_agent
 from flocks.utils.log import Log
@@ -92,6 +97,7 @@ def agent_to_response(
     delegatable_override: Optional[bool] = None,
     skills: Optional[List[str]] = None,
     tools: Optional[List[str]] = None,
+    permission: Optional[List[Dict[str, Any]]] = None,
 ) -> AgentResponse:
     """Convert internal AgentInfo to API response format."""
     delegatable = (
@@ -124,7 +130,7 @@ def agent_to_response(
         topP=agent.top_p,
         temperature=temperature_override if temperature_override is not None else agent.temperature,
         color=agent.color,
-        permission=[],
+        permission=permission or [],
         model=model_info,
         prompt=agent.prompt,
         options=agent.options,
@@ -155,6 +161,8 @@ def _agent_data_to_info(agent_data: Dict[str, Any]) -> AgentInfoModel:
         temperature=agent_data.get("temperature"),
         color=agent_data.get("color"),
         mode=mode,
+        permission=permission_items_to_ruleset(agent_data.get("permission")),
+        tools=agent_data.get("tools", []),
         model=AgentModelConfig(
             model_id=model_data["modelID"],
             provider_id=model_data["providerID"],
@@ -185,7 +193,7 @@ def _custom_agent_data_to_response(agent_data: Dict[str, Any]) -> AgentResponse:
         model=model_info,
         native=agent_data.get("native", False),
         hidden=agent_data.get("hidden", False),
-        permission=[],
+        permission=normalize_permission_items(agent_data.get("permission")),
         options={},
         delegatable=delegatable,
         skills=agent_data.get("skills", []),
@@ -208,8 +216,8 @@ def _load_delegatable_overrides() -> Dict[str, bool]:
     return delegatable_settings.load_overrides()
 
 
-async def _load_custom_agent_extras(name: str) -> tuple[List[str], List[str]]:
-    """Load skills/tools list for an agent from storage.
+async def _load_custom_agent_extras(name: str) -> tuple[List[str], List[str], List[Dict[str, Any]]]:
+    """Load skills/tools/permission overlay for an agent from storage.
 
     Works for both full Storage-based custom agents and YAML agents with
     a skills/tools overlay (written by the YAML update path).
@@ -218,10 +226,14 @@ async def _load_custom_agent_extras(name: str) -> tuple[List[str], List[str]]:
     try:
         data = await Storage.read(f"agent/custom/{name}")
         if not isinstance(data, dict):
-            return [], []
-        return data.get("skills", []), data.get("tools", [])
+            return [], [], []
+        return (
+            data.get("skills", []),
+            data.get("tools", []),
+            normalize_permission_items(data.get("permission")),
+        )
     except Exception:
-        return [], []
+        return [], [], []
 
 
 def _get_all_tool_names() -> List[str]:
@@ -257,8 +269,9 @@ async def _build_single_agent_response(
     if agent.native:
         tools = _compute_native_agent_tools(agent, all_tool_names)
         skills: List[str] = []
+        permission: List[Dict[str, Any]] = []
     else:
-        skills, tools = await _load_custom_agent_extras(agent.name)
+        skills, tools, permission = await _load_custom_agent_extras(agent.name)
     override = overrides.get(agent.name, {})
     model_override = {k: override[k] for k in ("modelID", "providerID") if k in override} or None
     temperature_override = override.get("temperature")
@@ -269,6 +282,7 @@ async def _build_single_agent_response(
         delegatable_override=delegatable_overrides.get(agent.name),
         skills=skills,
         tools=tools,
+        permission=permission,
     )
 
 
@@ -359,6 +373,7 @@ class AgentCreateRequest(BaseModel):
     mode: str = Field("primary", description="Agent mode")
     model: Optional[AgentModelInfo] = Field(None, description="Preferred model")
     delegatable: Optional[bool] = Field(None, description="Whether this agent can be delegated to")
+    permission: List[Dict[str, Any]] = Field(default_factory=list, description="Permission rules")
     skills: List[str] = Field(default_factory=list, description="Enabled skill names")
     tools: List[str] = Field(default_factory=list, description="Enabled tool names")
 
@@ -373,6 +388,7 @@ class AgentUpdateRequest(BaseModel):
     color: Optional[str] = Field(None, description="Color")
     model: Optional[AgentModelInfo] = Field(None, description="Preferred model")
     delegatable: Optional[bool] = Field(None, description="Whether this agent can be delegated to")
+    permission: Optional[List[Dict[str, Any]]] = Field(None, description="Permission rules")
     skills: Optional[List[str]] = Field(None, description="Enabled skill names")
     tools: Optional[List[str]] = Field(None, description="Enabled tool names")
 
@@ -402,6 +418,11 @@ async def create_agent(req: AgentCreateRequest):
         if existing:
             raise HTTPException(status_code=409, detail=f"Agent {req.name} already exists")
 
+        permission = (
+            sync_question_permission_with_tools(req.permission, req.tools)
+            if "tools" in req.model_fields_set
+            else normalize_permission_items(req.permission)
+        )
         agent_data: Dict[str, Any] = {
             "name": req.name,
             "name_cn": req.nameCn,
@@ -415,6 +436,7 @@ async def create_agent(req: AgentCreateRequest):
             "delegatable": req.delegatable if req.delegatable is not None else req.mode != "primary",
             "native": False,
             "hidden": False,
+            "permission": permission,
             "skills": req.skills,
             "tools": req.tools,
         }
@@ -468,10 +490,16 @@ async def update_agent(name: str, req: AgentUpdateRequest):
             if req.delegatable is not None:
                 agent_data["delegatable"] = req.delegatable
                 delegatable_settings.forget_override(name)
+            if req.permission is not None:
+                agent_data["permission"] = normalize_permission_items(req.permission)
             if req.skills is not None:
                 agent_data["skills"] = req.skills
             if req.tools is not None:
                 agent_data["tools"] = req.tools
+                agent_data["permission"] = sync_question_permission_with_tools(
+                    agent_data.get("permission"),
+                    req.tools,
+                )
 
             await Storage.write(agent_key, agent_data)
 
@@ -508,12 +536,18 @@ async def update_agent(name: str, req: AgentUpdateRequest):
             # Persist skills/tools overlay for YAML agents in Storage.
             # The entry intentionally omits "name" so it is not mistaken
             # for a full Storage-based custom agent on subsequent updates.
-            if req.skills is not None or req.tools is not None:
+            if req.skills is not None or req.tools is not None or req.permission is not None:
                 extras: Dict[str, Any] = agent_data if isinstance(agent_data, dict) else {}
+                if req.permission is not None:
+                    extras["permission"] = normalize_permission_items(req.permission)
                 if req.skills is not None:
                     extras["skills"] = req.skills
                 if req.tools is not None:
                     extras["tools"] = req.tools
+                    extras["permission"] = sync_question_permission_with_tools(
+                        extras.get("permission"),
+                        req.tools,
+                    )
                 await Storage.write(agent_key, extras)
 
             # Sync: apply updates to the in-memory AgentInfo cache
@@ -538,6 +572,11 @@ async def update_agent(name: str, req: AgentUpdateRequest):
                     )
                 if req.delegatable is not None:
                     agent.delegatable = req.delegatable
+                if req.tools is not None:
+                    agent.tools = req.tools
+                    agent.permission = permission_items_to_ruleset(extras.get("permission"))
+                elif req.permission is not None:
+                    agent.permission = permission_items_to_ruleset(extras.get("permission"))
                 overrides = await _load_model_overrides()
                 delegatable_overrides = _load_delegatable_overrides()
                 all_tool_names = await _get_all_tool_names_async()

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -590,18 +590,35 @@ class SessionRunner:
         messages: List[MessageInfo],
     ) -> Tuple[List[Any], Dict[str, Any]]:
         execution_mode = self._execution_mode_from_messages(messages)
+        from flocks.agent.tool_permissions import QUESTION_TOOL_NAME
+        from flocks.permission.next import PermissionNext
+
+        declared_tool_names = getattr(agent, "tools", None)
+        permission_ruleset = getattr(self, "_turn_permission_ruleset", None)
+        if permission_ruleset is None:
+            permission_ruleset = self._permission_ruleset_for_agent(agent)
         result = await list_session_callable_tool_infos(
             session_id=self.session.id,
-            declared_tool_names=getattr(agent, "tools", None),
+            declared_tool_names=declared_tool_names,
             agent=agent.name,
             step=self._step,
             event_publish_callback=self.callbacks.event_publish_callback,
         )
-        tool_infos = [
-            tool_info
-            for tool_info in result.tool_infos
-            if is_tool_allowed(execution_mode, tool_info.name)
-        ]
+        permission_denied_tool_names: List[str] = []
+        tool_infos = []
+        for tool_info in result.tool_infos:
+            if not is_tool_allowed(execution_mode, tool_info.name):
+                continue
+            if tool_info.name == QUESTION_TOOL_NAME:
+                denied_by_permission = PermissionNext.evaluate_request(
+                    tool_info.name,
+                    ["*"],
+                    permission_ruleset,
+                ) == "deny"
+                if denied_by_permission:
+                    permission_denied_tool_names.append(tool_info.name)
+                    continue
+            tool_infos.append(tool_info)
         if (
             execution_mode == SessionExecutionMode.PLAN
             and all(tool_info.name != "plan_exit" for tool_info in tool_infos)
@@ -611,6 +628,7 @@ class SessionRunner:
                 tool_infos.append(plan_exit.info)
         metadata = dict(result.metadata)
         metadata["executionMode"] = execution_mode.value
+        metadata["permissionDeniedToolNames"] = sorted(permission_denied_tool_names)
         metadata["modeAllowedToolNames"] = sorted(
             tool_info.name for tool_info in tool_infos
         )
@@ -3999,6 +4017,8 @@ class SessionRunner:
             patterns,
             ruleset,
         )
+        metadata = dict(getattr(request, "metadata", None) or {})
+        deny_only_preflight = metadata.get("reason") == "question_tool"
 
         tool_metadata = get_tool_catalog_metadata(str(getattr(request, "permission", "") or ""))
         if self.callbacks.event_publish_callback:
@@ -4014,6 +4034,8 @@ class SessionRunner:
             raise PermissionError(f"Permission denied: {request.permission}")
         if configured_action == "allow":
             return
+        if deny_only_preflight:
+            return
 
         if self.callbacks.on_permission_request:
             allowed = await self.callbacks.on_permission_request(request)
@@ -4026,7 +4048,6 @@ class SessionRunner:
         if configured_action is None and not legacy_tool_permission_prompt_required():
             return
 
-        metadata = dict(getattr(request, "metadata", None) or {})
         metadata.setdefault("messageID", getattr(request, "message_id", "") or "")
         metadata.setdefault("sessionID", self.session.id)
 

--- a/flocks/tool/system/question.py
+++ b/flocks/tool/system/question.py
@@ -422,6 +422,21 @@ async def question_tool(
             error="No valid questions provided"
         )
 
+    try:
+        await ctx.ask(
+            "question",
+            ["*"],
+            metadata={"reason": "question_tool"},
+        )
+    except (PermissionError, asyncio.TimeoutError) as e:
+        error = str(e) or "question"
+        if not error.lower().startswith("permission denied"):
+            error = f"Permission denied: {error}"
+        return ToolResult(
+            success=False,
+            error=error,
+        )
+
     channel_result = await _send_channel_question_if_applicable(ctx, normalized_questions)
     if channel_result is not None:
         return channel_result

--- a/tests/server/routes/test_agent_routes.py
+++ b/tests/server/routes/test_agent_routes.py
@@ -174,6 +174,93 @@ class TestAgentCreate:
         assert "test-agent" in [agent["name"] for agent in list_resp.json()]
 
     @pytest.mark.asyncio
+    async def test_create_agent_without_tools_field_keeps_permission_unchanged(
+        self,
+        client: AsyncClient,
+    ):
+        """Older clients that omit tools do not implicitly disable question."""
+        payload = {k: v for k, v in _AGENT_PAYLOAD.items() if k != "tools"}
+        payload["name"] = "legacy-create-agent"
+
+        resp = await client.post("/api/agent", json=payload)
+
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.json()["permission"] == []
+
+    @pytest.mark.asyncio
+    async def test_create_agent_without_question_tool_adds_persistent_deny(self, client: AsyncClient):
+        """Unchecking the question tool persists a deny rule for the always-load tool."""
+        from flocks.agent.registry import Agent
+        from flocks.storage.storage import Storage
+
+        payload = {
+            **_AGENT_PAYLOAD,
+            "name": "no-question-agent",
+            "tools": ["tool_search"],
+        }
+
+        resp = await client.post("/api/agent", json=payload)
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.json()["permission"] == [{
+            "permission": "question",
+            "action": "deny",
+            "pattern": "*",
+            "source": "agent_tools",
+        }]
+
+        stored = await Storage.read("agent/custom/no-question-agent")
+        assert stored["permission"] == resp.json()["permission"]
+
+        Agent._custom_agents.clear()
+        Agent.invalidate_cache()
+
+        agent = await Agent.get("no-question-agent")
+        assert agent is not None
+        assert any(
+            rule.permission == "question" and rule.level.value == "deny"
+            for rule in agent.permission
+        )
+
+        get_resp = await client.get("/api/agent/no-question-agent")
+        assert get_resp.status_code == status.HTTP_200_OK
+        assert get_resp.json()["permission"] == resp.json()["permission"]
+
+    @pytest.mark.asyncio
+    async def test_update_agent_question_tool_toggle_adds_and_removes_managed_deny(
+        self,
+        client: AsyncClient,
+    ):
+        """The Tools checkbox controls only the system-managed question deny rule."""
+        payload = {
+            **_AGENT_PAYLOAD,
+            "name": "question-toggle-agent",
+            "tools": ["question", "tool_search"],
+        }
+
+        create_resp = await client.post("/api/agent", json=payload)
+        assert create_resp.status_code == status.HTTP_200_OK
+        assert create_resp.json()["permission"] == []
+
+        disable_resp = await client.put(
+            "/api/agent/question-toggle-agent",
+            json={"tools": ["tool_search"]},
+        )
+        assert disable_resp.status_code == status.HTTP_200_OK
+        assert disable_resp.json()["permission"] == [{
+            "permission": "question",
+            "action": "deny",
+            "pattern": "*",
+            "source": "agent_tools",
+        }]
+
+        enable_resp = await client.put(
+            "/api/agent/question-toggle-agent",
+            json={"tools": ["question", "tool_search"]},
+        )
+        assert enable_resp.status_code == status.HTTP_200_OK
+        assert enable_resp.json()["permission"] == []
+
+    @pytest.mark.asyncio
     async def test_create_subagent_defaults_to_delegatable(self, client: AsyncClient):
         """Sub-agents default to delegatable=true when the field is omitted."""
         resp = await client.post("/api/agent", json=_SUBAGENT_PAYLOAD)

--- a/tests/session/test_execution_mode.py
+++ b/tests/session/test_execution_mode.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
@@ -406,6 +407,7 @@ async def test_runner_filters_tools_with_message_mode(monkeypatch) -> None:
     runner._step = 1
     runner.callbacks = SimpleNamespace(event_publish_callback=None)
     agent = SimpleNamespace(
+        name="rex",
         tools=[
             "read",
             "bash",
@@ -479,3 +481,240 @@ async def test_runner_filters_tools_with_message_mode(monkeypatch) -> None:
         "task",
         "write",
     ]
+
+
+@pytest.mark.asyncio
+async def test_runner_hides_always_load_question_when_permission_denied(monkeypatch) -> None:
+    from flocks.permission.helpers import from_config
+    from flocks.session.runner import SessionRunner
+
+    runner = object.__new__(SessionRunner)
+    runner.session = SimpleNamespace(id="session-question-deny")
+    runner._step = 1
+    runner.callbacks = SimpleNamespace(event_publish_callback=None)
+    runner._turn_permission_ruleset = from_config({"question": "deny"})
+    agent = SimpleNamespace(name="custom-agent", tools=["request_ledger"])
+
+    result = SimpleNamespace(
+        tool_infos=[
+            SimpleNamespace(name="question"),
+            SimpleNamespace(name="tool_search"),
+            SimpleNamespace(name="request_ledger"),
+        ],
+        metadata={},
+    )
+
+    async def list_tools(**_kwargs):
+        return result
+
+    monkeypatch.setattr(
+        "flocks.session.runner.list_session_callable_tool_infos",
+        list_tools,
+    )
+
+    messages = [
+        SimpleNamespace(
+            role="user",
+            executionMode=SessionExecutionMode.BUILD,
+        )
+    ]
+
+    tools, metadata = await runner._list_callable_tool_infos_for_turn(
+        agent,
+        messages,
+    )
+
+    assert [tool.name for tool in tools] == ["tool_search", "request_ledger"]
+    assert metadata["permissionDeniedToolNames"] == ["question"]
+    assert metadata["modeAllowedToolNames"] == ["request_ledger", "tool_search"]
+
+
+@pytest.mark.asyncio
+async def test_runner_keeps_always_load_question_without_permission_denial(monkeypatch) -> None:
+    from flocks.session.runner import SessionRunner
+
+    runner = object.__new__(SessionRunner)
+    runner.session = SimpleNamespace(id="session-question-allowed")
+    runner._step = 1
+    runner.callbacks = SimpleNamespace(event_publish_callback=None)
+    runner._turn_permission_ruleset = []
+    agent = SimpleNamespace(name="custom-agent", tools=["question", "request_ledger"])
+
+    result = SimpleNamespace(
+        tool_infos=[
+            SimpleNamespace(name="question"),
+            SimpleNamespace(name="tool_search"),
+            SimpleNamespace(name="request_ledger"),
+        ],
+        metadata={},
+    )
+
+    async def list_tools(**_kwargs):
+        return result
+
+    monkeypatch.setattr(
+        "flocks.session.runner.list_session_callable_tool_infos",
+        list_tools,
+    )
+
+    messages = [
+        SimpleNamespace(
+            role="user",
+            executionMode=SessionExecutionMode.BUILD,
+        )
+    ]
+
+    tools, metadata = await runner._list_callable_tool_infos_for_turn(
+        agent,
+        messages,
+    )
+
+    assert [tool.name for tool in tools] == [
+        "question",
+        "tool_search",
+        "request_ledger",
+    ]
+    assert metadata["permissionDeniedToolNames"] == []
+
+
+@pytest.mark.asyncio
+async def test_runner_keeps_question_visible_when_only_tool_list_omits_it(monkeypatch) -> None:
+    from flocks.session.runner import SessionRunner
+
+    runner = object.__new__(SessionRunner)
+    runner.session = SimpleNamespace(id="session-question-unchecked")
+    runner._step = 1
+    runner.callbacks = SimpleNamespace(event_publish_callback=None)
+    runner._turn_permission_ruleset = []
+    agent = SimpleNamespace(name="custom-agent", tools=["request_ledger"])
+
+    result = SimpleNamespace(
+        tool_infos=[
+            SimpleNamespace(name="question"),
+            SimpleNamespace(name="tool_search"),
+            SimpleNamespace(name="request_ledger"),
+        ],
+        metadata={},
+    )
+
+    async def list_tools(**_kwargs):
+        return result
+
+    monkeypatch.setattr(
+        "flocks.session.runner.list_session_callable_tool_infos",
+        list_tools,
+    )
+
+    messages = [
+        SimpleNamespace(
+            role="user",
+            executionMode=SessionExecutionMode.BUILD,
+        )
+    ]
+
+    tools, metadata = await runner._list_callable_tool_infos_for_turn(
+        agent,
+        messages,
+    )
+
+    assert [tool.name for tool in tools] == [
+        "question",
+        "tool_search",
+        "request_ledger",
+    ]
+    assert metadata["permissionDeniedToolNames"] == []
+
+
+@pytest.mark.asyncio
+async def test_runner_keeps_non_question_tools_visible_when_permission_denied(monkeypatch) -> None:
+    from flocks.permission.helpers import from_config
+    from flocks.session.runner import SessionRunner
+
+    runner = object.__new__(SessionRunner)
+    runner.session = SimpleNamespace(id="session-bash-deny")
+    runner._step = 1
+    runner.callbacks = SimpleNamespace(event_publish_callback=None)
+    runner._turn_permission_ruleset = from_config({"bash": "deny"})
+    agent = SimpleNamespace(name="custom-agent", tools=["question", "bash"])
+
+    result = SimpleNamespace(
+        tool_infos=[
+            SimpleNamespace(name="question"),
+            SimpleNamespace(name="bash"),
+        ],
+        metadata={},
+    )
+
+    async def list_tools(**_kwargs):
+        return result
+
+    monkeypatch.setattr(
+        "flocks.session.runner.list_session_callable_tool_infos",
+        list_tools,
+    )
+
+    messages = [
+        SimpleNamespace(
+            role="user",
+            executionMode=SessionExecutionMode.BUILD,
+        )
+    ]
+
+    tools, metadata = await runner._list_callable_tool_infos_for_turn(
+        agent,
+        messages,
+    )
+
+    assert [tool.name for tool in tools] == ["question", "bash"]
+    assert metadata["permissionDeniedToolNames"] == []
+
+
+@pytest.mark.asyncio
+async def test_question_preflight_ask_permission_does_not_prompt() -> None:
+    from flocks.permission.helpers import from_config
+    from flocks.session.runner import SessionRunner
+
+    runner = object.__new__(SessionRunner)
+    runner.session = SimpleNamespace(id="session-question-ask")
+    runner._step = 1
+    runner.callbacks = SimpleNamespace(
+        event_publish_callback=None,
+        on_permission_request=AsyncMock(return_value=False),
+    )
+    runner._turn_permission_ruleset = from_config({"question": "ask"})
+
+    await runner._handle_permission(SimpleNamespace(
+        permission="question",
+        patterns=["*"],
+        always=[],
+        metadata={"reason": "question_tool"},
+        message_id="msg_1",
+    ))
+
+    runner.callbacks.on_permission_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_question_preflight_deny_permission_still_blocks() -> None:
+    from flocks.permission.helpers import from_config
+    from flocks.session.runner import SessionRunner
+
+    runner = object.__new__(SessionRunner)
+    runner.session = SimpleNamespace(id="session-question-deny")
+    runner._step = 1
+    runner.callbacks = SimpleNamespace(
+        event_publish_callback=None,
+        on_permission_request=AsyncMock(return_value=True),
+    )
+    runner._turn_permission_ruleset = from_config({"question": "deny"})
+
+    with pytest.raises(PermissionError, match="Permission denied: question"):
+        await runner._handle_permission(SimpleNamespace(
+            permission="question",
+            patterns=["*"],
+            always=[],
+            metadata={"reason": "question_tool"},
+            message_id="msg_1",
+        ))
+
+    runner.callbacks.on_permission_request.assert_not_awaited()

--- a/tests/tool/test_question_channel.py
+++ b/tests/tool/test_question_channel.py
@@ -107,6 +107,35 @@ async def test_question_tool_preserves_custom_flag(
 
 
 @pytest.mark.asyncio
+async def test_question_tool_respects_permission_denial_before_waiting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = AsyncMock(return_value=[["yes"]])
+    channel_send = AsyncMock(return_value=None)
+
+    async def deny_question(_request):
+        raise PermissionError("Permission denied: question")
+
+    monkeypatch.setattr(question_module, "_question_handler", handler)
+    monkeypatch.setattr(question_module, "_send_channel_question_if_applicable", channel_send)
+
+    result = await question_module.question_tool(
+        ToolContext(
+            session_id="ses_question_denied",
+            message_id="msg_1",
+            call_id="call_1",
+            permission_callback=deny_question,
+        ),
+        questions=[{"question": "Continue?", "type": "confirm"}],
+    )
+
+    assert result.success is False
+    assert "Permission denied" in (result.error or "")
+    handler.assert_not_awaited()
+    channel_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_question_tool_sends_plain_text_for_channel_session() -> None:
     binding = SimpleNamespace(
         channel_id="feishu",


### PR DESCRIPTION
## 变更说明

修复用户在 Agent 工具配置中关闭 `question` 后，对话中仍可能调用该工具的问题。

主要改动：
- Agent 显式关闭 `question` 时，自动同步系统管理的 `question: deny` 权限规则。
- 会话组装可调用工具时，若 `question` 被 deny，则不再暴露给模型。
- `question` 工具执行前增加权限预检，避免异常路径继续等待用户回答。
- 避免 `question: ask` 场景下出现额外权限确认弹窗。

## 测试

相关回归通过：`79 passed, 3 warnings`