### PR TITLE
fix(project): prevent project creation errors from unavailable historical directories

### DIFF
--- a/flocks/project/project.py
+++ b/flocks/project/project.py
@@ -299,7 +299,16 @@ class Project:
 
     @staticmethod
     def _normalized_worktree(worktree: str) -> str:
-        return os.path.normcase(str(Path(worktree).expanduser().resolve(strict=True)))
+        """Compare registry paths even after their directories become unavailable."""
+
+        path = Path(worktree).expanduser()
+        try:
+            path = path.resolve(strict=False)
+        except (OSError, RuntimeError):
+            # Unreadable paths and symlink loops must not block other projects.
+            # New/restored worktrees are still checked by validate_worktree.
+            path = Path(os.path.abspath(path))
+        return os.path.normcase(str(path))
 
     @staticmethod
     def _directory_context(directory: str) -> Tuple[Path, Path, Optional[str]]:


### PR DESCRIPTION
历史项目目录被删除或移动后，新建项目会在遍历注册表、比较路径时抛出 FileNotFoundError，使其他正常目录也返回 HTTP 500。已移除项目记录的复用和项目恢复同样受影响。

将历史路径的比较改为非严格解析；遇到无法解析的路径或符号链接循环时，回退到绝对路径规范化。新建及恢复目标仍由 validate_worktree 校验，保留目录去重、重名检查和原有项目记录。

### 验证

- flocks_autotest 独立回归用例：修复前 11 失败、5 通过；修复后 16 全部通过。覆盖历史目录删除、移动、失效链接、符号链接循环、项目恢复、目录去重、重名和目标目录校验。测试位于该仓库 tests/regression/project_registry/test_missing_worktree.py，未包含在本 PR。
- 现有 tests/project/test_project.py 和 tests/server/routes/test_project_routes.py：32 项全部通过。pytest 输出通过结果后，进程在线程退出阶段挂起，随后手动中断；该次运行未正常退出。
- Ruff 检查及 git diff --check 通过。
