### PR TITLE
Add per-session runtime status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,18 @@ Non-browser clients (TUI, SDKs, scripts):
   curl -H "Authorization: Bearer <token>" https://flocks.example.com/api/health
   ```
 
+  Query the live runtime status of a specific session:
+
+  ```bash
+  curl -H "Authorization: Bearer <token>" \
+    https://flocks.example.com/api/session/<sessionID>/status
+  ```
+
+  `status.type` is one of `idle`, `queued`, `busy`, `retry`, `compacting`, or
+  `dreaming`. Automation clients can use `isProcessing` to determine whether
+  accepted work is still running or waiting. `idle` only means that the session
+  is currently inactive; it does not indicate whether the previous run succeeded.
+
 Reverse-proxy deployments:
 
 - Always set `X-Forwarded-For` on the proxy. Without it, any direct

--- a/README_zh.md
+++ b/README_zh.md
@@ -261,6 +261,17 @@ flocks start --server-host 0.0.0.0 --webui-host 0.0.0.0
   curl -H "Authorization: Bearer <token>" https://flocks.example.com/api/health
   ```
 
+  查询指定会话的实时运行状态：
+
+  ```bash
+  curl -H "Authorization: Bearer <token>" \
+    https://flocks.example.com/api/session/<sessionID>/status
+  ```
+
+  `status.type` 可能为 `idle`、`queued`、`busy`、`retry`、`compacting` 或
+  `dreaming`。自动化调用可通过 `isProcessing` 判断是否仍有已接收的工作正在执行或等待执行；
+  `idle` 只表示当前空闲，不代表上一次执行成功。
+
 反向代理部署：
 
 - 反代必须主动注入 `X-Forwarded-For`。若缺失该头，且前方存在代理，中间件会拒绝信任回环地址，避免任何直连本机的请求被自动提升为 `admin`。

--- a/flocks/server/app.py
+++ b/flocks/server/app.py
@@ -709,6 +709,11 @@ def _is_noisy_request_path(path: str) -> bool:
     """Return True for high-frequency polling endpoints that are noisy on success."""
     if path in _REQUEST_LOG_SKIP_EXACT:
         return True
+    if (
+        path.startswith(("/api/session/", "/session/"))
+        and path.endswith("/status")
+    ):
+        return True
     if path.startswith("/api/session/") and path.endswith("/message"):
         return True
     if path.startswith("/api/question/session/") and path.endswith("/pending"):

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -783,7 +783,10 @@ async def _build_session_runtime_status(session: SessionModel) -> SessionRuntime
     # starts. Treat that window (and inter-prompt queue hand-offs) as queued
     # so API clients never mistake accepted work for completion.
     if runtime_status.type == "idle":
-        if SessionLoop.is_running(session.id):
+        if (
+            Session.has_active_operations(session.id)
+            or SessionLoop.is_running(session.id)
+        ):
             runtime_status = SessionStatusBusy()
         elif (
             _is_prompt_chain_active(session.id)
@@ -5016,6 +5019,7 @@ class ShellRequest(BaseModel):
 async def run_shell_command(sessionID: str, request: ShellRequest, http_request: Request):
     """Run shell command"""
     from flocks.hooks.execution import ExecutionStopped
+    from flocks.server.routes.event import publish_event
     from flocks.session.runner import SessionRunner
 
     current_user = require_user(http_request)
@@ -5038,6 +5042,7 @@ async def run_shell_command(sessionID: str, request: ShellRequest, http_request:
                 agent=request.agent,
                 command=request.command,
                 model=model,
+                event_publish_callback=publish_event,
             )
     except SessionNotFoundError as exc:
         raise HTTPException(

--- a/flocks/server/routes/session.py
+++ b/flocks/server/routes/session.py
@@ -12,8 +12,8 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Any, Dict, Literal, Union, Tuple
-from fastapi import APIRouter, HTTPException, status, Query, Request
+from typing import List, Optional, Any, Dict, Literal, Union, Tuple, cast
+from fastapi import APIRouter, HTTPException, status, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, ConfigDict
 
@@ -41,6 +41,11 @@ from flocks.session.session import (
 )
 from flocks.session.policy import SessionPolicy
 from flocks.session.execution_mode import SessionExecutionMode
+from flocks.session.core.status import (
+    SessionStatusBusy,
+    SessionStatusInfo,
+    SessionStatusQueued,
+)
 from flocks.utils.log import Log
 from flocks.utils.json_repair import parse_json_robust, repair_truncated_json
 from flocks.utils.monitor import get_monitor
@@ -296,6 +301,20 @@ class SessionListItem(BaseModel):
     canWrite: bool = False
     canDelete: bool = False
     isShared: bool = False
+
+
+class SessionRuntimeStatusResponse(BaseModel):
+    """Runtime status snapshot for one session."""
+
+    sessionID: str = Field(..., description="Session ID")
+    lifecycleStatus: Literal["active", "archived"] = Field(
+        ...,
+        description="Persisted session lifecycle status",
+    )
+    status: SessionStatusInfo = Field(..., description="Current runtime status")
+    isProcessing: bool = Field(..., description="Whether accepted session work is still in progress")
+    pendingPromptCount: int = Field(0, ge=0, description="Number of prompts waiting in the session queue")
+    observedAt: int = Field(..., description="Server observation timestamp in milliseconds")
 
 
 @dataclass(frozen=True)
@@ -745,6 +764,67 @@ async def get_session_status() -> Dict[str, Any]:
         }
         for session_id, status in statuses.items()
     }
