### PR TITLE
fix workspace uploads with symlink root

### DIFF
--- a/flocks/server/routes/workspace.py
+++ b/flocks/server/routes/workspace.py
@@ -352,8 +352,10 @@ async def upload_files(
     files: List[UploadFile] = File(...),
 ):
     mgr = _get_manager()
+    workspace_root = _workspace_root(mgr)
     try:
         dest_dir = mgr.resolve_workspace_path(dest) if dest else mgr.get_workspace_dir()
+        relative_dest_dir = dest_dir.resolve().relative_to(workspace_root)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -411,7 +413,7 @@ async def upload_files(
         })
         results.append({
             "name": target.name,
-            "path": str(target.relative_to(mgr.get_workspace_dir())),
+            "path": str(relative_dest_dir / filename),
             "abs_path": str(target),
             "size": total,
             "is_text_file": is_text,

--- a/tests/workspace/test_workspace_routes.py
+++ b/tests/workspace/test_workspace_routes.py
@@ -392,6 +392,66 @@ class TestUpload:
         assert r.status_code == 200
         assert (_ws(workspace_client) / "new_folder" / "x.txt").exists()
 
+    @pytest.mark.parametrize("purpose", [None, "chat"])
+    def test_upload_to_dest_when_workspace_root_is_symlink(
+        self,
+        workspace_client,
+        tmp_path: Path,
+        purpose: str | None,
+    ):
+        ws = _ws(workspace_client)
+        link = tmp_path / "workspace-link"
+        try:
+            link.symlink_to(ws, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+        from flocks.workspace.manager import WorkspaceManager
+
+        WorkspaceManager.get_instance()._workspace_dir = link
+        url = "/api/workspace/upload?dest=uploads"
+        if purpose:
+            url += f"&purpose={purpose}"
+
+        response = _client(workspace_client).post(
+            url,
+            files=[("files", ("report.pdf", b"report", "application/pdf"))],
+        )
+
+        assert response.status_code == 200
+        result = response.json()["uploaded"][0]
+        assert result.get("error") is None
+        assert result["path"] == "uploads/report.pdf"
+        assert result["abs_path"] == str(ws / "uploads" / "report.pdf")
+        assert (ws / "uploads" / "report.pdf").read_bytes() == b"report"
+
+    def test_upload_to_root_when_workspace_root_is_symlink(
+        self,
+        workspace_client,
+        tmp_path: Path,
+    ):
+        ws = _ws(workspace_client)
+        link = tmp_path / "workspace-link"
+        try:
+            link.symlink_to(ws, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+        from flocks.workspace.manager import WorkspaceManager
+
+        WorkspaceManager.get_instance()._workspace_dir = link
+        response = _client(workspace_client).post(
+            "/api/workspace/upload",
+            files=[("files", ("root.txt", b"root", "text/plain"))],
+        )
+
+        assert response.status_code == 200
+        result = response.json()["uploaded"][0]
+        assert result.get("error") is None
+        assert result["path"] == "root.txt"
+        assert result["abs_path"] == str(link / "root.txt")
+        assert (ws / "root.txt").read_bytes() == b"root"
+
     def test_upload_overwrites_duplicate_file_without_chat_purpose(self, workspace_client):
         client = _client(workspace_client)
         first = client.post(


### PR DESCRIPTION
## 问题

当 workspace 根目录为软链接时，上传文件到 `workspace/uploads` 会因真实路径与软链接路径不一致而返回 500。

## 修改

- 使用规范化 workspace 根目录计算上传文件的相对路径。
- 保持现有 `abs_path`、覆盖策略及路径安全校验不变。
- 增加普通上传、聊天上传和根目录上传的软链接回归测试。

## 验证

- Workspace 全量测试：156 passed
- Ruff 静态检查通过