### PR TITLE
fix workspace listing with symlink root

### DIFF
--- a/flocks/server/routes/workspace.py
+++ b/flocks/server/routes/workspace.py
@@ -101,6 +101,11 @@ def _get_manager() -> WorkspaceManager:
     return mgr
 
 
+def _workspace_root(mgr: WorkspaceManager) -> Path:
+    """Return the canonical workspace root used for relative path rendering."""
+    return mgr.get_workspace_dir().resolve()
+
+
 def _is_allowed_upload_filename(filename: str) -> bool:
     return Path(filename).suffix.lower() in _ALLOWED_UPLOAD_EXTENSIONS
 
@@ -250,15 +255,16 @@ async def list_tree(
     depth: int = Query(2, ge=1, le=5, description="Tree depth"),
 ):
     mgr = _get_manager()
+    workspace_root = _workspace_root(mgr)
     try:
-        base = mgr.resolve_workspace_path(path) if path else mgr.get_workspace_dir()
+        base = mgr.resolve_workspace_path(path) if path else workspace_root
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if not base.exists():
         raise HTTPException(status_code=404, detail=f"Path not found: {path}")
     if not base.is_dir():
         raise HTTPException(status_code=400, detail=f"Not a directory: {path}")
-    return await asyncio.to_thread(_build_tree_sync, base, mgr.get_workspace_dir(), depth)
+    return await asyncio.to_thread(_build_tree_sync, base, workspace_root, depth)
 
 
 @router.get("/list", response_model=List[WorkspaceNode], summary="List directory")
@@ -266,15 +272,16 @@ async def list_dir(
     path: str = Query("", description="Relative path from workspace root"),
 ):
     mgr = _get_manager()
+    workspace_root = _workspace_root(mgr)
     try:
-        base = mgr.resolve_workspace_path(path) if path else mgr.get_workspace_dir()
+        base = mgr.resolve_workspace_path(path) if path else workspace_root
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if not base.exists():
         raise HTTPException(status_code=404, detail=f"Path not found: {path}")
     if not base.is_dir():
         raise HTTPException(status_code=400, detail=f"Not a directory: {path}")
-    return await asyncio.to_thread(_list_dir_sync, base, mgr.get_workspace_dir())
+    return await asyncio.to_thread(_list_dir_sync, base, workspace_root)
 
 
 class DirCreateRequest(BaseModel):

--- a/tests/workspace/test_workspace_routes.py
+++ b/tests/workspace/test_workspace_routes.py
@@ -138,6 +138,33 @@ class TestDirList:
         r = _client(workspace_client).get("/api/workspace/list?path=file.txt")
         assert r.status_code == 400
 
+    def test_list_subdir_when_workspace_root_is_symlink(self, workspace_client, tmp_path: Path):
+        ws = _ws(workspace_client)
+        link = tmp_path / "workspace-link"
+        try:
+            link.symlink_to(ws, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+        from flocks.workspace.manager import WorkspaceManager
+
+        manager = WorkspaceManager.get_instance()
+        manager._workspace_dir = link
+        (ws / "outputs" / "report.txt").write_text("ok")
+
+        root = _client(workspace_client).get("/api/workspace/list")
+        r = _client(workspace_client).get("/api/workspace/list?path=outputs")
+
+        assert root.status_code == 200
+        assert any(item["name"] == "outputs" and item["path"] == "outputs" for item in root.json())
+        assert r.status_code == 200
+        assert any(
+            item["name"] == "report.txt"
+            and item["path"] == "outputs/report.txt"
+            and item["type"] == "file"
+            for item in r.json()
+        )
+
 
 class TestDirTree:
     def test_tree_root(self, workspace_client):
@@ -162,6 +189,30 @@ class TestDirTree:
     def test_tree_nonexistent_returns_404(self, workspace_client):
         r = _client(workspace_client).get("/api/workspace/tree?path=nope")
         assert r.status_code == 404
+
+    def test_tree_subdir_when_workspace_root_is_symlink(self, workspace_client, tmp_path: Path):
+        ws = _ws(workspace_client)
+        link = tmp_path / "workspace-link"
+        try:
+            link.symlink_to(ws, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+        from flocks.workspace.manager import WorkspaceManager
+
+        manager = WorkspaceManager.get_instance()
+        manager._workspace_dir = link
+        (ws / "outputs" / "nested").mkdir()
+
+        root = _client(workspace_client).get("/api/workspace/tree?depth=1")
+        r = _client(workspace_client).get("/api/workspace/tree?path=outputs&depth=1")
+
+        assert root.status_code == 200
+        assert root.json()["path"] == ""
+        assert r.status_code == 200
+        data = r.json()
+        assert data["path"] == "outputs"
+        assert any(child["path"] == "outputs/nested" for child in data["children"])
 
 
 class TestDirCreate:


### PR DESCRIPTION
## 变更说明

修复 workspace 目录为软链接时，文件列表/目录树接口因路径形态不一致导致 500 的问题。

当 `FLOCKS_WORKSPACE_DIR` 使用软链路径（如 `/home/...`），但运行中目录被解析为真实路径（如 `/data/...`）时，`Path.relative_to()` 会因为字符串路径不一致抛出异常。本次在 `/api/workspace/list` 和 `/api/workspace/tree` 中统一使用 canonical workspace root 计算相对路径。

## 验证

- 新增软链接 workspace root 回归测试，覆盖 list/tree 的 root 和子目录场景
- `pytest tests/workspace -q` 通过
- `ruff check flocks/server/routes/workspace.py tests/workspace/test_workspace_routes.py` 通过
- `git diff --check` 通过