+
+
+async def _build_session_runtime_status(session: SessionModel) -> SessionRuntimeStatusResponse:
+    """Build a process-local runtime status snapshot for one session."""
+    from flocks.session.core.status import SessionStatus
+    from flocks.session.interaction_queue import InteractionQueue
+    from flocks.session.session_loop import SessionLoop
+
+    queued_prompts = await InteractionQueue.list(session.id)
+    runtime_status = SessionStatus.get_for_session(
+        session.id,
+        preferred_instance_id=session.directory,
+    )
+
+    # ``prompt_async`` marks its route-owned chain active before returning
+    # 202, while SessionLoop sets ``busy`` only after the background task
+    # starts. Treat that window (and inter-prompt queue hand-offs) as queued
+    # so API clients never mistake accepted work for completion.
+    if runtime_status.type == "idle":
+        if SessionLoop.is_running(session.id):
+            runtime_status = SessionStatusBusy()
+        elif (
+            _is_prompt_chain_active(session.id)
+            or has_pending_session_tasks(session.id)
+            or queued_prompts
+        ):
+            runtime_status = SessionStatusQueued()
+
+    return SessionRuntimeStatusResponse(
+        sessionID=session.id,
+        lifecycleStatus=cast(Literal["active", "archived"], session.status),
+        status=runtime_status,
+        isProcessing=runtime_status.type != "idle",
+        pendingPromptCount=len(queued_prompts),
+        observedAt=int(time.time() * 1000),
+    )
+
+
+@router.get(
+    "/{sessionID}/status",
+    response_model=SessionRuntimeStatusResponse,
+    summary="Get session runtime status",
+    description="Get the current runtime status of a specific session",
+    operation_id="session.statusById",
+)
+async def get_session_status_by_id(
+    sessionID: str,
+    request: Request,
+    response: Response,
+) -> SessionRuntimeStatusResponse:
+    """Return an explicit runtime status, including idle, for one session."""
+    response.headers["Cache-Control"] = "no-store"
+    current_user = require_user(request)
+    session = await _get_session_by_id_unfiltered(sessionID)
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session {sessionID} not found",
+        )
+    _require_session_read_access(session, current_user)
+    return await _build_session_runtime_status(session)
 
 
 @router.get(

--- a/flocks/session/core/status.py
+++ b/flocks/session/core/status.py
@@ -1,7 +1,7 @@
 """
 Session status tracking
 
-Manages session execution state (idle, busy, retry).
+Manages session execution state (idle, queued, busy, retry).
 Based on Flocks' ported src/session/status.ts
 """
 
@@ -23,6 +23,12 @@ class SessionStatusIdle(BaseModel):
 class SessionStatusBusy(BaseModel):
     """Busy status"""
     type: Literal["busy"] = "busy"
+
+
+class SessionStatusQueued(BaseModel):
+    """Queued status - accepted work is waiting to enter the session loop."""
+
+    type: Literal["queued"] = "queued"
 
 
 class SessionStatusRetry(BaseModel):
@@ -52,6 +58,7 @@ class SessionStatusDreaming(BaseModel):
 # Union of all status types
 SessionStatusInfo = (
     SessionStatusIdle
+    | SessionStatusQueued
     | SessionStatusBusy
     | SessionStatusRetry
     | SessionStatusCompacting
@@ -97,6 +104,34 @@ class SessionStatus:
         """
         state = cls._get_state()
         return state.get(session_id, SessionStatusIdle())
+
+    @classmethod
+    def get_for_session(
+        cls,
+        session_id: str,
+        preferred_instance_id: Optional[str] = None,
+    ) -> SessionStatusInfo:
+        """Get a session status without relying on the ambient instance context.
+
+        Session IDs are globally unique, but runtime state remains grouped by
+        instance directory for compatibility. Prefer the session's persisted
+        directory and fall back to the remaining live instance states so a
+        canonicalized or historical directory cannot cause a false idle.
+        """
+        if preferred_instance_id:
+            preferred_state = cls._state.get(preferred_instance_id, {})
+            status = preferred_state.get(session_id)
+            if status is not None:
+                return status
+
+        for instance_id, state in list(cls._state.items()):
+            if instance_id == preferred_instance_id:
+                continue
+            status = state.get(session_id)
+            if status is not None:
+                return status
+
+        return SessionStatusIdle()
     
     @classmethod
     def list(cls) -> Dict[str, SessionStatusInfo]:

--- a/flocks/session/message.py
+++ b/flocks/session/message.py
@@ -2469,7 +2469,12 @@ class Message:
             # Update timestamp
             time_data = message.time if hasattr(message, 'time') else message.model_dump().get("time", {})
             if isinstance(time_data, dict):
-                patch["time"] = {**time_data, "updated": int(datetime.now().timestamp() * 1000)}
+                requested_time = patch.get("time")
+                patch["time"] = {
+                    **time_data,
+                    **(requested_time if isinstance(requested_time, dict) else {}),
+                    "updated": int(datetime.now().timestamp() * 1000),
+                }
             
             updated = message.model_copy(update=patch)
             messages[msg_index] = updated

--- a/flocks/session/runner.py
+++ b/flocks/session/runner.py
@@ -27,7 +27,15 @@ import httpx
 from flocks.utils.log import Log
 from flocks.utils.id import Identifier
 from flocks.session.session import Session, SessionInfo
-from flocks.session.message import Message, MessageInfo, MessageRole, TextPart
+from flocks.session.message import (
+    Message,
+    MessageInfo,
+    MessageRole,
+    TextPart,
+    ToolPart,
+    ToolStateCompleted,
+    ToolStateRunning,
+)
 from flocks.session.prompt import SessionPrompt, SystemPromptBlock, TurnPromptContext
 from flocks.session.core.status import SessionStatus, SessionStatusRetry, SessionStatusBusy
 from flocks.session.core.defaults import (
@@ -1132,6 +1140,9 @@ class SessionRunner:
         agent: str,
         command: str,
         model: Optional[Dict[str, str]] = None,
+        event_publish_callback: Optional[
+            Callable[[str, Dict[str, Any]], Awaitable[None]]
+        ] = None,
     ) -> Dict[str, Any]:
         """
         Execute a shell command in session context.
@@ -1151,24 +1162,89 @@ class SessionRunner:
         
         cwd = session.directory or os.getcwd()
 
+        async def _publish(event_type: str, payload: Dict[str, Any]) -> None:
+            if event_publish_callback is None:
+                return
+            try:
+                await event_publish_callback(event_type, payload)
+            except Exception as exc:
+                log.debug("runner.shell.publish_failed", {
+                    "session_id": session_id,
+                    "event_type": event_type,
+                    "error": str(exc),
+                })
+
         async def _effect(
             execution_command: str = command,
             execution_cwd: str = cwd,
         ) -> Dict[str, Any]:
+            started_at_ms = int(time.time() * 1000)
+            user_part_id = Identifier.create("part")
             user_msg = await Message.create(
                 session_id=session_id,
                 role=MessageRole.USER,
                 content="The following tool was executed by the user",
                 agent=agent,
+                time={"created": started_at_ms},
+                part_id=user_part_id,
             )
 
+            assistant_part_id = Identifier.create("part")
             assistant_msg = await Message.create(
                 session_id=session_id,
                 role=MessageRole.ASSISTANT,
                 content="",
                 agent=agent,
                 parent_id=user_msg.id,
+                providerID="builtin",
+                modelID="shell",
+                mode=agent,
+                path={"cwd": execution_cwd, "root": execution_cwd},
+                time={"created": started_at_ms},
+                part_id=assistant_part_id,
             )
+
+            call_id = Identifier.create("call")
+            tool_part_id = Identifier.create("part")
+            tool_input = {
+                "command": execution_command,
+                "workdir": execution_cwd,
+            }
+            running_part = ToolPart(
+                id=tool_part_id,
+                messageID=assistant_msg.id,
+                sessionID=session_id,
+                callID=call_id,
+                tool="bash",
+                metadata=None,
+                state=ToolStateRunning(
+                    input=tool_input,
+                    title="Shell",
+                    metadata={},
+                    time={"start": started_at_ms},
+                ),
+            )
+            await Message.store_part(session_id, assistant_msg.id, running_part)
+
+            await _publish("message.updated", {
+                "info": user_msg.model_dump(mode="json", by_alias=True),
+            })
+            await _publish("message.part.updated", {
+                "part": {
+                    "id": user_part_id,
+                    "messageID": user_msg.id,
+                    "sessionID": session_id,
+                    "type": "text",
+                    "text": "The following tool was executed by the user",
+                    "time": {"start": started_at_ms},
+                },
+            })
+            await _publish("message.updated", {
+                "info": assistant_msg.model_dump(mode="json", by_alias=True),
+            })
+            await _publish("message.part.updated", {
+                "part": running_part.model_dump(mode="json", by_alias=True),
+            })
 
             start_time = asyncio.get_event_loop().time()
             try:
@@ -1196,6 +1272,7 @@ class SessionRunner:
                 exit_code = -1
 
             end_time = asyncio.get_event_loop().time()
+            finished_at_ms = int(time.time() * 1000)
 
             log.info("runner.shell", {
                 "session_id": session_id,
@@ -1204,25 +1281,48 @@ class SessionRunner:
                 "duration_ms": int((end_time - start_time) * 1000),
             })
 
+            completed_part = ToolPart(
+                id=tool_part_id,
+                messageID=assistant_msg.id,
+                sessionID=session_id,
+                callID=call_id,
+                tool="bash",
+                metadata=None,
+                state=ToolStateCompleted(
+                    input=tool_input,
+                    output=output,
+                    title="Shell",
+                    metadata={"exitCode": exit_code},
+                    time={"start": started_at_ms, "end": finished_at_ms},
+                    attachments=None,
+                ),
+            )
+            stored_part = await Message.store_part(
+                session_id,
+                assistant_msg.id,
+                completed_part,
+            )
+            updated_assistant = await Message.update(
+                session_id,
+                assistant_msg.id,
+                finish="stop",
+                time={"completed": finished_at_ms},
+            )
+            if updated_assistant is None:
+                raise RuntimeError(
+                    f"Failed to finalize shell message {assistant_msg.id}"
+                )
+
+            await _publish("message.part.updated", {
+                "part": stored_part.model_dump(mode="json", by_alias=True),
+            })
+            await _publish("message.updated", {
+                "info": updated_assistant.model_dump(mode="json", by_alias=True),
+            })
+
             return {
-                "info": {
-                    "id": assistant_msg.id,
-                    "sessionID": session_id,
-                    "role": "assistant",
-                    "agent": agent,
-                },
-                "parts": [{
-                    "id": Identifier.create("part"),
-                    "messageID": assistant_msg.id,
-                    "sessionID": session_id,
-                    "type": "tool",
-                    "tool": "bash",
-                    "state": {
-                        "status": "completed",
-                        "input": {"command": execution_command},
-                        "output": output,
-                    },
-                }],
+                "info": updated_assistant.model_dump(mode="json", by_alias=True),
+                "parts": [stored_part.model_dump(mode="json", by_alias=True)],
             }
 
         from flocks.session.tool_execution import (

--- a/tests/server/routes/test_session_status_by_id.py
+++ b/tests/server/routes/test_session_status_by_id.py
@@ -1,0 +1,202 @@
+"""Tests for querying one session's runtime status."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+
+import pytest
+from fastapi import status
+from flocks.auth.context import AuthUser
+from flocks.project.instance import Instance
+from flocks.server.routes import session as session_routes
+from flocks.session.core.status import (
+    SessionStatus,
+    SessionStatusBusy,
+    SessionStatusRetry,
+)
+
+
+async def _set_status_for_directory(directory: str, update: Callable[[], None]) -> None:
+    await Instance.provide(directory=directory, fn=update)
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_status() -> Iterator[None]:
+    SessionStatus._state.clear()
+    active_sessions = getattr(session_routes.router, "_prompt_queue_active_sessions", set())
+    active_sessions.clear()
+    yield
+    SessionStatus._state.clear()
+    active_sessions = getattr(session_routes.router, "_prompt_queue_active_sessions", set())
+    active_sessions.clear()
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_returns_explicit_idle(client, session_id: str) -> None:
+    response = await client.get(f"/api/session/{session_id}/status")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.headers["cache-control"] == "no-store"
+    payload = response.json()
+    assert payload["sessionID"] == session_id
+    assert payload["lifecycleStatus"] == "active"
+    assert payload["status"] == {"type": "idle"}
+    assert payload["isProcessing"] is False
+    assert payload["pendingPromptCount"] == 0
+    assert isinstance(payload["observedAt"], int)
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_returns_busy(client, session_id: str) -> None:
+    session = await session_routes._get_session_by_id_unfiltered(session_id)
+    assert session is not None
+    await _set_status_for_directory(
+        session.directory,
+        lambda: SessionStatus.set(session_id, SessionStatusBusy()),
+    )
+
+    response = await client.get(f"/api/session/{session_id}/status")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == {"type": "busy"}
+    assert response.json()["isProcessing"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_preserves_retry_details(client, session_id: str) -> None:
+    session = await session_routes._get_session_by_id_unfiltered(session_id)
+    assert session is not None
+    await _set_status_for_directory(
+        session.directory,
+        lambda: SessionStatus.set(
+            session_id,
+            SessionStatusRetry(attempt=2, message="Rate limited", next=123456789),
+        ),
+    )
+
+    response = await client.get(f"/api/session/{session_id}/status")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == {
+        "type": "retry",
+        "attempt": 2,
+        "message": "Rate limited",
+        "next": 123456789,
+    }
+    assert response.json()["isProcessing"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_reports_prompt_chain_as_queued(client, session_id: str) -> None:
+    session_routes._set_prompt_chain_active(session_id, True)
+
+    response = await client.get(f"/api/session/{session_id}/status")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == {"type": "queued"}
+    assert response.json()["isProcessing"] is True
+
+
+@pytest.mark.asyncio
+async def test_prompt_async_is_observable_as_queued_before_background_loop(
+    client,
+    session_id: str,
+    monkeypatch,
+) -> None:
+    def _hold_background_work(coro, **_kwargs) -> None:
+        coro.close()
+
+    monkeypatch.setattr(session_routes, "_schedule_background_coro", _hold_background_work)
+
+    accepted = await client.post(
+        f"/api/session/{session_id}/prompt_async",
+        json={"parts": [{"type": "text", "text": "hello"}]},
+    )
+    status_response = await client.get(f"/api/session/{session_id}/status")
+
+    assert accepted.status_code == status.HTTP_202_ACCEPTED
+    assert accepted.json()["status"] == "accepted"
+    assert status_response.status_code == status.HTTP_200_OK
+    assert status_response.json()["status"] == {"type": "queued"}
+    assert status_response.json()["isProcessing"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_prefers_busy_and_counts_queued_prompts(client, session_id: str) -> None:
+    from flocks.session.interaction_queue import InteractionQueue
+
+    session = await session_routes._get_session_by_id_unfiltered(session_id)
+    assert session is not None
+    await _set_status_for_directory(
+        session.directory,
+        lambda: SessionStatus.set(session_id, SessionStatusBusy()),
+    )
+    await InteractionQueue.enqueue(
+        session_id,
+        parts=[{"type": "text", "text": "next"}],
+    )
+
+    try:
+        response = await client.get(f"/api/session/{session_id}/status")
+    finally:
+        await InteractionQueue.clear(session_id)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == {"type": "busy"}
+    assert response.json()["pendingPromptCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_resolves_the_session_directory(client, tmp_path) -> None:
+    directory = str(tmp_path.resolve())
+    create_response = await client.post(
+        "/api/session",
+        json={"title": "other directory"},
+        headers={"X-Flocks-Directory": directory},
+    )
+    assert create_response.status_code == status.HTTP_200_OK
+    session_id = create_response.json()["id"]
+    await _set_status_for_directory(
+        directory,
+        lambda: SessionStatus.set(session_id, SessionStatusBusy()),
+    )
+
+    response = await client.get(f"/api/session/{session_id}/status")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["status"] == {"type": "busy"}
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_returns_archived_lifecycle(client, session_id: str) -> None:
+    archive_response = await client.post(f"/api/session/{session_id}/archive")
+    assert archive_response.status_code == status.HTTP_200_OK
+
+    response = await client.get(f"/api/session/{session_id}/status")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["lifecycleStatus"] == "archived"
+    assert response.json()["status"] == {"type": "idle"}
+    assert response.json()["isProcessing"] is False
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_returns_not_found(client) -> None:
+    response = await client.get("/api/session/session_missing/status")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_status_by_id_enforces_read_access(client, session_id: str, monkeypatch) -> None:
+    viewer = AuthUser(
+        id="usr_other",
+        username="other",
+        role="user",
+        status="active",
+    )
+    monkeypatch.setattr(session_routes, "require_user", lambda _request: viewer)
+
+    response = await client.get(f"/api/session/{session_id}/status")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/server/routes/test_session_status_by_id.py
+++ b/tests/server/routes/test_session_status_by_id.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Iterator
+from types import SimpleNamespace
 
 import pytest
 from fastapi import status
@@ -119,6 +121,110 @@ async def test_prompt_async_is_observable_as_queued_before_background_loop(
     assert status_response.status_code == status.HTTP_200_OK
     assert status_response.json()["status"] == {"type": "queued"}
     assert status_response.json()["isProcessing"] is True
+
+
+@pytest.mark.asyncio
+async def test_shell_is_busy_while_active_and_idle_after_completion(
+    client,
+    session_id: str,
+    monkeypatch,
+) -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hold_shell(**_kwargs):
+        started.set()
+        await release.wait()
+        return {"info": {"id": "msg_shell"}, "parts": []}
+
+    monkeypatch.setattr(
+        "flocks.session.runner.SessionRunner.shell",
+        _hold_shell,
+    )
+
+    shell_request = asyncio.create_task(
+        client.post(
+            f"/api/session/{session_id}/shell",
+            json={"agent": "rex", "command": "printf done"},
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    try:
+        running_response = await client.get(f"/api/session/{session_id}/status")
+    finally:
+        release.set()
+
+    shell_response = await asyncio.wait_for(shell_request, timeout=1)
+    completed_response = await client.get(f"/api/session/{session_id}/status")
+
+    assert running_response.status_code == status.HTTP_200_OK
+    assert running_response.json()["status"] == {"type": "busy"}
+    assert running_response.json()["isProcessing"] is True
+    assert running_response.json()["pendingPromptCount"] == 0
+    assert shell_response.status_code == status.HTTP_200_OK
+    assert completed_response.status_code == status.HTTP_200_OK
+    assert completed_response.json()["status"] == {"type": "idle"}
+    assert completed_response.json()["isProcessing"] is False
+    assert completed_response.json()["pendingPromptCount"] == 0
+    assert not session_routes.Session.has_active_operations(session_id)
+
+
+@pytest.mark.asyncio
+async def test_shell_response_is_available_after_message_cache_reload(
+    client,
+    session_id: str,
+    monkeypatch,
+) -> None:
+    from flocks.session.message import Message
+
+    process = SimpleNamespace(
+        communicate=lambda: asyncio.sleep(
+            0,
+            result=(b"PR741_SHELL_PERSISTENCE_OK", b""),
+        ),
+        returncode=0,
+    )
+
+    async def _create_subprocess(*_args, **_kwargs):
+        return process
+
+    async def _run_lifecycle(_payload, effect, **_kwargs):
+        return await effect()
+
+    monkeypatch.setattr(
+        "flocks.session.runner.asyncio.create_subprocess_shell",
+        _create_subprocess,
+    )
+    monkeypatch.setattr(
+        "flocks.session.tool_execution.run_tool_execution_lifecycle",
+        _run_lifecycle,
+    )
+
+    shell_response = await client.post(
+        f"/api/session/{session_id}/shell",
+        json={"agent": "rex", "command": "printf PR741_SHELL_PERSISTENCE_OK"},
+    )
+    assert shell_response.status_code == status.HTTP_200_OK
+    assistant_id = shell_response.json()["info"]["id"]
+
+    Message.invalidate_cache(session_id)
+    history_response = await client.get(f"/api/session/{session_id}/message")
+
+    assert history_response.status_code == status.HTTP_200_OK
+    assistant = next(
+        item
+        for item in history_response.json()
+        if item["info"]["id"] == assistant_id
+    )
+    assert assistant["info"]["finish"] == "stop"
+    tool_part = next(part for part in assistant["parts"] if part["type"] == "tool")
+    assert tool_part["tool"] == "bash"
+    assert tool_part["state"]["status"] == "completed"
+    assert tool_part["state"]["input"]["command"] == (
+        "printf PR741_SHELL_PERSISTENCE_OK"
+    )
+    assert tool_part["state"]["output"] == "PR741_SHELL_PERSISTENCE_OK"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_openapi_schema.py
+++ b/tests/server/test_openapi_schema.py
@@ -20,3 +20,8 @@ def test_session_router_openapi_schema_generates_successfully():
     schema = response.json()
     assert schema["openapi"].startswith("3.")
     assert "/api/session/{sessionID}/prompt_async" in schema["paths"]
+    assert "/api/session/{sessionID}/status" in schema["paths"]
+    operation = schema["paths"]["/api/session/{sessionID}/status"]["get"]
+    assert operation["operationId"] == "session.statusById"
+    response_schema = schema["components"]["schemas"]["SessionRuntimeStatusResponse"]
+    assert response_schema["properties"]["lifecycleStatus"]["enum"] == ["active", "archived"]

--- a/tests/server/test_request_logging.py
+++ b/tests/server/test_request_logging.py
@@ -12,6 +12,8 @@ from flocks.server import app as server_app
         "/api/health",
         "/api/event",
         "/api/session/status",
+        "/api/session/ses_123/status",
+        "/session/ses_123/status",
         "/api/session/ses_123/message",
         "/api/question/session/ses_123/pending",
     ],

--- a/tests/session/test_runner_shell_hook.py
+++ b/tests/session/test_runner_shell_hook.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from flocks.hooks.pipeline import HookBase, HookPipeline
+from flocks.session.message import Message, ToolPart
 from flocks.session.runner import SessionRunner
 from flocks.session.tool_execution import build_session_tool_execution_payload
 
@@ -39,15 +40,11 @@ async def test_session_shell_uses_tool_execute_hook_pipeline(
     create_process = AsyncMock(return_value=process)
     monkeypatch.setattr(
         "flocks.session.runner.Session.get_by_id",
-        AsyncMock(return_value=SimpleNamespace(directory=str(tmp_path))),
-    )
-    monkeypatch.setattr(
-        "flocks.session.runner.Message.create",
         AsyncMock(
-            side_effect=[
-                SimpleNamespace(id="msg_user"),
-                SimpleNamespace(id="msg_assistant"),
-            ]
+            return_value=SimpleNamespace(
+                directory=str(tmp_path),
+                project_id="project_shell_hook",
+            )
         ),
     )
     monkeypatch.setattr(
@@ -75,6 +72,73 @@ async def test_session_shell_uses_tool_execute_hook_pipeline(
         cwd=str(tmp_path),
     )
     assert result["parts"][0]["state"]["output"] == "ok\n"
+
+
+@pytest.mark.asyncio
+async def test_session_shell_persists_completed_tool_and_publishes_events(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """The HTTP result and reloaded message history share one terminal tool part."""
+
+    process = SimpleNamespace(
+        communicate=AsyncMock(return_value=(b"PERSISTED\n", b"")),
+        returncode=0,
+    )
+    monkeypatch.setattr(
+        "flocks.session.runner.Session.get_by_id",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                directory=str(tmp_path),
+                project_id="project_shell_persistence",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "flocks.session.runner.asyncio.create_subprocess_shell",
+        AsyncMock(return_value=process),
+    )
+    publish_event = AsyncMock()
+
+    result = await SessionRunner.shell(
+        session_id="ses_shell_persistence",
+        agent="rex",
+        command="printf PERSISTED",
+        event_publish_callback=publish_event,
+    )
+
+    assistant_id = result["info"]["id"]
+    Message.invalidate_cache("ses_shell_persistence")
+    restored = await Message.get_with_parts_lazy(
+        "ses_shell_persistence",
+        assistant_id,
+    )
+
+    assert restored is not None
+    assert restored.info.finish == "stop"
+    assert restored.info.time["completed"] >= restored.info.time["created"]
+    tool_parts = [part for part in restored.parts if isinstance(part, ToolPart)]
+    assert len(tool_parts) == 1
+    tool_part = tool_parts[0]
+    assert tool_part.tool == "bash"
+    assert tool_part.state.status == "completed"
+    assert tool_part.state.input == {
+        "command": "printf PERSISTED",
+        "workdir": str(tmp_path),
+    }
+    assert tool_part.state.output == "PERSISTED\n"
+    assert tool_part.state.metadata["exitCode"] == 0
+    assert result["parts"] == [tool_part.model_dump(mode="json", by_alias=True)]
+
+    event_names = [call.args[0] for call in publish_event.await_args_list]
+    assert event_names.count("message.updated") == 3
+    assert event_names.count("message.part.updated") == 3
+    final_part_event = publish_event.await_args_list[-2].args
+    final_message_event = publish_event.await_args_list[-1].args
+    assert final_part_event[0] == "message.part.updated"
+    assert final_part_event[1]["part"]["state"]["status"] == "completed"
+    assert final_message_event[0] == "message.updated"
+    assert final_message_event[1]["info"]["finish"] == "stop"
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_status.py
+++ b/tests/session/test_status.py
@@ -16,6 +16,7 @@ from flocks.session.core.status import (
     SessionStatusCompacting,
     SessionStatusDreaming,
     SessionStatusIdle,
+    SessionStatusQueued,
     SessionStatusRetry,
 )
 
@@ -42,6 +43,10 @@ class TestSessionStatusDefaults:
         result = SessionStatus.list()
         assert isinstance(result, dict)
         assert len(result) == 0
+
+    def test_get_for_session_defaults_to_idle(self):
+        status = SessionStatus.get_for_session("nonexistent_session")
+        assert isinstance(status, SessionStatusIdle)
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +100,19 @@ class TestSessionStatusSetGet:
         SessionStatus.set("ses_6", SessionStatusCompacting())
         status = SessionStatus.get("ses_6")
         assert isinstance(status, SessionStatusCompacting)
+
+    def test_get_for_session_searches_instance_states(self):
+        SessionStatus._state["/project/a"] = {"ses_cross_instance": SessionStatusBusy()}
+
+        try:
+            status = SessionStatus.get_for_session(
+                "ses_cross_instance",
+                preferred_instance_id="/project/b",
+            )
+        finally:
+            SessionStatus._state.pop("/project/a", None)
+
+        assert isinstance(status, SessionStatusBusy)
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +185,10 @@ class TestStatusModels:
     def test_busy_type_literal(self):
         busy = SessionStatusBusy()
         assert busy.type == "busy"
+
+    def test_queued_type_literal(self):
+        queued = SessionStatusQueued()
+        assert queued.type == "queued"
 
     def test_retry_required_fields(self):
         retry = SessionStatusRetry(attempt=3, message="Overloaded", next=9999)


### PR DESCRIPTION
Summary
新增指定会话运行状态查询接口：

GET /api/session/{sessionID}/status

支持返回 idle、queued、busy、retry、compacting 和 dreaming 状态，同时包含：

会话生命周期状态
是否仍在处理中
待处理提示数量
状态采样时间
接口包含鉴权、会话读取权限校验、归档会话支持及禁止缓存响应头，并补充了中英文文档和自动化测试。

Testing
定向回归：106 passed
扩大回归：1135 passed
Ruff 和 diff 检查通过
其余失败均可在 dev 分支复现，不属于本次变更